### PR TITLE
WOR-80 Split /start-ticket into preflight + /implement-ticket skill

### DIFF
--- a/.claude/commands/implement-ticket.md
+++ b/.claude/commands/implement-ticket.md
@@ -1,0 +1,111 @@
+Local worker entrypoint. Reads the execution manifest for $ARGUMENTS and implements the ticket within the declared scope. Does NOT re-read Linear, re-interpret the project, or make architectural decisions — the manifest is the sole source of truth.
+
+### 0. Load the manifest
+
+Read the manifest from `.claude/artifacts/<ticket_id_lower>/manifest.json`
+(e.g. for WOR-80: `.claude/artifacts/wor_80/manifest.json`).
+
+If the file does not exist:
+```
+ABORT: Manifest not found at .claude/artifacts/<ticket_id_lower>/manifest.json
+Run /start-ticket $ARGUMENTS first to generate it.
+```
+
+If `manifest_version` is not `"1.0"`:
+```
+ABORT: Unsupported manifest_version '<version>'. This worker supports 1.0 only.
+```
+
+Confirm the following fields are present before continuing:
+- `ticket_id`, `worker_branch`, `base_branch`, `objective`, `artifact_paths`
+
+### 1. Verify branch
+
+Confirm the current git branch matches `worker_branch` from the manifest:
+```bash
+git branch --show-current
+```
+
+If not on the correct branch:
+```
+ABORT: Expected branch '<worker_branch>' but current branch is '<actual>'.
+Check out the correct branch before running /implement-ticket.
+```
+
+### 2. Set ticket state to InProgressLocal
+
+`save_issue(id: "<ticket_id>", state: "<ticket_state_map.in_progress_local>")`
+
+### 3. Implement
+
+Implement the work described in `objective` and `acceptance_criteria`. Obey these hard rules at all times:
+
+**Allowed paths** — only write to paths matching `allowed_paths` globs. If the list is empty, any path under the repo root is allowed (excluding forbidden paths below).
+
+**Forbidden paths** — never write to paths matching `forbidden_paths` globs. If a task seems to require touching a forbidden path, ABORT and write a failed result artifact (see step 5).
+
+**Constraints** — follow every item in `implementation_constraints` exactly.
+
+**No re-planning** — do not re-read Linear, re-query the project, or change scope. If something in the codebase is surprising, implement defensively within the manifest scope and note it in the result artifact summary.
+
+### 4. Run required checks
+
+After implementation, run each command in `required_checks` in order:
+
+```bash
+<check command 1>
+<check command 2>
+...
+```
+
+If any required check fails:
+- Record the failure in the result artifact (step 5)
+- If `failure_policy.on_check_failure` is `"abort"`: stop here, write a failed result
+- If `failure_policy.on_check_failure` is `"warn"`: log the failure and continue
+
+Run each command in `optional_checks` for information only — failures do not block.
+
+### 5. Write the result artifact
+
+Write a JSON result file to `artifact_paths.result_json`. Create parent dirs as needed.
+
+**On success:**
+```json
+{
+  "ticket_id": "<ticket_id>",
+  "status": "success",
+  "summary": "<one-paragraph description of what was implemented>",
+  "checks_passed": ["<check1>", "<check2>"],
+  "checks_failed": [],
+  "notes": "<any surprising findings or edge cases encountered>"
+}
+```
+
+**On failure:**
+```json
+{
+  "ticket_id": "<ticket_id>",
+  "status": "failed",
+  "summary": "<what was attempted>",
+  "checks_passed": ["<any that passed>"],
+  "checks_failed": ["<failed check command>"],
+  "failure_reason": "<specific error or reason>",
+  "notes": "<context for the watcher or cloud escalation>"
+}
+```
+
+Also copy the manifest to `artifact_paths.manifest_copy` for audit purposes.
+
+### 6. Update Linear
+
+**On success:**
+- `save_issue(id: "<ticket_id>", state: "<ticket_state_map.merged_to_epic>")` — only after the PR is created (run `/finalize-ticket` to create the PR first)
+- Actually: at this point just leave the ticket in `InProgressLocal` — `/finalize-ticket` will create the PR and advance the state
+
+**On failure:**
+- If `failure_policy.escalate_to_cloud` is `true`: `save_issue(id: "<ticket_id>", state: "In Progress")` and post a Linear comment: `"Local worker failed after <N> checks. Escalating to cloud. See result artifact: <artifact_paths.result_json>"`
+- Otherwise: `save_issue(id: "<ticket_id>", state: "Blocked")` and post a comment with the failure reason
+
+### 7. On success — proceed to finalize
+
+Run `/finalize-ticket` to create the PR targeting the epic branch and advance the ticket state to `MergedToEpic` (after CI passes).

--- a/.claude/commands/start-ticket.md
+++ b/.claude/commands/start-ticket.md
@@ -88,9 +88,6 @@ git push -u origin <branch-name>
 ```
 No worktree needed for solo work.
 
-Then immediately set the issue status to **In Progress** in Linear:
-`save_issue(id: "$ARGUMENTS", state: "In Progress")`
-
 **If the parent epic was previously Backlog** (i.e., this is the first sub-ticket being started in this epic), also promote all other Backlog children to **Todo**:
 ```
 list_issues(project: "repo-scaffold-desktop", parentId: <epicId>, state: "Backlog")
