### PR TITLE
Fix invalid JSON in settings.json email-leak hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -18,6 +18,15 @@
             "command": "FILE=\"$CLAUDE_TOOL_INPUT_FILE_PATH\"; if echo \"$FILE\" | grep -qE '(\\.env|\\.mcp\\.json|\\.claude/settings)'; then echo \"Blocked: writes to sensitive file not allowed: $FILE\" >&2; exit 1; fi"
           }
         ]
+      },
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python -c \"import json,sys,re; d=json.load(sys.stdin); f=d.get('tool_input',{}).get('file_path',''); t=d.get('tool_name',''); skip = not re.search(r'\\.(md|toml|yaml|yml|json)$',f) or 'tests/' in f or f.endswith('.py'); c=(d.get('tool_input',{}).get('content','') if t=='Write' else d.get('tool_input',{}).get('new_string','')); sys.exit(1) if not skip and re.search(r'[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}',c) and print(f'Blocked: email detected in {f}',file=sys.stderr) is None else sys.exit(0)\""
+          }
+        ]
       }
     ],
     "Stop": [


### PR DESCRIPTION
## Summary

- Fixes the email-leak PreToolUse hook added manually — literal newlines in the Python command string made settings.json unparseable
- Removes trailing comma after the last PreToolUse entry (also invalid JSON)

## Test plan

- [ ] `/doctor` reports no issues
- [ ] `python -c "import json; json.load(open('.claude/settings.json'))"` exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)