### PR TITLE
WOR-98 Reduce finalize-reviewer friction — remove file-read tools

### DIFF
--- a/.claude/agents/epic-reviewer.md
+++ b/.claude/agents/epic-reviewer.md
@@ -1,14 +1,11 @@
 ---
 name: epic-reviewer
-description: Read-only epic review subagent. Spawned by /close-epic to evaluate naming drift, test gaps, and integration risks across all sub-ticket diffs without loading raw diffs into the main session context. Returns a structured verdict only.
+description: Read-only epic review subagent. Spawned by /close-epic to evaluate naming drift, test gaps, and integration risks across all sub-ticket diffs without loading raw diffs into the main session context. Works only from the prompt payload — no file reads. Returns a structured verdict only.
 model: claude-haiku-4-5-20251001
-tools:
-  - Glob
-  - Grep
-  - Read
+tools: []
 ---
 
-You are a read-only epic reviewer. You receive a list of sub-ticket identifiers with their acceptance criteria, a git diff of the epic branch against main, and a pytest coverage report. You evaluate integration quality and return a structured verdict. You never edit files.
+You are a read-only epic reviewer. You receive a list of sub-ticket identifiers with their acceptance criteria, the full content of CLAUDE.md, a git diff of the epic branch against main, and a pytest coverage report — all as part of this prompt. You evaluate integration quality and return a structured verdict. You never edit files and you never read files — work only from the content provided in this prompt.
 
 Return **only** the following verdict block — no preamble, no explanation outside it:
 
@@ -33,7 +30,7 @@ Overall verdict: <READY | NEEDS_ATTENTION | BLOCKED>
 ```
 
 **Rules:**
-- Naming drift: read CLAUDE.md (passed as a path) to learn conventions. Compare changed filenames and key identifiers in the diff against those conventions. Only flag genuine mismatches, not stylistic preferences.
+- Naming drift: use the CLAUDE.md content passed inline in this prompt to learn conventions. Compare changed filenames and key identifiers in the diff against those conventions. Only flag genuine mismatches, not stylistic preferences.
 - Test gaps: for each sub-ticket's acceptance criteria, check whether the coverage report shows a corresponding test. Mark `covered` if test evidence exists, `partial` if inferred, `missing` if no evidence.
 - Integration risks: look for cases where two or more sub-tickets changed code that calls each other or shares state, but no test exercises that interaction end-to-end. Flag only real interactions, not theoretical ones.
 - Follow-up candidates: anything in the diff that looks incomplete, deferred, or out of scope for this epic — surface it as a potential new ticket rather than a blocker.

--- a/.claude/agents/finalize-reviewer.md
+++ b/.claude/agents/finalize-reviewer.md
@@ -1,14 +1,11 @@
 ---
 name: finalize-reviewer
-description: Read-only finalize review subagent. Spawned by /finalize-ticket to evaluate scope drift, regression risk, and test sufficiency without loading raw diffs into the main session context. Returns a structured verdict only.
+description: Read-only finalize review subagent. Spawned by /finalize-ticket to evaluate scope drift, regression risk, and test sufficiency without loading raw diffs into the main session context. Works only from the prompt payload — no file reads. Returns a structured verdict only.
 model: claude-haiku-4-5-20251001
-tools:
-  - Glob
-  - Grep
-  - Read
+tools: []
 ---
 
-You are a read-only finalize reviewer. You receive a ticket description, a git diff, and a pytest output log. You evaluate the implementation and return a structured verdict. You never edit files.
+You are a read-only finalize reviewer. You receive a ticket description, a git diff, and a pytest output log as part of this prompt. You evaluate the implementation and return a structured verdict. You never edit files and you never read files — work only from the content provided in this prompt.
 
 Return **only** the following verdict block — no preamble, no explanation outside it:
 

--- a/.claude/commands/close-epic.md
+++ b/.claude/commands/close-epic.md
@@ -100,9 +100,11 @@ pytest --cov=app --cov-report=term-missing --tb=short -q 2>&1 | tail -60
 
 Fetch each child issue's title and acceptance criteria with `get_issue(id: "WOR-X")` (limit to sub-tickets identified in step 1).
 
+Read the full content of `CLAUDE.md` now so it can be included inline in the subagent prompt.
+
 Spawn the **epic-reviewer** subagent with a prompt containing:
 1. List of sub-ticket identifiers, titles, and acceptance criteria (full text)
-2. Path to CLAUDE.md: `CLAUDE.md`
+2. Full content of CLAUDE.md (pasted inline — do not pass a file path)
 3. The full git diff
 4. The pytest coverage output
 


### PR DESCRIPTION
## Summary
- Removed `Glob`, `Grep`, `Read` tools from `finalize-reviewer` and `epic-reviewer` agent definitions so they cannot trigger file-read permission prompts
- Updated agent prompt instructions to explicitly state: work only from prompt payload, never read files
- Updated `/close-epic` step 6 to read and inline `CLAUDE.md` content before spawning `epic-reviewer`, preserving naming-drift checks without file I/O

## Test plan
- [ ] Run `/finalize-ticket` on a branch — confirm finalize-reviewer returns a verdict with no Read permission prompts
- [ ] Run `/close-epic` on an epic — confirm epic-reviewer returns a verdict with no Read permission prompts

Closes WOR-98