### PR TITLE
WOR-110 Push worker branch and handle PR creation errors gracefully

### DIFF
--- a/app/core/linear_client.py
+++ b/app/core/linear_client.py
@@ -112,6 +112,19 @@ class LinearClient:
             {"issueId": issue_id, "stateId": state_id},
         )
 
+    def post_comment(self, issue_id: str, body: str) -> None:
+        """Post a comment on *issue_id*."""
+        self._query(
+            """
+            mutation CreateComment($issueId: String!, $body: String!) {
+              commentCreate(input: { issueId: $issueId, body: $body }) {
+                success
+              }
+            }
+            """,
+            {"issueId": issue_id, "body": body},
+        )
+
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------

--- a/app/core/watcher.py
+++ b/app/core/watcher.py
@@ -59,6 +59,7 @@ class LinearClientProtocol(Protocol):
     def list_ready_for_local(self) -> list[dict[str, Any]]: ...
     def get_open_blockers(self, issue_id: str) -> list[str]: ...
     def set_state(self, issue_id: str, state_name: str) -> None: ...
+    def post_comment(self, issue_id: str, body: str) -> None: ...
 
 
 # ---------------------------------------------------------------------------
@@ -344,12 +345,29 @@ class Watcher:
                 outcome = "failure"
                 self._linear.set_state(linear_id, manifest.ticket_state_map.failed)
             else:
-                pr_url = self._create_pr(manifest, worker.worktree_path)
-                outcome = "success"
-                logger.info("PR created for %s: %s", ticket_id, pr_url)
-                self._linear.set_state(
-                    linear_id, manifest.ticket_state_map.merged_to_epic
-                )
+                try:
+                    pr_url = self._create_pr(manifest, worker.worktree_path)
+                except subprocess.CalledProcessError as exc:
+                    err_detail = (exc.stderr or exc.stdout or str(exc)).strip()
+                    logger.error("PR creation failed for %s: %s", ticket_id, err_detail)
+                    outcome = "failure"
+                    self._linear.set_state(linear_id, manifest.ticket_state_map.failed)
+                    try:
+                        body = (
+                            f"PR creation failed for `{ticket_id}`:"
+                            f"\n```\n{err_detail}\n```"
+                        )
+                        self._linear.post_comment(linear_id, body)
+                    except Exception:
+                        logger.warning(
+                            "Could not post failure comment to Linear for %s", ticket_id
+                        )
+                else:
+                    outcome = "success"
+                    logger.info("PR created for %s: %s", ticket_id, pr_url)
+                    self._linear.set_state(
+                        linear_id, manifest.ticket_state_map.merged_to_epic
+                    )
 
         eff = resolve_effective_mode(self._mode, manifest.implementation_mode)
         self._metrics.record(
@@ -513,6 +531,13 @@ class Watcher:
     # ------------------------------------------------------------------
 
     def _create_pr(self, manifest: ExecutionManifest, worktree_path: Path) -> str:
+        subprocess.run(  # nosec B603 B607
+            ["git", "push", "-u", "origin", manifest.worker_branch],
+            cwd=str(worktree_path),
+            check=True,
+            capture_output=True,
+            text=True,
+        )
         result = subprocess.run(  # nosec B603 B607
             [
                 "gh",

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -349,3 +349,75 @@ def test_watcher_verbose_defaults_to_false() -> None:
 def test_watcher_stores_verbose_true() -> None:
     w = Watcher(linear_client=MagicMock(), verbose=True)
     assert w._verbose is True
+
+
+# ---------------------------------------------------------------------------
+# _create_pr — push before gh pr create
+# ---------------------------------------------------------------------------
+
+
+def test_create_pr_pushes_branch_before_gh_pr(tmp_path: Path) -> None:
+    manifest = _make_manifest(
+        ticket_id="WOR-10",
+        worker_branch="wor-10-test-ticket",
+        base_branch="main",
+        title="Test ticket",
+        done_definition="It works.",
+    )
+    call_order: list[str] = []
+
+    def fake_run(cmd: list[str], **_kwargs: object) -> MagicMock:
+        if cmd[:2] == ["git", "push"]:
+            call_order.append("push")
+        elif cmd[:3] == ["gh", "pr", "create"]:
+            call_order.append("gh_pr")
+        result = MagicMock()
+        result.stdout = "https://github.com/example/pr/1"
+        return result
+
+    w = Watcher(linear_client=MagicMock())
+    with patch("app.core.watcher.subprocess.run", side_effect=fake_run):
+        w._create_pr(manifest, tmp_path)
+
+    assert call_order == ["push", "gh_pr"]
+
+
+# ---------------------------------------------------------------------------
+# _finalize_worker — PR creation failure marks ticket Blocked, no crash
+# ---------------------------------------------------------------------------
+
+
+def test_finalize_worker_pr_failure_marks_blocked(tmp_path: Path) -> None:
+    manifest = _make_manifest(
+        ticket_id="WOR-10",
+        worker_branch="wor-10-test-ticket",
+        base_branch="main",
+    )
+    linear_mock = MagicMock()
+    w = Watcher(linear_client=linear_mock)
+
+    worker = ActiveWorker(
+        ticket_id="WOR-10",
+        linear_id="fake-linear-id",
+        manifest=manifest,
+        worktree_path=tmp_path,
+        process=MagicMock(spec=subprocess.Popen),
+    )
+
+    exc = subprocess.CalledProcessError(1, "gh", stderr="Head sha can't be blank")
+
+    with (
+        patch.object(w, "_run_checks", return_value=True),
+        patch.object(w, "_create_pr", side_effect=exc),
+        patch.object(w, "_cleanup_worktree"),
+        patch.object(w, "_metrics") as metrics_mock,
+    ):
+        # Must not raise
+        w._finalize_worker(worker, returncode=0, wall_time=1.0)
+
+    linear_mock.set_state.assert_called_with("fake-linear-id", "Blocked")
+    linear_mock.post_comment.assert_called_once()
+    comment_body: str = linear_mock.post_comment.call_args[0][1]
+    assert "WOR-10" in comment_body
+    assert "Head sha can't be blank" in comment_body
+    metrics_mock.record.assert_called_once()


### PR DESCRIPTION
- `_create_pr` now runs `git push -u origin` before `gh pr create`, fixing the "Head sha can't be blank" crash
- `_finalize_worker` catches `CalledProcessError` from PR creation, marks ticket `Blocked` in Linear with an explanatory comment, and continues the daemon loop without crashing
- `LinearClient.post_comment` added; `LinearClientProtocol` updated to match

**Milestone:** Agentic Scaffolding

## Test plan
- [x] `test_create_pr_pushes_branch_before_gh_pr` — verifies push precedes `gh pr create`
- [x] `test_finalize_worker_pr_failure_marks_blocked` — verifies `Blocked` state + Linear comment on failure, no daemon crash
- [x] All 227 tests pass, 83.95% coverage

Closes WOR-110