### PR TITLE
Add .claude/artifacts/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,5 +48,8 @@ litellm-local.yaml
 # Claude Code local settings
 .claude/settings.local.json
 
+# Claude Code local worker artifacts (ephemeral, machine-generated)
+.claude/artifacts/
+
 # Local LiteLLM config
 litellm-local.yaml


### PR DESCRIPTION
## Summary
- Adds `.claude/artifacts/` to `.gitignore` — these are ephemeral local worker artifacts (manifests, result files) generated per session by the watcher pipeline and should not be tracked in git.

## Test plan
- [ ] Verify `.claude/artifacts/` no longer appears as untracked after the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)