### PR TITLE
Trim PostToolUse hooks: remove mypy, scope pytest to tests/ only

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -72,16 +72,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "FILE=\"$CLAUDE_TOOL_INPUT_FILE_PATH\"; if [[ \"$FILE\" == *.py ]] && command -v mypy >/dev/null 2>&1; then mypy --config-file pyproject.toml \"$FILE\" 2>/dev/null || echo \"[mypy] Type errors found — run mypy app/ for details\"; fi"
-          }
-        ]
-      },
-      {
-        "matcher": "Edit|Write",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "FILE=\"$CLAUDE_TOOL_INPUT_FILE_PATH\"; if [[ \"$FILE\" == */app/* || \"$FILE\" == */tests/* ]]; then pytest --no-cov --tb=short -q; fi"
+            "command": "FILE=\"$CLAUDE_TOOL_INPUT_FILE_PATH\"; if [[ \"$FILE\" == */tests/* ]]; then pytest --no-cov --tb=short -q; fi"
           }
         ]
       }


### PR DESCRIPTION
## Summary
- **Remove mypy PostToolUse hook** — per-file mypy is redundant with `mypy app/` in `required_checks`; running it after every edit adds 2-5s of latency with no new signal
- **Scope pytest to `tests/` only** — previously ran the full suite on any `app/` or `tests/` edit; now only fires when a test file changes (the only time the feedback is actionable mid-session). Implementation edits no longer trigger the full suite.

Together with #204 (--no-cov), these changes make the PostToolUse feedback loop fast and non-redundant: ruff/format for style, bandit for security, lint-imports for architecture, and pytest only when you're actually editing tests.

## Test plan
- [ ] Edit a file in `app/` — only ruff, bandit, lint-imports should fire (no pytest)
- [ ] Edit a file in `tests/` — pytest should fire without coverage output
- [ ] Run `mypy app/` and `pytest` manually to confirm they still work as required_checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)