### PR TITLE
WOR-99 Add classify_human_trigger() method to EscalationPolicy

### DIFF
--- a/app/core/escalation_policy.py
+++ b/app/core/escalation_policy.py
@@ -16,6 +16,14 @@ from pydantic import BaseModel, field_validator
 Action = Literal["escalate", "fix_locally", "human"]
 
 _VALID_SONAR_SEVERITIES = frozenset({"blocker", "critical", "major", "minor", "info"})
+_VALID_HUMAN_TRIGGERS = frozenset(
+    {
+        "architecture_change",
+        "schema_migration",
+        "cross_module_refactor",
+        "auth_payments_touched",
+    }
+)
 _VALID_ACTIONS: frozenset[str] = frozenset({"escalate", "fix_locally", "human"})
 
 DEFAULT_POLICY_PATH = (
@@ -100,6 +108,20 @@ class EscalationPolicy(BaseModel):
         if security_blocker:
             return self.auto_escalate.security_blocker
         return "fix_locally"
+
+    def classify_human_trigger(self, trigger: str) -> Action:
+        """Return the action for a human-escalation trigger name.
+
+        Raises ValueError for unrecognised trigger names so that unknown
+        triggers fail loudly rather than being silently ignored.
+        """
+        trigger = trigger.lower()
+        if trigger not in _VALID_HUMAN_TRIGGERS:
+            raise ValueError(
+                f"Unknown human trigger {trigger!r}. "
+                f"Valid values: {sorted(_VALID_HUMAN_TRIGGERS)}"
+            )
+        return getattr(self.human_escalate, trigger)
 
     def classify_sonar_finding(self, severity: str) -> Action:
         """Return the action for a SonarLint/SonarCloud finding severity.

--- a/tests/test_escalation_policy.py
+++ b/tests/test_escalation_policy.py
@@ -160,6 +160,42 @@ def test_sonar_unknown_severity_raises(policy: EscalationPolicy) -> None:
 
 
 # ---------------------------------------------------------------------------
+# classify_human_trigger
+# ---------------------------------------------------------------------------
+
+
+def test_human_trigger_architecture_change(policy: EscalationPolicy) -> None:
+    assert policy.classify_human_trigger("architecture_change") == "human"
+
+
+def test_human_trigger_schema_migration(policy: EscalationPolicy) -> None:
+    assert policy.classify_human_trigger("schema_migration") == "human"
+
+
+def test_human_trigger_cross_module_refactor(policy: EscalationPolicy) -> None:
+    assert policy.classify_human_trigger("cross_module_refactor") == "human"
+
+
+def test_human_trigger_auth_payments_touched(policy: EscalationPolicy) -> None:
+    assert policy.classify_human_trigger("auth_payments_touched") == "human"
+
+
+def test_human_trigger_case_insensitive(policy: EscalationPolicy) -> None:
+    assert policy.classify_human_trigger("ARCHITECTURE_CHANGE") == "human"
+    assert policy.classify_human_trigger("Schema_Migration") == "human"
+
+
+def test_human_trigger_unknown_raises(policy: EscalationPolicy) -> None:
+    with pytest.raises(ValueError, match="Unknown human trigger"):
+        policy.classify_human_trigger("unknown_trigger")
+
+
+def test_human_trigger_auto_escalate_key_rejected(policy: EscalationPolicy) -> None:
+    with pytest.raises(ValueError, match="Unknown human trigger"):
+        policy.classify_human_trigger("scope_drift")
+
+
+# ---------------------------------------------------------------------------
 # Retry config
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
- Add `classify_human_trigger(trigger: str) -> Action` method to `EscalationPolicy`, mirroring the pattern of `classify_sonar_finding`
- Add `_VALID_HUMAN_TRIGGERS` frozenset for input validation; unknown trigger names raise `ValueError` loudly
- Add 7 tests covering all 4 trigger keys, case insensitivity, unknown trigger, and auto-escalate key rejection

**Milestone:** Hybrid Execution Engine
**Epic:** WOR-96 Local Worker Engine

## Test plan
- [x] All 4 `human_escalate` keys return correct action
- [x] Case-insensitive normalization matches `classify_sonar_finding` behaviour
- [x] Unknown trigger raises `ValueError` with helpful message
- [x] `auto_escalate` key correctly rejected (cross-section contamination guard)
- [x] 154 tests pass, 97.6% total coverage, `escalation_policy.py` at 100%

Closes WOR-99