### PR TITLE
Add litellm-local.yaml to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ Thumbs.db
 
 # Claude Code local settings
 .claude/settings.local.json
+
+# Local LiteLLM config
+litellm-local.yaml


### PR DESCRIPTION
## Summary
- Adds `litellm-local.yaml` to `.gitignore` to prevent personal local LiteLLM config from being tracked

## Test plan
- [ ] Verify `litellm-local.yaml` no longer appears as untracked after checkout

🤖 Generated with [Claude Code](https://claude.com/claude-code)