### PR TITLE
Revert --bare from worker command

### DIFF
--- a/app/core/watcher.py
+++ b/app/core/watcher.py
@@ -132,15 +132,13 @@ def build_worker_env(
 def build_worker_cmd(ticket_id: str, mode: str) -> list[str]:
     """Return the claude subprocess command list for the given mode."""
     prompt = f"/implement-ticket {ticket_id}"
-    # --bare: skips CLAUDE.md, auto-memory, hooks, LSP, and background
-    # prefetches — saves ~10-15K tokens of system-prompt overhead. Auth still
-    # works via ANTHROPIC_API_KEY env var. Skills still resolve (/implement-ticket).
     # --strict-mcp-config + empty config prevents Claude Code from loading
     # .mcp.json in the worktree, which would block for ~180s trying to
     # authenticate the Linear HTTP MCP server via OAuth in non-interactive mode.
+    # Note: --bare is intentionally omitted — it strips .claude/commands/ loading,
+    # making /implement-ticket an unknown command.
     base = [
         "claude",
-        "--bare",
         "--dangerously-skip-permissions",
         "--strict-mcp-config",
         "--mcp-config",


### PR DESCRIPTION
## Summary
- Removes `--bare` added in #209 — it strips `.claude/commands/` loading, making `/implement-ticket` resolve as "Unknown command" with no GPU activity
- The help text says "Skills still resolve via /skill-name" but that refers to agent skills in `.claude/agents/`, not project commands in `.claude/commands/`
- Context savings from `--bare` are noted in WOR-119 as a future spike (requires replacing slash-command dispatch with `--system-prompt-file`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)