### PR TITLE
Improve slash commands with milestones, labels, blockers, and project page updates

### DIFF
--- a/.claude/commands/finalize-ticket.md
+++ b/.claude/commands/finalize-ticket.md
@@ -21,14 +21,30 @@ Only update docs if the change is meaningful — do not document implementation 
 ### 3. Create the pull request
 Derive the Linear identifier from the current branch name (e.g., `WOR-42-short-description` → `WOR-42`).
 
+Fetch the issue with `get_issue(id, includeMilestone: true)` to get its milestone name.
+
 - PR title: `WOR-NNN Short description`
-- PR body: 2–3 bullet summary + test plan checklist + `Closes WOR-NNN`
+- PR body:
+  - 2–3 bullet summary
+  - Milestone line: `**Milestone:** <milestone name>`
+  - Test plan checklist
+  - `Closes WOR-NNN`
 - Run: `gh pr create`
 
 ### 4. Update Linear
-Use the Linear MCP server to mark the issue as "In Review" (`save_issue` with the appropriate status).
+Use the Linear MCP server to:
+1. Mark the issue as **In Review**: `save_issue(id: "WOR-NNN", state: "In Review")`
+2. Fetch the milestone this issue belongs to with `list_milestones(project: "repo-scaffold-desktop")`. If the milestone's progress has reached 100%, note it explicitly: "🎉 Milestone '<name>' is now complete."
 
-### 5. Return to main
+### 5. Update the project page
+Update the **repo-scaffold-desktop** project summary to reflect what just shipped.
+
+Call `save_project(id: "87ca9685-f2e6-493f-a022-03ef2425d2ab")` with an updated `summary` (max 255 chars) capturing the current state. Example format:
+`MVP Build 88% | WOR-NNN just merged | In Review: WOR-X | Next: WOR-Y`
+
+Only update `summary` here — full description refresh happens in `/prioritize`.
+
+### 6. Return to main
 ```bash
 git checkout main
 ```

--- a/.claude/commands/groom-ticket.md
+++ b/.claude/commands/groom-ticket.md
@@ -1,4 +1,4 @@
-Look up the Linear issue with identifier $ARGUMENTS in the repo-scaffold-desktop project using the Linear MCP server.
+Look up the Linear issue with identifier $ARGUMENTS in the repo-scaffold-desktop project using the Linear MCP server. Also fetch `get_issue($ARGUMENTS, includeRelations: true)` to see existing labels, milestone, and blocking relations.
 
 As a Product Owner, evaluate the issue before development begins:
 
@@ -12,6 +12,25 @@ As a Product Owner, evaluate the issue before development begins:
 
 4. **Splitting** — if the ticket should be split, draft sub-issue titles and brief descriptions for each.
 
-5. **Dependencies** — note any other tickets or work that must come first.
+5. **Dependencies** — note any other tickets or work that must come first. Check actual Linear relations from `get_issue(includeRelations: true)` before inferring.
 
-**STOP HERE.** Do not update Linear, create sub-issues, or begin any implementation. Present your analysis and wait for human approval. Only after the human confirms should you make any changes in Linear.
+6. **Metadata recommendations** — propose values for any of these that are missing or wrong:
+   - **Type label** — one of: Feature / Fix / Refactor / Spike / Bug
+   - **Stream label** — one of: Product / Infra / AI / Docs
+   - **Milestone** — which of the project milestones this belongs to: Discovery / Scope Locked / MVP Build / Test/polish / Release
+   - **Priority** — 1=Urgent / 2=High / 3=Normal / 4=Low
+   - **Blockers** — any issues that must ship first (by WOR-NNN identifier)
+
+**STOP HERE.** Present your analysis and wait for human approval before making any changes.
+
+---
+
+After the human approves, take all of the following actions in Linear using `save_issue`:
+
+1. **Labels** — set the Type and Stream labels on the issue (use label names, not IDs)
+2. **Milestone** — assign the issue to the recommended milestone
+3. **Priority** — update if the current value is wrong or missing
+4. **Blockers** — add any missing `blockedBy` relations (append-only; existing relations are never removed)
+5. **Sub-issues** — if splitting was recommended and the human approved, create each sub-issue with `save_issue` using `parentId: "$ARGUMENTS"`, then set the same milestone and labels on each sub-issue
+
+Report a summary of every change made in Linear.

