### PR TITLE
WOR-38 User preferences model and persistent store

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,10 +12,15 @@ pip install -r requirements-dev.txt
 # Run app
 python -m app.main
 
-# CLI
+# CLI — scaffold
 python -m app.cli generate --preset python_basic --repo-name myrepo --output ./out
 # With optional toggles: --pre-commit --ci --pr-template --issue-templates --codeowners --claude-files
 # With post-setup:       --git-init --install-precommit
+
+# CLI — user preferences
+python -m app.cli config get
+python -m app.cli config set author-name "Your Name"
+python -m app.cli config set github-username "your-username"
 
 # Lint and format
 ruff check .
@@ -46,6 +51,7 @@ Module responsibilities:
 - `presets.py` — preset definitions (maps preset name → file list + options)
 - `generator.py` — renders templates and writes files to disk
 - `post_setup.py` — side effects: `git init`, `pre-commit install`, etc.
+- `user_prefs.py` — `UserPreferences` model + `PrefsStore` (platform-aware JSON persistence)
 - `main.py` — PySide6 `QApplication` entry point
 
 Data flows one way: UI → config model → generator → disk. Post-setup runs after generation.

--- a/app/cli.py
+++ b/app/cli.py
@@ -8,6 +8,10 @@ from app.core.config import RepoConfig
 from app.core.generator import generate
 from app.core.post_setup import run_git_init, run_precommit_install
 from app.core.presets import _PRESETS
+from app.core.user_prefs import PrefsStore, UserPreferences
+
+_PREFS_KEYS = set(UserPreferences.model_fields)
+_KEY_TO_FIELD = {k.replace("_", "-"): k for k in _PREFS_KEYS}
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -16,6 +20,19 @@ def _build_parser() -> argparse.ArgumentParser:
         description="Generate a repository scaffold from a preset.",
     )
     sub = parser.add_subparsers(dest="command")
