### PR TITLE
Add epic branch model and parallel agent workflow

### DIFF
--- a/.claude/commands/close-epic.md
+++ b/.claude/commands/close-epic.md
@@ -1,0 +1,100 @@
+Finalize an epic and create the pull request to main.
+
+Usage: `/close-epic WOR-NNN` where WOR-NNN is the epic issue identifier.
+
+### 1. Verify all sub-tickets are done
+Fetch the epic with `get_issue($ARGUMENTS, includeRelations: true)` to get all child issues.
+
+Check the status of each child in Linear. If any child is not **Done**:
+- List the incomplete tickets
+- Block and stop: "Cannot close epic — the following tickets are not Done: WOR-X, WOR-Y"
+
+### 2. Pull and verify the epic branch
+Derive the epic branch name from the Linear "Copy branch name" format (e.g. `wor-49-template-system`).
+
+```bash
+git fetch origin
+git checkout <epic-branch>
+git pull origin <epic-branch>
+```
+
+### 3. Security check
+Run a full security scan against main:
+```bash
+bandit -r app/ -q
+```
+
+Run a diff review: examine `git diff main..<epic-branch>` for OWASP Top 10 patterns —
+- Unsanitised user input passed to subprocess, eval, or file paths
+- Hardcoded credentials or tokens
+- SQL/command injection surface
+- Insecure file permissions
+
+Report: **PASS**, **WARNINGS** (list them), or **FAIL** (block PR creation until fixed).
+
+### 4. Test suite — full run
+```bash
+pytest --cov=app --cov-report=term-missing --tb=short -q
+```
+
+Coverage must be ≥ 80%. If below threshold: identify uncovered paths and write missing tests before continuing.
+
+### 5. UI / integration tests
+Run UI or integration tests if they exist:
+```bash
+# Try common locations — skip gracefully if none found
+pytest tests/ui/ -q 2>/dev/null || echo "[skip] No UI tests found"
+pytest tests/integration/ -q 2>/dev/null || echo "[skip] No integration tests found"
+```
+
+If no UI tests exist yet, note it explicitly: "No UI tests present — consider adding them before the next epic closes."
+
+### 6. Create the epic → main PR
+```bash
+gh pr create --base main \
+  --title "WOR-NNN <Epic title>" \
+  --body "$(cat <<'EOF'
+## Summary
+- <bullet 1>
+- <bullet 2>
+- <bullet 3>
+
+## Sub-tickets included
+- WOR-X Title
+- WOR-Y Title
+
+## Test plan
+- [ ] pytest passes with ≥ 80% coverage
+- [ ] Security scan: PASS
+- [ ] UI tests: <passed | not yet present>
+
+**Milestone:** <milestone name>
+
+Closes WOR-NNN
+EOF
+)"
+```
+
+This PR requires **human review and approval** — no auto-merge.
+
+### 7. Update Linear
+1. Mark the epic issue **In Review**: `save_issue(id: "$ARGUMENTS", state: "In Review")`
+2. Check milestone progress with `list_milestones(project: "repo-scaffold-desktop")`. If 100%, note: "🎉 Milestone '<name>' is now complete."
+
+### 8. Clean up worktrees
+List any worktrees for sub-tickets that have already been merged into the epic branch:
+```bash
+git worktree list
+```
+
+For each sub-ticket worktree whose branch is fully merged (confirm with `git branch --merged <epic-branch>`):
+```bash
+git worktree remove <worktree-path>
+git branch -d <sub-ticket-branch>
+```
+
+Do not remove the epic branch worktree yet — wait until the epic PR merges to main.
+
+### 9. Update the project page
+Call `save_project(id: "87ca9685-f2e6-493f-a022-03ef2425d2ab")` with an updated `summary` (max 255 chars):
+`WOR-NNN epic in review | <N> sub-tickets shipped | Next: <next epic or milestone>`

--- a/.claude/commands/finalize-ticket.md
+++ b/.claude/commands/finalize-ticket.md
@@ -21,16 +21,31 @@ Only update docs if the change is meaningful — do not document implementation 
 ### 3. Create the pull request
 Derive the Linear identifier from the current branch name (e.g., `WOR-42-short-description` → `WOR-42`).
 
-Fetch the issue with `get_issue(id, includeRelations: true)` to get its milestone and parent epic.
+Fetch the issue with `get_issue(id, includeRelations: true)` to get its milestone and parent epic. If the epic has an in-progress branch (not main), that is the PR target.
 
