### PR TITLE
Use local-ready label to drive implementation_mode in manifests

### DIFF
--- a/.claude/commands/groom-ticket.md
+++ b/.claude/commands/groom-ticket.md
@@ -42,6 +42,7 @@ As a Product Owner, evaluate the issue before development begins:
    - **Milestone** — which project milestone to assign. **First check `list_milestones` progress — do not assign to any milestone at 100%; it is complete and closed to new work.** Suggest the next appropriate open milestone instead. If no existing milestone fits (e.g. clear post-V1 work), flag this and suggest creating a new one with name and description.
    - **Priority** — 1=Urgent / 2=High / 3=Normal / 4=Low
    - **Blockers** — any issues that must ship first (by WOR-NNN identifier)
+   - **local-ready label** — assess whether this ticket is safe for local LLM execution. Recommend adding the `local-ready` label if ALL of the following are true: (a) scope touches ≤3 files, none of which are large/complex orchestration modules (e.g. watcher.py, generator.py); (b) the task is straightforward wiring or additive changes requiring minimal cross-file reasoning; (c) no cloud-only dependencies or sensitive credentials needed. If any condition fails, recommend withholding the label — the watcher will route it to cloud. State your reasoning explicitly.
 
 **STOP HERE.** Present your analysis and wait for human approval before making any changes.
 
@@ -49,7 +50,7 @@ As a Product Owner, evaluate the issue before development begins:
 
 After the human approves, take all of the following actions in Linear:
 
-1. **Labels** — set the Type and Stream labels on the issue using `save_issue` (use label names, not IDs)
+1. **Labels** — set the Type and Stream labels on the issue using `save_issue` (use label names, not IDs). If `local-ready` was recommended, add it to the labels list too.
 2. **Epic** — set `parentId` to the approved epic identifier using `save_issue`. If a new epic was proposed and approved, create it first with `save_issue` (no parentId, with Type+Stream labels), then set it as parent on this issue
 3. **Milestone** — assign with `save_issue`. If a new milestone was approved, create it first with `save_milestone(project: "repo-scaffold-desktop", name: "...", description: "...")`, then assign
 4. **Priority** — update if the current value is wrong or missing

--- a/.claude/commands/start-ticket.md
+++ b/.claude/commands/start-ticket.md
@@ -88,6 +88,7 @@ If no siblings are In Progress, skip this block silently.
 - List what new tests are needed (file, test name, what it verifies)
 - Flag any security surface introduced: new I/O, user input handling, file operations, subprocess calls
 - Note edge cases and overwrite behavior to consider
+- Assess local-model suitability: is the scope bounded (≤3 small/medium files, straightforward wiring)? Or does it touch large/complex modules (e.g. watcher.py, generator.py) requiring multi-step reasoning across many dependencies? Record your conclusion — it determines `implementation_mode` in the manifest.
 
 ### 3. Create the branch and update Linear
 Using the branch name from Linear's "Copy branch name" format (usually `WOR-NNN-short-description`):
@@ -123,6 +124,7 @@ Summarize as:
 Branch: <branch-name> (off <epic-branch | main>)
 Milestone: <milestone name> (<progress>%)
 Epic: <parent issue title or "none">
+Implementation mode: <local|cloud> — local-ready label <present → local / absent → cloud>
 Files to change:
   - path/to/file.py — what changes
 Tests to write:
@@ -158,7 +160,7 @@ Construct the manifest from the planning context gathered in steps 1–4:
   "parallel_safe": <true if no file conflicts with In-Progress siblings>,
   "risk_level": "<low|medium|high — from security surface assessment>",
   "risk_flags": ["<any specific risk notes>"],
-  "implementation_mode": "local",
+  "implementation_mode": "<local if ticket has local-ready label, otherwise cloud>",
   "review_mode": "auto",
   "base_branch": "<epic-branch or main>",
   "worker_branch": "<sub-ticket-branch>",


### PR DESCRIPTION
## Summary
- `groom-ticket` now recommends/withholds the `local-ready` label based on scope complexity (file count, module complexity, reasoning requirements)
- `start-ticket` reads the label from Linear and sets `implementation_mode` to `"local"` or `"cloud"` in the manifest accordingly
- Plan summary now shows the chosen mode and why

## Test plan
- [ ] Run `/groom-ticket` on a simple ticket — confirm `local-ready` label is recommended
- [ ] Run `/groom-ticket` on a watcher.py-touching ticket — confirm label is withheld
- [ ] Run `/start-ticket` — confirm manifest `implementation_mode` reflects the label

🤖 Generated with [Claude Code](https://claude.com/claude-code)