### PR TITLE
WOR-111 LinearClient.post_comment silently ignores commentCreate success=false

### DIFF
--- a/app/core/linear_client.py
+++ b/app/core/linear_client.py
@@ -101,7 +101,7 @@ class LinearClient:
     def set_state(self, issue_id: str, state_name: str) -> None:
         """Move *issue_id* to the workflow state with the given name."""
         state_id = self._resolve_state_id(state_name)
-        self._query(
+        data = self._query(
             """
             mutation SetState($issueId: String!, $stateId: String!) {
               issueUpdate(id: $issueId, input: { stateId: $stateId }) {
@@ -111,10 +111,11 @@ class LinearClient:
             """,
             {"issueId": issue_id, "stateId": state_id},
         )
+        self._check_success(data, "issueUpdate", issue_id)
 
     def post_comment(self, issue_id: str, body: str) -> None:
         """Post a comment on *issue_id*."""
-        self._query(
+        data = self._query(
             """
             mutation CreateComment($issueId: String!, $body: String!) {
               commentCreate(input: { issueId: $issueId, body: $body }) {
@@ -124,10 +125,19 @@ class LinearClient:
             """,
             {"issueId": issue_id, "body": body},
         )
+        self._check_success(data, "commentCreate", issue_id)
 
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
+
+    def _check_success(
+        self, data: dict[str, Any], mutation_key: str, issue_id: str
+    ) -> None:
+        if not data[mutation_key]["success"]:
+            raise LinearError(
+                f"{mutation_key} returned success=false for issue {issue_id!r}"
+            )
 
     def _resolve_state_id(self, state_name: str) -> str:
         if state_name in self._state_cache:

--- a/tests/test_linear_client.py
+++ b/tests/test_linear_client.py
@@ -208,3 +208,57 @@ def test_set_state_caches_state_ids() -> None:
         client.set_state("id-2", "InProgressLocal")  # cached — mutate only = 1 call
 
     assert call_count == 3  # 1 state lookup + 2 mutations
+
+
+def test_set_state_raises_when_success_false() -> None:
+    states_response = {
+        "data": {
+            "teams": {
+                "nodes": [
+                    {
+                        "states": {
+                            "nodes": [{"id": "state-abc", "name": "InProgressLocal"}]
+                        }
+                    }
+                ]
+            }
+        }
+    }
+    mutation_response = {"data": {"issueUpdate": {"success": False}}}
+
+    responses = [states_response, mutation_response]
+    call_idx = 0
+
+    def fake_urlopen(req: object, timeout: int = 30) -> MagicMock:
+        nonlocal call_idx
+        resp = _mock_response(responses[call_idx])
+        call_idx += 1
+        return resp
+
+    with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+        with pytest.raises(
+            LinearError, match="issueUpdate.*success=false.*issue-id-123"
+        ):
+            _client().set_state("issue-id-123", "InProgressLocal")
+
+
+# ---------------------------------------------------------------------------
+# post_comment
+# ---------------------------------------------------------------------------
+
+
+def test_post_comment_succeeds() -> None:
+    response = {"data": {"commentCreate": {"success": True}}}
+
+    with patch("urllib.request.urlopen", return_value=_mock_response(response)):
+        _client().post_comment("issue-id-123", "hello")
+
+
+def test_post_comment_raises_when_success_false() -> None:
+    response = {"data": {"commentCreate": {"success": False}}}
+
+    with patch("urllib.request.urlopen", return_value=_mock_response(response)):
+        with pytest.raises(
+            LinearError, match="commentCreate.*success=false.*issue-id-123"
+        ):
+            _client().post_comment("issue-id-123", "hello")


### PR DESCRIPTION
Closes WOR-111

_check_success helper exists and is called in both post_comment and set_state; LinearError raised on success=false; new tests pass; ruff and mypy clean.