### PR TITLE
Add commit step to implement-ticket skill (step 4.5)

### DIFF
--- a/.claude/commands/implement-ticket.md
+++ b/.claude/commands/implement-ticket.md
@@ -65,6 +65,19 @@ If any required check fails:
 
 Run each command in `optional_checks` for information only — failures do not block.
 
+### 4.5. Commit changes
+
+After all required checks pass, stage and commit everything:
+
+```bash
+git add -A
+git commit -m "Part of <ticket_id>: <one-line summary of what was implemented>"
+```
+
+If there is nothing to commit (no changes made), write a failed result artifact with `failure_reason: "No changes were made — nothing to commit"` and stop.
+
+If the commit is rejected by a pre-commit hook, fix the issue and retry the commit once. If it still fails, write a failed result artifact with the hook output as `failure_reason`.
+
 ### 5. Write the result artifact
 
 Write a JSON result file to `artifact_paths.result_json`. Create parent dirs as needed.


### PR DESCRIPTION
## Summary
- Adds step 4.5 between "run checks" and "write result artifact": `git add -A && git commit -m "Part of <ticket_id>: ..."`
- Without this, the watcher's `git push` pushes nothing and `gh pr create` fails with "No commits between branches"
- Also handles the two failure cases: nothing to commit → failed artifact; pre-commit hook rejection → fix + retry once

## Root cause
`implement-ticket` was designed for interactive use where `/finalize-ticket` (step 7) handles the commit+PR. The watcher bypasses finalize and calls its own PR creation — so commits were never made.

## Test plan
- [ ] Restart watcher, let it pick up WOR-117 again
- [ ] Worker log shows a `git commit` line
- [ ] PR is created successfully for WOR-117

🤖 Generated with [Claude Code](https://claude.com/claude-code)