### PR TITLE
WOR-101 Spike: hooks and skills coupling in scaffolded repos

### DIFF
--- a/docs/spikes/wor-101-hooks-skills-coupling.md
+++ b/docs/spikes/wor-101-hooks-skills-coupling.md
@@ -1,0 +1,45 @@
+# WOR-101 Spike: Hooks and Skills Coupling in Scaffolded Repos
+
+**Question:** Do the Claude Code hooks (`.claude/settings.json`) and skills (`.claude/commands/`) in this repo need to be replicated into repos scaffolded by the `full_agentic` preset?
+
+## Findings
+
+### Hooks
+
+The source repo's `.claude/settings.json` defines:
+- 5 × PostToolUse hooks: ruff lint+format, bandit, lint-imports, mypy, pytest with coverage
+- 2 × PreToolUse guards: blocks destructive shell commands and writes to sensitive files
+- 1 × Stop hook: `pre-commit run --all-files`
+
+The `full_agentic` preset template (`templates/full_agentic/.claude/settings.json.j2`) generates only an empty stub:
+
+```json
+{"permissions": {"allow": [], "deny": []}}
+```
+
+No hooks are included. A scaffolded `full_agentic` repo gets no quality-gate automation.
+
+Additionally, `bandit`, `mypy`, and `lint-imports` are not in the scaffolded `requirements-dev.txt` template, so even if hooks were copied, they would fail for those tools.
+
+### Skills (slash commands)
+
+Six `.claude/commands/*.md` files exist in this repo: `groom-ticket`, `start-ticket`, `implement-ticket`, `security-check`, `finalize-ticket`, `close-epic`. No template equivalents exist — scaffolded repos receive no slash commands.
+
+**WOR-82 covers this gap** via a `repo-scaffold-skills` standalone repo model: scaffolded repos will reference the skills repo rather than copying command files. This avoids frozen copies that drift. WOR-82 is Todo but scoped correctly.
+
+## Gap Summary
+
+| Item | Source repo | Scaffolded `full_agentic` |
+|------|-------------|--------------------------|
+| PostToolUse hooks (ruff, bandit, mypy, lint-imports, pytest) | ✅ | ❌ Empty stub |
+| PreToolUse guards | ✅ | ❌ |
+| Stop hook (pre-commit) | ✅ | ❌ |
+| Tool deps (bandit, mypy, lint-imports) | ✅ | ❌ |
+| Slash commands (6 skills) | ✅ | ❌ — covered by WOR-82 |
+
+## Recommendation
+
+- **Skills**: No action needed beyond WOR-82 (reference-repo model is the right approach).
+- **Hooks**: New sub-ticket needed. The `settings.json.j2` template must be populated with the quality-gate hooks, and the scaffolded `requirements-dev.txt` must include `bandit`, `mypy`, and `lint-imports`. Hooks are project tooling (not methodology), so direct inclusion in the template is appropriate — unlike skills, they don't drift in the same way.
+
+Follow-up: **WOR-102** — Populate `full_agentic` `settings.json.j2` with quality-gate hooks.

--- a/docs/spikes/wor-101-hooks-skills-coupling.md
+++ b/docs/spikes/wor-101-hooks-skills-coupling.md
@@ -19,11 +19,11 @@ The `full_agentic` preset template (`templates/full_agentic/.claude/settings.jso
 
 No hooks are included. A scaffolded `full_agentic` repo gets no quality-gate automation.
 
-Additionally, `bandit`, `mypy`, and `lint-imports` are not in the scaffolded `requirements-dev.txt` template, so even if hooks were copied, they would fail for those tools.
+Additionally, `bandit`, `mypy`, and `lint-imports` are absent from the scaffolded `pyproject.toml.j2` dev dependencies (`[project.optional-dependencies] dev` only includes `pytest`, `pytest-cov`, `ruff`), so even if hooks were copied, they would fail for those tools.
 
 ### Skills (slash commands)
 
-Six `.claude/commands/*.md` files exist in this repo: `groom-ticket`, `start-ticket`, `implement-ticket`, `security-check`, `finalize-ticket`, `close-epic`. No template equivalents exist — scaffolded repos receive no slash commands.
+Seven `.claude/commands/*.md` files exist in this repo: `groom-ticket`, `start-ticket`, `implement-ticket`, `security-check`, `finalize-ticket`, `close-epic`, `prioritize`. No template equivalents exist — scaffolded repos receive no slash commands.
 
 **WOR-82 covers this gap** via a `repo-scaffold-skills` standalone repo model: scaffolded repos will reference the skills repo rather than copying command files. This avoids frozen copies that drift. WOR-82 is Todo but scoped correctly.
 
@@ -42,4 +42,4 @@ Six `.claude/commands/*.md` files exist in this repo: `groom-ticket`, `start-tic
 - **Skills**: No action needed beyond WOR-82 (reference-repo model is the right approach).
 - **Hooks**: New sub-ticket needed. The `settings.json.j2` template must be populated with the quality-gate hooks, and the scaffolded `requirements-dev.txt` must include `bandit`, `mypy`, and `lint-imports`. Hooks are project tooling (not methodology), so direct inclusion in the template is appropriate — unlike skills, they don't drift in the same way.
 
-Follow-up: **WOR-102** — Populate `full_agentic` `settings.json.j2` with quality-gate hooks.
+Follow-up: **WOR-103** — Populate `full_agentic` `settings.json.j2` with quality-gate hooks.


### PR DESCRIPTION
- Investigated whether Claude Code hooks (`.claude/settings.json`) and skills (`.claude/commands/`) need replication into `full_agentic` scaffolded repos
- Confirmed gap: hooks template is an empty stub; `bandit`/`mypy`/`lint-imports` missing from scaffolded `pyproject.toml.j2` dev deps; 7 slash commands entirely absent
- Skills gap covered by WOR-82 (reference-repo model); hooks gap tracked in new WOR-103

**Milestone:** Hybrid Execution Engine
**Epic:** WOR-96 Local Worker Engine

## Test plan
- [x] No code changed — spike deliverable is `docs/spikes/wor-101-hooks-skills-coupling.md`
- [x] All 170 existing tests pass (97% coverage)
- [x] Doc reviewed for accuracy: command count, tool names, correct ticket references

Closes WOR-101