### PR TITLE
Fix Semgrep false positives and Windows pre-commit encoding

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,14 +18,15 @@ repos:
     rev: 1.9.4
     hooks:
       - id: bandit
-        args: ["-c", "pyproject.toml"]
+        args: ["-c", "pyproject.toml", "-r", "app/"]
+        pass_filenames: false
 
   - repo: local
     hooks:
       - id: semgrep
         name: semgrep
         language: python
-        entry: semgrep
+        entry: python scripts/semgrep_run.py
         args: ["--config", "auto", "--error"]
         types: [python]
         pass_filenames: false

--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,5 +1,0 @@
-# Suppress confirmed false positives from Jinja2 template usage.
-# These rules fire on deliberate, safe template rendering patterns in this repo.
-# Reviewed in WOR-87 spike — not real vulnerabilities.
-python.flask.security.xss.audit.direct-use-of-jinja2
-python.lang.security.audit.jinja2.autoescape-disabled

--- a/app/core/generator.py
+++ b/app/core/generator.py
@@ -38,10 +38,11 @@ def generate(
     )
 
     templates_dir = _TEMPLATES_DIR / config.preset
-    env = Environment(  # nosec B701 — autoescape not relevant for text file generation
+    env = Environment(  # nosec B701  # nosemgrep: python.flask.security.xss.audit.direct-use-of-jinja2.direct-use-of-jinja2
         loader=FileSystemLoader([str(templates_dir), str(_SHARED_DIR)]),
         undefined=StrictUndefined,
         keep_trailing_newline=True,
+        autoescape=False,  # text file generation, not HTML
     )
 
     context = {**config.model_dump(), **prefs.model_dump()}
@@ -51,7 +52,7 @@ def generate(
 
     for relative_path in files_to_write:
         template = env.get_template(f"{relative_path}.j2")
-        content = template.render(**context)
+        content = template.render(**context)  # nosec  # nosemgrep: python.flask.security.xss.audit.direct-use-of-jinja2.direct-use-of-jinja2
         dest = output_path / relative_path
         dest.parent.mkdir(parents=True, exist_ok=True)
         dest.write_text(content, encoding="utf-8")

--- a/scripts/semgrep_run.py
+++ b/scripts/semgrep_run.py
@@ -1,0 +1,22 @@
+"""Wrapper that sets PYTHONUTF8=1 before invoking semgrep.
+
+Required on Windows where the default codepage (cp1252) cannot encode all
+characters in Semgrep's --config auto rule downloads. CI sets this via the
+workflow env block; pre-commit must set it here instead.
+"""
+
+import os
+import shutil
+import subprocess
+import sys
+
+semgrep_bin = shutil.which("semgrep")
+if semgrep_bin is None:
+    print("semgrep not found in PATH", file=sys.stderr)
+    sys.exit(1)
+
+env = os.environ.copy()
+env["PYTHONUTF8"] = "1"
+
+result = subprocess.run([semgrep_bin, *sys.argv[1:]], env=env)  # nosec B603
+sys.exit(result.returncode)


### PR DESCRIPTION
- Fix `jinja2.autoescape-disabled` finding by explicitly passing `autoescape=False` to `Environment()` instead of suppressing it
- Replace broken `.semgrepignore` (which used rule IDs as file glob patterns — never worked) with inline `# nosemgrep` tags on the two affected lines in `generator.py`
- Add `scripts/semgrep_run.py` wrapper that sets `PYTHONUTF8=1` before invoking semgrep, fixing the Windows cp1252 crash in pre-commit; use `shutil.which` to resolve full path (fixes bandit B607)
- Lock bandit pre-commit hook to `app/` with `pass_filenames: false`, matching the manual invocation and keeping `scripts/` out of scope

**Milestone:** Hybrid Execution Engine
**Epic:** WOR-75 Hybrid Execution Engine

## Test plan
- [x] `PYTHONUTF8=1 semgrep --config auto --error app/` → 0 findings
- [x] All pre-commit hooks pass locally
- [x] 126 tests pass, 97% coverage
- [ ] Verify CI green on this PR