### PR TITLE
Add opportunistic issue capture, milestone lifecycle, and epic grouping to commands

### DIFF
--- a/.claude/commands/finalize-ticket.md
+++ b/.claude/commands/finalize-ticket.md
@@ -21,12 +21,13 @@ Only update docs if the change is meaningful — do not document implementation 
 ### 3. Create the pull request
 Derive the Linear identifier from the current branch name (e.g., `WOR-42-short-description` → `WOR-42`).
 
-Fetch the issue with `get_issue(id, includeMilestone: true)` to get its milestone name.
+Fetch the issue with `get_issue(id, includeRelations: true)` to get its milestone and parent epic.
 
 - PR title: `WOR-NNN Short description`
 - PR body:
   - 2–3 bullet summary
-  - Milestone line: `**Milestone:** <milestone name>`
+  - `**Milestone:** <milestone name>` (if set)
+  - `**Epic:** <parent issue title>` (if set)
   - Test plan checklist
   - `Closes WOR-NNN`
 - Run: `gh pr create`
@@ -48,3 +49,30 @@ Only update `summary` here — full description refresh happens in `/prioritize`
 ```bash
 git checkout main
 ```
+
+---
+
+### 7. Opportunistic issue capture
+
+Now that implementation is complete, you have the deepest context on this area of the codebase. Surface anything noticed during implementation that falls outside the current ticket's scope:
+- Bugs encountered in code you touched or read
+- Missing features that would naturally complement what was just built
+- Unhandled edge cases or input validation gaps
+
+**Rules:**
+- Only surface things genuinely encountered during implementation — no extra scans
+- Check existing Linear issues first (`list_issues` with `project: "repo-scaffold-desktop"`) to avoid duplicates
+- Maximum 3 suggestions; keep only the most impactful
+- Present suggestions and wait for approval before creating anything
+
+If you have suggestions:
+
+```
+**Spotted during implementation:**
+1. [Bug/Feature/Fix] Title — one-line description
+   Suggested: Type=<label>, Stream=<label>, Epic=WOR-NNN or "new epic needed", Milestone=<name>, Priority=<N>
+```
+
+On human approval: create each approved issue with `save_issue`, setting labels, `parentId` (epic), and milestone. If the right epic doesn't exist yet, create it first with `save_issue` (no parentId), then set it as parent.
+
+If nothing was spotted, skip this section silently — do not say "nothing spotted."

--- a/.claude/commands/groom-ticket.md
+++ b/.claude/commands/groom-ticket.md
@@ -1,4 +1,6 @@
-Look up the Linear issue with identifier $ARGUMENTS in the repo-scaffold-desktop project using the Linear MCP server. Also fetch `get_issue($ARGUMENTS, includeRelations: true)` to see existing labels, milestone, and blocking relations.
+Look up the Linear issue with identifier $ARGUMENTS in the repo-scaffold-desktop project using the Linear MCP server. Run these in parallel:
+- `get_issue($ARGUMENTS, includeRelations: true)` — see existing labels, milestone, parent epic, priority, blocking relations
+- `list_milestones(project: "repo-scaffold-desktop")` — check milestone progress before suggesting assignment
 
 As a Product Owner, evaluate the issue before development begins:
 
@@ -15,9 +17,18 @@ As a Product Owner, evaluate the issue before development begins:
 5. **Dependencies** — note any other tickets or work that must come first. Check actual Linear relations from `get_issue(includeRelations: true)` before inferring.
 
 6. **Metadata recommendations** — propose values for any of these that are missing or wrong:
+
    - **Type label** — one of: Feature / Fix / Refactor / Spike / Bug
    - **Stream label** — one of: Product / Infra / AI / Docs
-   - **Milestone** — which of the project milestones this belongs to: Discovery / Scope Locked / MVP Build / Test/polish / Release
+   - **Epic (parent issue)** — which thematic epic this belongs under. Current epics:
+     - WOR-49 Template System
+     - WOR-50 User Preferences
+     - WOR-51 Custom Presets
+     - WOR-52 GitHub Integration
+     - WOR-53 Desktop UI
+     - WOR-26 Penpot Integration
+     - If none fit, propose a new epic title
+   - **Milestone** — which project milestone to assign. **First check `list_milestones` progress — do not assign to any milestone at 100%; it is complete and closed to new work.** Suggest the next appropriate open milestone instead. If no existing milestone fits (e.g. clear post-V1 work), flag this and suggest creating a new one with name and description.
    - **Priority** — 1=Urgent / 2=High / 3=Normal / 4=Low
    - **Blockers** — any issues that must ship first (by WOR-NNN identifier)
 
