### PR TITLE
WOR-90 Fix pyproject.toml missing [project.dependencies]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install dependencies
-        run: pip install pydantic jinja2 pyyaml pytest pytest-cov ruff bandit semgrep detect-secrets
+        run: pip install -r requirements-dev.txt
 
       - name: Lint
         run: ruff check .
@@ -34,6 +34,9 @@ jobs:
         run: semgrep --config auto --error app/
         env:
           PYTHONUTF8: "1"
+
+      - name: Dependency check
+        run: deptry . --requirements-files requirements.txt,requirements-dev.txt
 
       - name: Test
         run: pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,10 @@
 name = "repo-scaffold-desktop"
 version = "0.1.0"
 requires-python = ">=3.12"
+dependencies = [
+    "pydantic>=2.0",
+    "jinja2>=3.0",
+]
 
 [project.scripts]
 scaffold = "app.cli:main"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,3 +6,4 @@ bandit>=1.7
 pre-commit>=3.0
 semgrep>=1.0
 detect-secrets>=1.4
+deptry>=0.12


### PR DESCRIPTION
- Add `[project.dependencies]` to `pyproject.toml` with `pydantic>=2.0` and `jinja2>=3.0` (the two packages currently imported; `pyyaml`/`pyside6` omitted until their code lands to avoid DEP002 noise)
- Add `deptry>=0.12` to `requirements-dev.txt`
- Switch CI install step from hardcoded package list to `-r requirements-dev.txt`; add `deptry` dependency-check step — zero findings confirmed locally

**Milestone:** Hybrid Execution Engine
**Epic:** WOR-75 Hybrid Execution Engine

## Test plan
- [x] `deptry . --requirements-files requirements.txt,requirements-dev.txt` reports zero issues
- [x] `pytest` passes (126 tests, 97% coverage)
- [x] `ruff check .` and `ruff format --check .` pass
- [ ] CI passes on this PR (deptry step runs for the first time)

Closes WOR-90