### PR TITLE
WOR-28 Scope claude-code-review workflow to first-time contributors only

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,11 +12,7 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    if: github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
 
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary

- Uncommented the job-level `if:` condition on the `claude-review` job
- Scoped to `author_association == 'FIRST_TIME_CONTRIBUTOR'` only — effectively never fires on a solo project but stays available for external contributors
- Removes redundancy with local Claude Code review and eliminates unnecessary token cost on routine PRs

## Test plan

- [ ] Verify CI passes on this PR
- [ ] Confirm `claude-code-review` job shows as skipped (not failed) since author is OWNER

Closes WOR-28