### PR TITLE
WOR-20 Add local git init and pre-commit install option

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,7 @@ python -m app.main
 # CLI
 python -m app.cli generate --preset python_basic --repo-name myrepo --output ./out
 # With optional toggles: --pre-commit --ci --pr-template --issue-templates --codeowners --claude-files
+# With post-setup:       --git-init --install-precommit
 
 # Lint and format
 ruff check .

--- a/app/cli.py
+++ b/app/cli.py
@@ -6,6 +6,7 @@ from pydantic import ValidationError
 
 from app.core.config import RepoConfig
 from app.core.generator import generate
+from app.core.post_setup import run_git_init, run_precommit_install
 from app.core.presets import _PRESETS
 
 
@@ -44,6 +45,14 @@ def _build_parser() -> argparse.ArgumentParser:
     gen.add_argument(
         "--claude-files", action="store_true", help="Include Claude Code files."
     )
+    gen.add_argument(
+        "--git-init", action="store_true", help="Run git init in the output directory."
+    )
+    gen.add_argument(
+        "--install-precommit",
+        action="store_true",
+        help="Run pre-commit install in the output directory.",
+    )
 
     return parser
 
@@ -73,6 +82,8 @@ def main(argv: list[str] | None = None) -> int:
             include_issue_templates=args.issue_templates,
             include_codeowners=args.codeowners,
             include_claude_files=args.claude_files,
+            git_init=args.git_init,
+            install_precommit=args.install_precommit,
         )
     except ValidationError as exc:
         print(f"Error: {exc}", file=sys.stderr)
@@ -86,6 +97,17 @@ def main(argv: list[str] | None = None) -> int:
 
     for path in written:
         print(f"✓ {path}")
+
+    try:
+        if config.git_init:
+            run_git_init(args.output)
+            print("✓ git init")
+        if config.install_precommit:
+            run_precommit_install(args.output)
+            print("✓ pre-commit install")
+    except RuntimeError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
 
     return 0
 

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -16,6 +16,9 @@ class RepoConfig(BaseModel):
     include_codeowners: bool = False
     include_claude_files: bool = False
 
+    git_init: bool = False
+    install_precommit: bool = False
+
     @field_validator("repo_name")
     @classmethod
     def repo_name_must_be_valid(cls, v: str) -> str:

--- a/app/core/post_setup.py
+++ b/app/core/post_setup.py
@@ -1,0 +1,36 @@
+import subprocess  # nosec B404 — controlled calls with hardcoded command lists, no shell=True
+from pathlib import Path
+
+
+def run_git_init(output_path: Path) -> None:
+    """Run `git init` in output_path. Raises RuntimeError on failure."""
+    try:
+        subprocess.run(  # nosec B603 B607 — hardcoded command, no user input, no shell
+            ["git", "init"],
+            cwd=output_path,
+            check=True,
+            capture_output=True,
+        )
+    except FileNotFoundError:
+        raise RuntimeError("git not found on PATH — install git and try again")
+    except subprocess.CalledProcessError as exc:
+        stderr = exc.stderr.decode(errors="replace").strip()
+        raise RuntimeError(f"git init failed: {stderr}")
+
+
+def run_precommit_install(output_path: Path) -> None:
+    """Run `pre-commit install` in output_path. Raises RuntimeError on failure."""
+    try:
+        subprocess.run(  # nosec B603 B607 — hardcoded command, no user input, no shell
+            ["pre-commit", "install"],
+            cwd=output_path,
+            check=True,
+            capture_output=True,
+        )
+    except FileNotFoundError:
+        raise RuntimeError(
+            "pre-commit not found on PATH — install pre-commit and try again"
+        )
+    except subprocess.CalledProcessError as exc:
+        stderr = exc.stderr.decode(errors="replace").strip()
+        raise RuntimeError(f"pre-commit install failed: {stderr}")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import pytest
 
 from app.cli import main
@@ -111,3 +113,60 @@ def test_no_subcommand_shows_help(capsys):
     assert rc == 1
     captured = capsys.readouterr()
     assert "usage" in captured.out.lower()
