### PR TITLE
Fix watcher local mode: inject ANTHROPIC_API_KEY for LiteLLM proxy

### DIFF
--- a/.claude/commands/start-epic.md
+++ b/.claude/commands/start-epic.md
@@ -12,9 +12,16 @@ cat .claude/watcher.pid 2>/dev/null && echo "Watcher: running (PID $(cat .claude
 If not running, print this advisory (do not block):
 ```
 Watcher: not running
-  Start with: python -m app.cli watcher
-  Start with: python -m app.cli watcher --worker-mode cloud
-  Start with: python -m app.cli watcher --worker-mode local
+
+  Cloud mode (Anthropic API):
+    python -m app.cli watcher --worker-mode cloud
+
+  Local mode (RTX 5090 + Ollama — pre-warm GPU first):
+    ollama run qwen3-coder:30b ""      # loads model into VRAM; exit immediately after
+    python -m app.cli watcher --worker-mode local
+
+  Auto mode (uses each manifest's implementation_mode):
+    python -m app.cli watcher
 ```
 
 ---

--- a/.claude/commands/start-ticket.md
+++ b/.claude/commands/start-ticket.md
@@ -10,9 +10,16 @@ cat .claude/watcher.pid 2>/dev/null && echo "Watcher: running (PID $(cat .claude
 If not running, print this advisory (do not block or prompt):
 ```
 Watcher: not running
-  Start with: python -m app.cli watcher                          # respects each manifest's implementation_mode
-  Start with: python -m app.cli watcher --worker-mode cloud      # force cloud for all tickets
-  Start with: python -m app.cli watcher --worker-mode local      # force local (RTX 5090 required)
+
+  Cloud mode (Anthropic API):
+    python -m app.cli watcher --worker-mode cloud
+
+  Local mode (RTX 5090 + Ollama — pre-warm GPU first):
+    ollama run qwen3-coder:30b ""      # loads model into VRAM; exit immediately after
+    python -m app.cli watcher --worker-mode local
+
+  Auto mode (uses each manifest's implementation_mode):
+    python -m app.cli watcher
 ```
 
 ### 0. Clean up local branches

--- a/app/core/watcher.py
+++ b/app/core/watcher.py
@@ -113,7 +113,9 @@ def build_worker_env(
 
     cloud   — strips ANTHROPIC_BASE_URL and related vars so the process routes
               to the real Anthropic API.
-    local   — injects ANTHROPIC_BASE_URL pointing to the LiteLLM proxy.
+    local   — injects ANTHROPIC_BASE_URL pointing to the LiteLLM proxy and sets
+              ANTHROPIC_API_KEY=sk-dummy if not already present (LiteLLM doesn't
+              validate the key; this satisfies Claude Code's auth check).
     default — passes base_env unchanged.
     """
     env = dict(base_env)
@@ -122,6 +124,7 @@ def build_worker_env(
             env.pop(var, None)
     elif mode == "local":
         env["ANTHROPIC_BASE_URL"] = _LITELLM_BASE_URL
+        env.setdefault("ANTHROPIC_API_KEY", "sk-dummy")
     return env
 
 


### PR DESCRIPTION
## Summary
- `build_worker_env()` was not setting `ANTHROPIC_API_KEY` for local mode — Claude Code exited rc=1 immediately with an empty log because it fails the auth check before making any API calls
- Added `env.setdefault("ANTHROPIC_API_KEY", "sk-dummy")` so LiteLLM's no-auth proxy is satisfied; `setdefault` means a real key in the environment is never overwritten
- Also updates the watcher-not-running advisory in `start-ticket` and `start-epic` skills to include the Ollama pre-warm step and remove the redundant cloud API key line

## Test plan
- [ ] Restart watcher with `--worker-mode local`, verify worker log is non-empty and GPU fans ramp up
- [ ] Verify `mypy` / `ruff` / `pytest` still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)