### PR TITLE
WOR-103 Populate full_agentic settings.json.j2 with quality-gate hooks

### DIFF
--- a/templates/full_agentic/.claude/settings.json.j2
+++ b/templates/full_agentic/.claude/settings.json.j2
@@ -1,6 +1,90 @@
 {
-  "permissions": {
-    "allow": [],
-    "deny": []
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "CMD=\"$CLAUDE_TOOL_INPUT_COMMAND\"; if echo \"$CMD\" | grep -qE '(rm\\s+-[^\\s]*r|git\\s+push\\s+--force|git\\s+reset\\s+--hard|git\\s+checkout\\s+--|git\\s+clean\\s+-f)'; then echo \"Blocked: dangerous command detected: $CMD\" >&2; exit 1; fi"
+          }
+        ]
+      },
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "FILE=\"$CLAUDE_TOOL_INPUT_FILE_PATH\"; if echo \"$FILE\" | grep -qE '(\\.env|\\.mcp\\.json|\\.claude/settings)'; then echo \"Blocked: writes to sensitive file not allowed: $FILE\" >&2; exit 1; fi"
+          }
+        ]
+      },
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python -c \"import json,sys,re; d=json.load(sys.stdin); f=d.get('tool_input',{}).get('file_path',''); t=d.get('tool_name',''); skip = not re.search(r'\\.(md|toml|yaml|yml|json)$',f) or 'tests/' in f or f.endswith('.py'); c=(d.get('tool_input',{}).get('content','') if t=='Write' else d.get('tool_input',{}).get('new_string','')); sys.exit(1) if not skip and re.search(r'[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}',c) and print(f'Blocked: email detected in {f}',file=sys.stderr) is None else sys.exit(0)\""
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "pre-commit run --all-files"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "FILE=\"$CLAUDE_TOOL_INPUT_FILE_PATH\"; if [[ \"$FILE\" == *.py ]]; then ruff check --fix \"$FILE\" && ruff format \"$FILE\"; fi"
+          }
+        ]
+      },
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "FILE=\"$CLAUDE_TOOL_INPUT_FILE_PATH\"; if [[ \"$FILE\" == *.py ]] && command -v bandit >/dev/null 2>&1; then bandit -q \"$FILE\" 2>/dev/null || echo \"[bandit] Issues found — run /security-check\"; fi"
+          }
+        ]
+      },
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "FILE=\"$CLAUDE_TOOL_INPUT_FILE_PATH\"; if [[ \"$FILE\" == *.py ]] && command -v lint-imports >/dev/null 2>&1; then lint-imports 2>/dev/null || echo \"[import-linter] Architecture contract violation — run lint-imports for details\"; fi"
+          }
+        ]
+      },
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "FILE=\"$CLAUDE_TOOL_INPUT_FILE_PATH\"; if [[ \"$FILE\" == *.py ]] && command -v mypy >/dev/null 2>&1; then mypy --config-file pyproject.toml \"$FILE\" 2>/dev/null || echo \"[mypy] Type errors found — run mypy app/ for details\"; fi"
+          }
+        ]
+      },
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "FILE=\"$CLAUDE_TOOL_INPUT_FILE_PATH\"; if [[ \"$FILE\" == */app/* || \"$FILE\" == */tests/* ]]; then pytest --tb=short -q; fi"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/templates/full_agentic/pyproject.toml.j2
+++ b/templates/full_agentic/pyproject.toml.j2
@@ -8,7 +8,7 @@ authors = [{name = "{{ author_name }}", email = "{{ author_email }}"}]
 dependencies = []
 
 [project.optional-dependencies]
-dev = ["pytest", "pytest-cov", "ruff"]
+dev = ["pytest", "pytest-cov", "ruff", "bandit", "mypy", "lint-imports"]
 
 [tool.ruff]
 line-length = 88

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -135,6 +135,24 @@ def test_full_agentic_required_files_written(output_dir):
     assert (output_dir / ".claude" / "settings.json").exists()
 
 
+def test_full_agentic_settings_json_contains_hooks(output_dir):
+    config = RepoConfig(repo_name="my-agentic-project", preset="full_agentic")
+    generate(config, output_dir)
+    content = (output_dir / ".claude" / "settings.json").read_text()
+    for marker in ("PostToolUse", "PreToolUse", "Stop", "ruff", "bandit"):
+        assert marker in content, (
+            f"settings.json missing expected hook marker: {marker}"
+        )
+
+
+def test_full_agentic_pyproject_contains_quality_tools(output_dir):
+    config = RepoConfig(repo_name="my-agentic-project", preset="full_agentic")
+    generate(config, output_dir)
+    content = (output_dir / "pyproject.toml").read_text()
+    for tool in ("bandit", "mypy", "lint-imports"):
+        assert tool in content, f"pyproject.toml dev deps missing: {tool}"
+
+
 def test_full_agentic_ci_toggle(output_dir):
     config = RepoConfig(
         repo_name="my-agentic-project", preset="full_agentic", include_ci=True

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -139,7 +139,15 @@ def test_full_agentic_settings_json_contains_hooks(output_dir):
     config = RepoConfig(repo_name="my-agentic-project", preset="full_agentic")
     generate(config, output_dir)
     content = (output_dir / ".claude" / "settings.json").read_text()
-    for marker in ("PostToolUse", "PreToolUse", "Stop", "ruff", "bandit"):
+    for marker in (
+        "PostToolUse",
+        "PreToolUse",
+        "Stop",
+        "ruff",
+        "bandit",
+        "mypy",
+        "lint-imports",
+    ):
         assert marker in content, (
             f"settings.json missing expected hook marker: {marker}"
         )


### PR DESCRIPTION
- Replace empty permissions stub in `templates/full_agentic/.claude/settings.json.j2` with full PostToolUse/PreToolUse/Stop hooks matching this repo's `.claude/settings.json`
- Add `bandit`, `mypy`, `lint-imports` to `pyproject.toml.j2` dev dependencies so the hooks can run in scaffolded repos
- Two new tests assert hook content (not just file presence) and quality tool presence in generated output

**Milestone:** Hybrid Execution Engine
**Epic:** WOR-96 — Local Worker Engine

## Test plan
- [x] `test_full_agentic_settings_json_contains_hooks` — generated `.claude/settings.json` contains PostToolUse, PreToolUse, Stop, ruff, bandit, mypy, lint-imports markers
- [x] `test_full_agentic_pyproject_contains_quality_tools` — generated `pyproject.toml` dev deps include bandit, mypy, lint-imports
- [x] All 172 existing tests pass, 97% coverage

Closes WOR-103