### PR TITLE
Configure ruff, pytest, and Claude Code workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,38 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_args: |
+            --allowedTools "Bash(pip install *),Bash(pytest*),Bash(ruff*)"


### PR DESCRIPTION
## Summary
- Add `[tool.ruff]` and `[tool.pytest.ini_options]` to `pyproject.toml`
- Add placeholder test to keep CI green
- Add `.github/workflows/claude.yml` to enable `@claude` mentions in issues and PRs

## Manual step required
Add `ANTHROPIC_API_KEY` as a repository secret at:
https://github.com/virppa/repo-scaffold-desktop/settings/secrets/actions

## Test plan
- [ ] CI lint-and-test passes
- [ ] Mention `@claude` in an issue to verify the workflow triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)