### PR TITLE
Add --verbose flag to watcher for live worker output streaming

### DIFF
--- a/.claude/commands/start-ticket.md
+++ b/.claude/commands/start-ticket.md
@@ -91,15 +91,17 @@ git checkout <epic-branch>
 git pull origin <epic-branch>
 git checkout -b <sub-ticket-branch>
 git push -u origin <sub-ticket-branch>
+git checkout main
 ```
-Then call `EnterWorktree` so this session operates in the sub-ticket branch's worktree, isolated from other parallel sessions.
+The final `git checkout main` is required — the watcher uses `git worktree add` to check out the branch in an isolated directory, and git refuses to do that if the branch is already checked out in the main working tree.
 
 **If no parent epic (targeting main):**
 ```bash
 git checkout -b <branch-name>
 git push -u origin <branch-name>
+git checkout main
 ```
-No worktree needed for solo work.
+Same reason — leave main checked out so the watcher can worktree the sub-ticket branch.
 
 **If the parent epic was previously Backlog** (i.e., this is the first sub-ticket being started in this epic), also promote all other Backlog children to **Todo**:
 ```
@@ -190,6 +192,17 @@ Then:
 The cloud preflight is now complete.
 
 **STOP HERE. Do NOT run `/implement-ticket`. The watcher daemon will pick this ticket up automatically once it detects `ReadyForLocal` state. Your job for this session is done.**
+
+To monitor worker progress once the watcher picks up the ticket:
+```bash
+# Worker log (stdout + stderr from the claude session):
+tail -f .claude/worktrees/<worker-branch>/.claude/worker_<ticket_id_lower>.log
+# e.g. for WOR-62:
+tail -f ".claude/worktrees/wor-62-structured-claudemdj2-for-full_agentic-preset/.claude/worker_wor-62.log"
+
+# Result artifact (written when worker finishes):
+cat .claude/artifacts/<ticket_id_lower>/result.json
+```
 
 ---
 

--- a/app/cli.py
+++ b/app/cli.py
@@ -100,15 +100,33 @@ def _build_parser() -> argparse.ArgumentParser:
         default=1,
         help="Maximum number of concurrent worker sessions (default: 1).",
     )
+    watcher.add_argument(
+        "--verbose",
+        action="store_true",
+        default=False,
+        help=(
+            "Stream worker stdout+stderr live to the daemon's stderr, "
+            "prefixed with [WOR-NN]. Output is still written to the log file."
+        ),
+    )
 
     return parser
 
 
 def _run_watcher(args: argparse.Namespace) -> int:
+    import logging
+
     from app.core.watcher import Watcher
 
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)-8s %(name)s: %(message)s",
+        stream=sys.stderr,
+    )
     mode = args.worker_mode or os.environ.get("WORKER_MODE", "default")
-    watcher = Watcher(worker_mode=mode, max_workers=args.max_workers)
+    watcher = Watcher(
+        worker_mode=mode, max_workers=args.max_workers, verbose=args.verbose
+    )
     try:
         watcher.run()
     except FileNotFoundError as exc:

--- a/app/core/watcher.py
+++ b/app/core/watcher.py
@@ -23,10 +23,11 @@ import shlex
 import signal
 import subprocess  # nosec B404
 import sys
+import threading
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Protocol
+from typing import IO, Any, Protocol
 
 from app.core.manifest import ExecutionManifest
 from app.core.metrics import ImplementationMode, MetricsStore, Outcome, TicketMetrics
@@ -151,6 +152,28 @@ def resolve_effective_mode(worker_mode: str, manifest_mode: str) -> str:
     return manifest_mode
 
 
+def _tee_worker_output(
+    pipe: IO[bytes],
+    log_file: IO[bytes],
+    prefix: bytes,
+    dest: IO[bytes],
+) -> None:
+    """Read *pipe* line-by-line, writing each line to *log_file* and *dest*.
+
+    Runs in a daemon thread; returns when the pipe reaches EOF (worker exit).
+    Closes *log_file* in the finally block — ownership transfers from the
+    caller to this thread in verbose mode.
+    """
+    try:
+        for raw_line in pipe:
+            log_file.write(raw_line)
+            log_file.flush()
+            dest.write(prefix + raw_line)
+            dest.flush()
+    finally:
+        log_file.close()
+
+
 # ---------------------------------------------------------------------------
 # Watcher
 # ---------------------------------------------------------------------------
@@ -169,6 +192,7 @@ class Watcher:
         metrics_store: MetricsStore | None = None,
         repo_root: Path | None = None,
         project_id: str = "repo-scaffold-desktop",
+        verbose: bool = False,
     ) -> None:
         if linear_client is None:
             from app.core.linear_client import LinearClient  # lazy import
@@ -184,6 +208,9 @@ class Watcher:
         self._active: list[ActiveWorker] = []
         self._running = True
         self._litellm_proc: subprocess.Popen[bytes] | None = None
+        self._verbose = verbose
+        self._worker_counter = 0
+        self._worker_counter_lock = threading.Lock()
 
     # ------------------------------------------------------------------
     # Public entry point
@@ -427,7 +454,30 @@ class Watcher:
 
         log_path = worktree_path / f".claude/worker_{manifest.ticket_id.lower()}.log"
         log_path.parent.mkdir(parents=True, exist_ok=True)
