### PR TITLE
WOR-77 Add schema drift test and fix stale committed schema

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,8 @@ app/core/      # All business logic — no UI here
 app/ui/        # PySide6 only — calls core, contains no logic
 templates/     # Jinja2 template files for scaffold output
 tests/         # Tests against core only
+schemas/       # Exported JSON Schemas for non-Python consumers
+docs/spikes/   # Spike investigation docs
 ```
 
 Module responsibilities:
@@ -52,6 +54,7 @@ Module responsibilities:
 - `generator.py` — renders templates and writes files to disk
 - `post_setup.py` — side effects: `git init`, `pre-commit install`, etc.
 - `user_prefs.py` — `UserPreferences` model + `PrefsStore` (platform-aware JSON persistence)
+- `manifest.py` — `ExecutionManifest` Pydantic model: cloud→local worker contract for hybrid execution
 - `main.py` — PySide6 `QApplication` entry point
 
 Data flows one way: UI → config model → generator → disk. Post-setup runs after generation.

--- a/app/core/__init__.py
+++ b/app/core/__init__.py
@@ -1,0 +1,3 @@
+from app.core.manifest import ExecutionManifest
+
+__all__ = ["ExecutionManifest"]

--- a/app/core/manifest.py
+++ b/app/core/manifest.py
@@ -1,0 +1,265 @@
+"""Execution manifest schema.
+
+The ExecutionManifest is the machine-readable contract written by the cloud
+producer (/start-ticket) and consumed by the local worker (/implement-ticket).
+The worker executes what the manifest specifies — it does not re-read Linear,
+re-interpret the project, or make architectural decisions on its own.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Annotated, Literal
+
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+MANIFEST_VERSION = "1.0"
+
+
+# ---------------------------------------------------------------------------
+# Nested models
+# ---------------------------------------------------------------------------
+
+
+class TicketStateMap(BaseModel):
+    """Linear workflow state names used by the watcher to advance ticket state."""
+
+    model_config = {"extra": "forbid"}
+
+    in_progress_local: str = "InProgressLocal"
+    merged_to_epic: str = "MergedToEpic"
+    ready_for_review: str = "EpicReadyForCloudReview"
+    failed: str = "Blocked"
+
+
+class ArtifactPaths(BaseModel):
+    """Paths where the worker writes result artifacts (relative to repo root)."""
+
+    model_config = {"extra": "forbid"}
+
+    result_json: str
+    """JSON file the worker writes on completion: {status, summary, checks_passed}."""
+
+    manifest_copy: str
+    """Copy of the manifest as executed — preserves the exact contract for audit."""
+
+    @classmethod
+    def from_ticket_id(cls, ticket_id: str) -> "ArtifactPaths":
+        """Generate default artifact paths for a given ticket ID."""
+        slug = ticket_id.lower().replace("-", "_")
+        base = f".claude/artifacts/{slug}"
+        return cls(
+            result_json=f"{base}/result.json",
+            manifest_copy=f"{base}/manifest.json",
+        )
+
+    @field_validator("result_json", "manifest_copy")
+    @classmethod
+    def no_path_traversal(cls, v: str) -> str:
+        resolved = Path(v)
+        if ".." in resolved.parts:
+            raise ValueError(f"Path must not contain '..': {v!r}")
+        return v
+
+
+class FailurePolicy(BaseModel):
+    """What the worker should do when a required check fails."""
+
+    model_config = {"extra": "forbid"}
+
+    on_check_failure: Literal["abort", "warn"] = "abort"
+    """abort — stop immediately and write a failed result artifact.
+    warn  — log the failure but continue (use only for non-blocking checks)."""
+
+    max_retries: Annotated[int, Field(ge=0, le=5)] = 0
+    """Number of times the worker may retry a failed required check before giving up."""
+
+    escalate_to_cloud: bool = False
+    """If True the watcher should escalate to a cloud session when the worker fails."""
+
+
+# ---------------------------------------------------------------------------
+# Root manifest model
+# ---------------------------------------------------------------------------
+
+
+class ExecutionManifest(BaseModel):
+    """Full execution manifest — contract between cloud producer and local worker."""
+
+    model_config = {"extra": "forbid"}
+
+    # ------------------------------------------------------------------
+    # Schema version
+    # ------------------------------------------------------------------
+    manifest_version: str = MANIFEST_VERSION
+    """Semver-style schema version. Must match what the worker supports."""
+
+    # ------------------------------------------------------------------
+    # Ticket identity
+    # ------------------------------------------------------------------
+    ticket_id: str
+    """Linear ticket identifier, e.g. 'WOR-77'."""
+
+    epic_id: str | None = None
+    """Linear epic identifier, e.g. 'WOR-75'. None for top-level (non-epic) tickets."""
+
+    title: str
+    """Human-readable ticket title copied from Linear."""
+
+    priority: Annotated[int, Field(ge=0, le=4)]
+    """Linear priority: 0=None, 1=Urgent, 2=High, 3=Normal, 4=Low."""
+
+    status: str
+    """Linear status at manifest generation time, e.g. 'ReadyForLocal'."""
+
+    # ------------------------------------------------------------------
+    # Execution control
+    # ------------------------------------------------------------------
+    parallel_safe: bool
+    """True if this ticket can run concurrently with other local workers.
+    The watcher enforces allowed_paths non-overlap; this flag is advisory."""
+
+    risk_level: Literal["low", "medium", "high"]
+    """Overall risk classification assigned by the cloud producer."""
+
+    risk_flags: list[str] = Field(default_factory=list)
+    """Specific risk notes, e.g. ['touches migrations', 'modifies CI config']."""
+
+    implementation_mode: Literal["local", "cloud", "hybrid"]
+    """Which execution mode this manifest is targeting."""
+
+    review_mode: Literal["auto", "human"]
+    """auto — PR auto-merges to epic branch when CI passes.
+    human — PR requires explicit human approval."""
+
+    # ------------------------------------------------------------------
+    # Branch / worktree
+    # ------------------------------------------------------------------
+    base_branch: str
+    """Branch the worker bases its work on, e.g. 'wor-75-hybrid-execution-engine'."""
+
+    worker_branch: str
+    """Branch the worker commits to, e.g. 'wor-77-design-and-implement-...'."""
+
+    worktree_name: str | None = None
+    """Git worktree directory name. None when not using isolated worktrees."""
+
+    # ------------------------------------------------------------------
+    # Scope
+    # ------------------------------------------------------------------
+    objective: str
+    """One-paragraph description of what the worker must accomplish."""
+
+    acceptance_criteria: list[str] = Field(default_factory=list)
+    """Bullet list of conditions that must be true for the ticket to be Done."""
+
+    implementation_constraints: list[str] = Field(default_factory=list)
+    """Hard rules the worker must follow, e.g. 'do not modify app/ui/'."""
+
+    allowed_paths: list[str] = Field(default_factory=list)
+    """Glob patterns the worker is allowed to write to. Empty list = no restriction."""
+
+    forbidden_paths: list[str] = Field(default_factory=list)
+    """Glob patterns the worker must never write to."""
+
+    related_files_hint: list[str] = Field(default_factory=list)
+    """Files likely relevant to this ticket (informational, not a whitelist)."""
+
+    # ------------------------------------------------------------------
+    # Checks
+    # ------------------------------------------------------------------
+    required_checks: list[str] = Field(default_factory=list)
+    """Shell commands that must pass before the worker marks the ticket done.
+    E.g. ['pytest tests/test_manifest.py', 'ruff check app/core/manifest.py']."""
+
+    optional_checks: list[str] = Field(default_factory=list)
+    """Shell commands run for information only — failures do not block completion."""
+
+    # ------------------------------------------------------------------
+    # Done definition and failure policy
+    # ------------------------------------------------------------------
+    done_definition: str = ""
+    """Plain-English description of what 'Done' means for this ticket."""
+
+    failure_policy: FailurePolicy = Field(default_factory=FailurePolicy)
+
+    # ------------------------------------------------------------------
+    # State mapping and artifacts
+    # ------------------------------------------------------------------
+    ticket_state_map: TicketStateMap = Field(default_factory=TicketStateMap)
+
+    artifact_paths: ArtifactPaths
+    """Where the worker writes its result. Use ArtifactPaths.from_ticket_id()."""
+
+    # ------------------------------------------------------------------
+    # Validators
+    # ------------------------------------------------------------------
+
+    @field_validator("manifest_version")
+    @classmethod
+    def version_must_be_supported(cls, v: str) -> str:
+        if v != MANIFEST_VERSION:
+            raise ValueError(
+                f"Unsupported manifest_version {v!r}. "
+                f"This implementation supports {MANIFEST_VERSION!r}."
+            )
+        return v
+
+    @field_validator("ticket_id", "epic_id")
+    @classmethod
+    def identifier_format(cls, v: str | None) -> str | None:
+        if v is None:
+            return v
+        if not v.strip():
+            raise ValueError("Identifier must not be blank")
+        return v.strip().upper()
+
+    @field_validator("required_checks", "optional_checks")
+    @classmethod
+    def no_empty_check_strings(cls, v: list[str]) -> list[str]:
+        for item in v:
+            if not item.strip():
+                raise ValueError("Check commands must not be empty strings")
+        return v
+
+    @model_validator(mode="after")
+    def forbidden_not_subset_of_allowed(self) -> "ExecutionManifest":
+        """Warn (via ValueError) when a forbidden path is also explicitly allowed."""
+        if self.allowed_paths and self.forbidden_paths:
+            overlap = set(self.allowed_paths) & set(self.forbidden_paths)
+            if overlap:
+                raise ValueError(
+                    f"Paths appear in both allowed_paths and forbidden_paths: {overlap}"
+                )
+        return self
+
+    # ------------------------------------------------------------------
+    # Serialization helpers
+    # ------------------------------------------------------------------
+
+    def to_json(self, path: str | Path, *, indent: int = 2) -> Path:
+        """Serialize manifest to a JSON file. Creates parent directories as needed."""
+        dest = Path(path)
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_text(self.model_dump_json(indent=indent), encoding="utf-8")
+        return dest
+
+    @classmethod
+    def from_json(cls, path: str | Path) -> "ExecutionManifest":
+        """Load and validate a manifest from a JSON file.
+
+        Raises ValueError if the path contains '..' (traversal guard).
+        Raises FileNotFoundError if the file does not exist.
+        Raises pydantic.ValidationError if the JSON fails schema validation.
+        """
+        resolved = Path(path).resolve()
+        # Traversal guard: reject paths that escape via '..'
+        if ".." in Path(path).parts:
+            raise ValueError(f"Manifest path must not contain '..': {path!r}")
+        raw = resolved.read_text(encoding="utf-8")
+        return cls.model_validate_json(raw)
+
+    @classmethod
+    def json_schema(cls) -> dict:
+        """Return the JSON Schema dict for this model."""
+        return cls.model_json_schema()

--- a/docs/spikes/wor-77-execution-manifest-schema.md
+++ b/docs/spikes/wor-77-execution-manifest-schema.md
@@ -1,0 +1,237 @@
+# WOR-77 Spike: Execution Manifest Schema
+
+**Milestone:** Hybrid Execution Engine
+**Status:** Done
+**Blocks:** WOR-80 (Split /start-ticket into preflight + /implement-ticket skill)
+
+---
+
+## What is the execution manifest?
+
+The execution manifest is a machine-readable JSON file that acts as the **handoff contract** between two components of the hybrid execution engine:
+
+- **Cloud producer** — the updated `/start-ticket` skill running on Claude Sonnet/Opus. It reads Linear, interprets the project, makes architectural decisions, and writes a manifest to disk.
+- **Local worker** — the future `/implement-ticket` skill running on a local model (Qwen3-Coder or similar). It reads the manifest and executes it **without re-interpreting the project**.
+
+The manifest carries everything the local worker needs. The worker is intentionally dumb: it follows the manifest, runs the required checks, and writes a result artifact. It does not re-read Linear or consult CLAUDE.md.
+
+---
+
+## Design decisions
+
+### Why Pydantic?
+
+The rest of `app/core/` uses Pydantic (see `config.py`). Pydantic v2 gives us:
+- Free JSON serialization / deserialization
+- Auto-generated JSON Schema (committed as `schemas/execution_manifest.schema.json`)
+- Strict validation with `extra = "forbid"` — unknown fields fail loudly rather than silently disappearing
+
+### Why `extra = "forbid"` on all models?
+
+Manifest version mismatches should fail loudly. If a future field is added, old workers will reject the manifest rather than silently ignore the new constraint. The producer must bump `manifest_version` when the schema changes in a breaking way.
+
+### Why `manifest_version` validation instead of a version range?
+
+For v1 of this system we have exactly one worker implementation. A range check would be premature generalization. When we need backwards compatibility we will revisit.
+
+### `allowed_paths` empty list = no restriction
+
+An empty `allowed_paths` list means the worker is not path-restricted. This is intentional for spike/research tickets where the scope is exploratory. The watcher checks that two concurrent workers' `allowed_paths` don't overlap — an empty list means "potentially touches anything" and the watcher must treat it conservatively (serialize it, don't allow concurrency).
+
+### Path traversal guard in `from_json`
+
+`ArtifactPaths` validates individual paths at construction time. `from_json` adds a second check at the file-loading layer. Defense in depth — the manifest file itself might come from an untrusted source in future.
+
+### `ticket_state_map` is configurable
+
+Linear state names are project-specific and may differ across repos. The map defaults to the names defined in WOR-78 but can be overridden per-manifest, making the schema portable.
+
+---
+
+## Field reference
+
+### Identity
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `manifest_version` | `str` | default `"1.0"` | Schema version. Must match `MANIFEST_VERSION` constant. |
+| `ticket_id` | `str` | yes | Linear identifier, e.g. `"WOR-77"`. Normalized to uppercase. |
+| `epic_id` | `str \| null` | no | Parent epic identifier. `null` for standalone tickets. |
+| `title` | `str` | yes | Ticket title from Linear. |
+| `priority` | `int` 0–4 | yes | Linear priority (0=None … 4=Low). |
+| `status` | `str` | yes | Linear status at manifest generation time. |
+
+### Execution control
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `parallel_safe` | `bool` | yes | Advisory flag. Watcher enforces concurrency via `allowed_paths`. |
+| `risk_level` | `"low"\|"medium"\|"high"` | yes | Overall risk classification. Drives review mode and escalation. |
+| `risk_flags` | `list[str]` | no | Specific risk notes, e.g. `["touches migrations"]`. |
+| `implementation_mode` | `"local"\|"cloud"\|"hybrid"` | yes | Target execution mode for this manifest. |
+| `review_mode` | `"auto"\|"human"` | yes | `auto` = PR auto-merges to epic when CI passes. `human` = requires approval. |
+
+### Branch / worktree
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `base_branch` | `str` | yes | Branch the worker bases its work on. |
+| `worker_branch` | `str` | yes | Branch the worker commits to. |
+| `worktree_name` | `str \| null` | no | Git worktree directory name for isolated execution. |
+
+### Scope
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `objective` | `str` | yes | One-paragraph implementation goal. |
+| `acceptance_criteria` | `list[str]` | no | Conditions that must be true for "Done". |
+| `implementation_constraints` | `list[str]` | no | Hard rules, e.g. `"do not modify app/ui/"`. |
+| `allowed_paths` | `list[str]` | no | Glob patterns the worker may write to. `[]` = no restriction. |
+| `forbidden_paths` | `list[str]` | no | Glob patterns the worker must never write to. |
+| `related_files_hint` | `list[str]` | no | Informational — files likely relevant (not a whitelist). |
+
+`allowed_paths` and `forbidden_paths` must not overlap (validated at construction).
+
+### Checks
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `required_checks` | `list[str]` | no | Shell commands that must pass before the worker marks Done. |
+| `optional_checks` | `list[str]` | no | Informational — failures do not block completion. |
+
+Empty strings in either list are rejected at construction.
+
+### Done definition and failure policy
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `done_definition` | `str` | no | Plain-English "Done" description. |
+| `failure_policy.on_check_failure` | `"abort"\|"warn"` | default `"abort"` | How the worker handles a failed required check. |
+| `failure_policy.max_retries` | `int` 0–5 | default `0` | Retry budget before giving up. |
+| `failure_policy.escalate_to_cloud` | `bool` | default `false` | Ask watcher to hand off to a cloud session on failure. |
+
+### State mapping
+
+| Field | Default | Description |
+|---|---|---|
+| `ticket_state_map.in_progress_local` | `"InProgressLocal"` | State set when worker starts. |
+| `ticket_state_map.merged_to_epic` | `"MergedToEpic"` | State set after PR merges to epic. |
+| `ticket_state_map.ready_for_review` | `"EpicReadyForCloudReview"` | State set when epic PR is ready. |
+| `ticket_state_map.failed` | `"Blocked"` | State set on worker failure. |
+
+### Artifacts
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `artifact_paths.result_json` | `str` | yes | Path the worker writes `{status, summary, checks_passed}` to. |
+| `artifact_paths.manifest_copy` | `str` | yes | Copy of the executed manifest for audit. |
+
+Use `ArtifactPaths.from_ticket_id("WOR-77")` to generate defaults.
+
+---
+
+## Example manifest
+
+```json
+{
+  "manifest_version": "1.0",
+  "ticket_id": "WOR-78",
+  "epic_id": "WOR-75",
+  "title": "Update Linear workflow states and ticket lifecycle",
+  "priority": 2,
+  "status": "ReadyForLocal",
+  "parallel_safe": true,
+  "risk_level": "low",
+  "risk_flags": [],
+  "implementation_mode": "local",
+  "review_mode": "auto",
+  "base_branch": "wor-75-hybrid-execution-engine",
+  "worker_branch": "wor-78-update-linear-workflow-states-and-ticket-lifecycle",
+  "worktree_name": "worktree-wor-78",
+  "objective": "Add new Linear workflow states to support the hybrid lifecycle and update CLAUDE.md to document the new lifecycle.",
+  "acceptance_criteria": [
+    "Required Linear states exist: Groomed, ReadyForLocal, InProgressLocal, MergedToEpic, EpicReadyForCloudReview, MainPRReady",
+    "CLAUDE.md documents the new lifecycle with a state transition diagram",
+    "local-ready label exists in Linear"
+  ],
+  "implementation_constraints": [
+    "Do not modify app/ui/ or app/core/",
+    "CLAUDE.md changes only — no Python code"
+  ],
+  "allowed_paths": [
+    "CLAUDE.md",
+    ".claude/**"
+  ],
+  "forbidden_paths": [
+    "app/**",
+    "tests/**"
+  ],
+  "related_files_hint": [
+    "CLAUDE.md",
+    ".claude/commands/start-ticket.md"
+  ],
+  "required_checks": [
+    "pre-commit run --files CLAUDE.md"
+  ],
+  "optional_checks": [],
+  "done_definition": "CLAUDE.md updated with the new state diagram and all required Linear states exist.",
+  "failure_policy": {
+    "on_check_failure": "abort",
+    "max_retries": 0,
+    "escalate_to_cloud": false
+  },
+  "ticket_state_map": {
+    "in_progress_local": "InProgressLocal",
+    "merged_to_epic": "MergedToEpic",
+    "ready_for_review": "EpicReadyForCloudReview",
+    "failed": "Blocked"
+  },
+  "artifact_paths": {
+    "result_json": ".claude/artifacts/wor_78/result.json",
+    "manifest_copy": ".claude/artifacts/wor_78/manifest.json"
+  }
+}
+```
+
+---
+
+## Consuming the schema in Python
+
+```python
+from app.core.manifest import ExecutionManifest, ArtifactPaths
+
+# Producer (cloud) — build and write a manifest
+manifest = ExecutionManifest(
+    ticket_id="WOR-78",
+    title="Update Linear workflow states",
+    priority=2,
+    status="ReadyForLocal",
+    parallel_safe=True,
+    risk_level="low",
+    implementation_mode="local",
+    review_mode="auto",
+    base_branch="wor-75-hybrid-execution-engine",
+    worker_branch="wor-78-update-linear-workflow-states-and-ticket-lifecycle",
+    objective="Add new Linear workflow states and update CLAUDE.md.",
+    artifact_paths=ArtifactPaths.from_ticket_id("WOR-78"),
+)
+manifest.to_json(".claude/manifests/wor-78.json")
+
+# Worker (local) — load and validate
+manifest = ExecutionManifest.from_json(".claude/manifests/wor-78.json")
+print(manifest.required_checks)
+```
+
+---
+
+## JSON Schema for non-Python consumers
+
+The schema is exported at `schemas/execution_manifest.schema.json` and can be used to validate manifests from any language. Regenerate after model changes:
+
+```bash
+python -c "
+import json
+from app.core.manifest import ExecutionManifest
+print(json.dumps(ExecutionManifest.json_schema(), indent=2))
+" > schemas/execution_manifest.schema.json
+```

--- a/schemas/execution_manifest.schema.json
+++ b/schemas/execution_manifest.schema.json
@@ -1,0 +1,260 @@
+{
+  "$defs": {
+    "ArtifactPaths": {
+      "additionalProperties": false,
+      "description": "Paths where the worker writes result artifacts (relative to repo root).",
+      "properties": {
+        "result_json": {
+          "title": "Result Json",
+          "type": "string"
+        },
+        "manifest_copy": {
+          "title": "Manifest Copy",
+          "type": "string"
+        }
+      },
+      "required": [
+        "result_json",
+        "manifest_copy"
+      ],
+      "title": "ArtifactPaths",
+      "type": "object"
+    },
+    "FailurePolicy": {
+      "additionalProperties": false,
+      "description": "What the worker should do when a required check fails.",
+      "properties": {
+        "on_check_failure": {
+          "default": "abort",
+          "enum": [
+            "abort",
+            "warn"
+          ],
+          "title": "On Check Failure",
+          "type": "string"
+        },
+        "max_retries": {
+          "default": 0,
+          "maximum": 5,
+          "minimum": 0,
+          "title": "Max Retries",
+          "type": "integer"
+        },
+        "escalate_to_cloud": {
+          "default": false,
+          "title": "Escalate To Cloud",
+          "type": "boolean"
+        }
+      },
+      "title": "FailurePolicy",
+      "type": "object"
+    },
+    "TicketStateMap": {
+      "additionalProperties": false,
+      "description": "Linear workflow state names used by the watcher to advance ticket state.",
+      "properties": {
+        "in_progress_local": {
+          "default": "InProgressLocal",
+          "title": "In Progress Local",
+          "type": "string"
+        },
+        "merged_to_epic": {
+          "default": "MergedToEpic",
+          "title": "Merged To Epic",
+          "type": "string"
+        },
+        "ready_for_review": {
+          "default": "EpicReadyForCloudReview",
+          "title": "Ready For Review",
+          "type": "string"
+        },
+        "failed": {
+          "default": "Blocked",
+          "title": "Failed",
+          "type": "string"
+        }
+      },
+      "title": "TicketStateMap",
+      "type": "object"
+    }
+  },
+  "additionalProperties": false,
+  "description": "Full execution manifest \u2014 the contract between cloud producer and local worker.",
+  "properties": {
+    "manifest_version": {
+      "default": "1.0",
+      "title": "Manifest Version",
+      "type": "string"
+    },
+    "ticket_id": {
+      "title": "Ticket Id",
+      "type": "string"
+    },
+    "epic_id": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Epic Id"
+    },
+    "title": {
+      "title": "Title",
+      "type": "string"
+    },
+    "priority": {
+      "maximum": 4,
+      "minimum": 0,
+      "title": "Priority",
+      "type": "integer"
+    },
+    "status": {
+      "title": "Status",
+      "type": "string"
+    },
+    "parallel_safe": {
+      "title": "Parallel Safe",
+      "type": "boolean"
+    },
+    "risk_level": {
+      "enum": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "title": "Risk Level",
+      "type": "string"
+    },
+    "risk_flags": {
+      "items": {
+        "type": "string"
+      },
+      "title": "Risk Flags",
+      "type": "array"
+    },
+    "implementation_mode": {
+      "enum": [
+        "local",
+        "cloud",
+        "hybrid"
+      ],
+      "title": "Implementation Mode",
+      "type": "string"
+    },
+    "review_mode": {
+      "enum": [
+        "auto",
+        "human"
+      ],
+      "title": "Review Mode",
+      "type": "string"
+    },
+    "base_branch": {
+      "title": "Base Branch",
+      "type": "string"
+    },
+    "worker_branch": {
+      "title": "Worker Branch",
+      "type": "string"
+    },
+    "worktree_name": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Worktree Name"
+    },
+    "objective": {
+      "title": "Objective",
+      "type": "string"
+    },
+    "acceptance_criteria": {
+      "items": {
+        "type": "string"
+      },
+      "title": "Acceptance Criteria",
+      "type": "array"
+    },
+    "implementation_constraints": {
+      "items": {
+        "type": "string"
+      },
+      "title": "Implementation Constraints",
+      "type": "array"
+    },
+    "allowed_paths": {
+      "items": {
+        "type": "string"
+      },
+      "title": "Allowed Paths",
+      "type": "array"
+    },
+    "forbidden_paths": {
+      "items": {
+        "type": "string"
+      },
+      "title": "Forbidden Paths",
+      "type": "array"
+    },
+    "related_files_hint": {
+      "items": {
+        "type": "string"
+      },
+      "title": "Related Files Hint",
+      "type": "array"
+    },
+    "required_checks": {
+      "items": {
+        "type": "string"
+      },
+      "title": "Required Checks",
+      "type": "array"
+    },
+    "optional_checks": {
+      "items": {
+        "type": "string"
+      },
+      "title": "Optional Checks",
+      "type": "array"
+    },
+    "done_definition": {
+      "default": "",
+      "title": "Done Definition",
+      "type": "string"
+    },
+    "failure_policy": {
+      "$ref": "#/$defs/FailurePolicy"
+    },
+    "ticket_state_map": {
+      "$ref": "#/$defs/TicketStateMap"
+    },
+    "artifact_paths": {
+      "$ref": "#/$defs/ArtifactPaths"
+    }
+  },
+  "required": [
+    "ticket_id",
+    "title",
+    "priority",
+    "status",
+    "parallel_safe",
+    "risk_level",
+    "implementation_mode",
+    "review_mode",
+    "base_branch",
+    "worker_branch",
+    "objective",
+    "artifact_paths"
+  ],
+  "title": "ExecutionManifest",
+  "type": "object"
+}

--- a/schemas/execution_manifest.schema.json
+++ b/schemas/execution_manifest.schema.json
@@ -79,7 +79,7 @@
     }
   },
   "additionalProperties": false,
-  "description": "Full execution manifest \u2014 the contract between cloud producer and local worker.",
+  "description": "Full execution manifest \u2014 contract between cloud producer and local worker.",
   "properties": {
     "manifest_version": {
       "default": "1.0",

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -1,0 +1,334 @@
+"""Tests for the ExecutionManifest schema (WOR-77)."""
+
+import json
+
+import pytest
+from pydantic import ValidationError
+
+from app.core.manifest import (
+    MANIFEST_VERSION,
+    ArtifactPaths,
+    ExecutionManifest,
+    TicketStateMap,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _minimal_manifest(**overrides) -> dict:
+    """Return the smallest valid manifest payload."""
+    base = {
+        "ticket_id": "WOR-77",
+        "title": "Design manifest schema",
+        "priority": 2,
+        "status": "ReadyForLocal",
+        "parallel_safe": True,
+        "risk_level": "low",
+        "implementation_mode": "local",
+        "review_mode": "auto",
+        "base_branch": "wor-75-hybrid-execution-engine",
+        "worker_branch": "wor-77-design-and-implement-execution-manifest-schema",
+        "objective": "Define the execution manifest schema.",
+        "artifact_paths": {
+            "result_json": ".claude/artifacts/wor_77/result.json",
+            "manifest_copy": ".claude/artifacts/wor_77/manifest.json",
+        },
+    }
+    base.update(overrides)
+    return base
+
+
+def _make_manifest(**overrides) -> ExecutionManifest:
+    return ExecutionManifest(**_minimal_manifest(**overrides))
+
+
+# ---------------------------------------------------------------------------
+# Construction and defaults
+# ---------------------------------------------------------------------------
+
+
+def test_manifest_constructs_from_minimal_payload():
+    m = _make_manifest()
+    assert m.ticket_id == "WOR-77"
+    assert m.manifest_version == MANIFEST_VERSION
+
+
+def test_manifest_version_default():
+    m = _make_manifest()
+    assert m.manifest_version == "1.0"
+
+
+def test_optional_fields_default_to_empty_or_none():
+    m = _make_manifest()
+    assert m.epic_id is None
+    assert m.risk_flags == []
+    assert m.acceptance_criteria == []
+    assert m.implementation_constraints == []
+    assert m.allowed_paths == []
+    assert m.forbidden_paths == []
+    assert m.related_files_hint == []
+    assert m.required_checks == []
+    assert m.optional_checks == []
+    assert m.done_definition == ""
+    assert m.worktree_name is None
+
+
+def test_ticket_state_map_default_values():
+    m = _make_manifest()
+    assert m.ticket_state_map.in_progress_local == "InProgressLocal"
+    assert m.ticket_state_map.merged_to_epic == "MergedToEpic"
+
+
+def test_failure_policy_default_abort():
+    m = _make_manifest()
+    assert m.failure_policy.on_check_failure == "abort"
+    assert m.failure_policy.max_retries == 0
+    assert m.failure_policy.escalate_to_cloud is False
+
+
+# ---------------------------------------------------------------------------
+# Validation — required fields
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "missing_field",
+    [
+        "ticket_id",
+        "title",
+        "priority",
+        "status",
+        "parallel_safe",
+        "risk_level",
+        "implementation_mode",
+        "review_mode",
+        "base_branch",
+        "worker_branch",
+        "objective",
+        "artifact_paths",
+    ],
+)
+def test_manifest_missing_required_field_raises(missing_field):
+    payload = _minimal_manifest()
+    del payload[missing_field]
+    with pytest.raises(ValidationError):
+        ExecutionManifest(**payload)
+
+
+# ---------------------------------------------------------------------------
+# Field validation
+# ---------------------------------------------------------------------------
+
+
+def test_manifest_version_mismatch_raises():
+    with pytest.raises(ValidationError, match="Unsupported manifest_version"):
+        _make_manifest(manifest_version="0.9")
+
+
+def test_ticket_id_normalised_to_uppercase():
+    m = _make_manifest(ticket_id="wor-77")
+    assert m.ticket_id == "WOR-77"
+
+
+def test_epic_id_normalised_to_uppercase():
+    m = _make_manifest(epic_id="wor-75")
+    assert m.epic_id == "WOR-75"
+
+
+def test_epic_id_none_is_valid():
+    m = _make_manifest(epic_id=None)
+    assert m.epic_id is None
+
+
+def test_priority_bounds():
+    _make_manifest(priority=0)
+    _make_manifest(priority=4)
+    with pytest.raises(ValidationError):
+        _make_manifest(priority=-1)
+    with pytest.raises(ValidationError):
+        _make_manifest(priority=5)
+
+
+def test_risk_level_valid_values():
+    for level in ("low", "medium", "high"):
+        m = _make_manifest(risk_level=level)
+        assert m.risk_level == level
+
+
+def test_risk_level_invalid_raises():
+    with pytest.raises(ValidationError):
+        _make_manifest(risk_level="critical")
+
+
+def test_implementation_mode_valid_values():
+    for mode in ("local", "cloud", "hybrid"):
+        m = _make_manifest(implementation_mode=mode)
+        assert m.implementation_mode == mode
+
+
+def test_review_mode_valid_values():
+    for mode in ("auto", "human"):
+        m = _make_manifest(review_mode=mode)
+        assert m.review_mode == mode
+
+
+def test_allowed_paths_empty_list_is_valid():
+    m = _make_manifest(allowed_paths=[])
+    assert m.allowed_paths == []
+
+
+def test_required_checks_rejects_empty_strings():
+    with pytest.raises(ValidationError, match="must not be empty"):
+        _make_manifest(required_checks=["pytest", ""])
+
+
+def test_optional_checks_rejects_empty_strings():
+    with pytest.raises(ValidationError, match="must not be empty"):
+        _make_manifest(optional_checks=[""])
+
+
+def test_allowed_forbidden_overlap_raises():
+    with pytest.raises(ValidationError, match="both allowed_paths and forbidden_paths"):
+        _make_manifest(
+            allowed_paths=["app/core/*.py"],
+            forbidden_paths=["app/core/*.py"],
+        )
+
+
+def test_allowed_forbidden_no_overlap_is_valid():
+    m = _make_manifest(
+        allowed_paths=["app/core/*.py"],
+        forbidden_paths=["app/ui/*.py"],
+    )
+    assert "app/core/*.py" in m.allowed_paths
+    assert "app/ui/*.py" in m.forbidden_paths
+
+
+# ---------------------------------------------------------------------------
+# Extra fields rejected
+# ---------------------------------------------------------------------------
+
+
+def test_manifest_rejects_extra_fields():
+    with pytest.raises(ValidationError):
+        ExecutionManifest(**_minimal_manifest(unknown_future_field="oops"))
+
+
+def test_ticket_state_map_rejects_extra_fields():
+    with pytest.raises(ValidationError):
+        TicketStateMap(in_progress_local="X", surprise="Y")
+
+
+def test_artifact_paths_rejects_extra_fields():
+    with pytest.raises(ValidationError):
+        ArtifactPaths(
+            result_json=".claude/artifacts/x/result.json",
+            manifest_copy=".claude/artifacts/x/manifest.json",
+            extra="bad",
+        )
+
+
+# ---------------------------------------------------------------------------
+# ArtifactPaths helpers
+# ---------------------------------------------------------------------------
+
+
+def test_artifact_paths_from_ticket_id():
+    ap = ArtifactPaths.from_ticket_id("WOR-77")
+    assert ap.result_json == ".claude/artifacts/wor_77/result.json"
+    assert ap.manifest_copy == ".claude/artifacts/wor_77/manifest.json"
+
+
+def test_artifact_paths_no_traversal():
+    with pytest.raises(ValidationError, match="must not contain"):
+        ArtifactPaths(
+            result_json="../secrets/result.json",
+            manifest_copy=".claude/artifacts/x/manifest.json",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Round-trip serialization
+# ---------------------------------------------------------------------------
+
+
+def test_manifest_roundtrip_json_string():
+    m = _make_manifest(
+        epic_id="WOR-75",
+        risk_flags=["touches .claude/"],
+        acceptance_criteria=["Schema validates", "Tests pass"],
+        required_checks=["pytest tests/test_manifest.py"],
+    )
+    json_str = m.model_dump_json()
+    m2 = ExecutionManifest.model_validate_json(json_str)
+    assert m == m2
+
+
+def test_manifest_roundtrip_dict():
+    m = _make_manifest()
+    d = m.model_dump()
+    m2 = ExecutionManifest.model_validate(d)
+    assert m == m2
+
+
+# ---------------------------------------------------------------------------
+# File I/O helpers
+# ---------------------------------------------------------------------------
+
+
+def test_to_json_creates_file(tmp_path):
+    m = _make_manifest()
+    dest = tmp_path / "manifests" / "result.json"
+    written = m.to_json(dest)
+    assert written == dest
+    assert dest.exists()
+    loaded = json.loads(dest.read_text())
+    assert loaded["ticket_id"] == "WOR-77"
+    assert loaded["manifest_version"] == MANIFEST_VERSION
+
+
+def test_from_json_roundtrip(tmp_path):
+    m = _make_manifest(epic_id="WOR-75")
+    dest = tmp_path / "manifest.json"
+    m.to_json(dest)
+    m2 = ExecutionManifest.from_json(dest)
+    assert m == m2
+
+
+def test_from_json_file_not_found(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        ExecutionManifest.from_json(tmp_path / "nonexistent.json")
+
+
+def test_from_json_traversal_guard(tmp_path):
+    with pytest.raises(ValueError, match="must not contain"):
+        ExecutionManifest.from_json("some/../../etc/passwd")
+
+
+def test_from_json_invalid_schema(tmp_path):
+    bad = tmp_path / "bad.json"
+    bad.write_text(
+        '{"ticket_id": "WOR-1"}', encoding="utf-8"
+    )  # missing required fields
+    with pytest.raises(ValidationError):
+        ExecutionManifest.from_json(bad)
+
+
+# ---------------------------------------------------------------------------
+# JSON Schema export
+# ---------------------------------------------------------------------------
+
+
+def test_json_schema_is_dict():
+    schema = ExecutionManifest.json_schema()
+    assert isinstance(schema, dict)
+    assert schema.get("title") == "ExecutionManifest"
+
+
+def test_json_schema_contains_required_properties():
+    schema = ExecutionManifest.json_schema()
+    props = schema.get("properties", {})
+    for field in ("ticket_id", "title", "priority", "base_branch", "worker_branch"):
+        assert field in props, f"Expected {field!r} in JSON Schema properties"

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -1,6 +1,7 @@
 """Tests for the ExecutionManifest schema (WOR-77)."""
 
 import json
+from pathlib import Path
 
 import pytest
 from pydantic import ValidationError
@@ -332,3 +333,22 @@ def test_json_schema_contains_required_properties():
     props = schema.get("properties", {})
     for field in ("ticket_id", "title", "priority", "base_branch", "worker_branch"):
         assert field in props, f"Expected {field!r} in JSON Schema properties"
+
+
+def test_committed_schema_file_matches_model(tmp_path):
+    """Catch drift between the committed JSON Schema file and the Pydantic model.
+
+    If this test fails, regenerate with:
+        python -c "import json; from app.core.manifest import ExecutionManifest; \
+            print(json.dumps(ExecutionManifest.json_schema(), indent=2))" \
+            > schemas/execution_manifest.schema.json
+    """
+    schema_file = (
+        Path(__file__).parent.parent / "schemas" / "execution_manifest.schema.json"
+    )
+    committed = json.loads(schema_file.read_text(encoding="utf-8"))
+    current = ExecutionManifest.json_schema()
+    assert committed == current, (
+        "schemas/execution_manifest.schema.json is out of date. "
+        "Regenerate it with the command in the test docstring."
+    )


### PR DESCRIPTION
- Adds `test_committed_schema_file_matches_model` — CI test that catches divergence between `schemas/execution_manifest.schema.json` and the Pydantic model
- Fixes the schema file which had drifted after a docstring line-length fix in the same branch

**Milestone:** Hybrid Execution Engine
**Epic:** WOR-75 Hybrid Execution Engine

## Test plan
- [x] 46 tests pass (`pytest tests/test_manifest.py`)
- [x] New test verified it catches real drift (was failing before schema regen)
- [x] `pre-commit run --all-files` clean

Part of WOR-77