### PR TITLE
Add --bare --add-dir . to worker subprocess

### DIFF
--- a/app/core/watcher.py
+++ b/app/core/watcher.py
@@ -132,13 +132,16 @@ def build_worker_env(
 def build_worker_cmd(ticket_id: str, mode: str) -> list[str]:
     """Return the claude subprocess command list for the given mode."""
     prompt = f"/implement-ticket {ticket_id}"
+    # --bare skips CLAUDE.md, auto-memory, hooks, LSP — saves ~5-10K context tokens.
+    # --add-dir . re-enables .claude/commands/ discovery so /implement-ticket resolves.
     # --strict-mcp-config + empty config prevents Claude Code from loading
     # .mcp.json in the worktree, which would block for ~180s trying to
     # authenticate the Linear HTTP MCP server via OAuth in non-interactive mode.
-    # Note: --bare is intentionally omitted — it strips .claude/commands/ loading,
-    # making /implement-ticket an unknown command.
     base = [
         "claude",
+        "--bare",
+        "--add-dir",
+        ".",
         "--dangerously-skip-permissions",
         "--strict-mcp-config",
         "--mcp-config",


### PR DESCRIPTION
## Summary
- Adds `--bare --add-dir .` to `build_worker_cmd()`
- `--bare` skips CLAUDE.md, auto-memory, hooks, and LSP — saving ~5-10K context tokens per session
- `--add-dir .` re-enables `.claude/commands/` discovery from the worktree root so `/implement-ticket` still resolves (the issue that broke #209)
- Combined with `--effort max`, `think: false`, and `pytest.ini` override, this should give the worker enough room to complete WOR-117's implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)