### PR TITLE
WOR-23 Implement Jinja2 template rendering engine

### DIFF
--- a/app/core/generator.py
+++ b/app/core/generator.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+
+from jinja2 import Environment, FileSystemLoader, StrictUndefined
+
+from app.core.config import RepoConfig
+from app.core.presets import get_preset
+
+_TEMPLATES_DIR = Path(__file__).parent.parent.parent / "templates"
+
+
+def generate(config: RepoConfig, output_path: Path) -> None:
+    """Render all preset template files and write them to output_path."""
+    preset = get_preset(config.preset)
+
+    # Build file list: required files + enabled optional files, deduplicated
+    files_to_write: list[str] = list(
+        dict.fromkeys(
+            list(preset.required_files)
+            + [
+                f
+                for toggle_key, optional_files in preset.optional_files.items()
+                if getattr(config, toggle_key, False)
+                for f in optional_files
+            ]
+        )
+    )
+
+    templates_dir = _TEMPLATES_DIR / config.preset
+    env = Environment(  # nosec B701 — autoescape not relevant for text file generation
+        loader=FileSystemLoader(str(templates_dir)),
+        undefined=StrictUndefined,
+        keep_trailing_newline=True,
+    )
+
+    context = config.model_dump()
+
+    output_path = Path(output_path)
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    for relative_path in files_to_write:
+        template = env.get_template(f"{relative_path}.j2")
+        content = template.render(**context)
+        dest = output_path / relative_path
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_text(content, encoding="utf-8")


### PR DESCRIPTION
## Summary

- Implements `generate(config, output_path)` in `app/core/generator.py` — the core function that takes a `RepoConfig` + output path and writes all preset files to disk
- Builds a deduplicated file list from required files + any optional files whose config toggle is `True`, then renders each from `templates/<preset>/<file>.j2` via Jinja2
- Uses `StrictUndefined` so missing template variables fail loudly; creates output directories automatically

## Test plan

- [ ] Existing 21 tests (`test_config.py`, `test_presets.py`) pass with no regressions
- [ ] `ruff` and `bandit` hooks pass cleanly (B701 suppressed with `# nosec` — autoescape irrelevant for text file generation)
- [ ] Generator coverage will reach target in WOR-25 (integration tests depend on WOR-24 template files)

Closes WOR-23

🤖 Generated with [Claude Code](https://claude.ai/claude-code)