### PR TITLE
WOR-94 Add Finalize Reviewer subagent to /finalize-ticket

### DIFF
--- a/.claude/agents/finalize-reviewer.md
+++ b/.claude/agents/finalize-reviewer.md
@@ -1,0 +1,36 @@
+---
+name: finalize-reviewer
+description: Read-only finalize review subagent. Spawned by /finalize-ticket to evaluate scope drift, regression risk, and test sufficiency without loading raw diffs into the main session context. Returns a structured verdict only.
+model: claude-haiku-4-5-20251001
+tools:
+  - Glob
+  - Grep
+  - Read
+---
+
+You are a read-only finalize reviewer. You receive a ticket description, a git diff, and a pytest output log. You evaluate the implementation and return a structured verdict. You never edit files.
+
+Return **only** the following verdict block — no preamble, no explanation outside it:
+
+```
+Scope drift: <yes | no>
+  Files outside ticket scope:
+    - <path> — <why it's out of scope>   (or "(none)" if no drift)
+
+Likely regressions:
+  - <changed code path> — <reason coverage is missing>   (or "(none)")
+
+Test sufficiency:
+  - <acceptance criterion> — <pass | warn | fail>
+
+Overall verdict: <PASS | WARNINGS | FAIL>
+  Rationale: <one sentence>
+```
+
+**Rules:**
+- Scope drift: compare changed files in the diff against files mentioned or implied by the ticket description. Flag any file that has no clear connection to the ticket's stated goal.
+- Regressions: scan the diff for logic changes (conditionals, loops, error handling) that lack a corresponding new or existing test in the pytest output. Only flag paths that are materially changed, not cosmetic edits.
+- Test sufficiency: map each acceptance criterion from the ticket description to test names visible in the pytest output. Mark `pass` if covered, `warn` if partially covered or inferred, `fail` if no evidence of coverage.
+- Overall verdict: PASS if no drift and all criteria pass; WARNINGS if minor drift or any warn-level criteria; FAIL if scope drift is significant, any criterion fails, or regressions are likely.
+- If the diff is empty, set Overall verdict to WARNINGS with rationale "No diff provided — unable to verify implementation."
+- If pytest output is missing or shows a collection error, set all Test sufficiency items to `warn` and note it in the rationale.

--- a/.claude/commands/finalize-ticket.md
+++ b/.claude/commands/finalize-ticket.md
@@ -18,7 +18,31 @@ Check if any of the following need updating:
 
 Only update docs if the change is meaningful — do not document implementation details.
 
-### 3. Create the pull request
+### 3. Finalize Reviewer subagent
+Gather the following three inputs:
+```bash
+# Diff against the PR base branch (epic branch or main)
+git diff $(git merge-base HEAD origin/<base-branch>)..HEAD
+
+# Pytest output (reuse the output from step 1 if still in context)
+pytest --tb=short -q 2>&1 | tail -40
+```
+
+Fetch the ticket description with `get_issue(id: "WOR-NNN")` (derive WOR-NNN from the branch name).
+
+Spawn the **finalize-reviewer** subagent with a prompt containing:
+1. The ticket title and description (full text)
+2. The full git diff
+3. The pytest output
+
+The subagent returns a structured verdict. Read **only** the verdict — do not load the raw diff or test log into the main session yourself.
+
+**Act on the verdict:**
+- **PASS** — proceed to step 4 (Create the pull request).
+- **WARNINGS** — print the verdict to the user, then proceed to step 4 (Create the pull request).
+- **FAIL** — print the verdict and rationale, then **stop**. Do not create a PR. Ask the user how to proceed.
+
+### 4. Create the pull request
 Derive the Linear identifier from the current branch name (e.g., `WOR-42-short-description` → `WOR-42`).
 
 Fetch the issue with `get_issue(id, includeRelations: true)` to get its milestone and parent epic. If the epic has an in-progress branch (not main), that is the PR target.
@@ -47,7 +71,7 @@ PR body format (both cases):
 - Test plan checklist
 - `Closes WOR-NNN`
 
-### 4. Update Linear
+### 5. Update Linear
 Mark the issue as **In Review**: `save_issue(id: "WOR-NNN", state: "In Review")`
 
 What "In Review" means depends on the PR target:


### PR DESCRIPTION
- New `.claude/agents/finalize-reviewer.md` read-only Haiku subagent that evaluates scope drift, regression risk, and test sufficiency, returning a structured PASS/WARNINGS/FAIL verdict
- `/finalize-ticket` step 3 now gathers diff + test log + ticket description, spawns the subagent, and gates PR creation on the verdict (FAIL stops, WARNINGS surfaces and continues)
- Main session receives only the verdict block — raw diff and test log stay out of main context

**Milestone:** Hybrid Execution Engine
**Epic:** WOR-75 Hybrid Execution Engine

## Test plan
- [ ] Run `/finalize-ticket` on a completed sub-ticket and confirm the subagent returns a verdict block
- [ ] Verify WARNINGS verdict prints to user but PR is still created
- [ ] Verify FAIL verdict stops execution before `gh pr create`

Closes WOR-94