### PR TITLE
Fix Ollama keepalive flag in watcher advisory

### DIFF
--- a/.claude/commands/start-epic.md
+++ b/.claude/commands/start-epic.md
@@ -17,7 +17,7 @@ Watcher: not running
     python -m app.cli watcher --worker-mode cloud
 
   Local mode (RTX 5090 + Ollama — pre-warm GPU first):
-    ollama run qwen3-coder:30b ""      # loads model into VRAM; exit immediately after
+    ollama run --keepalive 0 qwen3-coder:30b ""      # loads model into VRAM indefinitely; exit immediately after
     python -m app.cli watcher --worker-mode local
 
   Auto mode (uses each manifest's implementation_mode):

--- a/.claude/commands/start-ticket.md
+++ b/.claude/commands/start-ticket.md
@@ -15,7 +15,7 @@ Watcher: not running
     python -m app.cli watcher --worker-mode cloud
 
   Local mode (RTX 5090 + Ollama — pre-warm GPU first):
-    ollama run qwen3-coder:30b ""      # loads model into VRAM; exit immediately after
+    ollama run --keepalive 0 qwen3-coder:30b ""      # loads model into VRAM indefinitely; exit immediately after
     python -m app.cli watcher --worker-mode local
 
   Auto mode (uses each manifest's implementation_mode):


### PR DESCRIPTION
## Summary
- `--keepalive -1` is invalid — Ollama requires a duration string
- Changed to `--keepalive 0` which means keep indefinitely

🤖 Generated with [Claude Code](https://claude.com/claude-code)