### PR TITLE
WOR-92 Add SonarCloud informational scan to sub→epic CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,14 @@ jobs:
       - name: Test
         run: pytest --cov=app --cov-report=xml
 
+      - name: SonarCloud scan (informational)
+        if: github.base_ref != 'main'
+        continue-on-error: true
+        uses: SonarSource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
       - name: SonarCloud scan
         if: github.base_ref == 'main'
         uses: SonarSource/sonarcloud-github-action@master

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,6 +126,17 @@ main
 
 Human gates: plan approval after `/start-ticket`; explicit PASS from `/security-check` before any main-targeting PR; human review of the epic → main PR created by `/close-epic`. Command files live in `.claude/commands/`.
 
+### CI quality gate tiers
+
+Two-tier SonarCloud strategy:
+
+| PR target | SonarCloud step | Blocks merge? |
+|-----------|----------------|---------------|
+| sub→epic  | "SonarCloud scan (informational)" — `continue-on-error: true` | No — findings logged, advisory only |
+| epic→main | "SonarCloud scan" — blocking | Yes — gate must pass |
+
+The informational scan runs on `github.base_ref != 'main'`; the blocking scan runs on `github.base_ref == 'main'`. Both use the same `SonarSource/sonarcloud-github-action@master` and the same `SONAR_TOKEN`. The sub→epic tier lets the LLM see and fix code smells cheaply before they surface as blocking findings at the epic→main gate.
+
 ---
 
 ## Claude Code hooks


### PR DESCRIPTION
- Add "SonarCloud scan (informational)" step to CI, gated on `github.base_ref != 'main'` (sub→epic PRs only)
- Step is `continue-on-error: true` — findings visible in CI log but do not block merge
- Blocking SonarCloud scan on epic→main PRs unchanged
- Document two-tier CI quality gate strategy in CLAUDE.md

**Milestone:** Hybrid Execution Engine
**Epic:** WOR-75 Hybrid Execution Engine

## Test plan
- [ ] CI passes on this PR (sub→epic) — informational step runs, any findings are logged but merge is not blocked
- [ ] After merging to epic branch, verify epic→main PR would run the blocking step (base_ref == 'main')
- [ ] CLAUDE.md two-tier table renders correctly

Closes WOR-92