-- PR title: `WOR-NNN Short description`
-- PR body:
-  - 2–3 bullet summary
-  - `**Milestone:** <milestone name>` (if set)
-  - `**Epic:** <parent issue title>` (if set)
-  - Test plan checklist
-  - `Closes WOR-NNN`
-- Run: `gh pr create`
+**If this ticket has a parent epic with an epic branch:**
+```bash
+gh pr create --base <epic-branch> \
+  --title "WOR-NNN Short description" \
+  --body "..."
+# Enable auto-merge — merges automatically when CI passes, no manual approval needed
+gh pr merge --auto --squash <PR-number>
+```
+
+**If no parent epic (targeting main):**
+```bash
+gh pr create --base main \
+  --title "WOR-NNN Short description" \
+  --body "..."
+# No auto-merge — human review required for main
+```
+
+PR body format (both cases):
+- 2–3 bullet summary
+- `**Milestone:** <milestone name>` (if set)
+- `**Epic:** <parent issue title>` (if set)
+- Test plan checklist
+- `Closes WOR-NNN`
 
 ### 4. Update Linear
 Use the Linear MCP server to:
@@ -45,7 +60,9 @@ Call `save_project(id: "87ca9685-f2e6-493f-a022-03ef2425d2ab")` with an updated 
 
 Only update `summary` here — full description refresh happens in `/prioritize`.
 
-### 6. Return to main
+### 6. Return to base context
+If this session entered a worktree via `EnterWorktree`, call `ExitWorktree` now to return to the main repo context.
+
 ```bash
 git checkout main
 ```

--- a/.claude/commands/start-ticket.md
+++ b/.claude/commands/start-ticket.md
@@ -11,6 +11,51 @@ git pull
 git branch --merged main | grep -v '^\*\? *main$' | xargs -r git branch -d
 ```
 
+### 0.5. Epic branch setup
+Check whether this ticket has a parent epic (`parentId` from `get_issue` relations):
+
+**If a parent epic exists:**
+- Derive the epic branch name from the epic issue's Linear "Copy branch name" format (e.g. `wor-49-template-system`)
+- Check whether that branch exists on the remote:
+  ```bash
+  git fetch origin
+  git branch -a | grep wor-NN-epic-slug
+  ```
+- If the epic branch does **not** exist yet — create it from main and push it:
+  ```bash
+  git checkout -b <epic-branch>
+  git push -u origin <epic-branch>
+  git checkout main
+  ```
+- If it already exists — confirm it is present on origin (no further action needed)
+
+**If no parent epic exists:**
+- Warn: "This ticket has no parent epic — branch will target main instead of an epic branch."
+- Continue with the normal main-targeting flow (step 3 will branch off main)
+
+### 0.6. Coordination check
+Query Linear for sibling tickets in the same epic that are currently In Progress:
+```
+list_issues(project: "repo-scaffold-desktop", filter: { parent: <epicId>, state: "In Progress" })
+```
+For each In-Progress sibling:
+- Show ticket ID, title, branch name
+- Note which files it likely touches (infer from the ticket title/description or its Linear body)
+
+Also list epic backlog tickets (not In Progress, not Done) and flag which are likely safe to start in parallel vs. likely conflicting based on expected file overlap.
+
+Print a coordination summary before the plan:
+```
+Parallel work in this epic:
+  WOR-45 (wor-45-branch) — likely touches presets.py, config.py — AVOID OVERLAP
+Safe to start in another session now:
+  WOR-48 — templates/ only — no file conflict expected
+  WOR-51 — tests/ only — no file conflict expected
+Likely conflicts:
+  WOR-46 — also touches config.py
+```
+If no siblings are In Progress, skip this block silently.
+
 ### 1. As Product Owner — understand the requirement
 - Restate the requirement in plain terms (one paragraph)
 - Flag any ambiguity or missing information
@@ -25,22 +70,31 @@ git branch --merged main | grep -v '^\*\? *main$' | xargs -r git branch -d
 - Note edge cases and overwrite behavior to consider
 
 ### 3. Create the branch and update Linear
-Run `git checkout -b <branch-name>` using the branch name from Linear's "Copy branch name" format (usually `WOR-NNN-short-description`).
+Using the branch name from Linear's "Copy branch name" format (usually `WOR-NNN-short-description`):
+
+**If this ticket has a parent epic with an epic branch:**
+```bash
+git checkout <epic-branch>
+git pull origin <epic-branch>
+git checkout -b <sub-ticket-branch>
+git push -u origin <sub-ticket-branch>
+```
+Then call `EnterWorktree` so this session operates in the sub-ticket branch's worktree, isolated from other parallel sessions.
+
+**If no parent epic (targeting main):**
+```bash
+git checkout -b <branch-name>
+git push -u origin <branch-name>
+```
+No worktree needed for solo work.
 
 Then immediately set the issue status to **In Progress** in Linear:
 `save_issue(id: "$ARGUMENTS", state: "In Progress")`
 
-Also prune stale local branches:
-```bash
-git fetch --prune
-git branch --merged main | grep -v "^\*\? *main$"
-# delete any listed branches with: git branch -d <branch>
-```
-
 ### 4. Present the plan
 Summarize as:
 ```
