### PR TITLE
WOR-82 Propagate hybrid workflow to full_agentic scaffold preset

### DIFF
--- a/.claude/commands/contribute-skill.md
+++ b/.claude/commands/contribute-skill.md
@@ -1,0 +1,53 @@
+Open a pull request against the upstream skills repo with your local changes to a named skill file.
+
+Usage: `/contribute-skill <skill-name>`
+
+Example: `/contribute-skill groom-ticket`
+
+## Steps
+
+1. Read `.claude/settings.json` and extract `skills_source` and `skills_version`.
+
+2. Parse `skills_source` to get `<owner>/<repo>`.
+
+3. Resolve the local skill file path: `.claude/commands/<skill-name>.md`. Confirm it exists.
+
+4. Fetch the upstream base version of the file at `skills_version`:
+   ```bash
+   curl -s "https://raw.githubusercontent.com/<owner>/<repo>/<skills_version>/.claude/commands/<skill-name>.md" -o /tmp/upstream-<skill-name>.md
+   ```
+
+5. Show a diff between upstream and local:
+   ```bash
+   diff /tmp/upstream-<skill-name>.md .claude/commands/<skill-name>.md
+   ```
+   If no diff, print: `No changes to contribute for <skill-name>.` and stop.
+
+6. Clone the skills repo to a temp directory, create a branch, apply the diff, and push:
+   ```bash
+   git clone "https://github.com/<owner>/<repo>.git" /tmp/contribute-skill-work
+   cd /tmp/contribute-skill-work
+   git checkout -b "contribute/<skill-name>-from-$(basename $(git rev-parse --show-toplevel))"
+   cp /path/to/project/.claude/commands/<skill-name>.md .claude/commands/<skill-name>.md
+   git add .claude/commands/<skill-name>.md
+   git commit -m "Contribute updated <skill-name> skill"
+   git push -u origin HEAD
+   ```
+
+7. Open a pull request using `gh`:
+   ```bash
+   gh pr create \
+     --repo "<owner>/<repo>" \
+     --title "Contribute <skill-name> from <project-name>" \
+     --body "Local modifications to \`<skill-name>.md\` contributed from \`<project-name>\` at \`<skills_version>\`." \
+     --head "contribute/<skill-name>-from-<project-name>"
+   ```
+
+8. Print the PR URL. Clean up `/tmp/contribute-skill-work` and `/tmp/upstream-<skill-name>.md`.
+
+## Notes
+
+- Requires `gh` CLI authenticated to GitHub.
+- The PR targets `main` on `<owner>/<repo>`. The upstream maintainer reviews and merges.
+- After your PR is merged and a new release tag is published, run `/update-skills` to pull it back.
+- Contributes only the single named skill — not bulk changes to all skills.

--- a/.claude/commands/update-skills.md
+++ b/.claude/commands/update-skills.md
@@ -1,0 +1,50 @@
+Fetch the latest `.claude/commands/` files from the upstream skills repo and update `skills_version` in `.claude/settings.json`.
+
+## Steps
+
+1. Read `.claude/settings.json` and extract `skills_source` and `skills_version`.
+
+2. Parse `skills_source` (format: `github:<owner>/<repo>`) to get the owner and repo name.
+
+3. Call the GitHub API to find the latest release tag:
+   ```bash
+   curl -s "https://api.github.com/repos/<owner>/<repo>/releases/latest" | python3 -c "import sys,json; print(json.load(sys.stdin)['tag_name'])"
+   ```
+
+4. If already at the latest tag, print: `Skills are up to date (<version>).` and stop.
+
+5. Otherwise, fetch the full tree for the latest tag:
+   ```bash
+   curl -s "https://api.github.com/repos/<owner>/<repo>/git/trees/<latest-tag>?recursive=1"
+   ```
+   Filter entries where `path` starts with `.claude/commands/` and `type == "blob"`.
+
+6. For each file, download and overwrite the local copy:
+   ```bash
+   curl -s "https://raw.githubusercontent.com/<owner>/<repo>/<latest-tag>/<path>" -o "<path>"
+   ```
+
+7. Bump `skills_version` in `.claude/settings.json` to the latest tag using Python:
+   ```bash
+   python3 -c "
+   import json, pathlib
+   p = pathlib.Path('.claude/settings.json')
+   d = json.loads(p.read_text())
+   d['skills_version'] = '<latest-tag>'
+   p.write_text(json.dumps(d, indent=2) + '\n')
+   "
+   ```
+
+8. Print a summary:
+   ```
+   Updated skills from <old-version> → <latest-tag>
+   ✓ .claude/commands/update-skills.md
+   ✓ .claude/commands/contribute-skill.md
+   ... (each file updated)
+   ```
+
+## Notes
+
+- Only update files under `.claude/commands/` — never touch `settings.json` hooks or permissions.
+- Locally modified skill files are overwritten. If you have local customizations you want to keep, use `/contribute-skill` first to open an upstream PR.
+- If the GitHub API is unreachable, print a warning and exit without modifying any files.

