### PR TITLE
WOR-91 CI workflow doesn't trigger on sub-ticket → epic branch PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    branches: [main, 'wor-*']
 
 jobs:
   lint-and-test:


### PR DESCRIPTION
- Extend `pull_request.branches` in `ci.yml` to include `'wor-*'` so all quality gates (ruff, bandit, pytest — and the upcoming Semgrep step from WOR-88) run on every sub-ticket → epic PR
- Single character change; no conflict expected with WOR-88 which adds a new step in a different block
- `push: branches: [main]` unchanged — no regression on main-targeting CI

**Milestone:** Hybrid Execution Engine
**Epic:** WOR-75 Hybrid Execution Engine

## Test plan
- [x] All 126 tests pass, 97% coverage
- [x] `check yaml` pre-commit hook passes on the modified file
- [ ] Verify CI triggers on this PR (targeting `wor-75-hybrid-execution-engine`)

Closes WOR-91