### PR TITLE
Fix worker: disable MCP OAuth timeout and improve LiteLLM readiness

### DIFF
--- a/app/core/watcher.py
+++ b/app/core/watcher.py
@@ -131,16 +131,19 @@ def build_worker_env(
 def build_worker_cmd(ticket_id: str, mode: str) -> list[str]:
     """Return the claude subprocess command list for the given mode."""
     prompt = f"/implement-ticket {ticket_id}"
+    # --strict-mcp-config + empty config prevents Claude Code from loading
+    # .mcp.json in the worktree, which would block for ~180s trying to
+    # authenticate the Linear HTTP MCP server via OAuth in non-interactive mode.
+    base = [
+        "claude",
+        "--dangerously-skip-permissions",
+        "--strict-mcp-config",
+        "--mcp-config",
+        '{"mcpServers":{}}',
+    ]
     if mode == "local":
-        return [
-            "claude",
-            "--dangerously-skip-permissions",
-            "--model",
-            _LOCAL_MODEL,
-            "-p",
-            prompt,
-        ]
-    return ["claude", "--dangerously-skip-permissions", "-p", prompt]
+        return base + ["--model", _LOCAL_MODEL, "-p", prompt]
+    return base + ["-p", prompt]
 
 
 def resolve_effective_mode(worker_mode: str, manifest_mode: str) -> str:
@@ -616,8 +619,20 @@ class Watcher:
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
         )
-        # Give the proxy a moment to bind
-        time.sleep(3)
+        self._wait_for_litellm_ready()
+
+    def _wait_for_litellm_ready(self, timeout: float = 30.0) -> None:
+        """Poll TCP until LiteLLM's port accepts connections."""
+        import socket
+
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+                sock.settimeout(2)
+                if sock.connect_ex(("localhost", _LITELLM_PORT)) == 0:
+                    return
+            time.sleep(0.5)
+        raise TimeoutError(f"LiteLLM proxy not ready after {timeout}s")
 
     # ------------------------------------------------------------------
     # Graceful shutdown


### PR DESCRIPTION
## Summary

- **Root cause found**: `.mcp.json` is committed to git, so every watcher-created worktree contains it. When Claude Code starts in non-interactive `-p` mode, it tries to authenticate the Linear HTTP MCP server via OAuth. With no browser available, the flow times out after exactly 180 seconds — explaining the consistent `rc=1, elapsed=180s` failures with no GPU activity.
- **Fix 1** (`build_worker_cmd`): Add `--strict-mcp-config --mcp-config '{"mcpServers":{}}'` to all worker commands. This prevents `.mcp.json` from being loaded. The watcher handles all Linear state transitions directly, so the worker subprocess doesn't need MCP access.
- **Fix 2** (`_wait_for_litellm_ready`): Replace the fixed `time.sleep(3)` with a TCP polling loop that waits until LiteLLM's port actually accepts connections (up to 30s), eliminating the startup race condition.

## Test plan

- [ ] Merge PR, `git pull`, pre-warm Ollama: `set OLLAMA_KEEP_ALIVE=-1 && ollama run qwen3-coder:30b ""`
- [ ] Start watcher: `python -m app.cli watcher --worker-mode local`
- [ ] Confirm GPU fans ramp up within ~30s of "Launching worker" log line (inference actually starts)
- [ ] Confirm worker runs for more than 180s (actual work, not a timeout)
- [ ] Confirm `result.json` is written to `.claude/artifacts/wor_114/result.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)