### PR TITLE
Add .claude log and pid files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,7 @@ litellm-local.yaml
 
 # Local LiteLLM config
 litellm-local.yaml
+
+# Claude Code watcher logs
+.claude/*.log
+.claude/*.pid


### PR DESCRIPTION
## Summary
- `.claude/*.log` (e.g. `litellm.log`) and `.claude/*.pid` (e.g. `watcher.pid`) are now gitignored — these are ephemeral runtime files that shouldn't be tracked.

## Test plan
- [ ] `git status` shows no untracked `.claude/` log or pid files after watcher runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)