### PR TITLE
Add --effort max to worker subprocess command

### DIFF
--- a/app/core/watcher.py
+++ b/app/core/watcher.py
@@ -141,6 +141,8 @@ def build_worker_cmd(ticket_id: str, mode: str) -> list[str]:
         "--strict-mcp-config",
         "--mcp-config",
         '{"mcpServers":{}}',
+        "--effort",
+        "max",
     ]
     if mode == "local":
         return base + ["--model", _LOCAL_MODEL, "-p", prompt]


### PR DESCRIPTION
## Summary
- Adds `--effort max` to the `claude` subprocess command in `build_worker_cmd()`
- Without it, `claude -p` defaults to ~10 agentic turns, which the model exhausts reading files before it can implement or commit
- `--effort max` removes the cap so the worker can complete the full implement → check → commit cycle

## Test plan
- [ ] Run watcher with WOR-117 — worker should now get past file exploration and actually write code

🤖 Generated with [Claude Code](https://claude.com/claude-code)