### PR TITLE
WOR-117 Populate retry_count in watcher metrics

### DIFF
--- a/app/core/watcher.py
+++ b/app/core/watcher.py
@@ -77,6 +77,8 @@ class ActiveWorker:
     worktree_path: Path
     process: subprocess.Popen[bytes]
     start_time: float = field(default_factory=time.monotonic)
+    backed_up_plans: list[Path] = field(default_factory=list)
+    retry_count: int = 0
 
 
 # ---------------------------------------------------------------------------
@@ -391,6 +393,8 @@ class Watcher:
             self._safe_set_state(linear_id, manifest.ticket_state_map.failed, ticket_id)
         else:
             checks_ok = self._run_checks(manifest, worker.worktree_path)
+            if not checks_ok:
+                worker.retry_count += 1
             if not checks_ok and manifest.failure_policy.on_check_failure == "abort":
                 outcome = "failure"
                 self._safe_set_state(
@@ -412,6 +416,7 @@ class Watcher:
                 local_wall_time=wall_time,
                 escalated_to_cloud=escalated,
                 outcome=outcome,
+                retry_count=worker.retry_count,
             )
         )
 

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -425,6 +425,87 @@ def test_finalize_worker_pr_failure_marks_blocked(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# retry_count wiring in _finalize_worker
+# ---------------------------------------------------------------------------
+
+
+def test_finalize_worker_retry_count_zero_on_success(tmp_path: Path) -> None:
+    manifest = _make_manifest(ticket_id="WOR-10", worker_branch="wor-10-test-ticket")
+    w = Watcher(linear_client=MagicMock())
+    worker = ActiveWorker(
+        ticket_id="WOR-10",
+        linear_id="fake-linear-id",
+        manifest=manifest,
+        worktree_path=tmp_path,
+        process=MagicMock(spec=subprocess.Popen),
+    )
+    with (
+        patch.object(w, "_run_checks", return_value=True),
+        patch.object(w, "_create_pr", return_value="https://github.com/example/pr/1"),
+        patch.object(w, "_cleanup_worktree"),
+        patch.object(w, "_metrics") as metrics_mock,
+    ):
+        w._finalize_worker(worker, returncode=0, wall_time=1.0)
+
+    call_kwargs = metrics_mock.record.call_args[0][0]
+    assert call_kwargs.retry_count == 0
+
+
+def test_finalize_worker_retry_count_increments_on_check_failure(
+    tmp_path: Path,
+) -> None:
+    manifest = _make_manifest(ticket_id="WOR-10", worker_branch="wor-10-test-ticket")
+    w = Watcher(linear_client=MagicMock())
+
+    # Simulate two check-failure cycles by calling _finalize_worker twice with
+    # the same worker (increments retry_count each time checks fail).
+    worker = ActiveWorker(
+        ticket_id="WOR-10",
+        linear_id="fake-linear-id",
+        manifest=manifest,
+        worktree_path=tmp_path,
+        process=MagicMock(spec=subprocess.Popen),
+    )
+    with (
+        patch.object(w, "_run_checks", return_value=False),
+        patch.object(w, "_cleanup_worktree"),
+        patch.object(w, "_metrics"),
+    ):
+        w._finalize_worker(worker, returncode=0, wall_time=1.0)
+        w._finalize_worker(worker, returncode=0, wall_time=1.0)
+
+    assert worker.retry_count == 2
+
+
+def test_finalize_worker_retry_count_two_failures_then_success(
+    tmp_path: Path,
+) -> None:
+    manifest = _make_manifest(ticket_id="WOR-10", worker_branch="wor-10-test-ticket")
+    w = Watcher(linear_client=MagicMock())
+    worker = ActiveWorker(
+        ticket_id="WOR-10",
+        linear_id="fake-linear-id",
+        manifest=manifest,
+        worktree_path=tmp_path,
+        process=MagicMock(spec=subprocess.Popen),
+    )
+    # Two failures then success
+    check_results = [False, False, True]
+    with (
+        patch.object(w, "_run_checks", side_effect=check_results),
+        patch.object(w, "_create_pr", return_value="https://github.com/example/pr/1"),
+        patch.object(w, "_cleanup_worktree"),
+        patch.object(w, "_metrics") as metrics_mock,
+    ):
+        w._finalize_worker(worker, returncode=0, wall_time=1.0)
+        w._finalize_worker(worker, returncode=0, wall_time=1.0)
+        w._finalize_worker(worker, returncode=0, wall_time=1.0)
+
+    call_kwargs = metrics_mock.record.call_args[0][0]
+    assert call_kwargs.retry_count == 2
+
+
+# ---------------------------------------------------------------------------
 # _safe_set_state — daemon survives LinearError at all set_state sites
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Add `retry_count: int = 0` to `ActiveWorker` dataclass — counter lives on the per-session worker instance, not a class-level attribute
- In `_finalize_worker`, increment `worker.retry_count` each time `_run_checks` returns False, then pass the final value to `TicketMetrics(retry_count=...)`
- Counter resets naturally between sessions because each `ActiveWorker` is a fresh instance

## Test plan

- [x] `test_finalize_worker_retry_count_zero_on_success` — 0 when checks pass first try
- [x] `test_finalize_worker_retry_count_increments_on_check_failure` — 2 after two check-failure cycles
- [x] `test_finalize_worker_retry_count_two_failures_then_success` — retry_count=2 recorded in TicketMetrics after two failures then success
- [x] All existing tests pass

Closes WOR-117

🤖 Generated with [Claude Code](https://claude.com/claude-code)