### PR TITLE
WOR-61 Generate .claude/commands/ starter slash commands

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -74,6 +74,11 @@ def _build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Run pre-commit install in the output directory.",
     )
+    gen.add_argument(
+        "--linear-project",
+        default="",
+        help="Linear project name for slash command templates (default: repo name).",
+    )
 
     metrics = sub.add_parser("metrics", help="Metrics DB commands.")
     metrics_sub = metrics.add_subparsers(dest="metrics_cmd")
@@ -187,6 +192,7 @@ def _run_generate(args: argparse.Namespace) -> int:
             include_claude_files=args.claude_files,
             git_init=args.git_init,
             install_precommit=args.install_precommit,
+            linear_project=args.linear_project,
         )
     except ValidationError as exc:
         print(f"Error: {exc}", file=sys.stderr)

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -18,6 +18,7 @@ class RepoConfig(BaseModel):
 
     git_init: bool = False
     install_precommit: bool = False
+    linear_project: str = ""
 
     @field_validator("repo_name")
     @classmethod

--- a/app/core/presets.py
+++ b/app/core/presets.py
@@ -13,6 +13,10 @@ _F_FEATURE_REQUEST = ".github/ISSUE_TEMPLATE/feature_request.md"
 _F_CODEOWNERS = ".github/CODEOWNERS"
 _F_CLAUDE_MD = "CLAUDE.md"
 _F_MCP_JSON = ".mcp.json"
+_F_CMD_GROOM = ".claude/commands/groom-ticket.md"
+_F_CMD_START = ".claude/commands/start-ticket.md"
+_F_CMD_FINALIZE = ".claude/commands/finalize-ticket.md"
+_F_CMD_SECURITY = ".claude/commands/security-check.md"
 
 
 @dataclass(frozen=True)
