### PR TITLE
Update command files with new epic list

### DIFF
--- a/.claude/commands/groom-ticket.md
+++ b/.claude/commands/groom-ticket.md
@@ -21,12 +21,13 @@ As a Product Owner, evaluate the issue before development begins:
    - **Type label** — one of: Feature / Fix / Refactor / Spike / Bug
    - **Stream label** — one of: Product / Infra / AI / Docs
    - **Epic (parent issue)** — which thematic epic this belongs under. Current epics:
-     - WOR-49 Template System
-     - WOR-50 User Preferences
-     - WOR-51 Custom Presets
+     - WOR-55 Agentic Scaffolding
+     - WOR-56 Wizard CLI
+     - WOR-57 UI Testing & Test Infrastructure
      - WOR-52 GitHub Integration
+     - WOR-51 Custom Presets
      - WOR-53 Desktop UI
-     - WOR-26 Penpot Integration
+     - WOR-26 Wireframing (Penpot / Superdesign)
      - If none fit, propose a new epic title
    - **Milestone** — which project milestone to assign. **First check `list_milestones` progress — do not assign to any milestone at 100%; it is complete and closed to new work.** Suggest the next appropriate open milestone instead. If no existing milestone fits (e.g. clear post-V1 work), flag this and suggest creating a new one with name and description.
    - **Priority** — 1=Urgent / 2=High / 3=Normal / 4=Low

--- a/.claude/commands/start-ticket.md
+++ b/.claude/commands/start-ticket.md
@@ -36,7 +36,7 @@ Check whether this ticket has a parent epic (`parentId` from `get_issue` relatio
 ### 0.6. Coordination check
 Query Linear for sibling tickets in the same epic that are currently In Progress:
 ```
-list_issues(project: "repo-scaffold-desktop", filter: { parent: <epicId>, state: "In Progress" })
+list_issues(project: "repo-scaffold-desktop", state: "In Progress", parentId: <epicId>)
 ```
 For each In-Progress sibling:
 - Show ticket ID, title, branch name


### PR DESCRIPTION
## Summary
- Replaces stale WOR-49/WOR-50 epics with new WOR-55 Agentic Scaffolding, WOR-56 Wizard CLI, WOR-57 UI Testing & Test Infrastructure in `groom-ticket.md`
- Updates WOR-26 label to "Wireframing (Penpot / Superdesign)"
- Fixes `list_issues` filter syntax in `start-ticket.md` coordination check

Part of the Linear restructuring plan (new milestones, epics, and child tickets created in Linear).

## Test plan
- [ ] Verify `/groom-ticket` shows the correct epic list when run
- [ ] Verify `/start-ticket` coordination check uses correct `list_issues` syntax

🤖 Generated with [Claude Code](https://claude.com/claude-code)