--- a/app/cli.py
+++ b/app/cli.py
@@ -9,7 +9,7 @@ from pydantic import ValidationError
 from app.core.config import RepoConfig
 from app.core.generator import generate
 from app.core.metrics import MetricsStore
-from app.core.post_setup import run_git_init, run_precommit_install
+from app.core.post_setup import fetch_skills, run_git_init, run_precommit_install
 from app.core.presets import _PRESETS
 from app.core.user_prefs import PrefsStore, UserPreferences
 
@@ -222,6 +222,15 @@ def main(argv: list[str] | None = None) -> int:
 
     for path in written:
         print(f"✓ {path}")
+
+    if config.preset == "full_agentic":
+        skills_written = fetch_skills(
+            args.output,
+            skills_source="github:virppa/repo-scaffold-skills",
+            skills_version="v1.0.0",
+        )
+        for path in skills_written:
+            print(f"✓ {path}")
 
     try:
         if config.git_init:

--- a/app/core/post_setup.py
+++ b/app/core/post_setup.py
@@ -1,5 +1,75 @@
+import json
+import re
 import subprocess  # nosec B404 — controlled calls with hardcoded command lists, no shell=True
+import urllib.error
+import urllib.request
 from pathlib import Path
+
+_GITHUB_SOURCE_RE = re.compile(r"^github:([A-Za-z0-9_.-]+)/([A-Za-z0-9_.-]+)$")
+_SAFE_PATH_RE = re.compile(r"^[A-Za-z0-9_.\-/]+$")
+
+
+def fetch_skills(
+    output_path: Path, skills_source: str, skills_version: str
+) -> list[str]:
+    """Fetch .claude/commands/ from a versioned skills repo and write to output_path.
+
+    Returns the list of relative paths written. On network or API errors, logs a
+    warning and returns an empty list — fetch failure is intentionally non-fatal.
+
+    Raises ValueError immediately for malformed skills_source to catch config bugs.
+    """
+    match = _GITHUB_SOURCE_RE.match(skills_source)
+    if not match:
+        raise ValueError(
+            f"Invalid skills_source {skills_source!r}. "
+            "Expected format: github:<owner>/<repo>"
+        )
+    owner, repo = match.group(1), match.group(2)
+
+    api_url = (
+        f"https://api.github.com/repos/{owner}/{repo}"
+        f"/git/trees/{skills_version}?recursive=1"
+    )
+    try:
+        req = urllib.request.Request(  # nosec B310 — URL constructed from validated owner/repo/version
+            api_url, headers={"Accept": "application/vnd.github+json"}
+        )
+        with urllib.request.urlopen(req, timeout=10) as resp:  # nosec B310  # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected
+            tree = json.loads(resp.read())
+    except (urllib.error.URLError, OSError) as exc:
+        print(
+            f"[skills] Warning: could not fetch {skills_source}@{skills_version}: {exc}"
+        )
+        return []
+
+    commands_prefix = ".claude/commands/"
+    written: list[str] = []
+
+    for entry in tree.get("tree", []):
+        path: str = entry.get("path", "")
+        if not path.startswith(commands_prefix) or entry.get("type") != "blob":
+            continue
+        # Guard against path traversal in API-returned paths
+        if ".." in path or not _SAFE_PATH_RE.match(path):
+            print(f"[skills] Skipping unsafe path: {path}")
+            continue
+        raw_url = (
+            f"https://raw.githubusercontent.com/{owner}/{repo}/{skills_version}/{path}"
+        )
+        try:
+            with urllib.request.urlopen(raw_url, timeout=10) as resp:  # nosec B310  # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected
+                content = resp.read()
+        except (urllib.error.URLError, OSError) as exc:
+            print(f"[skills] Warning: could not download {path}: {exc}")
+            continue
+
+        dest = output_path / path
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_bytes(content)
+        written.append(path)
+
+    return written
 
 
 def run_git_init(output_path: Path) -> None:

