### PR TITLE
Copy manifest into worktree before launching worker

### DIFF
--- a/app/core/watcher.py
+++ b/app/core/watcher.py
@@ -294,6 +294,7 @@ class Watcher:
             self._mode, manifest.implementation_mode
         )
         worktree_path = self._create_worktree(manifest)
+        self._copy_manifest_to_worktree(manifest, worktree_path)
 
         self._safe_set_state(
             linear_id, manifest.ticket_state_map.in_progress_local, ticket_id
@@ -447,6 +448,14 @@ class Watcher:
         )
         logger.info("Worktree created at %s", worktree_path)
         return worktree_path
+
+    def _copy_manifest_to_worktree(
+        self, manifest: ExecutionManifest, worktree_path: Path
+    ) -> None:
+        src = self._repo_root / manifest.artifact_paths.manifest_copy
+        dest = worktree_path / manifest.artifact_paths.manifest_copy
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(src, dest)
 
     def _preserve_worker_log(self, worker: ActiveWorker) -> None:
         log_src = (

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -490,6 +490,7 @@ def test_start_ticket_set_state_failure_worker_still_starts(tmp_path: Path) -> N
     with (
         patch.object(w, "_load_manifest", return_value=manifest),
         patch.object(w, "_create_worktree", return_value=tmp_path),
+        patch.object(w, "_copy_manifest_to_worktree"),
         patch.object(w, "_launch_worker", return_value=fake_process),
     ):
         # set_state raises — worker must still be launched and added to _active


### PR DESCRIPTION
## Summary
`.claude/artifacts/` is gitignored, so the worktree the watcher creates has no manifest file. The worker's `/implement-ticket` reads `.claude/artifacts/<id>/manifest.json` relative to its CWD (the worktree) — when the file isn't there, the model ignores the ABORT instruction and improvises from the codebase for hundreds of seconds before exiting rc=0 with no commits.

Fix: `_copy_manifest_to_worktree()` copies the manifest to the equivalent path inside the worktree immediately after `_create_worktree()`.

## Test plan
- [ ] Restart watcher, worker picks up WOR-117
- [ ] Worker log shows it read the manifest and proceeds with the declared objective
- [ ] `git commit` appears in the log, PR is created

🤖 Generated with [Claude Code](https://claude.com/claude-code)