### PR TITLE
Fix deprecated GitHub Actions (Node.js 24)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 


### PR DESCRIPTION
## Summary
- Upgrade `actions/checkout@v4` → `@v6`
- Upgrade `actions/setup-python@v5` → `@v6`

Both v6 versions run on Node.js 24. The `actions/cache` warning is covered by the setup-python upgrade (it uses cache internally).

## Test plan
- [ ] CI passes on this PR with no Node.js 20 deprecation warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)