--- a/templates/full_agentic/.claude/settings.json.j2
+++ b/templates/full_agentic/.claude/settings.json.j2
@@ -1,4 +1,6 @@
 {
+  "skills_source": "github:virppa/repo-scaffold-skills",
+  "skills_version": "v1.0.0",
   "hooks": {
     "PreToolUse": [
       {

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -61,6 +61,39 @@ def test_all_toggles_enabled(output_dir):
     assert (output_dir / ".mcp.json").exists()
 
 
+def test_invalid_repo_name_exits(output_dir, capsys):
+    rc = main(
+        [
+            "generate",
+            "--preset",
+            "python_basic",
+            "--repo-name",
+            "",
+            "--output",
+            str(output_dir),
+        ]
+    )
+    assert rc == 1
+    assert "Error" in capsys.readouterr().err
+
+
+def test_generate_error_exits(output_dir, capsys):
+    with patch("app.cli.generate", side_effect=ValueError("unknown preset")):
+        rc = main(
+            [
+                "generate",
+                "--preset",
+                "python_basic",
+                "--repo-name",
+                "myrepo",
+                "--output",
+                str(output_dir),
+            ]
+        )
+    assert rc == 1
+    assert "unknown preset" in capsys.readouterr().err
+
+
 def test_missing_repo_name_exits(output_dir, capsys):
     with pytest.raises(SystemExit) as exc_info:
         main(
@@ -187,6 +220,29 @@ def test_config_set_output_dir(tmp_path, capsys):
 def test_config_no_subcommand_exits(capsys):
     rc = main(["config"])
     assert rc == 1
+
+
+def test_full_agentic_preset_calls_fetch_skills(output_dir):
+    with patch(
+        "app.cli.fetch_skills", return_value=[".claude/commands/groom-ticket.md"]
+    ) as mock_fetch:
+        rc = main(
+            [
+                "generate",
+                "--preset",
+                "full_agentic",
+                "--repo-name",
+                "myrepo",
+                "--output",
+                str(output_dir),
+            ]
+        )
+    assert rc == 0
+    mock_fetch.assert_called_once_with(
+        output_dir,
+        skills_source="github:virppa/repo-scaffold-skills",
+        skills_version="v1.0.0",
+    )
 
 
 def test_post_setup_error_exits_nonzero(output_dir, capsys):

--- a/tests/test_post_setup.py
+++ b/tests/test_post_setup.py
@@ -1,14 +1,101 @@
+import json
 import subprocess
-from unittest.mock import patch
+import urllib.error
+from unittest.mock import MagicMock, patch
 
 import pytest
 
-from app.core.post_setup import run_git_init, run_precommit_install
+from app.core.post_setup import fetch_skills, run_git_init, run_precommit_install
 
 
 @pytest.fixture()
 def repo_dir(tmp_path):
     return tmp_path / "repo"
+
+
+def _make_urlopen_mock(
+    tree_entries: list[dict], file_content: bytes = b"# skill"
+) -> MagicMock:
+    """Return a mock for urllib.request.urlopen that serves a tree then file blobs."""
+    call_count = 0
+
+    def fake_urlopen(req_or_url, timeout=None):  # noqa: ARG001
+        nonlocal call_count
+        cm = MagicMock()
+        if call_count == 0:
+            cm.__enter__ = lambda s: s
+            cm.__exit__ = MagicMock(return_value=False)
+            payload = json.dumps({"tree": tree_entries}).encode()
+            cm.read = MagicMock(return_value=payload)
+        else:
+            cm.__enter__ = lambda s: s
+            cm.__exit__ = MagicMock(return_value=False)
+            cm.read = MagicMock(return_value=file_content)
+        call_count += 1
+        return cm
+
+    return fake_urlopen
+
+
+class TestFetchSkills:
+    def test_writes_commands_to_output_path(self, tmp_path):
+        entries = [
+            {"path": ".claude/commands/groom-ticket.md", "type": "blob"},
+            {"path": ".claude/commands/start-ticket.md", "type": "blob"},
+            {"path": "README.md", "type": "blob"},  # should be ignored
+        ]
+        with patch(
+            "app.core.post_setup.urllib.request.urlopen",
+            side_effect=_make_urlopen_mock(entries, b"# skill content"),
+        ):
+            written = fetch_skills(
+                tmp_path, "github:virppa/repo-scaffold-skills", "v1.0.0"
+            )
+
+        assert written == [
+            ".claude/commands/groom-ticket.md",
+            ".claude/commands/start-ticket.md",
+        ]
+        assert (tmp_path / ".claude/commands/groom-ticket.md").read_bytes() == (
+            b"# skill content"
+        )
+        assert (tmp_path / ".claude/commands/start-ticket.md").read_bytes() == (
+            b"# skill content"
+        )
+        assert not (tmp_path / "README.md").exists()
+
+    def test_network_error_is_non_fatal(self, tmp_path, capsys):
+        with patch(
+            "app.core.post_setup.urllib.request.urlopen",
+            side_effect=urllib.error.URLError("connection refused"),
+        ):
+            written = fetch_skills(
+                tmp_path, "github:virppa/repo-scaffold-skills", "v1.0.0"
+            )
+
+        assert written == []
+        captured = capsys.readouterr()
+        assert "Warning" in captured.out
+
+    def test_invalid_source_format_raises_value_error(self, tmp_path):
+        with pytest.raises(ValueError, match="Invalid skills_source"):
+            fetch_skills(tmp_path, "notgithub:owner/repo", "v1.0.0")
+
+    def test_skips_path_traversal_entries(self, tmp_path, capsys):
+        entries = [
+            {"path": ".claude/commands/../../../etc/passwd", "type": "blob"},
+        ]
+        with patch(
+            "app.core.post_setup.urllib.request.urlopen",
+            side_effect=_make_urlopen_mock(entries),
+        ):
+            written = fetch_skills(
+                tmp_path, "github:virppa/repo-scaffold-skills", "v1.0.0"
+            )
+
+        assert written == []
+        captured = capsys.readouterr()
+        assert "unsafe" in captured.out
 
 
 class TestRunGitInit:

--- a/tests/test_post_setup.py
+++ b/tests/test_post_setup.py
@@ -81,6 +81,36 @@ class TestFetchSkills:
         with pytest.raises(ValueError, match="Invalid skills_source"):
             fetch_skills(tmp_path, "notgithub:owner/repo", "v1.0.0")
 
+    def test_skips_file_on_individual_download_error(self, tmp_path, capsys):
+        entries = [
+            {"path": ".claude/commands/groom-ticket.md", "type": "blob"},
+        ]
+        call_count = 0
+
+        def fake_urlopen(req_or_url, timeout=None):  # noqa: ARG001
+            nonlocal call_count
+            cm = MagicMock()
+            cm.__enter__ = lambda s: s
+            cm.__exit__ = MagicMock(return_value=False)
+            if call_count == 0:
+                payload = json.dumps({"tree": entries}).encode()
+                cm.read = MagicMock(return_value=payload)
+            else:
+                raise urllib.error.URLError("timeout")
+            call_count += 1
+            return cm
+
+        with patch(
+            "app.core.post_setup.urllib.request.urlopen", side_effect=fake_urlopen
+        ):
+            written = fetch_skills(
+                tmp_path, "github:virppa/repo-scaffold-skills", "v1.0.0"
+            )
+
+        assert written == []
+        captured = capsys.readouterr()
+        assert "Warning" in captured.out
+
     def test_skips_path_traversal_entries(self, tmp_path, capsys):
         entries = [
             {"path": ".claude/commands/../../../etc/passwd", "type": "blob"},


### PR DESCRIPTION
- Add `skills_source` and `skills_version` to `full_agentic` settings.json template — scaffolded repos reference `virppa/repo-scaffold-skills@v1.0.0` instead of embedding frozen skill copies
- Add `fetch_skills()` to `post_setup.py`: validates `github:<owner>/<repo>` format, fetches `.claude/commands/` tree via GitHub API, sanitizes paths against traversal, non-fatal on network errors
- Add `/update-skills` and `/contribute-skill` command files — initial content for `repo-scaffold-skills` v1.0.0, available in scaffolded repos after fetch

**Milestone:** Hybrid Execution Engine
**Epic:** WOR-96 Local Worker Engine

## Test plan
- [x] `fetch_skills()` writes command files to output path, filtering non-commands blobs
- [x] Network error at tree-fetch level is non-fatal (warns, returns `[]`)
- [x] Individual file download error skips that file (non-fatal)
- [x] Invalid `skills_source` format raises `ValueError` immediately
- [x] Path traversal entries in API response are skipped
- [x] CLI calls `fetch_skills()` for `full_agentic` preset with correct args
- [x] 213 tests pass, 80.33% coverage

Closes WOR-82