### PR TITLE
Fix Linear status gaps in epic branch workflow

### DIFF
--- a/.claude/commands/close-epic.md
+++ b/.claude/commands/close-epic.md
@@ -2,12 +2,51 @@ Finalize an epic and create the pull request to main.
 
 Usage: `/close-epic WOR-NNN` where WOR-NNN is the epic issue identifier.
 
-### 1. Verify all sub-tickets are done
-Fetch the epic with `get_issue($ARGUMENTS, includeRelations: true)` to get all child issues.
+### 1. Verify all sub-tickets are merged (GitHub is the source of truth)
 
-Check the status of each child in Linear. If any child is not **Done**:
-- List the incomplete tickets
-- Block and stop: "Cannot close epic — the following tickets are not Done: WOR-X, WOR-Y"
+Fetch the epic with `get_issue($ARGUMENTS, includeRelations: true)` to get all child issues and the epic branch name.
+
+**Step 1a — List all PRs that targeted the epic branch:**
+```bash
+gh pr list --base <epic-branch> --state all \
+  --json number,title,headRefName,state,mergedAt
+```
+Match each child issue to a PR by branch name (Linear branch format: `wor-NN-short-description`). A child with no corresponding PR is treated as unmerged.
+
+**Step 1b — Classify each PR and repair Linear state:**
+
+For each **merged** PR (`mergedAt` not null): if the corresponding Linear issue is not already Done, mark it Done now:
+`save_issue(id: "WOR-X", state: "Done")`
+(Linear's "merge → Done" automation never fires for epic-branch-targeting PRs — this is the repair step.)
+
+For each **open** PR: check CI status:
+```bash
+gh pr checks <PR-number> --json name,state,conclusion
+```
+Classify as:
+- **CI failing** — any check has `conclusion == "FAILURE"` or `"TIMED_OUT"`
+- **CI pending** — checks still running (`state == "IN_PROGRESS"`), none failing
+- **CI passing but not merged** — all checks pass; auto-merge may not have triggered, flag for investigation
+
+**Step 1c — Block if anything is unmerged:**
+
+If there are open PRs or children with no PR at all, stop:
+```
+Cannot close epic — the following sub-tickets are not yet merged:
+
+CI failing:
+  WOR-X: #<N> "<title>" — <failing check names>
+CI pending:
+  WOR-Y: #<M> "<title>" — checks still running
+CI passing, not merged (investigate auto-merge):
+  WOR-Z: #<P> "<title>"
+No PR found:
+  WOR-W — no PR was opened against <epic-branch>
+
+Fix these before running /close-epic again.
+```
+
+If all child PRs are merged: confirm "All N sub-tickets confirmed merged via GitHub. Linear state repaired where stale." and continue.
 
 ### 2. Pull and verify the epic branch
 Derive the epic branch name from the Linear "Copy branch name" format (e.g. `wor-49-template-system`).
@@ -71,9 +110,13 @@ gh pr create --base main \
 **Milestone:** <milestone name>
 
 Closes WOR-NNN
+Closes WOR-X
+Closes WOR-Y
 EOF
 )"
 ```
+
+Enumerate a `Closes WOR-X` line for **every child issue** in the epic (from Step 1 relations), one per line after `Closes WOR-NNN`. This triggers Linear's "merge to main → Done" automation for all sub-tickets as a final backstop.
 
 This PR requires **human review and approval** — no auto-merge.
 

--- a/.claude/commands/finalize-ticket.md
+++ b/.claude/commands/finalize-ticket.md
@@ -48,9 +48,13 @@ PR body format (both cases):
 - `Closes WOR-NNN`
 
 ### 4. Update Linear
-Use the Linear MCP server to:
-1. Mark the issue as **In Review**: `save_issue(id: "WOR-NNN", state: "In Review")`
-2. Fetch the milestone this issue belongs to with `list_milestones(project: "repo-scaffold-desktop")`. If the milestone's progress has reached 100%, note it explicitly: "🎉 Milestone '<name>' is now complete."
+Mark the issue as **In Review**: `save_issue(id: "WOR-NNN", state: "In Review")`
+
+What "In Review" means depends on the PR target:
+- **Sub-ticket → epic branch (auto-merge):** "In Review" = PR is open and will merge automatically when CI passes. `/close-epic` will repair this to Done once the PR is confirmed merged. If CI fails, the PR stays open and `/close-epic` will catch and report it.
+- **Ticket → main (human review):** "In Review" = PR is open, awaiting human approval.
+
+Fetch the milestone this issue belongs to with `list_milestones(project: "repo-scaffold-desktop")`. If the milestone's progress has reached 100%, note it explicitly: "🎉 Milestone '<name>' is now complete."
 
 ### 5. Update the project page
 Update the **repo-scaffold-desktop** project summary to reflect what just shipped.

--- a/.claude/commands/start-ticket.md
+++ b/.claude/commands/start-ticket.md
@@ -91,6 +91,13 @@ No worktree needed for solo work.
 Then immediately set the issue status to **In Progress** in Linear:
 `save_issue(id: "$ARGUMENTS", state: "In Progress")`
 
+**If the parent epic was previously Backlog** (i.e., this is the first sub-ticket being started in this epic), also promote all other Backlog children to **Todo**:
+```
+list_issues(project: "repo-scaffold-desktop", parentId: <epicId>, state: "Backlog")
+→ for each result (excluding the current ticket): save_issue(id: "WOR-X", state: "Todo")
+```
+"Todo" signals "actively queued in this epic, not yet started" — distinguishes from Backlog items that aren't in scope yet. Skip this step if the epic was already In Progress.
+
 ### 4. Present the plan
 Summarize as:
 ```


### PR DESCRIPTION
## Summary
- `close-epic`: use GitHub PR merge status as the source of truth instead of Linear state; repair stale "In Review" → Done before proceeding; enumerate `Closes WOR-X` for each sub-ticket in epic PR body
- `finalize-ticket`: annotate what "In Review" means for auto-merge-to-epic-branch vs. human-review-to-main PRs
- `start-ticket`: promote sibling Backlog issues to Todo when the epic first goes In Progress

## Why
Linear's "On PR merge → Done" automation only fires for merges into `main`. Sub-ticket PRs target the epic branch, so Linear never auto-advances them — causing `/close-epic` to falsely block on stale "In Review" state every time.

## Test plan
- [ ] Run `/start-ticket` on a sub-ticket in a Backlog epic → confirm siblings move to Todo
- [ ] Run `/finalize-ticket` on a sub-ticket → PR created, Linear → In Review, commentary is clear
- [ ] Run `/close-epic` → Step 1 uses `gh pr list` to confirm merges, repairs Done, proceeds
- [ ] Check epic PR body contains `Closes WOR-X` for each sub-ticket