### PR TITLE
WOR-34 Fix RepoConfig to accept all three preset values

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -2,12 +2,12 @@ from typing import Literal
 
 from pydantic import BaseModel, field_validator
 
-VALID_PRESETS = ("python_basic",)
+VALID_PRESETS = ("python_basic", "python_desktop", "full_agentic")
 
 
 class RepoConfig(BaseModel):
     repo_name: str
-    preset: Literal["python_basic"]
+    preset: Literal["python_basic", "python_desktop", "full_agentic"]
 
     include_precommit: bool = False
     include_ci: bool = False

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -64,6 +64,12 @@ def test_repo_name_with_backslash_rejected():
         RepoConfig(repo_name="foo\\bar", preset="python_basic")
 
 
+def test_all_valid_presets_accepted():
+    for preset in ("python_basic", "python_desktop", "full_agentic"):
+        config = RepoConfig(repo_name="my-repo", preset=preset)
+        assert config.preset == preset
+
+
 def test_invalid_preset_rejected():
     with pytest.raises(ValidationError):
         RepoConfig(repo_name="my-repo", preset="nonexistent_preset")


### PR DESCRIPTION
## Summary
- `RepoConfig` in `app/core/config.py` only accepted `python_basic` — `python_desktop` and `full_agentic` both crashed with a Pydantic validation error
- Expanded `Literal` type and `VALID_PRESETS` tuple to include all three valid presets
- Added `test_all_valid_presets_accepted` to verify each preset passes config validation

## Test plan
- [ ] `pytest tests/test_config.py` — all 10 tests pass
- [ ] `python -m app.cli generate --preset python_desktop --repo-name test --output /tmp/test-desktop` generates without error
- [ ] `python -m app.cli generate --preset full_agentic --repo-name test --output /tmp/test-agentic` generates without error
- [ ] `python -m app.cli generate --preset bad_preset --repo-name test --output /tmp/x` produces a clear validation error

Closes WOR-34