### PR TITLE
WOR-32 Fix Usage section in README templates and project README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ The tool makes it faster to start a new project with sensible defaults such as:
 
 ## Usage
 
+> Note: Desktop GUI is planned for V2. The CLI is the primary interface for V1.
+
 ```bash
 # Basic generation
 python -m app.cli generate --preset python_basic --repo-name myrepo --output ./out

--- a/templates/full_agentic/README.md.j2
+++ b/templates/full_agentic/README.md.j2
@@ -27,7 +27,8 @@ pre-commit run --all-files
 ## Usage
 
 ```bash
-python -m app.main
+# Add the entry point for your project here.
+# Example: python -m {{ repo_name }}
 ```
 
 ## Development

--- a/templates/python_basic/README.md.j2
+++ b/templates/python_basic/README.md.j2
@@ -27,7 +27,8 @@ pre-commit run --all-files
 ## Usage
 
 ```bash
-python -m app.main
+# Add the entry point for your project here.
+# Example: python -m {{ repo_name }}
 ```
 
 ## Development

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -185,6 +185,27 @@ def test_readme_no_claude_section_when_not_toggled(basic_config, output_dir):
     assert "Claude" not in content
 
 
+def test_python_basic_readme_does_not_contain_app_main(output_dir):
+    config = RepoConfig(repo_name="my-project", preset="python_basic")
+    generate(config, output_dir)
+    content = (output_dir / "README.md").read_text(encoding="utf-8")
+    assert "python -m app.main" not in content
+
+
+def test_python_desktop_readme_contains_app_main(output_dir):
+    config = RepoConfig(repo_name="my-desktop-app", preset="python_desktop")
+    generate(config, output_dir)
+    content = (output_dir / "README.md").read_text(encoding="utf-8")
+    assert "python -m app.main" in content
+
+
+def test_full_agentic_readme_does_not_contain_app_main(output_dir):
+    config = RepoConfig(repo_name="my-agentic-project", preset="full_agentic")
+    generate(config, output_dir)
+    content = (output_dir / "README.md").read_text(encoding="utf-8")
+    assert "python -m app.main" not in content
+
+
 def test_all_toggles_enabled(output_dir):
     config = RepoConfig(
         repo_name="my-project",


### PR DESCRIPTION
## Summary

- Replace `python -m app.main` with a generic placeholder in `python_basic` and `full_agentic` README templates — neither preset scaffolds `app/main.py`, so the command would reference a non-existent file
- Keep `python -m app.main` in `python_desktop` template (correct; `app/main.py` is a required file for that preset)
- Add a one-line GUI/V2 note to the project README's Usage section (closes the optional acceptance criterion)

## Test plan

- [x] `test_python_basic_readme_does_not_contain_app_main` — generated README has no `python -m app.main`
- [x] `test_python_desktop_readme_contains_app_main` — generated README retains `python -m app.main`
- [x] `test_full_agentic_readme_does_not_contain_app_main` — generated README has no `python -m app.main`
- [x] All 62 tests pass, 93% coverage

Closes WOR-32