### PR TITLE
WOR-89 Activate SonarCloud: populate sonar-project.properties and add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,4 +39,11 @@ jobs:
         run: deptry . --requirements-files requirements.txt,requirements-dev.txt
 
       - name: Test
-        run: pytest
+        run: pytest --cov=app --cov-report=xml
+
+      - name: SonarCloud scan
+        if: github.base_ref == 'main'
+        uses: SonarSource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,6 @@
+sonar.projectKey=virppa_repo-scaffold-desktop
+sonar.organization=virppa
+sonar.sources=app
+sonar.tests=tests
+sonar.python.coverage.reportPaths=coverage.xml
+sonar.python.version=3.12


### PR DESCRIPTION
## Summary

- Populates `sonar-project.properties` with project key, organization, sources, tests, coverage report path, and Python version
- Updates the `Test` CI step to always emit `coverage.xml` (`pytest --cov=app --cov-report=xml`)
- Adds a `SonarCloud scan` step gated on `if: github.base_ref == 'main'` so it only fires on epic→main PRs

## Manual prerequisite

`SONAR_TOKEN` must be present in GitHub repo secrets (already added). The SonarCloud project must be activated at sonarcloud.io for `virppa/repo-scaffold-desktop` before the gate passes on the first epic→main PR.

## Test plan

- [ ] Verify CI passes on this sub-ticket PR (SonarCloud step is skipped — `base_ref` is the epic branch, not `main`)
- [ ] On epic→main PR: confirm SonarCloud scan step runs and posts quality gate result to the PR
- [ ] Confirm default "Sonar way" gate is active (coverage ≥ 80% on new code, no new blocker/critical issues)

Closes WOR-89

🤖 Generated with [Claude Code](https://claude.com/claude-code)