### PR TITLE
Restrict Linear MCP scope to repo-scaffold-desktop

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,8 @@ This repo ships with `.mcp.json` configured to use the Linear MCP server. Claude
 
 On first use, run `/mcp` in Claude Code to authenticate via OAuth.
 
+Only interact with the **repo-scaffold-desktop** project in Linear unless explicitly told otherwise.
+
 ---
 
 ## Git and Linear workflow


### PR DESCRIPTION
## Summary
- Add instruction to CLAUDE.md telling agents to only interact with the repo-scaffold-desktop Linear project by default

This was missed in the previous PR (#6) because the commit was pushed after the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)