### PR TITLE
Fix WOR-120: restrict --disallowed-tools to cloud mode only

### DIFF
--- a/app/core/watcher.py
+++ b/app/core/watcher.py
@@ -630,7 +630,7 @@ class Watcher:
         prompt = self._expand_skill(manifest.ticket_id)
 
         disallowed_tools: list[str] | None = None
-        if manifest.context_snippets:
+        if manifest.context_snippets and effective_mode == "cloud":
             disallowed_tools = self._build_snippet_tool_restrictions(
                 manifest.context_snippets
             )


### PR DESCRIPTION
## Summary

One-line fix: `effective_mode == "cloud"` guard on the `--disallowed-tools` enforcement.

## Why

Local workers (qwen3-coder:30b) can't reason about blocked tools — when `Read` is denied they emit "permission denied" errors and spin confused for 100K+ tokens instead of using the pre-loaded `context_snippets`. Cloud workers (Sonnet 4.6) have the reasoning capacity to adapt.

The CRITICAL prompt warning still fires for local mode as a hint, but tools are not blocked. Local workers can freely read files; they just won't use snippets efficiently (which is a model capability issue, not a tooling issue).

## Test plan

- [x] All 38 existing tests pass
- [x] ruff + mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)