### PR TITLE
WOR-29 Add CLI interface

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,10 @@ pip install pyside6 pydantic jinja2 pyyaml pytest pytest-cov ruff bandit pre-com
 # Run app
 python -m app.main
 
+# CLI
+python -m app.cli generate --preset python_basic --repo-name myrepo --output ./out
+# With optional toggles: --pre-commit --ci --pr-template --issue-templates --codeowners --claude-files
+
 # Lint and format
 ruff check .
 ruff format .

--- a/app/cli.py
+++ b/app/cli.py
@@ -1,0 +1,94 @@
+import argparse
+import sys
+from pathlib import Path
+
+from pydantic import ValidationError
+
+from app.core.config import RepoConfig
+from app.core.generator import generate
+from app.core.presets import _PRESETS
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="scaffold",
+        description="Generate a repository scaffold from a preset.",
+    )
+    sub = parser.add_subparsers(dest="command")
+
+    gen = sub.add_parser("generate", help="Generate scaffold files.")
+    gen.add_argument(
+        "--preset",
+        required=True,
+        choices=list(_PRESETS),
+        help="Preset to use.",
+    )
+    gen.add_argument("--repo-name", required=True, help="Repository name.")
+    gen.add_argument(
+        "--output",
+        required=True,
+        type=Path,
+        help="Output directory.",
+    )
+    gen.add_argument(
+        "--pre-commit", action="store_true", help="Include pre-commit config."
+    )
+    gen.add_argument("--ci", action="store_true", help="Include CI workflow.")
+    gen.add_argument("--pr-template", action="store_true", help="Include PR template.")
+    gen.add_argument(
+        "--issue-templates", action="store_true", help="Include issue templates."
+    )
+    gen.add_argument(
+        "--codeowners", action="store_true", help="Include CODEOWNERS file."
+    )
+    gen.add_argument(
+        "--claude-files", action="store_true", help="Include Claude Code files."
+    )
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    # Ensure the terminal can emit UTF-8 (e.g. ✓); no-op on StringIO (pytest capsys).
+    if hasattr(sys.stdout, "reconfigure"):
+        try:
+            sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+        except Exception:  # nosec B110 — intentional no-op; stdout may not support reconfigure
+            pass
+
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    if args.command is None:
+        parser.print_help()
+        return 1
+
+    try:
+        config = RepoConfig(
+            repo_name=args.repo_name,
+            preset=args.preset,
+            include_precommit=args.pre_commit,
+            include_ci=args.ci,
+            include_pr_template=args.pr_template,
+            include_issue_templates=args.issue_templates,
+            include_codeowners=args.codeowners,
+            include_claude_files=args.claude_files,
+        )
+    except ValidationError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    try:
+        written = generate(config, args.output)
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    for path in written:
+        print(f"✓ {path}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/app/core/generator.py
+++ b/app/core/generator.py
@@ -8,8 +8,11 @@ from app.core.presets import get_preset
 _TEMPLATES_DIR = Path(__file__).parent.parent.parent / "templates"
 
 
-def generate(config: RepoConfig, output_path: Path) -> None:
-    """Render all preset template files and write them to output_path."""
+def generate(config: RepoConfig, output_path: Path) -> list[str]:
+    """Render all preset template files and write them to output_path.
+
+    Returns the list of relative file paths that were written.
+    """
     preset = get_preset(config.preset)
 
     # Build file list: required files + enabled optional files, deduplicated
@@ -43,3 +46,5 @@ def generate(config: RepoConfig, output_path: Path) -> None:
         dest = output_path / relative_path
         dest.parent.mkdir(parents=True, exist_ok=True)
         dest.write_text(content, encoding="utf-8")
+
+    return files_to_write

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,11 @@
+[project]
+name = "repo-scaffold-desktop"
+version = "0.1.0"
+requires-python = ">=3.12"
+
+[project.scripts]
+scaffold = "app.cli:main"
+
 [tool.ruff]
 target-version = "py312"
 line-length = 88

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,113 @@
+import pytest
+
+from app.cli import main
+
+
+@pytest.fixture()
+def output_dir(tmp_path):
+    return tmp_path / "out"
+
+
+def test_generate_subcommand_writes_files(output_dir):
+    rc = main(
+        [
+            "generate",
+            "--preset",
+            "python_basic",
+            "--repo-name",
+            "myrepo",
+            "--output",
+            str(output_dir),
+        ]
+    )
+    assert rc == 0
+    assert (output_dir / "README.md").exists()
+    assert (output_dir / "pyproject.toml").exists()
+    assert (output_dir / ".gitignore").exists()
+    assert (output_dir / "app" / "__init__.py").exists()
+    assert (output_dir / "tests" / "__init__.py").exists()
+
+
+def test_all_toggles_enabled(output_dir):
+    rc = main(
+        [
+            "generate",
+            "--preset",
+            "python_basic",
+            "--repo-name",
+            "myrepo",
+            "--output",
+            str(output_dir),
+            "--pre-commit",
+            "--ci",
+            "--pr-template",
+            "--issue-templates",
+            "--codeowners",
+            "--claude-files",
+        ]
+    )
+    assert rc == 0
+    assert (output_dir / ".pre-commit-config.yaml").exists()
+    assert (output_dir / ".github" / "workflows" / "ci.yml").exists()
+    assert (output_dir / ".github" / "pull_request_template.md").exists()
+    assert (output_dir / ".github" / "ISSUE_TEMPLATE" / "bug_report.md").exists()
+    assert (output_dir / ".github" / "ISSUE_TEMPLATE" / "feature_request.md").exists()
+    assert (output_dir / ".github" / "CODEOWNERS").exists()
+    assert (output_dir / "CLAUDE.md").exists()
+    assert (output_dir / ".mcp.json").exists()
+
+
+def test_missing_repo_name_exits(output_dir, capsys):
+    with pytest.raises(SystemExit) as exc_info:
+        main(
+            [
+                "generate",
+                "--preset",
+                "python_basic",
+                "--output",
+                str(output_dir),
+            ]
+        )
+    assert exc_info.value.code != 0
+
+
+def test_invalid_preset_exits(output_dir, capsys):
+    with pytest.raises(SystemExit) as exc_info:
+        main(
+            [
+                "generate",
+                "--preset",
+                "nonexistent_preset",
+                "--repo-name",
+                "myrepo",
+                "--output",
+                str(output_dir),
+            ]
+        )
+    assert exc_info.value.code != 0
+
+
+def test_progress_output(output_dir, capsys):
+    rc = main(
+        [
+            "generate",
+            "--preset",
+            "python_basic",
+            "--repo-name",
+            "myrepo",
+            "--output",
+            str(output_dir),
+        ]
+    )
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert "✓ README.md" in captured.out
+    assert "✓ pyproject.toml" in captured.out
+    assert "✓ .gitignore" in captured.out
+
+
+def test_no_subcommand_shows_help(capsys):
+    rc = main([])
+    assert rc == 1
+    captured = capsys.readouterr()
+    assert "usage" in captured.out.lower()


### PR DESCRIPTION
## Summary
- Add `app/cli.py` with `scaffold generate` subcommand (argparse); maps `--preset`, `--repo-name`, `--output`, and all six v1 toggle flags to `RepoConfig`
- Wire to existing `generate()` with per-file `✓ filename` progress output; handle Windows console UTF-8 encoding
- Add `[project.scripts]` entry point in `pyproject.toml` and update CLAUDE.md Commands section

## Test plan
- [ ] `pytest tests/test_cli.py` — 6 tests, all passing (91% total coverage)
- [ ] Manual: `python -m app.cli generate --preset python_basic --repo-name foo --output /tmp/out` writes expected files
- [ ] Manual: all toggle flags produce correct optional files
- [ ] Manual: invalid preset and missing `--repo-name` exit non-zero with error output

Closes WOR-29

🤖 Generated with [Claude Code](https://claude.com/claude-code)