### PR TITLE
Fix /start-ticket: hard stop after manifest write to prevent agent self-implementing

### DIFF
--- a/.claude/commands/start-ticket.md
+++ b/.claude/commands/start-ticket.md
@@ -187,7 +187,9 @@ Then:
 1. Set the ticket to **ReadyForLocal** in Linear: `save_issue(id: "$ARGUMENTS", state: "ReadyForLocal")`
 2. Post a Linear comment with the manifest path: `save_comment(issueId: "$ARGUMENTS", body: "Execution manifest written to .claude/artifacts/<ticket_id_lower>/manifest.json — watcher may now pick up.")`
 
-The cloud preflight is now complete. The local worker will pick this up via `/implement-ticket $ARGUMENTS`.
+The cloud preflight is now complete.
+
+**STOP HERE. Do NOT run `/implement-ticket`. The watcher daemon will pick this ticket up automatically once it detects `ReadyForLocal` state. Your job for this session is done.**
 
 ---
 


### PR DESCRIPTION
## Summary
- `/start-ticket` was proceeding to implement tickets instead of stopping after writing the manifest and setting `ReadyForLocal` in Linear
- Root cause: the phrase "The local worker will pick this up via `/implement-ticket $ARGUMENTS`" was read by the agent as an instruction to run the command itself
- Fix: replace with an explicit `STOP HERE` block mirroring the one at step 4

## Test plan
- [ ] Run `/start-ticket` on a groomed ticket, approve the plan
- [ ] Verify agent writes the manifest and sets `ReadyForLocal` then stops without implementing
- [ ] Verify watcher (if running) picks it up via `/implement-ticket`

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>