### PR TITLE
Add requirements.txt and requirements-dev.txt

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ```bash
 # Setup
 python -m venv .venv
-pip install pyside6 pydantic jinja2 pyyaml pytest pytest-cov ruff bandit pre-commit
+pip install -r requirements-dev.txt
 
 # Run app
 python -m app.main

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ python -m venv .venv
 source .venv/bin/activate  # Windows: .venv\Scripts\activate
 
 # Install dependencies
-pip install pyside6 pydantic jinja2 pyyaml pytest pytest-cov ruff bandit pre-commit
+pip install -r requirements-dev.txt
 
 # Install pre-commit hooks
 pre-commit install

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,6 @@
+-r requirements.txt
+pytest>=8.0
+pytest-cov>=5.0
+ruff>=0.4
+bandit>=1.7
+pre-commit>=3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+pydantic>=2.0
+jinja2>=3.0
+pyyaml>=6.0
+pyside6>=6.0


### PR DESCRIPTION
## Summary
- Add `requirements.txt` for runtime deps (pydantic, jinja2, pyyaml, pyside6)
- Add `requirements-dev.txt` for dev tools (pytest, ruff, bandit, pre-commit); includes `-r requirements.txt`
- Update install command in README and CLAUDE.md to `pip install -r requirements-dev.txt`

## Test plan
- [ ] `pip install -r requirements-dev.txt` in a fresh venv installs all needed packages
- [ ] `pip install -r requirements.txt` installs runtime-only deps

🤖 Generated with [Claude Code](https://claude.com/claude-code)