+
+    cfg = sub.add_parser("config", help="Manage user preferences.")
+    cfg_sub = cfg.add_subparsers(dest="config_cmd")
+
+    cfg_sub.add_parser("get", help="Print current preferences.")
+
+    cfg_set = cfg_sub.add_parser("set", help="Set a preference value.")
+    cfg_set.add_argument(
+        "key",
+        choices=sorted(_KEY_TO_FIELD),
+        help="Preference key (use hyphens, e.g. author-name).",
+    )
+    cfg_set.add_argument("value", help="Value to store.")
 
     gen = sub.add_parser("generate", help="Generate scaffold files.")
     gen.add_argument(
@@ -57,6 +74,37 @@ def _build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def _run_config(args: argparse.Namespace) -> int:
+    if args.config_cmd == "get":
+        prefs = PrefsStore.load()
+        for field, value in prefs.model_dump().items():
+            key = field.replace("_", "-")
+            print(f"{key}: {value}")
+        return 0
+
+    if args.config_cmd == "set":
+        field = _KEY_TO_FIELD[args.key]
+        prefs = PrefsStore.load()
+        raw = args.value
+        field_info = UserPreferences.model_fields[field]
+        annotation = field_info.annotation
+        # Handle Path | None
+        if annotation in (Path, "Path | None") or (
+            hasattr(annotation, "__args__") and Path in annotation.__args__
+        ):
+            value = Path(raw) if raw else None
+        else:
+            value = raw
+        updated = prefs.model_copy(update={field: value})
+        PrefsStore.save(updated)
+        print(f"✓ {args.key} = {value}")
+        return 0
+
+    # config with no sub-subcommand
+    print("Usage: scaffold config {get,set}", file=sys.stderr)
+    return 1
+
+
 def main(argv: list[str] | None = None) -> int:
     # Ensure the terminal can emit UTF-8 (e.g. ✓); no-op on StringIO (pytest capsys).
     if hasattr(sys.stdout, "reconfigure"):
@@ -71,6 +119,9 @@ def main(argv: list[str] | None = None) -> int:
     if args.command is None:
         parser.print_help()
         return 1
+
+    if args.command == "config":
+        return _run_config(args)
 
     try:
         config = RepoConfig(

--- a/app/core/user_prefs.py
+++ b/app/core/user_prefs.py
@@ -1,0 +1,56 @@
+import json
+import platform
+from pathlib import Path
+
+from pydantic import BaseModel
+
+
+class UserPreferences(BaseModel):
+    author_name: str = ""
+    author_email: str = ""
+    github_username: str = ""
+    default_output_dir: Path | None = None
+    default_preset: str = "python_basic"
+
+    model_config = {"extra": "ignore"}
+
+
+class PrefsStore:
+    _APP_DIR = "repo-scaffold"
+
+    @classmethod
+    def get_path(cls) -> Path:
+        if platform.system() == "Windows":
+            base = Path.home() / "AppData" / "Roaming"
+        else:
+            base = Path.home() / ".config"
+        return base / cls._APP_DIR / "prefs.json"
+
+    @classmethod
+    def load(cls) -> UserPreferences:
+        path = cls.get_path()
+        if not path.exists():
+            return UserPreferences()
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+            return UserPreferences.model_validate(data)
+        except (json.JSONDecodeError, ValueError):
+            return UserPreferences()
+
+    @classmethod
+    def save(cls, prefs: UserPreferences) -> None:
+        path = cls.get_path()
+        cls._assert_not_in_git_repo(path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            prefs.model_dump_json(indent=2),
+            encoding="utf-8",
+        )
+
+    @staticmethod
+    def _assert_not_in_git_repo(path: Path) -> None:
+        for parent in path.parents:
+            if (parent / ".git").exists():
+                raise RuntimeError(
+                    f"Refusing to write prefs inside a git repository: {path}"
+                )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,8 +1,10 @@
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
 from app.cli import main
+from app.core.user_prefs import PrefsStore
 
 
 @pytest.fixture()
@@ -149,6 +151,42 @@ def test_install_precommit_flag_calls_post_setup(output_dir):
         )
     assert rc == 0
     mock_pc.assert_called_once_with(output_dir)
+
+
+def test_config_get_defaults(tmp_path, capsys):
+    prefs_path = tmp_path / "prefs.json"
+    with patch.object(PrefsStore, "get_path", return_value=prefs_path):
+        rc = main(["config", "get"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "author-name:" in out
+    assert "default-preset: python_basic" in out
+
+
+def test_config_set_and_get(tmp_path, capsys):
+    prefs_path = tmp_path / "prefs.json"
+    with patch.object(PrefsStore, "get_path", return_value=prefs_path):
+        rc_set = main(["config", "set", "author-name", "Antti"])
+        assert rc_set == 0
+        rc_get = main(["config", "get"])
+    assert rc_get == 0
+    out = capsys.readouterr().out
+    assert "author-name: Antti" in out
+
+
+def test_config_set_output_dir(tmp_path, capsys):
+    prefs_path = tmp_path / "prefs.json"
+    with patch.object(PrefsStore, "get_path", return_value=prefs_path):
+        rc = main(["config", "set", "default-output-dir", "/tmp/repos"])
+    assert rc == 0
+    with patch.object(PrefsStore, "get_path", return_value=prefs_path):
+        prefs = PrefsStore.load()
+    assert prefs.default_output_dir == Path("/tmp/repos")
+
+
+def test_config_no_subcommand_exits(capsys):
+    rc = main(["config"])
+    assert rc == 1
 
 
 def test_post_setup_error_exits_nonzero(output_dir, capsys):

--- a/tests/test_user_prefs.py
+++ b/tests/test_user_prefs.py
@@ -1,0 +1,94 @@
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from app.core.user_prefs import PrefsStore, UserPreferences
+
+
+@pytest.fixture()
+def prefs_path(tmp_path):
+    path = tmp_path / "prefs.json"
+    with patch.object(PrefsStore, "get_path", return_value=path):
+        yield path
+
+
+def test_defaults(prefs_path):
+    prefs = PrefsStore.load()
+    assert prefs.author_name == ""
+    assert prefs.author_email == ""
+    assert prefs.github_username == ""
+    assert prefs.default_output_dir is None
+    assert prefs.default_preset == "python_basic"
+
+
+def test_save_and_load_roundtrip(prefs_path):
+    original = UserPreferences(
+        author_name="Antti",
+        author_email="antti@example.com",
+        github_username="virppa",
+        default_output_dir=Path("/tmp/repos"),
+        default_preset="full_agentic",
+    )
+    PrefsStore.save(original)
+    loaded = PrefsStore.load()
+    assert loaded.author_name == "Antti"
+    assert loaded.author_email == "antti@example.com"
+    assert loaded.github_username == "virppa"
+    assert loaded.default_output_dir == Path("/tmp/repos")
+    assert loaded.default_preset == "full_agentic"
+
+
+def test_save_creates_parent_dirs(tmp_path):
+    nested = tmp_path / "a" / "b" / "prefs.json"
+    with patch.object(PrefsStore, "get_path", return_value=nested):
+        PrefsStore.save(UserPreferences(author_name="X"))
+    assert nested.exists()
+
+
+def test_load_ignores_unknown_fields(prefs_path):
+    prefs_path.write_text(
+        json.dumps({"author_name": "Bob", "unknown_field": "ignored"}),
+        encoding="utf-8",
+    )
+    prefs = PrefsStore.load()
+    assert prefs.author_name == "Bob"
+
+
+def test_load_malformed_json_returns_defaults(prefs_path):
+    prefs_path.write_text("not-valid-json", encoding="utf-8")
+    prefs = PrefsStore.load()
+    assert prefs == UserPreferences()
+
+
+def test_get_path_windows():
+    with (
+        patch("platform.system", return_value="Windows"),
+        patch("pathlib.Path.home", return_value=Path("C:/Users/test")),
+    ):
+        path = PrefsStore.get_path()
+    assert "AppData" in str(path)
+    assert "Roaming" in str(path)
+    assert path.name == "prefs.json"
+
+
+def test_get_path_posix():
+    with (
+        patch("platform.system", return_value="Linux"),
+        patch("pathlib.Path.home", return_value=Path("/home/test")),
+    ):
+        path = PrefsStore.get_path()
+    assert ".config" in str(path)
+    assert path.name == "prefs.json"
+
+
+def test_save_blocked_inside_git_repo(tmp_path):
+    git_dir = tmp_path / ".git"
+    git_dir.mkdir()
+    prefs_path = tmp_path / "prefs.json"
+    with patch.object(PrefsStore, "get_path", return_value=prefs_path):
+        with pytest.raises(
+            RuntimeError, match="Refusing to write prefs inside a git repository"
+        ):
+            PrefsStore.save(UserPreferences())


### PR DESCRIPTION
## Summary

- Adds `UserPreferences` Pydantic model (`author_name`, `author_email`, `github_username`, `default_output_dir`, `default_preset`) with `extra="ignore"` for forward compatibility
- Adds `PrefsStore` with platform-aware JSON persistence (`%APPDATA%\repo-scaffold\prefs.json` on Windows, `~/.config/repo-scaffold/prefs.json` on Linux/Mac), silently returns defaults on missing or malformed file, and guards against accidentally writing inside a git repository
- Adds `cli config get` / `cli config set <key> <value>` subcommands; keys use hyphens (e.g. `author-name`)

**Milestone:** MVP Build
**Epic:** WOR-50 — Epic: User Preferences

## Test plan

- [ ] `test_defaults` — load on missing file returns all-default values
- [ ] `test_save_and_load_roundtrip` — round-trip preserves all fields including `Path`
- [ ] `test_save_creates_parent_dirs` — parent directories are created automatically
- [ ] `test_load_ignores_unknown_fields` — extra JSON keys don't crash load
- [ ] `test_load_malformed_json_returns_defaults` — corrupted file silently returns defaults
- [ ] `test_get_path_windows` / `test_get_path_posix` — correct platform path
- [ ] `test_save_blocked_inside_git_repo` — `RuntimeError` raised if path is inside a `.git` repo
- [ ] `test_config_get_defaults` — `config get` prints defaults when no prefs file exists
- [ ] `test_config_set_and_get` — `config set author-name X` reflected in subsequent `config get`
- [ ] `test_config_set_output_dir` — `default-output-dir` stored as `Path`
- [ ] `test_config_no_subcommand_exits` — bare `config` with no sub-subcommand exits non-zero

Closes WOR-38

🤖 Generated with [Claude Code](https://claude.com/claude-code)