@@ -96,6 +100,10 @@ _PRESETS: dict[str, Preset] = {
             _F_CLAUDE_MD,
             _F_MCP_JSON,
             ".claude/settings.json",
+            _F_CMD_GROOM,
+            _F_CMD_START,
+            _F_CMD_FINALIZE,
+            _F_CMD_SECURITY,
         ),
         optional_files={
             "include_precommit": (_F_PRECOMMIT,),

--- a/templates/full_agentic/.claude/commands/finalize-ticket.md.j2
+++ b/templates/full_agentic/.claude/commands/finalize-ticket.md.j2
@@ -1,0 +1,72 @@
+Finalize the current ticket and create a pull request.
+
+### 1. Test coverage
+Run pytest with coverage:
+```bash
+pytest --cov=app --cov-report=term-missing --tb=short -q
+```
+
+If coverage is below 80%:
+- Identify which code paths are uncovered
+- Write the missing tests before proceeding
+
+### 2. Documentation
+Check if any of the following need updating:
+- New slash commands or workflow steps → update the **Development workflow** section in `CLAUDE.md`
+- New CLI commands or setup steps → update the **Commands** section in `CLAUDE.md`
+- New architectural decisions → update the **Architecture** section in `CLAUDE.md`
+
+Only update docs if the change is meaningful — do not document implementation details.
+
+### 3. Review diff
+Get the current diff against the base branch:
+```bash
+git diff $(git merge-base HEAD origin/$(git rev-parse --abbrev-ref --symbolic-full-name @{u} | cut -d/ -f2-))..HEAD
+```
+
+Review for obvious issues: unrendered template variables, leftover debug code, missing test coverage for new paths.
+
+### 4. Create the pull request
+Derive the Linear identifier from the current branch name (e.g., `WOR-42-short-description` → `WOR-42`).
+
+Fetch the issue with `get_issue(id, includeRelations: true)` to get its milestone and parent epic. If the epic has an in-progress branch (not main), that is the PR target.
+
+**If this ticket has a parent epic with an epic branch:**
+```bash
+gh pr create --base <epic-branch> \
+  --title "WOR-NNN Short description" \
+  --body "..."
+gh pr merge --auto --squash <PR-number>
+```
+
+**If no parent epic (targeting main):**
+```bash
+gh pr create --base main \
+  --title "WOR-NNN Short description" \
+  --body "..."
+```
+
+PR body format:
+- 2–3 bullet summary
+- `**Milestone:** <milestone name>` (if set)
+- `**Epic:** <parent issue title>` (if set)
+- Test plan checklist
+- `Closes WOR-NNN`
+
+### 5. Update Linear
+Mark the issue as **In Review**: `save_issue(id: "WOR-NNN", state: "In Review")`
+
+Fetch the milestone with `list_milestones(project: "{{ linear_project or repo_name }}")`. If progress has reached 100%, note it: "🎉 Milestone '<name>' is now complete."
+
+### 6. Opportunistic issue capture
+
+Surface anything noticed during implementation that falls outside the current ticket's scope:
+- Bugs encountered in code you touched or read
+- Missing features that would naturally complement what was just built
+- Unhandled edge cases or input validation gaps
+
+**Rules:**
+- Only surface things genuinely encountered during implementation — no extra scans
+- Check existing Linear issues first (`list_issues` with `project: "{{ linear_project or repo_name }}"`) to avoid duplicates
+- Maximum 3 suggestions; keep only the most impactful
+- Present suggestions and wait for approval before creating anything

--- a/templates/full_agentic/.claude/commands/groom-ticket.md.j2
+++ b/templates/full_agentic/.claude/commands/groom-ticket.md.j2
@@ -1,0 +1,59 @@
+Before anything else, run a non-blocking skills staleness check:
+
+1. Read `.claude/settings.json` in the current working directory. If the file does not exist, or it has no `skills_source` or `skills_version` key, skip this check entirely and proceed to the grooming steps below.
+2. Parse `skills_source` (format: `github:<owner>/<repo>`) to extract owner and repo name.
+3. Use WebFetch to call `https://api.github.com/repos/<owner>/<repo>/releases?per_page=50`. If the request fails or returns an error (network unreachable, rate limited, etc.), skip silently and proceed.
+4. From the response array, take the first element's `tag_name` as the latest release. Compare it to `skills_version` from settings:
+   - If equal: no output, proceed.
+   - If `skills_version` is behind: count how many releases in the array have a `tag_name` semantically greater than `skills_version` (treat tags as semver; ignore non-semver tags). Print exactly one line:
+     ```
+     Skills are N version(s) behind (<skills_version> → <latest tag_name>). Run /update-skills to upgrade.
+     ```
+     Then proceed — this notice is non-blocking.
+
+---
+
+Look up the Linear issue with identifier $ARGUMENTS in the {{ linear_project or repo_name }} project using the Linear MCP server. Run these in parallel:
+- `get_issue($ARGUMENTS, includeRelations: true)` — see existing labels, milestone, parent epic, priority, blocking relations
+- `list_milestones(project: "{{ linear_project or repo_name }}")` — check milestone progress before suggesting assignment
+- `list_issues(project: "{{ linear_project or repo_name }}", state: "In Progress")` combined with issues that have no parentId — to get current active epics
+
+Then spawn the **repo-investigator** subagent, passing the ticket title and description as the prompt. Use its returned summary as context for the analysis below — do not read any source files yourself.
+
+As a Product Owner, evaluate the issue before development begins:
+
+1. **Restate** the requirement in one sentence in plain terms.
+
+2. **Scope check** — is this one coherent unit of work, or does it span multiple concerns?
+   - Flag if the ticket mixes UI + core logic + infrastructure
+   - Flag if it seems too large for a single PR (rule of thumb: >3 files changed, or >1 day of work)
+
+3. **Acceptance criteria** — if missing or vague, propose 3–5 bullet points that define "done".
+
+4. **Splitting** — if the ticket should be split, draft sub-issue titles and brief descriptions for each.
+
+5. **Dependencies** — note any other tickets or work that must come first. Check actual Linear relations from `get_issue(includeRelations: true)` before inferring.
+
+6. **Metadata recommendations** — propose values for any of these that are missing or wrong:
+
+   - **Type label** — one of: Feature / Fix / Refactor / Spike / Bug
+   - **Stream label** — one of: Product / Infra / AI / Docs
+   - **Epic (parent issue)** — which thematic epic this belongs under. Use the live epic list fetched above (issues with no parent that are not Done/Cancelled). If none fit, propose a new epic title.
+   - **Milestone** — which project milestone to assign. **First check `list_milestones` progress — do not assign to any milestone at 100%; it is complete and closed to new work.** Suggest the next appropriate open milestone instead. If no existing milestone fits (e.g. clear post-V1 work), flag this and suggest creating a new one with name and description.
+   - **Priority** — 1=Urgent / 2=High / 3=Normal / 4=Low
+   - **Blockers** — any issues that must ship first (by identifier)
+
+**STOP HERE.** Present your analysis and wait for human approval before making any changes.
+
+---
+
+After the human approves, take all of the following actions in Linear:
+
+1. **Labels** — set the Type and Stream labels on the issue using `save_issue` (use label names, not IDs)
+2. **Epic** — set `parentId` to the approved epic identifier using `save_issue`. If a new epic was proposed and approved, create it first with `save_issue` (no parentId, with Type+Stream labels), then set it as parent on this issue
+3. **Milestone** — assign with `save_issue`. If a new milestone was approved, create it first with `save_milestone(project: "{{ linear_project or repo_name }}", name: "...", description: "...")`, then assign
+4. **Priority** — update if the current value is wrong or missing
+5. **Blockers** — add any missing `blockedBy` relations (append-only; existing relations are never removed)
+6. **Sub-issues** — if splitting was recommended and approved, create each sub-issue with `save_issue` using `parentId: "$ARGUMENTS"`, then set the same labels, epic, and milestone on each
+
+Report a summary of every change made in Linear.

--- a/templates/full_agentic/.claude/commands/security-check.md.j2
+++ b/templates/full_agentic/.claude/commands/security-check.md.j2
@@ -1,0 +1,30 @@
+Run a security audit on the current changes.
+
+### 1. Static analysis
+Run bandit on the app directory:
+```bash
+bandit -r app/ -c pyproject.toml -f txt
+```
+Show the full output.
+
+### 2. Diff review
+Get the current diff against main:
+```bash
+git diff main
+```
+
+Review the diff for OWASP Top 10 patterns relevant to a Python desktop/CLI tool:
+- **A01 Broken Access Control** — unauthorized file access, path traversal (`../` in user-supplied paths)
+- **A02 Cryptographic Failures** — hardcoded secrets, tokens, or keys in source
+- **A03 Injection** — `subprocess` with `shell=True`, f-strings interpolated into shell commands
+- **A04 Insecure Design** — missing input validation, trusting user-supplied paths without sanitization
+- **A05 Security Misconfiguration** — debug flags left on, permissive file permissions (0o777)
+- **A08 Software/Data Integrity** — unvalidated Jinja2 template inputs, unsafe deserialization
+
+### 3. Verdict
+For each finding, state: **severity** (HIGH / MEDIUM / LOW), **file:line**, **description**, **fix**.
+
+End with an explicit verdict:
+- PASS — no issues found, safe to proceed to `/finalize-ticket`
+- WARNINGS — low-severity issues noted, can proceed with awareness
+- FAIL — issues must be fixed before creating a PR

--- a/templates/full_agentic/.claude/commands/start-ticket.md.j2
+++ b/templates/full_agentic/.claude/commands/start-ticket.md.j2
@@ -1,0 +1,97 @@
+Look up the Linear issue with identifier $ARGUMENTS in the {{ linear_project or repo_name }} project using the Linear MCP server. Also fetch `get_issue($ARGUMENTS, includeRelations: true)` to see its milestone, labels, priority, parent epic, and any blocking relations.
+
+Work through these phases in order:
+
+### 0. Clean up local branches
+Run the following to prune stale remote-tracking refs and delete any local branches that have been merged or whose remote is gone:
+```bash
+git fetch --prune
+git checkout main
+git pull
+git branch --merged main | grep -v '^\*\? *main$' | xargs -r git branch -d
+```
+
+### 0.5. Epic branch setup
+Check whether this ticket has a parent epic (`parentId` from `get_issue` relations):
+
+**If a parent epic exists:**
+- Derive the epic branch name from the epic issue's Linear "Copy branch name" format
+- Check whether that branch exists on the remote:
+  ```bash
+  git fetch origin
+  git branch -a | grep <epic-slug>
+  ```
+- If the epic branch does **not** exist yet — create it from main and push it:
+  ```bash
+  git checkout -b <epic-branch>
+  git push -u origin <epic-branch>
+  git checkout main
+  ```
+- If it already exists — confirm it is present on origin (no further action needed)
+
+**If no parent epic exists:**
+- Warn: "This ticket has no parent epic — branch will target main instead of an epic branch."
+- Continue with the normal main-targeting flow (step 3 will branch off main)
+
+### 0.6. Coordination check
+Query Linear for sibling tickets in the same epic that are currently In Progress:
+```
+list_issues(project: "{{ linear_project or repo_name }}", state: "In Progress", parentId: <epicId>)
+```
+For each In-Progress sibling, show ticket ID, title, branch name, and likely files touched.
+
+Also list epic backlog tickets and flag which are safe to start in parallel vs. likely conflicting.
+
+### 1. As Product Owner — understand the requirement
+- Restate the requirement in plain terms (one paragraph)
+- Flag any ambiguity or missing information
+- State the acceptance criteria (from the issue, or infer them if not specified)
+- Note the milestone this ticket belongs to and how it fits the current milestone's goal
+- Flag any active blockers from Linear — if this ticket is blocked by an open issue, warn before proceeding
+
+### 2. As Architect — plan the implementation
+- List which files need to change and what changes are needed
+- List what new tests are needed (file, test name, what it verifies)
+- Flag any security surface introduced: new I/O, user input handling, file operations, subprocess calls
+- Note edge cases and overwrite behavior to consider
+
+### 3. Create the branch and update Linear
+Using the branch name from Linear's "Copy branch name" format:
+
+**If this ticket has a parent epic with an epic branch:**
+```bash
+git checkout <epic-branch>
+git pull origin <epic-branch>
+git checkout -b <sub-ticket-branch>
+git push -u origin <sub-ticket-branch>
+```
+
+**If no parent epic (targeting main):**
+```bash
+git checkout -b <branch-name>
+git push -u origin <branch-name>
+```
+
+Then immediately set the issue status to **In Progress** in Linear:
+`save_issue(id: "$ARGUMENTS", state: "In Progress")`
+
+**If the parent epic was previously Backlog**, also promote all other Backlog children to **Todo**:
+```
+list_issues(project: "{{ linear_project or repo_name }}", parentId: <epicId>, state: "Backlog")
+→ for each result (excluding the current ticket): save_issue(id: "WOR-X", state: "Todo")
+```
+
+### 4. Present the plan
+```
+Branch: <branch-name> (off <epic-branch | main>)
+Milestone: <milestone name>
+Epic: <parent issue title or "none">
+Files to change:
+  - path/to/file.py — what changes
+Tests to write:
+  - tests/test_X.py::test_name — what it verifies
+Security surface: <none | description>
+Edge cases: <list>
+```
+
+**STOP HERE. Do not write any code until the human approves this plan.**

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -153,6 +153,45 @@ def test_full_agentic_settings_json_contains_hooks(output_dir):
         )
 
 
