### PR TITLE
Fix deprecated SonarCloud GitHub Action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,14 +50,14 @@ jobs:
       - name: SonarCloud scan (informational)
         if: github.base_ref != 'main'
         continue-on-error: true
-        uses: SonarSource/sonarcloud-github-action@master
+        uses: SonarSource/sonarqube-scan-action@v5.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
       - name: SonarCloud scan
         if: github.base_ref == 'main'
-        uses: SonarSource/sonarcloud-github-action@master
+        uses: SonarSource/sonarqube-scan-action@v5.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
## Summary
- Replace deprecated `SonarSource/sonarcloud-github-action@master` with `SonarSource/sonarqube-scan-action@v5.0.0` in both the informational and blocking scan steps

## Test plan
- [ ] CI passes on this PR
- [ ] No SonarCloud deprecation warning in the workflow run

🤖 Generated with [Claude Code](https://claude.com/claude-code)