### PR TITLE
WOR-85 Formalize local→cloud escalation policy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,7 @@ Module responsibilities:
 - `post_setup.py` — side effects: `git init`, `pre-commit install`, etc.
 - `user_prefs.py` — `UserPreferences` model + `PrefsStore` (platform-aware JSON persistence)
 - `manifest.py` — `ExecutionManifest` Pydantic model: cloud→local worker contract for hybrid execution
+- `escalation_policy.py` — `EscalationPolicy` Pydantic model: loads `config/escalation_policy.toml`, classifies result-artifact flags and Sonar findings into watcher actions
 - `main.py` — PySide6 `QApplication` entry point
 
 Data flows one way: UI → config model → generator → disk. Post-setup runs after generation.
@@ -201,6 +202,23 @@ Only interact with the **repo-scaffold-desktop** project in Linear unless explic
 ## Testing
 
 Test core logic only. Priority: config validation, preset selection, file generation, option toggles, overwrite behavior. Skip UI tests unless the UI contains meaningful logic.
+
+---
+
+## Escalation policy
+
+The watcher reads `config/escalation_policy.toml` at startup to decide when to stop a local worker session and escalate to cloud LLM. Rules are data-driven — no hardcoded logic in the watcher.
+
+**Location:** `config/escalation_policy.toml`
+**Model:** `app/core/escalation_policy.py` — `EscalationPolicy.from_toml()`
+
+Key sections:
+- `[retry]` — `max_consecutive_failures`: how many consecutive check failures before escalating
+- `[auto_escalate]` — flags in the result artifact that trigger automatic cloud escalation (e.g. `scope_drift`, `forbidden_path_touched`)
+- `[human_escalate]` — conditions requiring a human/cloud decision (watcher posts a Linear comment and pauses)
+- `[sonar]` — maps SonarLint/SonarCloud severity → action: `blocker`/`critical` → `escalate`; `major`/`minor`/`info` → `fix_locally`
+
+To change escalation rules, edit `config/escalation_policy.toml` and commit — no code changes required.
 
 ---
 