@@ -119,6 +116,65 @@ To work in parallel: open a new Claude Code session in this repo and run
 ```
 
 **STOP HERE. Do not write any code until the human approves this plan.**
+
+---
+
+### 4.5. After human approves the plan — generate the execution manifest
+
+Once the human says to proceed, generate and write an `ExecutionManifest` JSON to disk. This is the handoff artifact the local worker reads — it must not require re-reading Linear or re-planning.
+
+Construct the manifest from the planning context gathered in steps 1–4:
+
+```json
+{
+  "manifest_version": "1.0",
+  "ticket_id": "<TICKET_ID>",
+  "epic_id": "<EPIC_ID or null>",
+  "title": "<ticket title from Linear>",
+  "priority": <0-4 from Linear>,
+  "status": "ReadyForLocal",
+  "parallel_safe": <true if no file conflicts with In-Progress siblings>,
+  "risk_level": "<low|medium|high — from security surface assessment>",
+  "risk_flags": ["<any specific risk notes>"],
+  "implementation_mode": "local",
+  "review_mode": "auto",
+  "base_branch": "<epic-branch or main>",
+  "worker_branch": "<sub-ticket-branch>",
+  "worktree_name": null,
+  "objective": "<one-paragraph restatement from step 1>",
+  "acceptance_criteria": ["<each AC bullet from step 1>"],
+  "implementation_constraints": ["<hard rules from step 2, e.g. do not modify app/ui/>"],
+  "allowed_paths": ["<glob patterns for files to change, from step 2>"],
+  "forbidden_paths": ["app/ui/**", ".env", ".mcp.json", ".claude/settings*"],
+  "related_files_hint": ["<files listed as relevant in step 2>"],
+  "required_checks": ["ruff check .", "mypy app/", "pytest"],
+  "optional_checks": [],
+  "done_definition": "<plain-English done criteria>",
+  "failure_policy": {
+    "on_check_failure": "abort",
+    "max_retries": 0,
+    "escalate_to_cloud": false
+  },
+  "ticket_state_map": {
+    "in_progress_local": "InProgressLocal",
+    "merged_to_epic": "MergedToEpic",
+    "ready_for_review": "EpicReadyForCloudReview",
+    "failed": "Blocked"
+  },
+  "artifact_paths": {
+    "result_json": ".claude/artifacts/<ticket_id_lower>/result.json",
+    "manifest_copy": ".claude/artifacts/<ticket_id_lower>/manifest.json"
+  }
+}
+```
+
+Write this JSON to `.claude/artifacts/<ticket_id_lower>/manifest.json` (e.g. `.claude/artifacts/wor_80/manifest.json`). Create parent dirs as needed.
+
+Then:
+1. Set the ticket to **ReadyForLocal** in Linear: `save_issue(id: "$ARGUMENTS", state: "ReadyForLocal")`
+2. Post a Linear comment with the manifest path: `save_comment(issueId: "$ARGUMENTS", body: "Execution manifest written to .claude/artifacts/<ticket_id_lower>/manifest.json — watcher may now pick up.")`
+
+The cloud preflight is now complete. The local worker will pick this up via `/implement-ticket $ARGUMENTS`.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,7 +110,9 @@ Each ticket follows these phases. Use the corresponding slash command to enter e
 [watcher picks up ticket] # watcher polls for ReadyForLocal, creates worktree, launches local worker
                           # Linear: ReadyForLocal → InProgressLocal
 
-[Claude implements]       # hooks fire automatically: ruff, mypy, bandit, pytest, lint-imports
+/implement-ticket WOR-123 # local worker entrypoint: reads manifest, implements within allowed_paths,
+                          # runs required_checks, writes result artifact
+                          # hooks fire automatically: ruff, mypy, bandit, pytest, lint-imports
 
 /security-check           # bandit scan + OWASP diff review → PASS / WARNINGS / FAIL
 


### PR DESCRIPTION
- Adds `/implement-ticket` skill: local worker entrypoint that reads `ExecutionManifest` from disk, implements within `allowed_paths`/`forbidden_paths`, runs `required_checks`, and writes a result artifact — no re-reading Linear or re-planning
- Updates `/start-ticket` step 4.5: after plan approval, generates `ExecutionManifest` JSON to `.claude/artifacts/<ticket>/manifest.json` and sets ticket to `ReadyForLocal` instead of `In Progress`
- Updates `CLAUDE.md` development workflow to reference `/implement-ticket` as the local worker entrypoint

**Milestone:** Hybrid Execution Engine
**Epic:** WOR-96 Local Worker Engine

## Test plan
- [x] No Python source changes — all changes are skill (markdown) and CLAUDE.md documentation files
- [x] 154 tests pass, 97.61% coverage (existing suite unaffected)
- [x] `implement-ticket.md` present in `.claude/commands/`
- [x] `start-ticket.md` includes manifest generation step 4.5 and `ReadyForLocal` state transition

Closes WOR-80