+
+
+def test_git_init_flag_calls_post_setup(output_dir):
+    with patch("app.cli.run_git_init") as mock_git:
+        rc = main(
+            [
+                "generate",
+                "--preset",
+                "python_basic",
+                "--repo-name",
+                "myrepo",
+                "--output",
+                str(output_dir),
+                "--git-init",
+            ]
+        )
+    assert rc == 0
+    mock_git.assert_called_once_with(output_dir)
+
+
+def test_install_precommit_flag_calls_post_setup(output_dir):
+    with patch("app.cli.run_precommit_install") as mock_pc:
+        rc = main(
+            [
+                "generate",
+                "--preset",
+                "python_basic",
+                "--repo-name",
+                "myrepo",
+                "--output",
+                str(output_dir),
+                "--install-precommit",
+            ]
+        )
+    assert rc == 0
+    mock_pc.assert_called_once_with(output_dir)
+
+
+def test_post_setup_error_exits_nonzero(output_dir, capsys):
+    with patch(
+        "app.cli.run_git_init", side_effect=RuntimeError("git not found on PATH")
+    ):
+        rc = main(
+            [
+                "generate",
+                "--preset",
+                "python_basic",
+                "--repo-name",
+                "myrepo",
+                "--output",
+                str(output_dir),
+                "--git-init",
+            ]
+        )
+    assert rc == 1
+    captured = capsys.readouterr()
+    assert "git not found on PATH" in captured.err

--- a/tests/test_post_setup.py
+++ b/tests/test_post_setup.py
@@ -1,0 +1,57 @@
+import subprocess
+from unittest.mock import patch
+
+import pytest
+
+from app.core.post_setup import run_git_init, run_precommit_install
+
+
+@pytest.fixture()
+def repo_dir(tmp_path):
+    return tmp_path / "repo"
+
+
+class TestRunGitInit:
+    def test_invokes_subprocess_with_correct_args(self, repo_dir):
+        with patch("app.core.post_setup.subprocess.run") as mock_run:
+            run_git_init(repo_dir)
+        mock_run.assert_called_once_with(
+            ["git", "init"],
+            cwd=repo_dir,
+            check=True,
+            capture_output=True,
+        )
+
+    def test_raises_runtime_error_on_nonzero_exit(self, repo_dir):
+        error = subprocess.CalledProcessError(128, "git", stderr=b"not a git repo")
+        with patch("app.core.post_setup.subprocess.run", side_effect=error):
+            with pytest.raises(RuntimeError, match="git init failed"):
+                run_git_init(repo_dir)
+
+    def test_raises_runtime_error_when_git_not_found(self, repo_dir):
+        with patch("app.core.post_setup.subprocess.run", side_effect=FileNotFoundError):
+            with pytest.raises(RuntimeError, match="git not found on PATH"):
+                run_git_init(repo_dir)
+
+
+class TestRunPrecommitInstall:
+    def test_invokes_subprocess_with_correct_args(self, repo_dir):
+        with patch("app.core.post_setup.subprocess.run") as mock_run:
+            run_precommit_install(repo_dir)
+        mock_run.assert_called_once_with(
+            ["pre-commit", "install"],
+            cwd=repo_dir,
+            check=True,
+            capture_output=True,
+        )
+
+    def test_raises_runtime_error_on_nonzero_exit(self, repo_dir):
+        error = subprocess.CalledProcessError(1, "pre-commit", stderr=b"hook error")
+        with patch("app.core.post_setup.subprocess.run", side_effect=error):
+            with pytest.raises(RuntimeError, match="pre-commit install failed"):
+                run_precommit_install(repo_dir)
+
+    def test_raises_runtime_error_when_precommit_not_found(self, repo_dir):
+        with patch("app.core.post_setup.subprocess.run", side_effect=FileNotFoundError):
+            with pytest.raises(RuntimeError, match="pre-commit not found on PATH"):
+                run_precommit_install(repo_dir)


### PR DESCRIPTION
## Summary
- Add `--git-init` flag to run `git init` in the output directory after scaffold generation
- Add `--install-precommit` flag to run `pre-commit install` after generation (runs after git init when both are given)
- Errors (command not found, non-zero exit) surface to stderr and cause CLI to exit non-zero

## Test plan
- [ ] `pytest` passes (47 tests, 93% coverage)
- [ ] `python -m app.cli generate --preset python_basic --repo-name myrepo --output /tmp/test --git-init` initializes a git repo
- [ ] `python -m app.cli generate ... --git-init --install-precommit` runs both steps in order
- [ ] Removing git from PATH causes clear error message and rc=1
- [ ] Existing CLI invocations without new flags behave identically

Closes WOR-20

🤖 Generated with [Claude Code](https://claude.com/claude-code)