--- a/.claude/commands/prioritize.md
+++ b/.claude/commands/prioritize.md
@@ -1,33 +1,102 @@
-Pull all open issues from the **repo-scaffold-desktop** project using the Linear MCP server (`list_issues` with `project: "repo-scaffold-desktop"`, excluding Done/Cancelled). Also fetch each issue's relations with `get_issue` (includeRelations: true) for the ones that look like they may block others.
+Pull all open issues from the **repo-scaffold-desktop** project using the Linear MCP server. Run these fetches in parallel:
 
-Then produce a prioritized backlog overview in four sections:
+- `list_issues` with `project: "repo-scaffold-desktop"` — exclude Done/Cancelled
+- `list_milestones` with `project: "repo-scaffold-desktop"` — get progress % on each
+
+Then for every issue that has or appears to have blocking relations, fetch `get_issue(id, includeRelations: true)` to get the **actual Linear blocker chain** (do not infer from titles).
+
+Produce the following five sections:
 
 ---
 
-### 1. Current state
-List every open issue grouped by status (In Progress → In Review → Backlog → other). For each issue show: identifier, title, status, and one-line description of what it delivers.
+### 1. Milestone overview
 
-### 2. Dependency map
-Identify any blocking relationships (A must ship before B). If no explicit Linear relations exist, infer logical dependencies from the issue titles and descriptions (e.g., "generator core" clearly unblocks UI tickets). Show as a simple list:
+List each milestone with its progress % and status (complete / active / upcoming). Identify the **current active milestone** — the earliest incomplete one. Flag any milestone that is behind expectations.
+
+### 2. Current state
+
+List every open issue grouped first by milestone, then by status within each milestone (In Progress → In Review → Backlog). For each issue show:
+
+```
+WOR-NNN [Type/Stream labels] Title — one-line description of what it delivers
+         Status: <status>   Priority: <priority>
+```
+
+Issues not assigned to any milestone are listed last under **Unassigned (needs triage)**.
+
+### 3. Dependency map
+
+Use **actual blocking relations from Linear** (from `get_issue(includeRelations: true)`). Show as:
+
 ```
 WOR-X blocks WOR-Y, WOR-Z
 WOR-A blocks WOR-B
-(no dependencies) WOR-C, WOR-D
+(unblocked) WOR-C, WOR-D
 ```
 
-### 3. Recommended order
-Rank all Backlog issues by priority. Use this scoring logic — apply in order, stop when a ticket is differentiated:
+Flag any cycles or issues blocked by something that is already Done/Cancelled (stale blockers).
+
+### 4. Recommended order
+
+Rank all Backlog issues by priority using this scoring — apply in order, stop when a ticket is differentiated:
+
 1. **Unblocks the most other tickets** — do first
-2. **Currently blocked** — defer until its blocker ships
-3. **Smallest scope** (single file / doc-only) — prefer over large multi-file tickets at equal value
-4. **Closer to the immediate milestone** (per CLAUDE.md: "Generate a local repository skeleton from a selected preset and write all files to disk") — prefer
-5. **Release gate** (e.g., release checklist) — do last
+2. **Currently blocked** — defer until blocker ships
+3. **Fits current active milestone** — prefer over future milestone work
+4. **Smallest scope** (single file / doc-only) — prefer at equal value
+5. **Release gate** — do last
 
-Output as a numbered list with a one-line rationale per ticket.
+Output as a numbered list: `WOR-NNN [milestone] — rationale`.
 
-### 4. Suggested next ticket
+### 5. Suggested next ticket
+
 State the single best ticket to pick up right now and why. If something is already In Progress, say so and recommend finishing it first.
 
 ---
 