+def test_full_agentic_command_files_written(output_dir):
+    config = RepoConfig(repo_name="my-agentic-project", preset="full_agentic")
+    generate(config, output_dir)
+    for cmd in (
+        "groom-ticket.md",
+        "start-ticket.md",
+        "finalize-ticket.md",
+        "security-check.md",
+    ):
+        assert (output_dir / ".claude" / "commands" / cmd).exists(), f"missing {cmd}"
+
+
+def test_full_agentic_commands_substitute_vars(output_dir):
+    config = RepoConfig(
+        repo_name="my-agentic-project",
+        preset="full_agentic",
+        linear_project="my-linear-project",
+    )
+    generate(config, output_dir)
+    for cmd in ("groom-ticket.md", "start-ticket.md", "finalize-ticket.md"):
+        content = (output_dir / ".claude" / "commands" / cmd).read_text()
+        assert "my-linear-project" in content, f"{cmd} missing linear_project value"
+        assert "{{" not in content, f"{cmd} has unrendered Jinja2 variable"
+
+
+def test_full_agentic_commands_fallback_to_repo_name(output_dir):
+    config = RepoConfig(repo_name="my-repo", preset="full_agentic")
+    generate(config, output_dir)
+    content = (output_dir / ".claude" / "commands" / "groom-ticket.md").read_text()
+    assert "my-repo" in content
+    assert "{{" not in content
+
+
+def test_other_presets_have_no_command_files(output_dir):
+    config = RepoConfig(repo_name="my-project", preset="python_basic")
+    generate(config, output_dir)
+    assert not (output_dir / ".claude" / "commands").exists()
+
+
 def test_full_agentic_pyproject_contains_quality_tools(output_dir):
     config = RepoConfig(repo_name="my-agentic-project", preset="full_agentic")
     generate(config, output_dir)


### PR DESCRIPTION
- Add 4 Jinja2 command templates to `templates/full_agentic/.claude/commands/` (groom-ticket, start-ticket, finalize-ticket, security-check)
- Add `linear_project: str = ""` to `RepoConfig` and `--linear-project` CLI flag; templates use `{{ linear_project or repo_name }}` so the project name renders correctly with or without the flag
- Add `full_agentic` preset entries for all 4 command paths; other presets unaffected

**Milestone:** Agentic Scaffolding
**Epic:** WOR-55 Epic: Agentic Scaffolding

## Test plan
- [x] `test_full_agentic_command_files_written` — all 4 files exist in `.claude/commands/`
- [x] `test_full_agentic_commands_substitute_vars` — `linear_project` renders, no raw `{{` in output
- [x] `test_full_agentic_commands_fallback_to_repo_name` — empty `linear_project` falls back to `repo_name`
- [x] `test_other_presets_have_no_command_files` — `python_basic` gets no command directory
- [x] 223 tests passing, 82% coverage

Closes WOR-61