### PR TITLE
WOR-84 Define Import Linter architecture rules

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -63,6 +63,15 @@
         "hooks": [
           {
             "type": "command",
+            "command": "FILE=\"$CLAUDE_TOOL_INPUT_FILE_PATH\"; if [[ \"$FILE\" == *.py ]] && command -v lint-imports >/dev/null 2>&1; then lint-imports 2>/dev/null || echo \"[import-linter] Architecture contract violation — run lint-imports for details\"; fi"
+          }
+        ]
+      },
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
             "command": "FILE=\"$CLAUDE_TOOL_INPUT_FILE_PATH\"; if [[ \"$FILE\" == */app/* || \"$FILE\" == */tests/* ]]; then pytest --tb=short -q; fi"
           }
         ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Format check
         run: ruff format --check .
 
+      - name: Architecture contracts
+        run: lint-imports
+
       - name: Security scan
         run: bandit -c pyproject.toml -r app/
 

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@ htmlcov/
 # Ruff
 .ruff_cache/
 
+# Import Linter
+.import_linter_cache/
+
 # Pre-commit
 .pre-commit-cache/
 

--- a/.importlinter
+++ b/.importlinter
@@ -1,0 +1,27 @@
+[importlinter]
+root_package = app
+
+[importlinter:contract:ui-above-core]
+name = UI layer must not be imported by core
+type = layers
+# The app architecture flows one way: app.ui -> app.core -> disk.
+# Higher layers (app.ui) may import lower layers (app.core), but not vice versa.
+# This enforces the "UI stays thin" principle: no business logic in app.ui,
+# and no presentation concerns leaking into app.core.
+# CONTRACT OWNER: cloud LLM only — do not modify without explicit approval.
+layers =
+    app.ui
+    app.core
+
+[importlinter:contract:core-no-entry-points]
+name = Core must not import entry-point modules
+type = forbidden
+# app.cli and app.main are entry points (argument parsing, QApplication init).
+# If app.core imports either, it becomes coupled to a specific invocation style.
+# Core logic must remain callable from any entry point — CLI, GUI, or test suite.
+# CONTRACT OWNER: cloud LLM only — do not modify without explicit approval.
+source_modules =
+    app.core
+forbidden_modules =
+    app.cli
+    app.main

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,7 @@ Data flows one way: UI → config model → generator → disk. Post-setup runs 
 - Generated output must be deterministic and easy to diff.
 - Avoid over-abstracting v1. Three similar lines beat a premature helper.
 - Side effects (git, pre-commit) live only in `post_setup.py`.
+- **Architecture contracts are enforced by Import Linter (`lint-imports`).** The contracts live in `.importlinter`. Do not bypass them with `# noqa` or `--noqa`. Do not modify `.importlinter` without explicit cloud LLM approval — contract changes are architecture decisions.
 
 ---
 
@@ -145,6 +146,7 @@ The informational scan runs on `github.base_ref != 'main'`; the blocking scan ru
 
 - **PostToolUse** — ruff lint + format after any Python file edit
 - **PostToolUse** — bandit security scan after any Python file edit (if bandit is installed)
+- **PostToolUse** — `lint-imports` architecture contract check after any Python file edit
 - **PostToolUse** — pytest with coverage after changes to `app/` or `tests/`
 - **Stop** — `pre-commit run --all-files` at the end of every turn
 - **PreToolUse** — blocks destructive shell commands and writes to sensitive files (`.env`, `.mcp.json`, `.claude/settings*`)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,3 +7,4 @@ pre-commit>=3.0
 semgrep>=1.0
 detect-secrets>=1.4
 deptry>=0.12
+import-linter>=2.0


### PR DESCRIPTION
- Add `.importlinter` with two contracts: `app.ui` above `app.core` (layers), and `app.core` must not import entry-point modules (forbidden)
- Wire `lint-imports` into GitHub Actions CI (`Architecture contracts` step) and `.claude/settings.json` PostToolUse hook
- Document enforcement rule in `CLAUDE.md`: contracts are cloud-LLM-owned and must not be bypassed

**Milestone:** Hybrid Execution Engine
**Epic:** Hybrid Execution Engine (WOR-75)

## Test plan
- [ ] `lint-imports` passes on current codebase (2 contracts kept, 0 broken)
- [ ] CI `Architecture contracts` step runs `lint-imports`
- [ ] PostToolUse hook fires after Python file edits
- [ ] All 126 tests pass at 97% coverage

Closes WOR-84