### PR TITLE
Fix invalid JSON escape sequences in settings.json

### DIFF
--- a/.claude/commands/finalize-ticket.md
+++ b/.claude/commands/finalize-ticket.md
@@ -27,3 +27,8 @@ Derive the Linear identifier from the current branch name (e.g., `WOR-42-short-d
 
 ### 4. Update Linear
 Use the Linear MCP server to mark the issue as "In Review" (`save_issue` with the appropriate status).
+
+### 5. Return to main
+```bash
+git checkout main
+```

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "CMD=\"$CLAUDE_TOOL_INPUT_COMMAND\"; if echo \"$CMD\" | grep -qE '(rm\s+-[^\s]*r|git\s+push\s+--force|git\s+reset\s+--hard|git\s+checkout\s+--|git\s+clean\s+-f)'; then echo \"Blocked: dangerous command detected: $CMD\" >&2; exit 1; fi"
+            "command": "CMD=\"$CLAUDE_TOOL_INPUT_COMMAND\"; if echo \"$CMD\" | grep -qE '(rm\\s+-[^\\s]*r|git\\s+push\\s+--force|git\\s+reset\\s+--hard|git\\s+checkout\\s+--|git\\s+clean\\s+-f)'; then echo \"Blocked: dangerous command detected: $CMD\" >&2; exit 1; fi"
           }
         ]
       },
@@ -15,7 +15,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "FILE=\"$CLAUDE_TOOL_INPUT_FILE_PATH\"; if echo \"$FILE\" | grep -qE '(\.env|\.mcp\.json|\.claude/settings)'; then echo \"Blocked: writes to sensitive file not allowed: $FILE\" >&2; exit 1; fi"
+            "command": "FILE=\"$CLAUDE_TOOL_INPUT_FILE_PATH\"; if echo \"$FILE\" | grep -qE '(\\.env|\\.mcp\\.json|\\.claude/settings)'; then echo \"Blocked: writes to sensitive file not allowed: $FILE\" >&2; exit 1; fi"
           }
         ]
       }


### PR DESCRIPTION
## Summary
- `\s` and `\.` are not valid JSON escape sequences — replaced with `\s` and `\.`
- The file previously caused an \"Invalid or malformed JSON\" error in the IDE
- Regex behaviour of the hook commands is unchanged

## Test plan
- [ ] Verify `.claude/settings.json` passes JSON validation in the IDE
- [ ] Confirm hooks still fire correctly (PreToolUse blocks dangerous commands and sensitive file writes)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)