-**Do not update Linear, create issues, or begin implementation.** Present the analysis and wait for the human to decide.
+### 6. Project health summary
+
+Write a 5–8 line project status update in this format (ready to paste into Linear's project Updates tab or a team channel):
+
+```
+**Health:** On Track / At Risk / Off Track
+**Active milestone:** <name> (<progress>% complete)
+**In flight:** <list of In Progress / In Review issues>
+**Completed since last update:** <recently closed issues if visible>
+**Blockers / risks:** <any blocked or at-risk items>
+**Next up:** <top 2-3 items from recommended order>
+```
+
+Set health as: **On Track** if active milestone ≥ its expected progress and no High/Urgent issues are blocked; **At Risk** if milestone is behind or a High issue is blocked; **Off Track** if multiple milestones are slipping or blockers are unresolved for >1 cycle.
+
+---
+
+### 6. Update the Linear project page
+
+After presenting sections 1–5, update the **repo-scaffold-desktop** project in Linear to reflect current state. Do both of these:
+
+**A. Update `summary`** (max 255 chars) — a single sentence capturing the current milestone and what's in flight. Example format:
+`MVP Build 88% → Test/polish 40% | In flight: WOR-X, WOR-Y | Next: WOR-Z`
+
+**B. Update `description`** — read the current project description with `get_project`, then:
+1. Strip any existing block that starts with `## 📍 Current state` (everything up to the next `##` heading or end of that section)
+2. Prepend a fresh block at the very top:
+
+```markdown
+## 📍 Current state — <YYYY-MM-DD>
+
+**Active milestone:** <name> (<progress>%)
+**Health:** On Track / At Risk / Off Track
+**In flight:** WOR-X Title, WOR-Y Title
+**Blocked:** WOR-Z blocked by WOR-A (or "none")
+**Next up:** WOR-A, WOR-B, WOR-C
+
+---
+
+```
+
+3. Append the rest of the original description unchanged after the `---` separator.
+
+Call `save_project` with `id: "87ca9685-f2e6-493f-a022-03ef2425d2ab"` and both `summary` and `description` fields.
+
+**Do not create issues or begin implementation.** Present the analysis first (sections 1–5), then update the project page.

--- a/.claude/commands/start-ticket.md
+++ b/.claude/commands/start-ticket.md
@@ -1,4 +1,4 @@
-Look up the Linear issue with identifier $ARGUMENTS in the repo-scaffold-desktop project using the Linear MCP server.
+Look up the Linear issue with identifier $ARGUMENTS in the repo-scaffold-desktop project using the Linear MCP server. Also fetch `get_issue($ARGUMENTS, includeRelations: true)` to see its milestone, labels, priority, and any blocking relations.
 
 Work through these phases in order:
 
@@ -15,6 +15,8 @@ git branch --merged main | grep -v '^\*\? *main$' | xargs -r git branch -d
 - Restate the requirement in plain terms (one paragraph)
 - Flag any ambiguity or missing information
 - State the acceptance criteria (from the issue, or infer them if not specified)
+- Note the milestone this ticket belongs to and how it fits the current milestone's goal
+- Flag any active blockers from Linear — if this ticket is blocked by an open issue, warn before proceeding
 
 ### 2. As Architect — plan the implementation
 - List which files need to change and what changes are needed
@@ -22,13 +24,24 @@ git branch --merged main | grep -v '^\*\? *main$' | xargs -r git branch -d
 - Flag any security surface introduced: new I/O, user input handling, file operations, subprocess calls
 - Note edge cases and overwrite behavior to consider
 
-### 3. Create the branch
+### 3. Create the branch and update Linear
 Run `git checkout -b <branch-name>` using the branch name from Linear's "Copy branch name" format (usually `WOR-NNN-short-description`).
+
+Then immediately set the issue status to **In Progress** in Linear:
+`save_issue(id: "$ARGUMENTS", state: "In Progress")`
+
+Also prune stale local branches:
+```bash
+git fetch --prune
+git branch --merged main | grep -v "^\*\? *main$"
+# delete any listed branches with: git branch -d <branch>
+```
 
 ### 4. Present the plan
 Summarize as:
 ```
 Branch: <branch-name>
+Milestone: <milestone name> (<progress>%)
 Files to change:
   - path/to/file.py — what changes
 Tests to write:


### PR DESCRIPTION
## Summary

- **`/prioritize`**: now fetches milestones and groups issues by them, reads actual Linear blocker chains (not inferred), and updates the project `summary` + prepends a `## 📍 Current state` block to the project `description` via `save_project`
- **`/groom-ticket`**: after human approval, assigns Type + Stream labels, milestone, priority, and blockers in Linear; creates sub-issues if splitting was recommended
- **`/start-ticket`**: sets issue status to **In Progress** immediately on branch creation, shows milestone context and active blockers, includes branch pruning step
- **`/finalize-ticket`**: adds milestone line to PR body, flags milestone completion at 100%, updates project `summary` via `save_project` after each merge

## Test plan

- [ ] Run `/prioritize` — verify milestone grouping appears, project page summary updates in Linear
- [ ] Run `/groom-ticket WOR-NNN` on an ungroomed issue — verify labels, milestone, and blockers are set in Linear after approval
- [ ] Run `/start-ticket WOR-NNN` — verify issue moves to In Progress in Linear immediately
- [ ] Run `/finalize-ticket` — verify PR body includes milestone line, project summary updates