### PR TITLE
WOR-93 Add Repo Investigator subagent to /groom-ticket and /prioritize

### DIFF
--- a/.claude/agents/repo-investigator.md
+++ b/.claude/agents/repo-investigator.md
@@ -1,0 +1,33 @@
+---
+name: repo-investigator
+description: Read-only codebase investigation agent. Spawned by /groom-ticket and /prioritize to map file impact, dependencies, and coupling risks without bloating the main session context. Returns a compact summary only.
+model: claude-haiku-4-5-20251001
+tools:
+  - Glob
+  - Grep
+  - Read
+  - WebSearch
+---
+
+You are a read-only codebase investigator. You receive a ticket title and description and return a compact investigation summary. You never edit files.
+
+Investigate the repository and return **only** the following five-item summary — no preamble, no explanation:
+
+```
+Files most likely touched:
+  - <path> — <why>
+
+Direct dependencies (imports / callers of those files):
+  - <path> — <relationship>
+
+Hidden coupling risks (structurally adjacent but not mentioned in ticket):
+  - <path> — <risk>
+
+Test files covering the affected area:
+  - <path> — <what they cover>
+
+Estimated change surface: small | medium | large
+  Rationale: <one sentence>
+```
+
+If a section has nothing to report, write `(none)` for that item. Keep each line to one short phrase. Do not include raw file contents in your output.

--- a/.claude/commands/groom-ticket.md
+++ b/.claude/commands/groom-ticket.md
@@ -1,6 +1,9 @@
 Look up the Linear issue with identifier $ARGUMENTS in the repo-scaffold-desktop project using the Linear MCP server. Run these in parallel:
 - `get_issue($ARGUMENTS, includeRelations: true)` — see existing labels, milestone, parent epic, priority, blocking relations
 - `list_milestones(project: "repo-scaffold-desktop")` — check milestone progress before suggesting assignment
+- `list_issues(project: "repo-scaffold-desktop", state: "In Progress")` combined with issues that have no parentId — to get current active epics
+
+Then spawn the **repo-investigator** subagent, passing the ticket title and description as the prompt. Use its returned summary as context for the analysis below — do not read any source files yourself.
 
 As a Product Owner, evaluate the issue before development begins:
 
@@ -20,15 +23,7 @@ As a Product Owner, evaluate the issue before development begins:
 
    - **Type label** — one of: Feature / Fix / Refactor / Spike / Bug
    - **Stream label** — one of: Product / Infra / AI / Docs
-   - **Epic (parent issue)** — which thematic epic this belongs under. Current epics:
-     - WOR-55 Agentic Scaffolding
-     - WOR-56 Wizard CLI
-     - WOR-57 UI Testing & Test Infrastructure
-     - WOR-52 GitHub Integration
-     - WOR-51 Custom Presets
-     - WOR-53 Desktop UI
-     - WOR-26 Wireframing (Penpot / Superdesign)
-     - If none fit, propose a new epic title
+   - **Epic (parent issue)** — which thematic epic this belongs under. Use the live epic list fetched above (issues with no parent that are not Done/Cancelled). If none fit, propose a new epic title.
    - **Milestone** — which project milestone to assign. **First check `list_milestones` progress — do not assign to any milestone at 100%; it is complete and closed to new work.** Suggest the next appropriate open milestone instead. If no existing milestone fits (e.g. clear post-V1 work), flag this and suggest creating a new one with name and description.
    - **Priority** — 1=Urgent / 2=High / 3=Normal / 4=Low
    - **Blockers** — any issues that must ship first (by WOR-NNN identifier)

--- a/.claude/commands/prioritize.md
+++ b/.claude/commands/prioritize.md
@@ -5,6 +5,8 @@ Pull all open issues from the **repo-scaffold-desktop** project using the Linear
 
 Then for every issue that has or appears to have blocking relations, fetch `get_issue(id, includeRelations: true)` to get the **actual Linear blocker chain** (do not infer from titles).
 
+For each Backlog or Todo issue in the current active milestone, spawn the **repo-investigator** subagent (passing the ticket title + description) to get the file-impact summary. Use the returned `Estimated change surface` and `Hidden coupling risks` fields to inform the dependency map and recommended order below. Do not read source files yourself.
+
 Produce the following five sections:
 
 ---


### PR DESCRIPTION
- Add `.claude/agents/repo-investigator.md`: read-only Haiku subagent returning a 5-item file-impact summary (touched files, dependencies, coupling risks, test coverage, change surface estimate)
- Update `/groom-ticket` to spawn the subagent before PO analysis and replace the hardcoded epic list with a live `list_issues` fetch
- Update `/prioritize` to spawn the subagent per Backlog/Todo ticket to inform the dependency map and recommended order

**Milestone:** Hybrid Execution Engine
**Epic:** WOR-75 Hybrid Execution Engine

## Test plan
- [ ] Run `/groom-ticket WOR-NN` on a real ticket — confirm subagent summary appears before PO analysis and no raw file contents land in main context
- [ ] Run `/prioritize` — confirm subagent is spawned per ticket and change-surface fields inform the output
- [ ] Confirm subagent definition uses only read-only tools (Glob, Grep, Read, WebSearch)

Closes WOR-93