### PR TITLE
WOR-122 Fix cloud worker auth: --bare strips OAuth credentials

### DIFF
--- a/app/core/watcher.py
+++ b/app/core/watcher.py
@@ -153,10 +153,12 @@ def build_worker_cmd(
     # the system prompt lean. --add-dir re-adds the worktree CLAUDE.md.
     # --strict-mcp-config + empty config prevents the Linear HTTP MCP server
     # from blocking ~180s on OAuth in non-interactive mode.
+    # NOTE: --bare also strips OAuth credential loading, so it must NOT be used
+    # for cloud mode where the worker authenticates via OAuth (Claude Max).
+    # Local mode uses a dummy API key via LiteLLM, so --bare is safe there.
     base = [
         "claude",
         "--dangerously-skip-permissions",
-        "--bare",
         "--add-dir",
         str(worktree_path),
         "--strict-mcp-config",
@@ -168,6 +170,8 @@ def build_worker_cmd(
         "--output-format",
         "stream-json",
     ]
+    if mode == "local":
+        base.insert(2, "--bare")
     if disallowed_tools:
         base += ["--disallowed-tools", ",".join(disallowed_tools)]
     if mode == "local":

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -188,6 +188,11 @@ def test_cmd_bare_mode_uses_worktree_path(tmp_path: Path) -> None:
     assert cmd[idx + 1] == str(tmp_path)
 
 
+def test_cloud_cmd_has_no_bare_flag(tmp_path: Path) -> None:
+    cmd = build_worker_cmd("WOR-10", "cloud", tmp_path)
+    assert "--bare" not in cmd
+
+
 def test_cmd_disallowed_tools_appended(tmp_path: Path) -> None:
     tools = ["Read(*watcher.py)", "Read(*metrics.py)"]
     cmd = build_worker_cmd("WOR-10", "cloud", tmp_path, disallowed_tools=tools)


### PR DESCRIPTION
## Summary
- `--bare` flag in Claude CLI suppresses OAuth credential loading, causing `apiKeySource: "none"` for cloud workers
- Cloud workers authenticate via OAuth (Claude Max subscription), so `--bare` must not be used in that mode
- Local mode is unaffected — it uses LiteLLM with a dummy API key where `--bare` is safe

## Root cause
Confirmed by testing `claude --bare --dangerously-skip-permissions --output-format stream-json --verbose -p "say hi"` interactively: produces `apiKeySource: "none"` + "Not logged in". Without `--bare`, OAuth works.

## Changes
- `build_worker_cmd`: inserts `--bare` only when `mode == "local"`
- `tests/test_watcher.py`: adds `test_cloud_cmd_has_no_bare_flag` assertion

## Test plan
- [ ] `pytest tests/test_watcher.py` passes (39 tests)
- [ ] Start watcher in cloud mode — worker should authenticate via OAuth without API key set

Closes WOR-122

🤖 Generated with [Claude Code](https://claude.com/claude-code)