### PR TITLE
WOR-58 Pass UserPreferences into Jinja2 template context

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -141,7 +141,8 @@ def main(argv: list[str] | None = None) -> int:
         return 1
 
     try:
-        written = generate(config, args.output)
+        prefs = PrefsStore.load()
+        written = generate(config, args.output, prefs)
     except ValueError as exc:
         print(f"Error: {exc}", file=sys.stderr)
         return 1


### PR DESCRIPTION
## Summary

- Load `PrefsStore.load()` in `cli.py` and pass the result to `generate()`
- `author_name`, `author_email`, `github_username` now available in all Jinja2 templates when prefs are set
- Existing callers without `prefs` argument are unaffected (parameter is optional)

## Test plan

- [x] ruff lint + format: PASS
- [x] bandit: PASS
- [x] pytest (80 tests, 96% coverage): PASS
- [x] Existing tests in `test_generator.py` cover merged context with and without prefs

Closes WOR-58

🤖 Generated with [Claude Code](https://claude.com/claude-code)