### PR TITLE
WOR-22 Define preset model and loading

### DIFF
--- a/app/core/presets.py
+++ b/app/core/presets.py
@@ -1,0 +1,108 @@
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class Preset:
+    name: str
+    description: str
+    required_files: tuple[str, ...]
+    # Keys must match RepoConfig boolean toggle field names
+    optional_files: dict[str, tuple[str, ...]] = field(default_factory=dict)
+
+
+_PRESETS: dict[str, Preset] = {
+    "python_basic": Preset(
+        name="python_basic",
+        description="Minimal Python project with ruff, pytest, and bandit.",
+        required_files=(
+            "pyproject.toml",
+            "README.md",
+            ".gitignore",
+            "app/__init__.py",
+            "tests/__init__.py",
+        ),
+        optional_files={
+            "include_precommit": (".pre-commit-config.yaml",),
+            "include_ci": (".github/workflows/lint-and-test.yml",),
+            "include_pr_template": (".github/pull_request_template.md",),
+            "include_issue_templates": (
+                ".github/ISSUE_TEMPLATE/bug_report.md",
+                ".github/ISSUE_TEMPLATE/feature_request.md",
+            ),
+            "include_codeowners": (".github/CODEOWNERS",),
+            "include_claude_files": (
+                "CLAUDE.md",
+                ".mcp.json",
+            ),
+        },
+    ),
+    "python_desktop": Preset(
+        name="python_desktop",
+        description="Python desktop app with PySide6, ruff, pytest, and bandit.",
+        required_files=(
+            "pyproject.toml",
+            "README.md",
+            ".gitignore",
+            "app/__init__.py",
+            "app/main.py",
+            "app/ui/__init__.py",
+            "tests/__init__.py",
+        ),
+        optional_files={
+            "include_precommit": (".pre-commit-config.yaml",),
+            "include_ci": (".github/workflows/lint-and-test.yml",),
+            "include_pr_template": (".github/pull_request_template.md",),
+            "include_issue_templates": (
+                ".github/ISSUE_TEMPLATE/bug_report.md",
+                ".github/ISSUE_TEMPLATE/feature_request.md",
+            ),
+            "include_codeowners": (".github/CODEOWNERS",),
+            "include_claude_files": (
+                "CLAUDE.md",
+                ".mcp.json",
+            ),
+        },
+    ),
+    "full_agentic": Preset(
+        name="full_agentic",
+        description=(
+            "Python project with Claude Code agentic workflow"
+            " (Linear MCP, hooks, slash commands)."
+        ),
+        required_files=(
+            "pyproject.toml",
+            "README.md",
+            ".gitignore",
+            "app/__init__.py",
+            "tests/__init__.py",
+            "CLAUDE.md",
+            ".mcp.json",
+            ".claude/settings.json",
+        ),
+        optional_files={
+            "include_precommit": (".pre-commit-config.yaml",),
+            "include_ci": (".github/workflows/lint-and-test.yml",),
+            "include_pr_template": (".github/pull_request_template.md",),
+            "include_issue_templates": (
+                ".github/ISSUE_TEMPLATE/bug_report.md",
+                ".github/ISSUE_TEMPLATE/feature_request.md",
+            ),
+            "include_codeowners": (".github/CODEOWNERS",),
+            "include_claude_files": (
+                "CLAUDE.md",
+                ".mcp.json",
+                ".claude/settings.json",
+            ),
+        },
+    ),
+}
+
+
+def get_preset(name: str) -> Preset:
+    try:
+        return _PRESETS[name]
+    except KeyError:
+        available = ", ".join(sorted(_PRESETS))
+        raise ValueError(
+            f"Unknown preset {name!r}. Available presets: {available}"
+        ) from None

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -1,0 +1,78 @@
+import pytest
+
+from app.core.presets import Preset, get_preset
+
+EXPECTED_TOGGLE_KEYS = {
+    "include_precommit",
+    "include_ci",
+    "include_pr_template",
+    "include_issue_templates",
+    "include_codeowners",
+    "include_claude_files",
+}
+
+ALL_PRESET_NAMES = ("python_basic", "python_desktop", "full_agentic")
+
+
+def test_get_preset_returns_preset_instance():
+    result = get_preset("python_basic")
+    assert isinstance(result, Preset)
+
+
+def test_get_preset_returns_correct_preset():
+    result = get_preset("python_basic")
+    assert result.name == "python_basic"
+
+
+def test_get_preset_unknown_name_raises_value_error():
+    with pytest.raises(ValueError, match="Unknown preset"):
+        get_preset("nonexistent")
+
+
+def test_get_preset_error_message_lists_available_presets():
+    with pytest.raises(ValueError, match="python_basic"):
+        get_preset("nonexistent")
+
+
+def test_python_basic_has_required_files():
+    preset = get_preset("python_basic")
+    assert len(preset.required_files) > 0
+
+
+def test_python_basic_optional_files_keys_match_toggles():
+    preset = get_preset("python_basic")
+    assert set(preset.optional_files.keys()) == EXPECTED_TOGGLE_KEYS
+
+
+def test_python_desktop_defined():
+    preset = get_preset("python_desktop")
+    assert preset.name == "python_desktop"
+
+
+def test_full_agentic_defined():
+    preset = get_preset("full_agentic")
+    assert preset.name == "full_agentic"
+
+
+def test_all_presets_have_non_empty_names():
+    for name in ALL_PRESET_NAMES:
+        preset = get_preset(name)
+        assert preset.name.strip() != ""
+
+
+def test_all_presets_have_non_empty_descriptions():
+    for name in ALL_PRESET_NAMES:
+        preset = get_preset(name)
+        assert preset.description.strip() != ""
+
+
+def test_all_presets_have_required_files():
+    for name in ALL_PRESET_NAMES:
+        preset = get_preset(name)
+        assert len(preset.required_files) > 0
+
+
+def test_preset_is_immutable():
+    preset = get_preset("python_basic")
+    with pytest.raises((AttributeError, TypeError)):
+        preset.name = "modified"


### PR DESCRIPTION
## Summary
- Add `Preset` frozen dataclass with `required_files` and `optional_files` (keyed by `RepoConfig` toggle names)
- Register `python_basic`, `python_desktop`, and `full_agentic` presets in a module-level registry
- Implement `get_preset(name)` loader that raises `ValueError` with helpful message on unknown preset

## Test plan
- [x] `get_preset("python_basic")` returns correct `Preset` instance
- [x] `get_preset("nonexistent")` raises `ValueError` mentioning available presets
- [x] `python_basic` optional files keys exactly match `RepoConfig` toggle field names
- [x] All three presets have non-empty names, descriptions, and required files
- [x] `Preset` is immutable (frozen dataclass)
- [x] 100% coverage on `presets.py`

Closes WOR-22