--- a/app/core/escalation_policy.py
+++ b/app/core/escalation_policy.py
@@ -1,0 +1,135 @@
+"""Escalation policy for the local worker engine.
+
+Loads config/escalation_policy.toml and exposes typed classification methods
+so the watcher can decide — without hardcoded logic — when to escalate a local
+worker session to cloud LLM.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+from typing import Literal
+
+from pydantic import BaseModel, field_validator
+
+Action = Literal["escalate", "fix_locally", "human"]
+
+_VALID_SONAR_SEVERITIES = frozenset({"blocker", "critical", "major", "minor", "info"})
+_VALID_ACTIONS: frozenset[str] = frozenset({"escalate", "fix_locally", "human"})
+
+DEFAULT_POLICY_PATH = (
+    Path(__file__).parent.parent.parent / "config" / "escalation_policy.toml"
+)
+
+
+class RetryConfig(BaseModel):
+    model_config = {"extra": "forbid"}
+
+    max_consecutive_failures: int
+
+    @field_validator("max_consecutive_failures")
+    @classmethod
+    def positive(cls, v: int) -> int:
+        if v < 1:
+            raise ValueError("max_consecutive_failures must be >= 1")
+        return v
+
+
+class AutoEscalateConfig(BaseModel):
+    model_config = {"extra": "forbid"}
+
+    scope_drift: Action
+    forbidden_path_touched: Action
+    import_linter_violation: Action
+    security_blocker: Action
+
+
+class HumanEscalateConfig(BaseModel):
+    model_config = {"extra": "forbid"}
+
+    architecture_change: Action
+    schema_migration: Action
+    cross_module_refactor: Action
+    auth_payments_touched: Action
+
+
+class SonarConfig(BaseModel):
+    model_config = {"extra": "forbid"}
+
+    blocker: Action
+    critical: Action
+    major: Action
+    minor: Action
+    info: Action
+
+
+class EscalationPolicy(BaseModel):
+    """Typed representation of escalation_policy.toml."""
+
+    model_config = {"extra": "forbid"}
+
+    retry: RetryConfig
+    auto_escalate: AutoEscalateConfig
+    human_escalate: HumanEscalateConfig
+    sonar: SonarConfig
+
+    # ------------------------------------------------------------------
+    # Classification helpers
+    # ------------------------------------------------------------------
+
+    def classify_result(
+        self,
+        *,
+        scope_drift: bool = False,
+        forbidden_path_touched: bool = False,
+        import_linter_violation: bool = False,
+        security_blocker: bool = False,
+    ) -> Action:
+        """Return the action for a worker result artifact.
+
+        Checks flags in priority order: the first truthy flag wins.
+        Returns "fix_locally" when no flags are set.
+        """
+        if scope_drift:
+            return self.auto_escalate.scope_drift
+        if forbidden_path_touched:
+            return self.auto_escalate.forbidden_path_touched
+        if import_linter_violation:
+            return self.auto_escalate.import_linter_violation
+        if security_blocker:
+            return self.auto_escalate.security_blocker
+        return "fix_locally"
+
+    def classify_sonar_finding(self, severity: str) -> Action:
+        """Return the action for a SonarLint/SonarCloud finding severity.
+
+        Raises ValueError for unrecognised severity strings so that unknown
+        findings fail loudly rather than being silently ignored.
+        """
+        severity = severity.lower()
+        if severity not in _VALID_SONAR_SEVERITIES:
+            raise ValueError(
+                f"Unknown Sonar severity {severity!r}. "
+                f"Valid values: {sorted(_VALID_SONAR_SEVERITIES)}"
+            )
+        return getattr(self.sonar, severity)
+
+    # ------------------------------------------------------------------
+    # Factory
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def from_toml(cls, path: Path | str | None = None) -> "EscalationPolicy":
+        """Load and validate escalation policy from a TOML file.
+
+        Uses DEFAULT_POLICY_PATH when path is None.
+        Raises FileNotFoundError if the file is missing.
+        Raises pydantic.ValidationError if the config is structurally invalid.
+        """
+        resolved = Path(path) if path is not None else DEFAULT_POLICY_PATH
+        if ".." in resolved.parts:
+            raise ValueError(f"Policy path must not contain '..': {path!r}")
+        raw = resolved.read_bytes()
+        data = tomllib.loads(raw.decode())
+        return cls.model_validate(data)

--- a/config/escalation_policy.toml
+++ b/config/escalation_policy.toml
@@ -1,0 +1,33 @@
+# Escalation policy for the local worker engine.
+# The watcher loads this at startup to decide when to escalate a local session
+# to cloud LLM vs. retrying locally. Edit rules here — no code changes needed.
+
+[retry]
+# Stop retrying and escalate after this many consecutive check failures with no progress.
+max_consecutive_failures = 3
+
+[auto_escalate]
+# Result artifact flags that immediately trigger cloud escalation.
+# Each value maps to a boolean field in the worker result JSON.
+scope_drift = "escalate"
+forbidden_path_touched = "escalate"
+import_linter_violation = "escalate"
+security_blocker = "escalate"
+
+[human_escalate]
+# Conditions that require a human or cloud decision (watcher pauses and posts a
+# Linear comment). These are detected from the result artifact or check output.
+architecture_change = "human"
+schema_migration = "human"
+cross_module_refactor = "human"
+auth_payments_touched = "human"
+
+[sonar]
+# Maps SonarLint/SonarCloud finding severity → action taken by the watcher.
+# fix_locally — local worker retries with the finding in context
+# escalate    — watcher stops local session and re-queues for cloud
+blocker = "escalate"
+critical = "escalate"
+major = "fix_locally"
+minor = "fix_locally"
+info = "fix_locally"

--- a/tests/test_escalation_policy.py
+++ b/tests/test_escalation_policy.py
@@ -1,0 +1,177 @@
+"""Tests for app.core.escalation_policy."""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from app.core.escalation_policy import EscalationPolicy
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def write_policy(tmp_path: Path, content: str) -> Path:
+    p = tmp_path / "escalation_policy.toml"
+    p.write_text(textwrap.dedent(content), encoding="utf-8")
+    return p
+
+
+MINIMAL_VALID_TOML = """
+    [retry]
+    max_consecutive_failures = 3
+
+    [auto_escalate]
+    scope_drift = "escalate"
+    forbidden_path_touched = "escalate"
+    import_linter_violation = "escalate"
+    security_blocker = "escalate"
+
+    [human_escalate]
+    architecture_change = "human"
+    schema_migration = "human"
+    cross_module_refactor = "human"
+    auth_payments_touched = "human"
+
+    [sonar]
+    blocker = "escalate"
+    critical = "escalate"
+    major = "fix_locally"
+    minor = "fix_locally"
+    info = "fix_locally"
+"""
+
+
+# ---------------------------------------------------------------------------
+# Loading
+# ---------------------------------------------------------------------------
+
+
+def test_policy_loads_from_toml(tmp_path: Path) -> None:
+    path = write_policy(tmp_path, MINIMAL_VALID_TOML)
+    policy = EscalationPolicy.from_toml(path)
+    assert policy.retry.max_consecutive_failures == 3
+    assert policy.sonar.blocker == "escalate"
+
+
+def test_default_policy_path_loads() -> None:
+    policy = EscalationPolicy.from_toml()
+    assert policy.retry.max_consecutive_failures >= 1
+
+
+def test_missing_file_raises(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        EscalationPolicy.from_toml(tmp_path / "nonexistent.toml")
+
+
+def test_missing_section_raises(tmp_path: Path) -> None:
+    toml = "[retry]\nmax_consecutive_failures = 3\n"
+    path = write_policy(tmp_path, toml)
+    with pytest.raises(ValidationError):
+        EscalationPolicy.from_toml(path)
+
+
+def test_extra_keys_raise(tmp_path: Path) -> None:
+    toml = MINIMAL_VALID_TOML + "\n[unexpected_section]\nfoo = 1\n"
+    path = write_policy(tmp_path, toml)
+    with pytest.raises(ValidationError):
+        EscalationPolicy.from_toml(path)
+
+
+def test_path_traversal_raises(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="must not contain"):
+        EscalationPolicy.from_toml(tmp_path / ".." / "escalation_policy.toml")
+
+
+# ---------------------------------------------------------------------------
+# classify_result — auto escalation triggers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def policy(tmp_path: Path) -> EscalationPolicy:
+    path = write_policy(tmp_path, MINIMAL_VALID_TOML)
+    return EscalationPolicy.from_toml(path)
+
+
+def test_scope_drift_triggers_escalation(policy: EscalationPolicy) -> None:
+    assert policy.classify_result(scope_drift=True) == "escalate"
+
+
+def test_forbidden_path_triggers_escalation(policy: EscalationPolicy) -> None:
+    assert policy.classify_result(forbidden_path_touched=True) == "escalate"
+
+
+def test_import_linter_violation_triggers_escalation(policy: EscalationPolicy) -> None:
+    assert policy.classify_result(import_linter_violation=True) == "escalate"
+
+
+def test_security_blocker_triggers_escalation(policy: EscalationPolicy) -> None:
+    assert policy.classify_result(security_blocker=True) == "escalate"
+
+
+def test_no_flags_returns_fix_locally(policy: EscalationPolicy) -> None:
+    assert policy.classify_result() == "fix_locally"
+
+
+def test_scope_drift_wins_over_other_flags(policy: EscalationPolicy) -> None:
+    # Priority order: scope_drift is checked first.
+    result = policy.classify_result(scope_drift=True, forbidden_path_touched=True)
+    assert result == "escalate"
+
+
+# ---------------------------------------------------------------------------
+# classify_sonar_finding
+# ---------------------------------------------------------------------------
+
+
+def test_sonar_blocker_escalates(policy: EscalationPolicy) -> None:
+    assert policy.classify_sonar_finding("blocker") == "escalate"
+
+
+def test_sonar_critical_escalates(policy: EscalationPolicy) -> None:
+    assert policy.classify_sonar_finding("critical") == "escalate"
+
+
+def test_sonar_major_fixes_locally(policy: EscalationPolicy) -> None:
+    assert policy.classify_sonar_finding("major") == "fix_locally"
+
+
+def test_sonar_minor_fixes_locally(policy: EscalationPolicy) -> None:
+    assert policy.classify_sonar_finding("minor") == "fix_locally"
+
+
+def test_sonar_info_fixes_locally(policy: EscalationPolicy) -> None:
+    assert policy.classify_sonar_finding("info") == "fix_locally"
+
+
+def test_sonar_severity_case_insensitive(policy: EscalationPolicy) -> None:
+    assert policy.classify_sonar_finding("BLOCKER") == "escalate"
+    assert policy.classify_sonar_finding("Minor") == "fix_locally"
+
+
+def test_sonar_unknown_severity_raises(policy: EscalationPolicy) -> None:
+    with pytest.raises(ValueError, match="Unknown Sonar severity"):
+        policy.classify_sonar_finding("unknown_severity")
+
+
+# ---------------------------------------------------------------------------
+# Retry config
+# ---------------------------------------------------------------------------
+
+
+def test_retry_limit_from_policy(policy: EscalationPolicy) -> None:
+    assert policy.retry.max_consecutive_failures == 3
+
+
+def test_retry_zero_raises(tmp_path: Path) -> None:
+    toml = MINIMAL_VALID_TOML.replace(
+        "max_consecutive_failures = 3", "max_consecutive_failures = 0"
+    )
+    path = write_policy(tmp_path, toml)
+    with pytest.raises(ValidationError):
+        EscalationPolicy.from_toml(path)


### PR DESCRIPTION
- Adds `config/escalation_policy.toml` — machine-readable rules for retry limits, auto-escalation triggers, human-escalation conditions, and Sonar severity → action mapping
- Adds `app/core/escalation_policy.py` — `EscalationPolicy` Pydantic model with `classify_result()` and `classify_sonar_finding()` typed classification methods; loaded via `from_toml()` at watcher startup
- 21 tests at 100% coverage; all classification paths, validation, path-traversal guard, and edge cases verified

**Milestone:** Hybrid Execution Engine
**Epic:** Local Worker Engine (WOR-96)

## Test plan
- [x] `pytest tests/test_escalation_policy.py` — 21/21 pass
- [x] `scope_drift=True` → `"escalate"` (AC 6)
- [x] Sonar `blocker` → `"escalate"`, `minor` → `"fix_locally"` (AC 7)
- [x] Missing TOML section raises `ValidationError`
- [x] Extra unknown TOML sections raise `ValidationError`
- [x] Unknown Sonar severity raises `ValueError`
- [x] mypy clean, ruff clean, bandit clean

Closes WOR-85