### PR TITLE
WOR-39 Inject user preferences into Jinja2 template context

### DIFF
--- a/app/core/generator.py
+++ b/app/core/generator.py
@@ -4,16 +4,24 @@ from jinja2 import Environment, FileSystemLoader, StrictUndefined
 
 from app.core.config import RepoConfig
 from app.core.presets import get_preset
+from app.core.user_prefs import UserPreferences
 
 _TEMPLATES_DIR = Path(__file__).parent.parent.parent / "templates"
 _SHARED_DIR = _TEMPLATES_DIR / "shared"
 
 
-def generate(config: RepoConfig, output_path: Path) -> list[str]:
+def generate(
+    config: RepoConfig,
+    output_path: Path,
+    prefs: UserPreferences | None = None,
+) -> list[str]:
     """Render all preset template files and write them to output_path.
 
     Returns the list of relative file paths that were written.
     """
+    if prefs is None:
+        prefs = UserPreferences()
+
     preset = get_preset(config.preset)
 
     # Build file list: required files + enabled optional files, deduplicated
@@ -36,7 +44,7 @@ def generate(config: RepoConfig, output_path: Path) -> list[str]:
         keep_trailing_newline=True,
     )
 
-    context = config.model_dump()
+    context = {**config.model_dump(), **prefs.model_dump()}
 
     output_path = Path(output_path)
     output_path.mkdir(parents=True, exist_ok=True)

--- a/templates/full_agentic/pyproject.toml.j2
+++ b/templates/full_agentic/pyproject.toml.j2
@@ -2,6 +2,9 @@
 name = "{{ repo_name }}"
 version = "0.1.0"
 requires-python = ">=3.11"
+{% if author_name or author_email %}
+authors = [{name = "{{ author_name }}", email = "{{ author_email }}"}]
+{% endif %}
 dependencies = []
 
 [project.optional-dependencies]

--- a/templates/python_basic/pyproject.toml.j2
+++ b/templates/python_basic/pyproject.toml.j2
@@ -2,6 +2,9 @@
 name = "{{ repo_name }}"
 version = "0.1.0"
 requires-python = ">=3.11"
+{% if author_name or author_email %}
+authors = [{name = "{{ author_name }}", email = "{{ author_email }}"}]
+{% endif %}
 dependencies = []
 
 [project.optional-dependencies]

--- a/templates/python_desktop/pyproject.toml.j2
+++ b/templates/python_desktop/pyproject.toml.j2
@@ -2,6 +2,9 @@
 name = "{{ repo_name }}"
 version = "0.1.0"
 requires-python = ">=3.11"
+{% if author_name or author_email %}
+authors = [{name = "{{ author_name }}", email = "{{ author_email }}"}]
+{% endif %}
 dependencies = ["pyside6"]
 
 [project.optional-dependencies]

--- a/templates/shared/.github/CODEOWNERS.j2
+++ b/templates/shared/.github/CODEOWNERS.j2
@@ -1,4 +1,4 @@
 # CODEOWNERS for {{ repo_name }}
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
-* @owner
+* @{{ github_username }}

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -2,6 +2,7 @@ import pytest
 
 from app.core.config import RepoConfig
 from app.core.generator import generate
+from app.core.user_prefs import UserPreferences
 
 
 @pytest.fixture()
@@ -242,3 +243,38 @@ def test_preset_template_overrides_shared(output_dir):
     generate(config, output_dir)
     content = (output_dir / "README.md").read_text(encoding="utf-8")
     assert "override-check" in content
+
+
+def test_generate_with_prefs_injects_author_name(output_dir):
+    config = RepoConfig(repo_name="my-project", preset="python_basic")
+    prefs = UserPreferences(author_name="Jane Doe", author_email="jane@example.com")
+    generate(config, output_dir, prefs=prefs)
+    content = (output_dir / "pyproject.toml").read_text(encoding="utf-8")
+    assert "Jane Doe" in content
+    assert "jane@example.com" in content
+
+
+def test_generate_with_prefs_injects_github_username(output_dir):
+    config = RepoConfig(
+        repo_name="my-project", preset="python_basic", include_codeowners=True
+    )
+    prefs = UserPreferences(github_username="jdoe")
+    generate(config, output_dir, prefs=prefs)
+    content = (output_dir / ".github" / "CODEOWNERS").read_text(encoding="utf-8")
+    assert "@jdoe" in content
+
+
+def test_generate_with_no_prefs_uses_empty_defaults(output_dir):
+    config = RepoConfig(repo_name="my-project", preset="python_basic")
+    generate(config, output_dir)
+    assert (output_dir / "pyproject.toml").exists()
+    content = (output_dir / "pyproject.toml").read_text(encoding="utf-8")
+    assert "authors" not in content
+
+
+def test_generate_no_authors_section_when_prefs_empty(output_dir):
+    config = RepoConfig(repo_name="my-project", preset="python_basic")
+    prefs = UserPreferences()
+    generate(config, output_dir, prefs=prefs)
+    content = (output_dir / "pyproject.toml").read_text(encoding="utf-8")
+    assert "authors" not in content


### PR DESCRIPTION
- `generate()` gains an optional `prefs: UserPreferences | None = None` parameter; merges prefs fields into the Jinja2 context alongside config fields
- `pyproject.toml` templates (all three presets) gain a conditional `authors` block rendered only when `author_name` or `author_email` is set
- `CODEOWNERS` template replaces hardcoded `@owner` with `@{{ github_username }}`

**Epic:** WOR-50 — Epic: User Preferences

## Test plan
- [x] `test_generate_with_prefs_injects_author_name` — author name/email appear in `pyproject.toml`
- [x] `test_generate_with_prefs_injects_github_username` — `@jdoe` appears in `CODEOWNERS`
- [x] `test_generate_with_no_prefs_uses_empty_defaults` — no `authors` section when prefs omitted
- [x] `test_generate_no_authors_section_when_prefs_empty` — no `authors` section when prefs fields are empty strings
- [x] All existing tests pass unmodified (backward compat)
- [x] Coverage: 95.65%

Closes WOR-39