@@ -25,12 +36,13 @@ As a Product Owner, evaluate the issue before development begins:
 
 ---
 
-After the human approves, take all of the following actions in Linear using `save_issue`:
+After the human approves, take all of the following actions in Linear:
 
-1. **Labels** — set the Type and Stream labels on the issue (use label names, not IDs)
-2. **Milestone** — assign the issue to the recommended milestone
-3. **Priority** — update if the current value is wrong or missing
-4. **Blockers** — add any missing `blockedBy` relations (append-only; existing relations are never removed)
-5. **Sub-issues** — if splitting was recommended and the human approved, create each sub-issue with `save_issue` using `parentId: "$ARGUMENTS"`, then set the same milestone and labels on each sub-issue
+1. **Labels** — set the Type and Stream labels on the issue using `save_issue` (use label names, not IDs)
+2. **Epic** — set `parentId` to the approved epic identifier using `save_issue`. If a new epic was proposed and approved, create it first with `save_issue` (no parentId, with Type+Stream labels), then set it as parent on this issue
+3. **Milestone** — assign with `save_issue`. If a new milestone was approved, create it first with `save_milestone(project: "repo-scaffold-desktop", name: "...", description: "...")`, then assign
+4. **Priority** — update if the current value is wrong or missing
+5. **Blockers** — add any missing `blockedBy` relations (append-only; existing relations are never removed)
+6. **Sub-issues** — if splitting was recommended and approved, create each sub-issue with `save_issue` using `parentId: "$ARGUMENTS"`, then set the same labels, epic, and milestone on each
 
 Report a summary of every change made in Linear.

