### PR TITLE
Remove Stop hook from settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -29,16 +29,6 @@
         ]
       }
     ],
-    "Stop": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "pre-commit run --all-files"
-          }
-        ]
-      }
-    ],
     "PostToolUse": [
       {
         "matcher": "Edit|Write",
@@ -54,7 +44,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "FILE=\"$CLAUDE_TOOL_INPUT_FILE_PATH\"; if [[ \"$FILE\" == *.py ]] && command -v bandit >/dev/null 2>&1; then bandit -q \"$FILE\" 2>/dev/null || echo \"[bandit] Issues found — run /security-check\"; fi"
+            "command": "FILE=\"$CLAUDE_TOOL_INPUT_FILE_PATH\"; if [[ \"$FILE\" == *.py ]] && command -v bandit >/dev/null 2>&1; then bandit -q \"$FILE\" 2>/dev/null || echo \"[bandit] Issues found \u00e2\u20ac\u201d run /security-check\"; fi"
           }
         ]
       },
@@ -63,7 +53,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "FILE=\"$CLAUDE_TOOL_INPUT_FILE_PATH\"; if [[ \"$FILE\" == *.py ]] && command -v lint-imports >/dev/null 2>&1; then lint-imports 2>/dev/null || echo \"[import-linter] Architecture contract violation — run lint-imports for details\"; fi"
+            "command": "FILE=\"$CLAUDE_TOOL_INPUT_FILE_PATH\"; if [[ \"$FILE\" == *.py ]] && command -v lint-imports >/dev/null 2>&1; then lint-imports 2>/dev/null || echo \"[import-linter] Architecture contract violation \u00e2\u20ac\u201d run lint-imports for details\"; fi"
           }
         ]
       },


### PR DESCRIPTION
## Summary
- Removes the `Stop` hook that ran `pre-commit run --all-files` at the end of every Claude Code turn
- Root cause of WOR-117 worker looping: in `-p` mode, a failed Stop hook causes Claude Code to re-invoke the model to fix pre-commit errors, consuming all context without committing
- pre-commit still fires automatically on every `git commit` via `.git/hooks/pre-commit` — no protection lost

## Test plan
- [ ] Run watcher with WOR-117 — worker should now commit and create PR
- [ ] Verify interactive Claude Code sessions still have ruff/bandit PostToolUse hooks firing

🤖 Generated with [Claude Code](https://claude.com/claude-code)