### PR TITLE
Fix SonarCloud issues and add SonarQube MCP server

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -3,6 +3,16 @@
     "linear-server": {
       "type": "http",
       "url": "https://mcp.linear.app/mcp"
+    },
+    "sonarqube": {
+      "type": "stdio",
+      "command": "cmd",
+      "args": ["/c", "npx", "-y", "sonarqube-mcp-server"],
+      "env": {
+        "SONARQUBE_TOKEN": "${SONARCLOUD_TOKEN}",
+        "SONARQUBE_URL": "https://sonarcloud.io",
+        "SONARQUBE_ORG": "virppa"
+      }
     }
   }
 }

--- a/app/cli.py
+++ b/app/cli.py
@@ -174,31 +174,7 @@ def _run_config(args: argparse.Namespace) -> int:
     return 1
 
 
-def main(argv: list[str] | None = None) -> int:
-    load_dotenv()
-    # Ensure the terminal can emit UTF-8 (e.g. ✓); no-op on StringIO (pytest capsys).
-    if hasattr(sys.stdout, "reconfigure"):
-        try:
-            sys.stdout.reconfigure(encoding="utf-8", errors="replace")
-        except Exception:  # nosec B110 — intentional no-op; stdout may not support reconfigure
-            pass
-
-    parser = _build_parser()
-    args = parser.parse_args(argv)
-
-    if args.command is None:
-        parser.print_help()
-        return 1
-
-    if args.command == "config":
-        return _run_config(args)
-
-    if args.command == "metrics":
-        return _run_metrics(args)
-
-    if args.command == "watcher":
-        return _run_watcher(args)
-
+def _run_generate(args: argparse.Namespace) -> int:
     try:
         config = RepoConfig(
             repo_name=args.repo_name,
@@ -247,6 +223,34 @@ def main(argv: list[str] | None = None) -> int:
         return 1
 
     return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    load_dotenv()
+    # Ensure the terminal can emit UTF-8 (e.g. ✓); no-op on StringIO (pytest capsys).
+    if hasattr(sys.stdout, "reconfigure"):
+        try:
+            sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+        except Exception:  # nosec B110 — intentional no-op; stdout may not support reconfigure
+            pass
+
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    if args.command is None:
+        parser.print_help()
+        return 1
+
+    if args.command == "config":
+        return _run_config(args)
+
+    if args.command == "metrics":
+        return _run_metrics(args)
+
+    if args.command == "watcher":
+        return _run_watcher(args)
+
+    return _run_generate(args)
 
 
 if __name__ == "__main__":

--- a/app/core/post_setup.py
+++ b/app/core/post_setup.py
@@ -37,7 +37,7 @@ def fetch_skills(
         )
         with urllib.request.urlopen(req, timeout=10) as resp:  # nosec B310  # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected
             tree = json.loads(resp.read())
-    except (urllib.error.URLError, OSError) as exc:
+    except OSError as exc:
         print(
             f"[skills] Warning: could not fetch {skills_source}@{skills_version}: {exc}"
         )
@@ -60,7 +60,7 @@ def fetch_skills(
         try:
             with urllib.request.urlopen(raw_url, timeout=10) as resp:  # nosec B310  # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected
                 content = resp.read()
-        except (urllib.error.URLError, OSError) as exc:
+        except OSError as exc:
             print(f"[skills] Warning: could not download {path}: {exc}")
             continue
 

--- a/app/core/watcher.py
+++ b/app/core/watcher.py
@@ -95,9 +95,9 @@ def check_allowed_paths_overlap(
     conflicts: list[str] = []
     candidate_set = set(candidate.allowed_paths)
     for worker in active:
-        if not worker.manifest.allowed_paths:
-            conflicts.append(worker.manifest.ticket_id)
-        elif candidate_set & set(worker.manifest.allowed_paths):
+        if not worker.manifest.allowed_paths or candidate_set & set(
+            worker.manifest.allowed_paths
+        ):
             conflicts.append(worker.manifest.ticket_id)
     return conflicts
 


### PR DESCRIPTION
## Summary

- **S1871** `watcher.py:98` — merged duplicate if/elif branches into a single `or` condition
- **S3776** `cli.py:177` — extracted `_run_generate()` to reduce `main()` cognitive complexity from 17 → 7
- **S5713** `post_setup.py:40,63` — removed redundant `urllib.error.URLError` from `except` clauses (`URLError` is a subclass of `OSError`)
- **Security hotspot** `watcher.py:591` — `os.kill(pid, 0)` is the standard POSIX process-existence check; errors are caught explicitly. Marked SAFE in SonarCloud (MCP tool had a parameter bug, needs manual confirmation on sonarcloud.io)
- **`.mcp.json`** — added SonarQube MCP server (`sonarqube-mcp-server` via `cmd /c npx`) for Windows compatibility

## Test plan

- [x] All 219 tests pass, coverage 82% (above 80% threshold)
- [x] ruff, mypy, bandit, semgrep all pass
- [ ] SonarCloud blocking scan on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)