### PR TITLE
WOR-120 Enforce context_snippets via --disallowed-tools

### DIFF
--- a/app/core/watcher.py
+++ b/app/core/watcher.py
@@ -131,7 +131,11 @@ def build_worker_env(
 
 
 def build_worker_cmd(
-    ticket_id: str, mode: str, worktree_path: Path, prompt: str | None = None
+    ticket_id: str,
+    mode: str,
+    worktree_path: Path,
+    prompt: str | None = None,
+    disallowed_tools: list[str] | None = None,
 ) -> list[str]:
     """Return the claude subprocess command list for the given mode.
 
@@ -139,6 +143,9 @@ def build_worker_cmd(
     slash-command shortcut (requires commands to be loaded by Claude Code).
     In --bare mode the shortcut is unavailable, so callers should pass the
     expanded implement-ticket.md content with $ARGUMENTS substituted.
+
+    disallowed_tools — list of tool-call patterns passed to --disallowed-tools
+    (e.g. ["Read(*watcher.py)", "Read(*metrics.py)"]) to enforce context_snippets.
     """
     if prompt is None:
         prompt = f"/implement-ticket {ticket_id}"
@@ -161,6 +168,8 @@ def build_worker_cmd(
         "--output-format",
         "stream-json",
     ]
+    if disallowed_tools:
+        base += ["--disallowed-tools", ",".join(disallowed_tools)]
     if mode == "local":
         return base + ["--model", _LOCAL_MODEL, "-p", prompt]
     return base + ["-p", prompt]
@@ -588,6 +597,30 @@ class Watcher:
             logger.warning("Could not read skill file %s; using shortcut", skill_path)
             return None
 
+    @staticmethod
+    def _build_snippet_tool_restrictions(snippets: list[str]) -> list[str]:
+        """Return --disallowed-tools patterns derived from context_snippets headers.
+
+        Each snippet starts with a comment line like:
+            # app/core/watcher.py lines 574-589
+        We extract the basename and return glob patterns that block Read on those
+        files regardless of the absolute path the worker uses.
+        """
+        import re
+
+        seen: set[str] = set()
+        patterns: list[str] = []
+        header_re = re.compile(r"^#\s+(\S+)\s+lines?\s+\d")
+        for snippet in snippets:
+            first_line = snippet.splitlines()[0] if snippet else ""
+            m = header_re.match(first_line)
+            if m:
+                basename = Path(m.group(1)).name
+                if basename not in seen:
+                    seen.add(basename)
+                    patterns.append(f"Read(*{basename})")
+        return patterns
+
     def _launch_worker(
         self,
         manifest: ExecutionManifest,
@@ -595,8 +628,28 @@ class Watcher:
         effective_mode: str,
     ) -> subprocess.Popen[bytes]:
         prompt = self._expand_skill(manifest.ticket_id)
+
+        disallowed_tools: list[str] | None = None
+        if manifest.context_snippets:
+            disallowed_tools = self._build_snippet_tool_restrictions(
+                manifest.context_snippets
+            )
+            if disallowed_tools and prompt:
+                file_list = ", ".join(
+                    p.removeprefix("Read(*").removesuffix(")") for p in disallowed_tools
+                )
+                warning = (
+                    f"CRITICAL: The following files are pre-loaded as context_snippets "
+                    f"in the manifest: {file_list}. "
+                    f"DO NOT use the Read tool on these files — "
+                    f"the tool is blocked and attempting to read them will "
+                    f"abort the task. "
+                    f"Use only the snippets already provided.\n\n"
+                )
+                prompt = warning + (prompt or "")
+
         cmd = build_worker_cmd(
-            manifest.ticket_id, effective_mode, worktree_path, prompt
+            manifest.ticket_id, effective_mode, worktree_path, prompt, disallowed_tools
         )
         env = build_worker_env(effective_mode, dict(os.environ))
 

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -188,6 +188,39 @@ def test_cmd_bare_mode_uses_worktree_path(tmp_path: Path) -> None:
     assert cmd[idx + 1] == str(tmp_path)
 
 
+def test_cmd_disallowed_tools_appended(tmp_path: Path) -> None:
+    tools = ["Read(*watcher.py)", "Read(*metrics.py)"]
+    cmd = build_worker_cmd("WOR-10", "cloud", tmp_path, disallowed_tools=tools)
+    assert "--disallowed-tools" in cmd
+    idx = cmd.index("--disallowed-tools")
+    assert cmd[idx + 1] == "Read(*watcher.py),Read(*metrics.py)"
+
+
+def test_cmd_no_disallowed_tools_when_none(tmp_path: Path) -> None:
+    cmd = build_worker_cmd("WOR-10", "cloud", tmp_path, disallowed_tools=None)
+    assert "--disallowed-tools" not in cmd
+
+
+def test_build_snippet_tool_restrictions_extracts_basenames() -> None:
+    from app.core.watcher import Watcher
+
+    snippets = [
+        "# app/core/watcher.py lines 574-589\nsome code",
+        "# app/core/metrics.py lines 1-20\nmore code",
+        "# app/core/watcher.py lines 600-620\nduplicate file",
+    ]
+    patterns = Watcher._build_snippet_tool_restrictions(snippets)
+    assert patterns == ["Read(*watcher.py)", "Read(*metrics.py)"]
+
+
+def test_build_snippet_tool_restrictions_ignores_malformed() -> None:
+    from app.core.watcher import Watcher
+
+    snippets = ["no header here", "# missing path\ncode"]
+    patterns = Watcher._build_snippet_tool_restrictions(snippets)
+    assert patterns == []
+
+
 # ---------------------------------------------------------------------------
 # resolve_effective_mode
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds `disallowed_tools: list[str] | None` parameter to `build_worker_cmd` — when provided, appends `--disallowed-tools <csv>` to the claude subprocess command
- Adds `Watcher._build_snippet_tool_restrictions(snippets)` static helper that parses context_snippet headers (e.g. `# app/core/watcher.py lines 574-589`) to extract basenames and produce `Read(*filename)` glob patterns
- `_launch_worker` now automatically derives tool restrictions from `manifest.context_snippets` and prepends a CRITICAL prompt warning so the model understands reads are blocked
- 4 new unit tests

## Motivation

Local workers with a 32K context window exhaust their budget reading large files like `watcher.py` (~900 lines). Pre-injected `context_snippets` in the manifest were being ignored because the model reads files anyway. Blocking `Read` on snippet files forces the model to use the pre-loaded excerpts.

## Test plan

- [x] `test_cmd_disallowed_tools_appended` — verifies flag appears in cmd
- [x] `test_cmd_no_disallowed_tools_when_none` — verifies no flag when param is None
- [x] `test_build_snippet_tool_restrictions_extracts_basenames` — extracts unique basenames, deduplicates
- [x] `test_build_snippet_tool_restrictions_ignores_malformed` — malformed headers produce no patterns
- [x] All existing tests pass

Closes WOR-120

🤖 Generated with [Claude Code](https://claude.com/claude-code)