### PR TITLE
Fix watcher PR state: In Review on creation, auto-merge enabled

### DIFF
--- a/app/core/manifest.py
+++ b/app/core/manifest.py
@@ -27,6 +27,7 @@ class TicketStateMap(BaseModel):
     model_config = {"extra": "forbid"}
 
     in_progress_local: str = "InProgressLocal"
+    in_review: str = "In Review"
     merged_to_epic: str = "MergedToEpic"
     ready_for_review: str = "EpicReadyForCloudReview"
     failed: str = "Blocked"

--- a/app/core/watcher.py
+++ b/app/core/watcher.py
@@ -361,9 +361,7 @@ class Watcher:
                 )
             return "failure"
         logger.info("PR created for %s: %s", ticket_id, pr_url)
-        self._safe_set_state(
-            linear_id, manifest.ticket_state_map.merged_to_epic, ticket_id
-        )
+        self._safe_set_state(linear_id, manifest.ticket_state_map.in_review, ticket_id)
         return "success"
 
     def _finalize_worker(
@@ -581,7 +579,15 @@ class Watcher:
             text=True,
             check=True,
         )
-        return result.stdout.strip()
+        pr_url = result.stdout.strip()
+        subprocess.run(  # nosec B603 B607
+            ["gh", "pr", "merge", "--auto", "--squash", pr_url],
+            cwd=str(worktree_path),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        return pr_url
 
     # ------------------------------------------------------------------
     # LiteLLM proxy

--- a/schemas/execution_manifest.schema.json
+++ b/schemas/execution_manifest.schema.json
@@ -58,6 +58,11 @@
           "title": "In Progress Local",
           "type": "string"
         },
+        "in_review": {
+          "default": "In Review",
+          "title": "In Review",
+          "type": "string"
+        },
         "merged_to_epic": {
           "default": "MergedToEpic",
           "title": "Merged To Epic",


### PR DESCRIPTION
## Summary
- Set ticket state to `In Review` (not `MergedToEpic`) when the PR is created — matches actual PR lifecycle and avoids conflict with the Linear GitHub integration that reverts premature state advances
- Enable `gh pr merge --auto --squash` immediately after PR creation so sub-ticket PRs self-merge when CI passes, no manual intervention needed
- Add `in_review` field to `TicketStateMap` (defaults to `"In Review"`)

## Test plan
- [ ] Run watcher with a ReadyForLocal ticket; confirm Linear moves to In Review after PR creation
- [ ] Confirm PR auto-merges after CI passes
- [ ] Confirm Linear moves to MergedToEpic after merge (via GitHub integration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)