### PR TITLE
WOR-100 Add Datasette-based browser UI for metrics DB

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,9 @@ python -m app.cli config get
 python -m app.cli config set author-name "Your Name"
 python -m app.cli config set github-username "your-username"
 
+# CLI — metrics
+python -m app.cli metrics browse   # open metrics DB in Datasette browser UI
+
 # Lint and format
 ruff check .
 ruff format .

--- a/app/cli.py
+++ b/app/cli.py
@@ -1,4 +1,5 @@
 import argparse
+import subprocess  # nosec B404
 import sys
 from pathlib import Path
 
@@ -6,6 +7,7 @@ from pydantic import ValidationError
 
 from app.core.config import RepoConfig
 from app.core.generator import generate
+from app.core.metrics import MetricsStore
 from app.core.post_setup import run_git_init, run_precommit_install
 from app.core.presets import _PRESETS
 from app.core.user_prefs import PrefsStore, UserPreferences
@@ -71,7 +73,35 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Run pre-commit install in the output directory.",
     )
 
+    metrics = sub.add_parser("metrics", help="Metrics DB commands.")
+    metrics_sub = metrics.add_subparsers(dest="metrics_cmd")
+    metrics_sub.add_parser("browse", help="Open metrics DB in Datasette browser UI.")
+
     return parser
+
+
+def _run_metrics(args: argparse.Namespace) -> int:
+    if args.metrics_cmd == "browse":
+        db_path = MetricsStore.get_db_path()
+        if not db_path.exists():
+            print(
+                f"Error: metrics DB not found at {db_path}. "
+                "Run the watcher at least once to create it.",
+                file=sys.stderr,
+            )
+            return 1
+        try:
+            subprocess.run(["datasette", str(db_path)], check=False)  # nosec B603 B607
+        except FileNotFoundError:
+            print(
+                "Error: datasette not installed. Run: pip install datasette",
+                file=sys.stderr,
+            )
+            return 1
+        return 0
+
+    print("Usage: scaffold metrics {browse}", file=sys.stderr)
+    return 1
 
 
 def _run_config(args: argparse.Namespace) -> int:
@@ -124,6 +154,9 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.command == "config":
         return _run_config(args)
+
+    if args.command == "metrics":
+        return _run_metrics(args)
 
     try:
         config = RepoConfig(

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,3 +9,4 @@ detect-secrets>=1.4
 deptry>=0.12
 import-linter>=2.0
 mypy>=1.0
+datasette>=0.64

--- a/tests/test_cli_metrics.py
+++ b/tests/test_cli_metrics.py
@@ -1,0 +1,59 @@
+"""Tests for `python -m app.cli metrics browse`."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.cli import main
+
+
+def test_metrics_browse_launches_datasette(tmp_path: Path) -> None:
+    db = tmp_path / "metrics.db"
+    db.touch()
+
+    with (
+        patch("app.cli.MetricsStore.get_db_path", return_value=db),
+        patch("app.cli.subprocess.run") as mock_run,
+    ):
+        mock_run.return_value = MagicMock(returncode=0)
+        rc = main(["metrics", "browse"])
+
+    assert rc == 0
+    mock_run.assert_called_once_with(["datasette", str(db)], check=False)
+
+
+def test_metrics_browse_missing_db_exits(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    db = tmp_path / "metrics.db"  # does not exist
+
+    with patch("app.cli.MetricsStore.get_db_path", return_value=db):
+        rc = main(["metrics", "browse"])
+
+    assert rc == 1
+    assert "not found" in capsys.readouterr().err
+
+
+def test_metrics_browse_datasette_not_installed(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    db = tmp_path / "metrics.db"
+    db.touch()
+
+    with (
+        patch("app.cli.MetricsStore.get_db_path", return_value=db),
+        patch("app.cli.subprocess.run", side_effect=FileNotFoundError),
+    ):
+        rc = main(["metrics", "browse"])
+
+    assert rc == 1
+    assert "datasette not installed" in capsys.readouterr().err
+
+
+def test_metrics_no_subcommand_prints_usage(capsys: pytest.CaptureFixture[str]) -> None:
+    rc = main(["metrics"])
+    assert rc == 1
+    assert "Usage" in capsys.readouterr().err


### PR DESCRIPTION
- Add `python -m app.cli metrics browse` subcommand that resolves the platform-aware DB path via `MetricsStore.get_db_path()` and launches Datasette via subprocess
- Graceful errors for missing DB file and missing datasette binary; no module-level import so the app works without datasette installed
- Add `datasette>=0.64` to `requirements-dev.txt` (dev dep only); document command in CLAUDE.md

**Milestone:** Hybrid Execution Engine
**Epic:** WOR-96 Local Worker Engine

## Test plan
- [x] `test_metrics_browse_launches_datasette` — subprocess called with correct path
- [x] `test_metrics_browse_missing_db_exits` — returns 1 with clear error when DB absent
- [x] `test_metrics_browse_datasette_not_installed` — returns 1 with install hint on FileNotFoundError
- [x] `test_metrics_no_subcommand_prints_usage` — returns 1 when no subcommand given
- [x] Full suite: 176 passed, 97.4% coverage

Closes WOR-100