### PR TITLE
WOR-113 Epic: Watcher Reliability & Error Handling

### DIFF
--- a/app/core/linear_client.py
+++ b/app/core/linear_client.py
@@ -101,7 +101,7 @@ class LinearClient:
     def set_state(self, issue_id: str, state_name: str) -> None:
         """Move *issue_id* to the workflow state with the given name."""
         state_id = self._resolve_state_id(state_name)
-        self._query(
+        data = self._query(
             """
             mutation SetState($issueId: String!, $stateId: String!) {
               issueUpdate(id: $issueId, input: { stateId: $stateId }) {
@@ -111,10 +111,11 @@ class LinearClient:
             """,
             {"issueId": issue_id, "stateId": state_id},
         )
+        self._check_success(data, "issueUpdate", issue_id)
 
     def post_comment(self, issue_id: str, body: str) -> None:
         """Post a comment on *issue_id*."""
-        self._query(
+        data = self._query(
             """
             mutation CreateComment($issueId: String!, $body: String!) {
               commentCreate(input: { issueId: $issueId, body: $body }) {
@@ -124,10 +125,19 @@ class LinearClient:
             """,
             {"issueId": issue_id, "body": body},
         )
+        self._check_success(data, "commentCreate", issue_id)
 
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
+
+    def _check_success(
+        self, data: dict[str, Any], mutation_key: str, issue_id: str
+    ) -> None:
+        if not data[mutation_key]["success"]:
+            raise LinearError(
+                f"{mutation_key} returned success=false for issue {issue_id!r}"
+            )
 
     def _resolve_state_id(self, state_name: str) -> str:
         if state_name in self._state_cache:

--- a/app/core/watcher.py
+++ b/app/core/watcher.py
@@ -29,6 +29,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import IO, Any, Protocol
 
+from app.core.linear_client import LinearError
 from app.core.manifest import ExecutionManifest
 from app.core.metrics import ImplementationMode, MetricsStore, Outcome, TicketMetrics
 
@@ -287,7 +288,9 @@ class Watcher:
         )
         worktree_path = self._create_worktree(manifest)
 
-        self._linear.set_state(linear_id, manifest.ticket_state_map.in_progress_local)
+        self._safe_set_state(
+            linear_id, manifest.ticket_state_map.in_progress_local, ticket_id
+        )
         logger.info("Launching worker for %s (mode=%s)", ticket_id, effective_mode)
 
         process = self._launch_worker(manifest, worktree_path, effective_mode)
@@ -322,6 +325,14 @@ class Watcher:
             self._finalize_worker(worker, returncode=rc, wall_time=elapsed)
         self._active = still_running
 
+    def _safe_set_state(self, linear_id: str, state: str, ticket_id: str) -> None:
+        try:
+            self._linear.set_state(linear_id, state)
+        except LinearError as exc:
+            logger.warning(
+                "set_state failed for %s (state=%s): %s", ticket_id, state, exc
+            )
+
     def _finalize_worker(
         self, worker: ActiveWorker, *, returncode: int, wall_time: float
     ) -> None:
@@ -338,12 +349,14 @@ class Watcher:
             if manifest.failure_policy.escalate_to_cloud:
                 logger.info("Escalating %s to cloud per failure policy", ticket_id)
                 escalated = True
-            self._linear.set_state(linear_id, manifest.ticket_state_map.failed)
+            self._safe_set_state(linear_id, manifest.ticket_state_map.failed, ticket_id)
         else:
             checks_ok = self._run_checks(manifest, worker.worktree_path)
             if not checks_ok and manifest.failure_policy.on_check_failure == "abort":
                 outcome = "failure"
-                self._linear.set_state(linear_id, manifest.ticket_state_map.failed)
+                self._safe_set_state(
+                    linear_id, manifest.ticket_state_map.failed, ticket_id
+                )
             else:
                 try:
                     pr_url = self._create_pr(manifest, worker.worktree_path)
@@ -351,7 +364,9 @@ class Watcher:
                     err_detail = (exc.stderr or exc.stdout or str(exc)).strip()
                     logger.error("PR creation failed for %s: %s", ticket_id, err_detail)
                     outcome = "failure"
-                    self._linear.set_state(linear_id, manifest.ticket_state_map.failed)
+                    self._safe_set_state(
+                        linear_id, manifest.ticket_state_map.failed, ticket_id
+                    )
                     try:
                         body = (
                             f"PR creation failed for `{ticket_id}`:"
@@ -365,8 +380,8 @@ class Watcher:
                 else:
                     outcome = "success"
                     logger.info("PR created for %s: %s", ticket_id, pr_url)
-                    self._linear.set_state(
-                        linear_id, manifest.ticket_state_map.merged_to_epic
+                    self._safe_set_state(
+                        linear_id, manifest.ticket_state_map.merged_to_epic, ticket_id
                     )
 
         eff = resolve_effective_mode(self._mode, manifest.implementation_mode)

--- a/tests/test_linear_client.py
+++ b/tests/test_linear_client.py
@@ -208,3 +208,57 @@ def test_set_state_caches_state_ids() -> None:
         client.set_state("id-2", "InProgressLocal")  # cached — mutate only = 1 call
 
     assert call_count == 3  # 1 state lookup + 2 mutations
+
+
+def test_set_state_raises_when_success_false() -> None:
+    states_response = {
+        "data": {
+            "teams": {
+                "nodes": [
+                    {
+                        "states": {
+                            "nodes": [{"id": "state-abc", "name": "InProgressLocal"}]
+                        }
+                    }
+                ]
+            }
+        }
+    }
+    mutation_response = {"data": {"issueUpdate": {"success": False}}}
+
+    responses = [states_response, mutation_response]
+    call_idx = 0
+
+    def fake_urlopen(req: object, timeout: int = 30) -> MagicMock:
+        nonlocal call_idx
+        resp = _mock_response(responses[call_idx])
+        call_idx += 1
+        return resp
+
+    with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+        with pytest.raises(
+            LinearError, match="issueUpdate.*success=false.*issue-id-123"
+        ):
+            _client().set_state("issue-id-123", "InProgressLocal")
+
+
+# ---------------------------------------------------------------------------
+# post_comment
+# ---------------------------------------------------------------------------
+
+
+def test_post_comment_succeeds() -> None:
+    response = {"data": {"commentCreate": {"success": True}}}
+
+    with patch("urllib.request.urlopen", return_value=_mock_response(response)):
+        _client().post_comment("issue-id-123", "hello")
+
+
+def test_post_comment_raises_when_success_false() -> None:
+    response = {"data": {"commentCreate": {"success": False}}}
+
+    with patch("urllib.request.urlopen", return_value=_mock_response(response)):
+        with pytest.raises(
+            LinearError, match="commentCreate.*success=false.*issue-id-123"
+        ):
+            _client().post_comment("issue-id-123", "hello")

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -14,6 +14,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from app.core.linear_client import LinearError
 from app.core.manifest import ArtifactPaths, ExecutionManifest
 from app.core.watcher import (
     ActiveWorker,
@@ -421,3 +422,78 @@ def test_finalize_worker_pr_failure_marks_blocked(tmp_path: Path) -> None:
     assert "WOR-10" in comment_body
     assert "Head sha can't be blank" in comment_body
     metrics_mock.record.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# _safe_set_state — daemon survives LinearError at all set_state sites
+# ---------------------------------------------------------------------------
+
+
+def test_finalize_worker_set_state_failure_nonzero_no_crash(tmp_path: Path) -> None:
+    manifest = _make_manifest(ticket_id="WOR-10", worker_branch="wor-10-test-ticket")
+    linear_mock = MagicMock()
+    linear_mock.set_state.side_effect = LinearError("rate limit")
+    w = Watcher(linear_client=linear_mock)
+
+    worker = ActiveWorker(
+        ticket_id="WOR-10",
+        linear_id="fake-linear-id",
+        manifest=manifest,
+        worktree_path=tmp_path,
+        process=MagicMock(spec=subprocess.Popen),
+    )
+
+    with (
+        patch.object(w, "_cleanup_worktree"),
+        patch.object(w, "_metrics"),
+    ):
+        # returncode != 0 triggers set_state(failed) — must not propagate
+        w._finalize_worker(worker, returncode=1, wall_time=1.0)
+
+
+def test_finalize_worker_set_state_failure_success_path_no_crash(
+    tmp_path: Path,
+) -> None:
+    manifest = _make_manifest(ticket_id="WOR-10", worker_branch="wor-10-test-ticket")
+    linear_mock = MagicMock()
+    linear_mock.set_state.side_effect = LinearError("network error")
+    w = Watcher(linear_client=linear_mock)
+
+    worker = ActiveWorker(
+        ticket_id="WOR-10",
+        linear_id="fake-linear-id",
+        manifest=manifest,
+        worktree_path=tmp_path,
+        process=MagicMock(spec=subprocess.Popen),
+    )
+
+    with (
+        patch.object(w, "_run_checks", return_value=True),
+        patch.object(w, "_create_pr", return_value="https://github.com/example/pr/1"),
+        patch.object(w, "_cleanup_worktree"),
+        patch.object(w, "_metrics"),
+    ):
+        # Success path calls set_state(merged_to_epic) — must not propagate
+        w._finalize_worker(worker, returncode=0, wall_time=1.0)
+
+
+def test_start_ticket_set_state_failure_worker_still_starts(tmp_path: Path) -> None:
+    manifest = _make_manifest(ticket_id="WOR-10", worker_branch="wor-10-test-ticket")
+    linear_mock = MagicMock()
+    linear_mock.get_open_blockers.return_value = []
+    linear_mock.set_state.side_effect = LinearError("unknown state")
+
+    w = Watcher(linear_client=linear_mock, repo_root=tmp_path)
+
+    fake_process = MagicMock(spec=subprocess.Popen)
+
+    with (
+        patch.object(w, "_load_manifest", return_value=manifest),
+        patch.object(w, "_create_worktree", return_value=tmp_path),
+        patch.object(w, "_launch_worker", return_value=fake_process),
+    ):
+        # set_state raises — worker must still be launched and added to _active
+        w._start_ticket("WOR-10", "fake-linear-id")
+
+    assert len(w._active) == 1
+    assert w._active[0].ticket_id == "WOR-10"


### PR DESCRIPTION
## Summary
- Add `_check_success` helper to `LinearClient` so `post_comment` and `set_state` raise `LinearError` when the GraphQL mutation returns `success=false` (WOR-111)
- Add `_safe_set_state` helper to `Watcher` wrapping all 5 `set_state` call sites in `_finalize_worker` and `_start_ticket` so `LinearError` is logged and swallowed rather than crashing the daemon (WOR-112)
- Worker branch is pushed to origin before `gh pr create` and PR creation failures mark the ticket `Blocked` without crashing the daemon (WOR-110, already in main via PR #178)

## Sub-tickets included
- WOR-110 Watcher crashes when worker does not push branch before PR creation
- WOR-111 LinearClient.post_comment silently ignores commentCreate success=false
- WOR-112 Watcher _finalize_worker Linear set_state failures are unhandled and leave ticket state stale

## Test plan
- [x] pytest passes with 86% coverage (threshold: 80%)
- [x] Security scan: PASS (bandit — no findings; nosec annotations on controlled subprocess calls)
- [x] UI tests: not yet present

**Milestone:** Agentic Scaffolding

Closes WOR-113
Closes WOR-110
Closes WOR-111
Closes WOR-112