### PR TITLE
WOR-17 Add generator config model

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -1,0 +1,27 @@
+from typing import Literal
+
+from pydantic import BaseModel, field_validator
+
+VALID_PRESETS = ("python_basic",)
+
+
+class RepoConfig(BaseModel):
+    repo_name: str
+    preset: Literal["python_basic"]
+
+    include_precommit: bool = False
+    include_ci: bool = False
+    include_pr_template: bool = False
+    include_issue_templates: bool = False
+    include_codeowners: bool = False
+    include_claude_files: bool = False
+
+    @field_validator("repo_name")
+    @classmethod
+    def repo_name_must_be_valid(cls, v: str) -> str:
+        stripped = v.strip()
+        if not stripped:
+            raise ValueError("repo_name must not be empty or whitespace")
+        if any(c in stripped for c in ("/", "\\", "\0")):
+            raise ValueError("repo_name must not contain path separators")
+        return stripped

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,4 +11,5 @@ addopts = "--cov=app --cov-report=term-missing"
 
 [tool.bandit]
 targets = ["app"]
+exclude_dirs = ["tests"]
 skips = []

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,69 @@
+import pytest
+from pydantic import ValidationError
+
+from app.core.config import RepoConfig
+
+
+def test_valid_config_minimal():
+    config = RepoConfig(repo_name="my-repo", preset="python_basic")
+    assert config.repo_name == "my-repo"
+    assert config.preset == "python_basic"
+
+
+def test_valid_config_all_options():
+    config = RepoConfig(
+        repo_name="my-repo",
+        preset="python_basic",
+        include_precommit=True,
+        include_ci=True,
+        include_pr_template=True,
+        include_issue_templates=True,
+        include_codeowners=True,
+        include_claude_files=True,
+    )
+    assert config.include_precommit is True
+    assert config.include_ci is True
+    assert config.include_pr_template is True
+    assert config.include_issue_templates is True
+    assert config.include_codeowners is True
+    assert config.include_claude_files is True
+
+
+def test_option_defaults():
+    config = RepoConfig(repo_name="my-repo", preset="python_basic")
+    assert config.include_precommit is False
+    assert config.include_ci is False
+    assert config.include_pr_template is False
+    assert config.include_issue_templates is False
+    assert config.include_codeowners is False
+    assert config.include_claude_files is False
+
+
+def test_empty_repo_name_rejected():
+    with pytest.raises(ValidationError, match="repo_name"):
+        RepoConfig(repo_name="", preset="python_basic")
+
+
+def test_whitespace_repo_name_rejected():
+    with pytest.raises(ValidationError, match="repo_name"):
+        RepoConfig(repo_name="   ", preset="python_basic")
+
+
+def test_repo_name_stripped_of_surrounding_whitespace():
+    config = RepoConfig(repo_name="  my-repo  ", preset="python_basic")
+    assert config.repo_name == "my-repo"
+
+
+def test_repo_name_with_forward_slash_rejected():
+    with pytest.raises(ValidationError, match="path separators"):
+        RepoConfig(repo_name="foo/bar", preset="python_basic")
+
+
+def test_repo_name_with_backslash_rejected():
+    with pytest.raises(ValidationError, match="path separators"):
+        RepoConfig(repo_name="foo\\bar", preset="python_basic")
+
+
+def test_invalid_preset_rejected():
+    with pytest.raises(ValidationError):
+        RepoConfig(repo_name="my-repo", preset="nonexistent_preset")

--- a/tests/test_placeholder.py
+++ b/tests/test_placeholder.py
@@ -1,3 +1,0 @@
-# TODO: Replace with real tests for config, presets, and generator
-def test_placeholder():
-    pass


### PR DESCRIPTION
## Summary
- Implements `RepoConfig` Pydantic model in `app/core/config.py` as the single source of truth for scaffold generation settings
- Validates repo name (non-empty, no path separators) and preset via `Literal` type; all v1 option toggles default to `False`
- Replaces placeholder test stub with 9 real tests covering valid configs, invalid inputs, and edge cases

## Test plan
- [ ] `pytest` passes (9 tests, 100% coverage on `config.py`)
- [ ] `ruff` and `bandit` hooks pass
- [ ] Invalid repo names (empty, whitespace, path separators) raise `ValidationError`
- [ ] Unknown preset raises `ValidationError`
- [ ] All option toggles default to `False`

Closes WOR-17