-        log_file = open(log_path, "wb")  # noqa: SIM115  # kept open for process lifetime
+        log_file = open(log_path, "wb")  # noqa: SIM115
+
+        if self._verbose:
+            with self._worker_counter_lock:
+                self._worker_counter += 1
+            prefix = f"[{manifest.ticket_id}] ".encode()
+            process = subprocess.Popen(  # nosec B603 B607
+                cmd,
+                cwd=str(worktree_path),
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+            )
+            assert process.stdout is not None  # guaranteed by stdout=PIPE  # nosec B101
+            stderr_buf: IO[bytes] = (
+                getattr(sys.stderr, "buffer", None) or sys.stderr.buffer
+            )
+            threading.Thread(
+                target=_tee_worker_output,
+                args=(process.stdout, log_file, prefix, stderr_buf),
+                daemon=True,
+                name=f"tee-{manifest.ticket_id}",
+            ).start()
+            return process
 
         return subprocess.Popen(  # nosec B603 B607
             cmd,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -267,3 +267,16 @@ def test_post_setup_error_exits_nonzero(output_dir, capsys):
     assert rc == 1
     captured = capsys.readouterr()
     assert "git not found on PATH" in captured.err
+
+
+def test_watcher_verbose_flag_forwarded(tmp_path):
+    from unittest.mock import MagicMock, patch
+
+    mock_instance = MagicMock()
+    mock_instance.run.return_value = None
+    # Watcher is a lazy import inside _run_watcher, so patch at source module
+    with patch("app.core.watcher.Watcher", return_value=mock_instance) as MockWatcher:
+        rc = main(["watcher", "--verbose"])
+    assert rc == 0
+    _, kwargs = MockWatcher.call_args
+    assert kwargs.get("verbose") is True

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -18,6 +18,7 @@ from app.core.manifest import ArtifactPaths, ExecutionManifest
 from app.core.watcher import (
     ActiveWorker,
     Watcher,
+    _tee_worker_output,
     build_worker_cmd,
     build_worker_env,
     check_allowed_paths_overlap,
@@ -272,3 +273,79 @@ def test_write_and_remove_pid_file(
 
     watcher._remove_pid_file()
     assert not pid_file.exists()
+
+
+# ---------------------------------------------------------------------------
+# _tee_worker_output
+# ---------------------------------------------------------------------------
+
+
+class _CaptureSink:
+    """Byte sink that accumulates writes and tracks close without discarding data."""
+
+    def __init__(self) -> None:
+        self.data = b""
+        self.closed = False
+
+    def write(self, b: bytes) -> int:
+        self.data += b
+        return len(b)
+
+    def flush(self) -> None:
+        pass
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def test_tee_writes_prefixed_lines_to_dest() -> None:
+    import io
+
+    pipe = io.BytesIO(b"hello\nsecond line\n")
+    log_sink: _CaptureSink = _CaptureSink()
+    dest_sink = io.BytesIO()
+
+    _tee_worker_output(pipe, log_sink, b"[WOR-62] ", dest_sink)  # type: ignore[arg-type]
+
+    assert log_sink.data == b"hello\nsecond line\n"
+    assert dest_sink.getvalue() == b"[WOR-62] hello\n[WOR-62] second line\n"
+
+
+def test_tee_closes_log_file() -> None:
+    import io
+
+    pipe = io.BytesIO(b"line\n")
+    log_sink = _CaptureSink()
+    dest_sink = io.BytesIO()
+
+    _tee_worker_output(pipe, log_sink, b"", dest_sink)  # type: ignore[arg-type]
+
+    assert log_sink.closed
+
+
+def test_tee_empty_pipe() -> None:
+    import io
+
+    pipe = io.BytesIO(b"")
+    log_sink = _CaptureSink()
+    dest_sink = io.BytesIO()
+
+    _tee_worker_output(pipe, log_sink, b"[X] ", dest_sink)  # type: ignore[arg-type]
+
+    assert log_sink.data == b""
+    assert dest_sink.getvalue() == b""
+
+
+# ---------------------------------------------------------------------------
+# Watcher verbose flag
+# ---------------------------------------------------------------------------
+
+
+def test_watcher_verbose_defaults_to_false() -> None:
+    w = Watcher(linear_client=MagicMock())
+    assert w._verbose is False
+
+
+def test_watcher_stores_verbose_true() -> None:
+    w = Watcher(linear_client=MagicMock(), verbose=True)
+    assert w._verbose is True


### PR DESCRIPTION
## Summary
- `python -m app.cli watcher --verbose` now streams each worker's stdout+stderr live to the daemon terminal, prefixed with `[WOR-62]` etc., while still writing the log file as before
- Uses `stdout=PIPE` + a daemon thread (`_tee_worker_output`) instead of a log-file tailer — avoids Windows file-locking issues and guarantees last-byte delivery
- Fixes a pre-existing bug: watcher INFO log messages (started, dispatching, worker launched) were silently dropped because `logging.basicConfig()` was never called — now always called in `_run_watcher`
- Also fixes `start-ticket.md`: adds `git checkout main` after branch push so the watcher can `git worktree add` the branch without conflict

## Usage
```bash
python -m app.cli watcher --worker-mode cloud --verbose
# 2026-04-17 21:45:01 INFO     app.core.watcher: Watcher started (mode=cloud, max_workers=1)
# 2026-04-17 21:45:32 INFO     app.core.watcher: Launching worker for WOR-62 (mode=cloud)
# [WOR-62] ╭─────────────────────────────────────────╮
# [WOR-62] │ ✻ Welcome to Claude Code ...             │
# ...
```

## Test plan
- [ ] `pytest tests/test_watcher.py tests/test_cli.py -v` — all pass
- [ ] `_tee_worker_output` unit tests verify prefix, log write, and close behaviour
- [ ] CLI test verifies `--verbose` is forwarded to `Watcher(verbose=True)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)