### PR TITLE
WOR-95 Add Epic Reviewer subagent to /close-epic

### DIFF
--- a/.claude/agents/epic-reviewer.md
+++ b/.claude/agents/epic-reviewer.md
@@ -1,0 +1,42 @@
+---
+name: epic-reviewer
+description: Read-only epic review subagent. Spawned by /close-epic to evaluate naming drift, test gaps, and integration risks across all sub-ticket diffs without loading raw diffs into the main session context. Returns a structured verdict only.
+model: claude-haiku-4-5-20251001
+tools:
+  - Glob
+  - Grep
+  - Read
+---
+
+You are a read-only epic reviewer. You receive a list of sub-ticket identifiers with their acceptance criteria, a git diff of the epic branch against main, and a pytest coverage report. You evaluate integration quality and return a structured verdict. You never edit files.
+
+Return **only** the following verdict block — no preamble, no explanation outside it:
+
+```
+Naming drift: <yes | no>
+  Identifiers or filenames inconsistent with CLAUDE.md conventions:
+    - <identifier or path> — <what convention it violates>   (or "(none)" if no drift)
+
+Test gaps:
+  - <sub-ticket ID>: <acceptance criterion> — <covered | partial | missing>   (or "(none)" if all covered)
+
+Integration risks:
+  - <description of risk> — <which sub-tickets interact>   (or "(none)" if no cross-ticket risks)
+
+Follow-up candidates:
+  - <description> — <why it should be a new ticket, not a blocker>   (or "(none)")
+
+Overall verdict: <READY | NEEDS_ATTENTION | BLOCKED>
+  Rationale: <one or two sentences>
+  Blockers:
+    - <specific blocker>   (only if BLOCKED; omit section otherwise)
+```
+
+**Rules:**
+- Naming drift: read CLAUDE.md (passed as a path) to learn conventions. Compare changed filenames and key identifiers in the diff against those conventions. Only flag genuine mismatches, not stylistic preferences.
+- Test gaps: for each sub-ticket's acceptance criteria, check whether the coverage report shows a corresponding test. Mark `covered` if test evidence exists, `partial` if inferred, `missing` if no evidence.
+- Integration risks: look for cases where two or more sub-tickets changed code that calls each other or shares state, but no test exercises that interaction end-to-end. Flag only real interactions, not theoretical ones.
+- Follow-up candidates: anything in the diff that looks incomplete, deferred, or out of scope for this epic — surface it as a potential new ticket rather than a blocker.
+- Overall verdict: READY if no naming drift and no missing criteria and no integration risks; NEEDS_ATTENTION if minor drift, partial coverage, or low-severity risks (user decides); BLOCKED if naming drift is significant, any acceptance criterion is missing, or a cross-ticket integration risk has no test coverage.
+- If the diff is empty, set Overall verdict to NEEDS_ATTENTION with rationale "No diff provided — unable to verify implementation."
+- If the coverage report is absent or unreadable, mark all test gap items as `partial` and note it in the rationale.

--- a/.claude/commands/close-epic.md
+++ b/.claude/commands/close-epic.md
@@ -88,7 +88,32 @@ pytest tests/integration/ -q 2>/dev/null || echo "[skip] No integration tests fo
 
 If no UI tests exist yet, note it explicitly: "No UI tests present — consider adding them before the next epic closes."
 
-### 6. Create the epic → main PR
+### 6. Epic Reviewer subagent
+Gather the following inputs:
+```bash
+# Full diff of epic branch against main
+git diff main..<epic-branch>
+
+# Coverage report (reuse from step 4 if still in context)
+pytest --cov=app --cov-report=term-missing --tb=short -q 2>&1 | tail -60
+```
+
+Fetch each child issue's title and acceptance criteria with `get_issue(id: "WOR-X")` (limit to sub-tickets identified in step 1).
+
+Spawn the **epic-reviewer** subagent with a prompt containing:
+1. List of sub-ticket identifiers, titles, and acceptance criteria (full text)
+2. Path to CLAUDE.md: `CLAUDE.md`
+3. The full git diff
+4. The pytest coverage output
+
+The subagent returns a structured verdict. Read **only** the verdict — do not load raw diffs or coverage logs into the main session yourself.
+
+**Act on the verdict:**
+- **READY** — proceed to step 7 (Create the epic → main PR).
+- **NEEDS_ATTENTION** — print the verdict to the user, then proceed to step 7 (Create the epic → main PR).
+- **BLOCKED** — print the verdict and specific blocker list, then **stop**. Do not create a PR. Ask the user how to proceed.
+
+### 7. Create the epic → main PR
 ```bash
 gh pr create --base main \
   --title "WOR-NNN <Epic title>" \
@@ -120,11 +145,11 @@ Enumerate a `Closes WOR-X` line for **every child issue** in the epic (from Step
 
 This PR requires **human review and approval** — no auto-merge.
 
-### 7. Update Linear
+### 8. Update Linear
 1. Mark the epic issue **In Review**: `save_issue(id: "$ARGUMENTS", state: "In Review")`
 2. Check milestone progress with `list_milestones(project: "repo-scaffold-desktop")`. If 100%, note: "🎉 Milestone '<name>' is now complete."
 
-### 8. Clean up worktrees
+### 9. Clean up worktrees
 List any worktrees for sub-tickets that have already been merged into the epic branch:
 ```bash
 git worktree list
@@ -138,6 +163,6 @@ git branch -d <sub-ticket-branch>
 
 Do not remove the epic branch worktree yet — wait until the epic PR merges to main.
 
-### 9. Update the project page
+### 10. Update the project page
 Call `save_project(id: "87ca9685-f2e6-493f-a022-03ef2425d2ab")` with an updated `summary` (max 255 chars):
 `WOR-NNN epic in review | <N> sub-tickets shipped | Next: <next epic or milestone>`


### PR DESCRIPTION
## Summary
- Adds `.claude/agents/epic-reviewer.md`: read-only Haiku subagent that evaluates naming drift, test gaps, integration risks, and follow-up candidates across all sub-ticket diffs
- Updates `/close-epic` with new step 6 to spawn the subagent before PR creation, gating on READY/NEEDS_ATTENTION/BLOCKED verdict
- Main session receives only the verdict — raw diffs and coverage logs stay out of main context

**Milestone:** Hybrid Execution Engine
**Epic:** WOR-75 Hybrid Execution Engine

## Test plan
- [ ] Subagent definition present at `.claude/agents/epic-reviewer.md` with tools: Glob, Grep, Read
- [ ] `/close-epic` step 6 spawns `epic-reviewer` before PR creation
- [ ] BLOCKED verdict halts PR and prints blockers
- [ ] NEEDS_ATTENTION verdict surfaces warnings and continues
- [ ] Manual: run `/close-epic WOR-75` when all sub-tickets are merged and confirm verdict quality

Closes WOR-95