### PR TITLE
Remove coverage from PostToolUse pytest hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -81,7 +81,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "FILE=\"$CLAUDE_TOOL_INPUT_FILE_PATH\"; if [[ \"$FILE\" == */app/* || \"$FILE\" == */tests/* ]]; then pytest --tb=short -q; fi"
+            "command": "FILE=\"$CLAUDE_TOOL_INPUT_FILE_PATH\"; if [[ \"$FILE\" == */app/* || \"$FILE\" == */tests/* ]]; then pytest --no-cov --tb=short -q; fi"
           }
         ]
       }


### PR DESCRIPTION
## Summary
- Changes `pytest --tb=short -q` → `pytest --no-cov --tb=short -q` in the PostToolUse hook
- Running `--cov-fail-under=80` after every file edit is wasteful: burns tokens in interactive sessions and traps the autonomous worker in a coverage loop mid-implementation (model edits implementation, coverage drops before tests are written, model panics and loops)
- Coverage is already enforced by the `pytest` entry in `required_checks` and by CI — the per-edit hook only needs fast pass/fail on test correctness, not a coverage gate

## Test plan
- [ ] Edit a Python file and confirm pytest runs quickly without coverage output
- [ ] Run `pytest` manually to confirm coverage still enforced at 80% threshold

🤖 Generated with [Claude Code](https://claude.com/claude-code)