### PR TITLE
WOR-83 Add mypy to local checks and CI

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -72,6 +72,15 @@
         "hooks": [
           {
             "type": "command",
+            "command": "FILE=\"$CLAUDE_TOOL_INPUT_FILE_PATH\"; if [[ \"$FILE\" == *.py ]] && command -v mypy >/dev/null 2>&1; then mypy --config-file pyproject.toml \"$FILE\" 2>/dev/null || echo \"[mypy] Type errors found — run mypy app/ for details\"; fi"
+          }
+        ]
+      },
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
             "command": "FILE=\"$CLAUDE_TOOL_INPUT_FILE_PATH\"; if [[ \"$FILE\" == */app/* || \"$FILE\" == */tests/* ]]; then pytest --tb=short -q; fi"
           }
         ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,9 @@ jobs:
         env:
           PYTHONUTF8: "1"
 
+      - name: Type check
+        run: mypy app/
+
       - name: Dependency check
         run: deptry . --requirements-files requirements.txt,requirements-dev.txt
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,8 +36,8 @@ repos:
     rev: v1.15.0
     hooks:
       - id: mypy
-        args: ["--config-file", "pyproject.toml"]
-        additional_dependencies: ["pydantic>=2.0", "types-jinja2"]
+        args: ["app/", "--config-file", "pyproject.toml"]
+        pass_filenames: false
 
   - repo: https://github.com/Yelp/detect-secrets
     rev: v1.5.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,6 +32,13 @@ repos:
         pass_filenames: false
         additional_dependencies: ["semgrep>=1.159.0"]
 
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.15.0
+    hooks:
+      - id: mypy
+        args: ["--config-file", "pyproject.toml"]
+        additional_dependencies: ["pydantic>=2.0", "types-jinja2"]
+
   - repo: https://github.com/Yelp/detect-secrets
     rev: v1.5.0
     hooks:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,9 @@ python -m app.cli config set github-username "your-username"
 ruff check .
 ruff format .
 
+# Type check (required — fix errors, do not suppress with # type: ignore)
+mypy app/
+
 # Tests
 pytest
 pytest tests/test_generator.py::test_name  # single test

--- a/app/cli.py
+++ b/app/cli.py
@@ -90,7 +90,9 @@ def _run_config(args: argparse.Namespace) -> int:
         annotation = field_info.annotation
         # Handle Path | None
         if annotation in (Path, "Path | None") or (
-            hasattr(annotation, "__args__") and Path in annotation.__args__
+            annotation is not None
+            and hasattr(annotation, "__args__")
+            and Path in annotation.__args__
         ):
             value = Path(raw) if raw else None
         else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,11 @@ select = ["E", "F", "I"]
 testpaths = ["tests"]
 addopts = "--cov=app --cov-report=term-missing --cov-fail-under=80"
 
+[tool.mypy]
+python_version = "3.12"
+disallow_untyped_defs = true
+ignore_missing_imports = true
+
 [tool.bandit]
 targets = ["app"]
 exclude_dirs = ["tests"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,3 +8,4 @@ semgrep>=1.0
 detect-secrets>=1.4
 deptry>=0.12
 import-linter>=2.0
+mypy>=1.0


### PR DESCRIPTION
- Wire mypy into all check layers: PostToolUse hook, pre-commit, CI, and CLAUDE.md docs
- Add [tool.mypy] config to pyproject.toml with disallow_untyped_defs = true and ignore_missing_imports = true
- Fix one real type error in app/cli.py (null-guard before __args__ access)

**Milestone:** Hybrid Execution Engine
**Epic:** WOR-96 — Local Worker Engine

## Test plan
- [x] mypy app/ passes with zero errors and zero # type: ignore suppressions
- [x] 126 tests passing, 97% coverage
- [x] Pre-commit mypy hook installs and passes
- [x] All existing pre-commit hooks pass

Closes WOR-83