--- a/.claude/commands/prioritize.md
+++ b/.claude/commands/prioritize.md
@@ -15,14 +15,14 @@ List each milestone with its progress % and status (complete / active / upcoming
 
 ### 2. Current state
 
-List every open issue grouped first by milestone, then by status within each milestone (In Progress → In Review → Backlog). For each issue show:
+List every open issue grouped first by epic (parent issue), then by status within each epic (In Progress → In Review → Backlog). For each issue show:
 
 ```
 WOR-NNN [Type/Stream labels] Title — one-line description of what it delivers
-         Status: <status>   Priority: <priority>
+         Status: <status>   Milestone: <name>   Priority: <priority>
 ```
 
-Issues not assigned to any milestone are listed last under **Unassigned (needs triage)**.
+Issues with no epic (parent) are listed last under **Ungrouped (needs triage)**.
 
 ### 3. Dependency map
 
@@ -46,7 +46,7 @@ Rank all Backlog issues by priority using this scoring — apply in order, stop 
 4. **Smallest scope** (single file / doc-only) — prefer at equal value
 5. **Release gate** — do last
 
-Output as a numbered list: `WOR-NNN [milestone] — rationale`.
+Output as a numbered list: `WOR-NNN [epic] [milestone] — rationale`.
 
 ### 5. Suggested next ticket
 
@@ -54,24 +54,21 @@ State the single best ticket to pick up right now and why. If something is alrea
 
 ---
 
-### 6. Project health summary
+### 6. Milestone lifecycle recommendations
 
-Write a 5–8 line project status update in this format (ready to paste into Linear's project Updates tab or a team channel):
+Based on the milestone overview and current issue distribution, recommend any of the following if warranted:
 
-```
-**Health:** On Track / At Risk / Off Track
-**Active milestone:** <name> (<progress>% complete)
-**In flight:** <list of In Progress / In Review issues>
-**Completed since last update:** <recently closed issues if visible>
-**Blockers / risks:** <any blocked or at-risk items>
-**Next up:** <top 2-3 items from recommended order>
-```
+- **Create a new milestone** — if there are ungrouped issues that belong to a phase not yet defined (e.g. a "V2" or "Post-MVP" milestone). Propose: name, description, and which issues should move into it.
+- **Retire a completed milestone** — if a milestone is at 100% but still has open issues incorrectly assigned to it, flag those issues and suggest reassigning them to an appropriate open milestone.
+- **Rename or redescribe a milestone** — if the current name no longer matches what the remaining work actually is.
 
-Set health as: **On Track** if active milestone ≥ its expected progress and no High/Urgent issues are blocked; **At Risk** if milestone is behind or a High issue is blocked; **Off Track** if multiple milestones are slipping or blockers are unresolved for >1 cycle.
+> Note: the MCP server supports `save_milestone` (create/edit) but not delete. To retire a milestone, prefix its name with `ARCHIVED:` or advise the user to delete it manually in Linear.
+
+**Do not act on these recommendations without human approval.** On approval, use `save_milestone` to create or update milestones, and `save_issue` to reassign issues.
 
 ---
 
-### 6. Update the Linear project page
+### 7. Update the Linear project page
 
 After presenting sections 1–5, update the **repo-scaffold-desktop** project in Linear to reflect current state. Do both of these:
 
@@ -99,4 +96,4 @@ After presenting sections 1–5, update the **repo-scaffold-desktop** project in
 
 Call `save_project` with `id: "87ca9685-f2e6-493f-a022-03ef2425d2ab"` and both `summary` and `description` fields.
 
-**Do not create issues or begin implementation.** Present the analysis first (sections 1–5), then update the project page.
+**Do not create issues or begin implementation.** Present sections 1–5, discuss section 6 recommendations with the human if warranted, then update the project page.

--- a/.claude/commands/start-ticket.md
+++ b/.claude/commands/start-ticket.md
@@ -1,4 +1,4 @@
-Look up the Linear issue with identifier $ARGUMENTS in the repo-scaffold-desktop project using the Linear MCP server. Also fetch `get_issue($ARGUMENTS, includeRelations: true)` to see its milestone, labels, priority, and any blocking relations.
+Look up the Linear issue with identifier $ARGUMENTS in the repo-scaffold-desktop project using the Linear MCP server. Also fetch `get_issue($ARGUMENTS, includeRelations: true)` to see its milestone, labels, priority, parent epic, and any blocking relations.
 
 Work through these phases in order:
 
@@ -42,6 +42,7 @@ Summarize as:
 ```
 Branch: <branch-name>
 Milestone: <milestone name> (<progress>%)
+Epic: <parent issue title or "none">
 Files to change:
   - path/to/file.py — what changes
 Tests to write:
@@ -51,3 +52,30 @@ Edge cases: <list>
 ```
 
 **STOP HERE. Do not write any code until the human approves this plan.**
+
+---
+
+### 5. Opportunistic issue capture (after plan is shown — do not delay the plan for this)
+
+While reading the codebase to plan this ticket you may have noticed things outside the current scope. Surface anything that looks like:
+- An apparent bug in code you read (not in scope for this ticket)
+- A missing feature that pairs naturally with this work
+- An unhandled edge case that could cause a real problem
+
+**Rules:**
+- Only surface things genuinely encountered while reading — no extra scans
+- Check existing Linear issues first (`list_issues` with `project: "repo-scaffold-desktop"`) to avoid duplicates
+- Maximum 3 suggestions; if you spotted more, keep only the most impactful
+- Do not create anything — present suggestions and wait for approval
+
+If you have suggestions, append them after the plan summary:
+
+```
+**Spotted while planning:**
+1. [Bug/Feature/Fix] Title — one-line description
+   Suggested: Type=<label>, Stream=<label>, Epic=WOR-NNN or "new epic needed", Milestone=<name>, Priority=<N>
+```
+
+On human approval: create each approved issue with `save_issue`, setting labels, `parentId` (epic), and milestone. If the right epic doesn't exist yet, create it first with `save_issue` (no parentId), then set it as parent on the new issue.
+
+If nothing was spotted, skip this section silently — do not say "nothing spotted."


### PR DESCRIPTION
## Summary
- `/start-ticket` and `/finalize-ticket`: Claude now surfaces noticed bugs/features at end of each phase (present first, create on approval; max 3 per turn)
- `/groom-ticket`: Added milestone lifecycle guidance (create via `save_milestone`, protection rule against assigning to 100%-complete milestones), epic parent assignment from current epic list (WOR-49–53, WOR-26)
- `/prioritize`: Issues now grouped by epic in dependency map; added milestone lifecycle section; project page updated via `save_project` with `summary` + `## 📍 Current state` block

## Test plan
- [ ] Run `/prioritize` — verify issues grouped by epic and milestone lifecycle section appears
- [ ] Run `/groom-ticket WOR-NNN` — verify metadata section 6 shows epic options and milestone warning
- [ ] Run `/start-ticket WOR-NNN` — verify plan includes `Epic:` line and Step 5 opportunistic capture appears
- [ ] Run `/finalize-ticket` — verify PR body includes `Epic:` and Step 7 opportunistic capture runs after returning to main

Closes WOR-34