### PR TITLE
WOR-97 Enable mypy strict mode across the codebase

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,6 +38,7 @@ repos:
       - id: mypy
         args: ["app/", "--config-file", "pyproject.toml"]
         pass_filenames: false
+        additional_dependencies: ["pydantic>=2.0"]
 
   - repo: https://github.com/Yelp/detect-secrets
     rev: v1.5.0

--- a/app/core/manifest.py
+++ b/app/core/manifest.py
@@ -9,7 +9,7 @@ re-interpret the project, or make architectural decisions on its own.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Annotated, Literal
+from typing import Annotated, Any, Literal
 
 from pydantic import BaseModel, Field, field_validator, model_validator
 
@@ -260,6 +260,6 @@ class ExecutionManifest(BaseModel):
         return cls.model_validate_json(raw)
 
     @classmethod
-    def json_schema(cls) -> dict:
+    def json_schema(cls) -> dict[str, Any]:
         """Return the JSON Schema dict for this model."""
         return cls.model_json_schema()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ addopts = "--cov=app --cov-report=term-missing --cov-fail-under=80"
 
 [tool.mypy]
 python_version = "3.12"
-disallow_untyped_defs = true
+strict = true
 ignore_missing_imports = true
 
 [tool.bandit]


### PR DESCRIPTION
- Set `strict = true` in `[tool.mypy]` replacing the conservative `disallow_untyped_defs` baseline
- Fixed the one strict violation: annotated `ExecutionManifest.json_schema()` return type as `dict[str, Any]`
- Added `pydantic>=2.0` to the pre-commit mypy hook's `additional_dependencies` so `BaseModel` resolves in the hook's isolated environment

**Test plan**
- [x] `mypy app/` passes with zero errors under strict mode
- [x] `mypy --strict app/` confirmed clean before enabling config flag
- [x] No `# type: ignore` suppressions anywhere in the codebase
- [x] Pre-commit mypy hook passes with pydantic installed
- [x] 126 tests pass, 97% coverage

Closes WOR-97