-Branch: <branch-name>
+Branch: <branch-name> (off <epic-branch | main>)
 Milestone: <milestone name> (<progress>%)
 Epic: <parent issue title or "none">
 Files to change:
@@ -49,6 +103,12 @@ Tests to write:
   - tests/test_X.py::test_name — what it verifies
 Security surface: <none | description>
 Edge cases: <list>
+```
+
+If parallel-safe sibling tickets exist, append:
+```
+To work in parallel: open a new Claude Code session in this repo and run
+`/start-ticket WOR-NN` for any ticket marked safe above.
 ```
 
 **STOP HERE. Do not write any code until the human approves this plan.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,6 +94,7 @@ Each ticket follows these phases. Use the corresponding slash command to enter e
                           # ↓ human approves — Linear updated only after this
 
 /start-ticket WOR-123     # PO + Architect: restate req, plan files/tests, create branch
+                          # auto-creates epic branch if needed; shows parallel-safe siblings
                           # ↓ human approves plan before any code is written
 
 [Claude implements]       # hooks fire automatically: ruff, bandit, pytest
@@ -101,9 +102,26 @@ Each ticket follows these phases. Use the corresponding slash command to enter e
 /security-check           # bandit scan + OWASP diff review → PASS / WARNINGS / FAIL
 
 /finalize-ticket          # coverage check, docs update, PR creation, Linear → In Review
+                          # PR targets epic branch (auto-merge) or main (human review)
+
+/close-epic WOR-123       # when all sub-tickets are Done: security + coverage + UI tests,
+                          # create epic → main PR (human review required)
 ```
 
-Human gates: plan approval after `/start-ticket`, and explicit PASS verdict from `/security-check` before creating the PR. Command files live in `.claude/commands/`.
+### Branch topology
+
+```
+main
+└── wor-49-template-system          ← epic branch (created by first /start-ticket in epic)
+    ├── wor-45-add-yaml-preset      ← sub-ticket branch → auto-merges to epic when CI passes
+    └── wor-47-jinja-context-fix    ← parallel sub-ticket → its own worktree, isolated
+```
+
+### Parallel work
+
+`/start-ticket` checks Linear for other In-Progress tickets in the same epic and flags file-safe parallel candidates. To work in parallel: open a second Claude Code session in the same repo directory and run `/start-ticket WOR-NN` for a candidate ticket. Each session enters its own isolated git worktree.
+
+Human gates: plan approval after `/start-ticket`; explicit PASS from `/security-check` before any main-targeting PR; human review of the epic → main PR created by `/close-epic`. Command files live in `.claude/commands/`.
 
 ---
 
@@ -137,6 +155,8 @@ Only interact with the **repo-scaffold-desktop** project in Linear unless explic
 - PR title format: `WOR-123 Short description`
 - Intermediate commits: `Part of WOR-123 ...`
 - Closing commit or PR body: `Closes WOR-123`
+- Sub-ticket PRs target the epic branch and auto-merge when CI passes — no manual approval needed
+- Epic PRs target main and always require human review
 
 ---
 


### PR DESCRIPTION
## Summary
- `start-ticket` now auto-creates an epic branch when a ticket has a parent epic, and shows a coordination table of in-progress siblings + safe parallel candidates
- `finalize-ticket` routes PRs to the epic branch with `gh pr merge --auto --squash` (no manual stamp needed for sub-tickets); only main-targeting PRs require human review
- New `/close-epic` command gates the epic → main PR behind all sub-tickets Done, security scan, coverage ≥ 80%, and UI/integration tests

## Parallel workflow
Each parallel Claude session runs `/start-ticket` from the same repo dir, enters its own isolated git worktree, and reads Linear + git to detect what other sessions are working on.

## Test plan
- [ ] `/start-ticket` on a ticket with a parent epic creates the epic branch if missing
- [ ] `/start-ticket` on a sibling ticket shows coordination summary and enters its own worktree
- [ ] `/finalize-ticket` on a sub-ticket targets the epic branch with auto-merge
- [ ] `/close-epic` blocks if any sub-ticket is not Done in Linear

🤖 Generated with [Claude Code](https://claude.com/claude-code)