### PR TITLE
WOR-107 Read skills_source/skills_version from preset config rather than hardcoding in CLI

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -4,13 +4,14 @@ import subprocess  # nosec B404
 import sys
 from pathlib import Path
 
+from dotenv import load_dotenv
 from pydantic import ValidationError
 
 from app.core.config import RepoConfig
 from app.core.generator import generate
 from app.core.metrics import MetricsStore
 from app.core.post_setup import fetch_skills, run_git_init, run_precommit_install
-from app.core.presets import _PRESETS
+from app.core.presets import _PRESETS, get_preset
 from app.core.user_prefs import PrefsStore, UserPreferences
 
 _PREFS_KEYS = set(UserPreferences.model_fields)
@@ -174,6 +175,7 @@ def _run_config(args: argparse.Namespace) -> int:
 
 
 def main(argv: list[str] | None = None) -> int:
+    load_dotenv()
     # Ensure the terminal can emit UTF-8 (e.g. ✓); no-op on StringIO (pytest capsys).
     if hasattr(sys.stdout, "reconfigure"):
         try:
@@ -223,11 +225,12 @@ def main(argv: list[str] | None = None) -> int:
     for path in written:
         print(f"✓ {path}")
 
-    if config.preset == "full_agentic":
+    preset = get_preset(config.preset)
+    if preset.skills_source is not None and preset.skills_version is not None:
         skills_written = fetch_skills(
             args.output,
-            skills_source="github:virppa/repo-scaffold-skills",
-            skills_version="v1.0.0",
+            skills_source=preset.skills_source,
+            skills_version=preset.skills_version,
         )
         for path in skills_written:
             print(f"✓ {path}")

--- a/app/core/presets.py
+++ b/app/core/presets.py
@@ -8,6 +8,8 @@ class Preset:
     required_files: tuple[str, ...]
     # Keys must match RepoConfig boolean toggle field names
     optional_files: dict[str, tuple[str, ...]] = field(default_factory=dict)
+    skills_source: str | None = None
+    skills_version: str | None = None
 
 
 _PRESETS: dict[str, Preset] = {
@@ -69,6 +71,8 @@ _PRESETS: dict[str, Preset] = {
             "Python project with Claude Code agentic workflow"
             " (Linear MCP, hooks, slash commands)."
         ),
+        skills_source="github:virppa/repo-scaffold-skills",
+        skills_version="v1.0.0",
         required_files=(
             "pyproject.toml",
             "README.md",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -238,10 +238,13 @@ def test_full_agentic_preset_calls_fetch_skills(output_dir):
             ]
         )
     assert rc == 0
+    from app.core.presets import get_preset
+
+    preset = get_preset("full_agentic")
     mock_fetch.assert_called_once_with(
         output_dir,
-        skills_source="github:virppa/repo-scaffold-skills",
-        skills_version="v1.0.0",
+        skills_source=preset.skills_source,
+        skills_version=preset.skills_version,
     )
 
 

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -76,3 +76,16 @@ def test_preset_is_immutable():
     preset = get_preset("python_basic")
     with pytest.raises((AttributeError, TypeError)):
         preset.name = "modified"
+
+
+def test_full_agentic_has_skills_config():
+    preset = get_preset("full_agentic")
+    assert preset.skills_source == "github:virppa/repo-scaffold-skills"
+    assert preset.skills_version == "v1.0.0"
+
+
+def test_non_agentic_presets_have_no_skills_config():
+    for name in ("python_basic", "python_desktop"):
+        preset = get_preset(name)
+        assert preset.skills_source is None
+        assert preset.skills_version is None


### PR DESCRIPTION
- Move `skills_source` and `skills_version` from hardcoded CLI literals into the `Preset` dataclass, defined once in `_PRESETS["full_agentic"]`
- `app/cli.py` now reads from `preset.skills_source` / `preset.skills_version` and gates on `not None` instead of comparing `config.preset == "full_agentic"`
- Also wires up `python-dotenv` `load_dotenv()` at CLI startup so `LINEAR_API_KEY` and other env vars load from `.env` automatically

**Milestone:** Hybrid Execution Engine
**Epic:** WOR-96 Local Worker Engine

## Test plan
- [ ] `test_full_agentic_has_skills_config` — asserts both fields are set on the full_agentic preset
- [ ] `test_non_agentic_presets_have_no_skills_config` — asserts both are `None` for python_basic/python_desktop
- [ ] `test_full_agentic_preset_calls_fetch_skills` — verifies fetch_skills is called with values from the preset object
- [ ] All 215 tests pass, coverage 80.44%

Closes WOR-107