### PR TITLE
Fix LiteLLM crash on Windows: set PYTHONUTF8=1 for subprocess

### DIFF
--- a/app/core/watcher.py
+++ b/app/core/watcher.py
@@ -612,6 +612,7 @@ class Watcher:
         logger.info(
             "Starting LiteLLM proxy (port %d)… (log: %s)", _LITELLM_PORT, log_path
         )
+        env = {**os.environ, "PYTHONUTF8": "1"}
         self._litellm_proc = subprocess.Popen(  # nosec B603 B607
             [
                 "litellm",
@@ -623,6 +624,7 @@ class Watcher:
             ],
             stdout=log_file,
             stderr=log_file,
+            env=env,
         )
         self._wait_for_litellm_ready()
 


### PR DESCRIPTION
## Summary
- LiteLLM's startup banner contains Unicode characters that fail to encode with Windows cp1252 when stdout is redirected to a file, causing an immediate `UnicodeEncodeError` and rc=3 crash
- Fix: pass `PYTHONUTF8=1` in the subprocess environment so LiteLLM uses UTF-8 for all I/O

## Test plan
- [ ] Run `python -m app.cli watcher --worker-mode local` — LiteLLM should start without crashing
- [ ] Verify `.claude/litellm.log` contains the LiteLLM banner output (with Unicode intact)
- [ ] Confirm watcher proceeds to poll for tickets

🤖 Generated with [Claude Code](https://claude.com/claude-code)