### PR TITLE
Fix cloud worker pipeline: no duplicate PRs, preserved result.json, fresh worktree

### DIFF
--- a/.claude/commands/implement-ticket.md
+++ b/.claude/commands/implement-ticket.md
@@ -119,13 +119,18 @@ Also copy the manifest to `artifact_paths.manifest_copy` for audit purposes.
 ### 6. Update Linear
 
 **On success:**
-- `save_issue(id: "<ticket_id>", state: "<ticket_state_map.merged_to_epic>")` — only after the PR is created (run `/finalize-ticket` to create the PR first)
-- Actually: at this point just leave the ticket in `InProgressLocal` — `/finalize-ticket` will create the PR and advance the state
+Leave the ticket in `InProgressLocal`. The watcher reads the result artifact and handles PR creation and state transitions — do NOT call `/finalize-ticket`.
 
 **On failure:**
 - If `failure_policy.escalate_to_cloud` is `true`: `save_issue(id: "<ticket_id>", state: "In Progress")` and post a Linear comment: `"Local worker failed after <N> checks. Escalating to cloud. See result artifact: <artifact_paths.result_json>"`
 - Otherwise: `save_issue(id: "<ticket_id>", state: "Blocked")` and post a comment with the failure reason
 
-### 7. On success — proceed to finalize
+### 7. Exit
 
-Run `/finalize-ticket` to create the PR targeting the epic branch and advance the ticket state to `MergedToEpic` (after CI passes).
+Exit cleanly after writing the result artifact. The watcher will:
+1. Detect the result artifact (rc=0)
+2. Run `required_checks` in the worktree
+3. Create the PR targeting `base_branch`
+4. Advance the Linear ticket state to `in_review`, then `merged_to_epic` once CI passes
+
+**Do NOT run `/finalize-ticket`** — calling it from a watcher-spawned session creates a duplicate PR and bypasses the correct state machine.

--- a/app/core/watcher.py
+++ b/app/core/watcher.py
@@ -543,7 +543,7 @@ class Watcher:
         )
 
         self._restore_plan_files(worker.backed_up_plans)
-        self._preserve_worker_log(worker)
+        self._preserve_worker_artifacts(worker)
         self._cleanup_worktree(worker.worktree_path)
 
     # ------------------------------------------------------------------
@@ -581,7 +581,45 @@ class Watcher:
             text=True,
         )
         logger.info("Worktree created at %s", worktree_path)
+        self._rebase_worktree_from_base(worktree_path, manifest.base_branch)
         return worktree_path
+
+    def _rebase_worktree_from_base(self, worktree_path: Path, base_branch: str) -> None:
+        """Fetch and rebase the worktree from origin/<base_branch>.
+
+        Ensures the worker starts from the latest epic state, not a stale
+        snapshot from when the branch was created.  Logs a warning on failure
+        rather than raising — a stale start is preferable to no start at all.
+        """
+        try:
+            subprocess.run(  # nosec B603 B607
+                ["git", "-C", str(worktree_path), "fetch", "origin", base_branch],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            subprocess.run(  # nosec B603 B607
+                [
+                    "git",
+                    "-C",
+                    str(worktree_path),
+                    "rebase",
+                    f"origin/{base_branch}",
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            logger.debug(
+                "Worktree at %s rebased onto origin/%s", worktree_path, base_branch
+            )
+        except subprocess.CalledProcessError as exc:
+            logger.warning(
+                "Could not rebase worktree onto origin/%s (worker will start from "
+                "branch tip instead): %s",
+                base_branch,
+                (exc.stderr or exc.stdout or str(exc)).strip(),
+            )
 
     def _copy_manifest_to_worktree(
         self, manifest: ExecutionManifest, worktree_path: Path
@@ -632,19 +670,35 @@ class Watcher:
         """
         (worktree_path / "pytest.ini").write_text("[pytest]\naddopts = --tb=short\n")
 
-    def _preserve_worker_log(self, worker: ActiveWorker) -> None:
-        log_src = (
-            worker.worktree_path / f".claude/worker_{worker.ticket_id.lower()}.log"
-        )
-        if not log_src.exists():
-            return
+    def _preserve_worker_artifacts(self, worker: ActiveWorker) -> None:
+        """Copy worker log and result.json from the worktree to the repo artifact dir.
+
+        The worktree is removed after this call, so any file not copied here is lost.
+        """
         artifact_dir = (
             self._repo_root / worker.manifest.artifact_paths.result_json
         ).parent
         artifact_dir.mkdir(parents=True, exist_ok=True)
-        dest = artifact_dir / log_src.name
-        shutil.copy2(log_src, dest)
-        logger.info("Worker log preserved at %s", dest)
+
+        log_src = (
+            worker.worktree_path / f".claude/worker_{worker.ticket_id.lower()}.log"
+        )
+        if log_src.exists():
+            shutil.copy2(log_src, artifact_dir / log_src.name)
+            logger.info("Worker log preserved at %s", artifact_dir / log_src.name)
+
+        result_src = worker.worktree_path / worker.manifest.artifact_paths.result_json
+        if result_src.exists():
+            shutil.copy2(result_src, artifact_dir / result_src.name)
+            logger.info(
+                "Result artifact preserved at %s", artifact_dir / result_src.name
+            )
+        else:
+            logger.warning(
+                "No result artifact found at %s for %s",
+                result_src,
+                worker.ticket_id,
+            )
 
     def _cleanup_worktree(self, worktree_path: Path) -> None:
         try:

--- a/app/core/watcher.py
+++ b/app/core/watcher.py
@@ -293,7 +293,9 @@ class Watcher:
     def _transition_waiting_manifest(
         self, manifest: ExecutionManifest, manifest_path: Path, new_status: str
     ) -> None:
-        updated = manifest.model_copy(update={"status": new_status})
+        updated = manifest.model_copy(
+            update={"status": new_status, "context_snippets": None}
+        )
         updated.to_json(manifest_path)
         logger.debug(
             "Manifest for %s written with status=%s", manifest.ticket_id, new_status

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -717,3 +717,86 @@ def test_promote_no_linear_id_updates_disk_only(tmp_path: Path) -> None:
     assert on_disk.status == "ReadyForLocal"
     mock_linear.set_state.assert_not_called()
     mock_linear.post_comment.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _preserve_worker_artifacts
+# ---------------------------------------------------------------------------
+
+
+def test_preserve_worker_artifacts_copies_log_and_result(tmp_path: Path) -> None:
+    manifest = _make_manifest(ticket_id="WOR-10", worker_branch="wor-10-test-ticket")
+    w = Watcher(linear_client=MagicMock(), repo_root=tmp_path)
+
+    worktree = tmp_path / "worktrees" / "wor-10"
+    worktree.mkdir(parents=True)
+
+    log_src = worktree / ".claude" / "worker_wor-10.log"
+    log_src.parent.mkdir(parents=True)
+    log_src.write_text("log content")
+
+    result_src = worktree / ".claude" / "artifacts" / "wor_10" / "result.json"
+    result_src.parent.mkdir(parents=True)
+    result_src.write_text('{"status": "success"}')
+
+    worker = ActiveWorker(
+        ticket_id="WOR-10",
+        linear_id="fake-id",
+        manifest=manifest,
+        worktree_path=worktree,
+        process=MagicMock(spec=subprocess.Popen),
+    )
+    w._preserve_worker_artifacts(worker)
+
+    artifact_dir = tmp_path / ".claude" / "artifacts" / "wor_10"
+    assert (artifact_dir / "worker_wor-10.log").read_text() == "log content"
+    assert (artifact_dir / "result.json").read_text() == '{"status": "success"}'
+
+
+def test_preserve_worker_artifacts_missing_result_warns(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    import logging
+
+    manifest = _make_manifest(ticket_id="WOR-10", worker_branch="wor-10-test-ticket")
+    w = Watcher(linear_client=MagicMock(), repo_root=tmp_path)
+
+    worktree = tmp_path / "worktrees" / "wor-10"
+    worktree.mkdir(parents=True)
+
+    worker = ActiveWorker(
+        ticket_id="WOR-10",
+        linear_id="fake-id",
+        manifest=manifest,
+        worktree_path=worktree,
+        process=MagicMock(spec=subprocess.Popen),
+    )
+
+    with caplog.at_level(logging.WARNING, logger="app.core.watcher"):
+        w._preserve_worker_artifacts(worker)
+
+    assert any("No result artifact" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# _rebase_worktree_from_base
+# ---------------------------------------------------------------------------
+
+
+def test_rebase_worktree_from_base_warns_on_failure(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    import logging
+
+    w = Watcher(linear_client=MagicMock(), repo_root=tmp_path)
+
+    def _raise(*args: Any, **kwargs: Any) -> None:
+        raise subprocess.CalledProcessError(1, "git", stderr="conflict")
+
+    with (
+        patch("subprocess.run", side_effect=_raise),
+        caplog.at_level(logging.WARNING, logger="app.core.watcher"),
+    ):
+        w._rebase_worktree_from_base(tmp_path, "some-epic-branch")
+
+    assert any("Could not rebase" in r.message for r in caplog.records)

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -800,3 +800,23 @@ def test_rebase_worktree_from_base_warns_on_failure(
         w._rebase_worktree_from_base(tmp_path, "some-epic-branch")
 
     assert any("Could not rebase" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# _promote_waiting_tickets — context_snippets cleared on promotion
+# ---------------------------------------------------------------------------
+
+
+def test_promote_clears_context_snippets(tmp_path: Path) -> None:
+    artifacts = tmp_path / ".claude" / "artifacts"
+    manifest = _make_waiting_manifest(
+        context_snippets=["# app/core/foo.py:1-10\nsome code"]
+    )
+    _write_manifest(manifest, artifacts)
+
+    watcher, _ = _make_watcher_with_mock_linear(tmp_path, {"WOR-45": "completed"})
+    watcher._promote_waiting_tickets()
+
+    on_disk = ExecutionManifest.from_json(artifacts / "wor_46" / "manifest.json")
+    assert on_disk.status == "ReadyForLocal"
+    assert on_disk.context_snippets is None


### PR DESCRIPTION
## Summary

- **Double PR bug**: `implement-ticket.md` step 7 was telling workers to call `/finalize-ticket`, which created a PR. The watcher *also* created a PR after seeing `rc=0`. Fix: workers now stop after writing the result artifact — watcher owns PR creation and all Linear state transitions.
- **Lost result.json**: `_preserve_worker_log` only copied the `.log` file; `result.json` written by the worker in the worktree was deleted when the worktree was removed. Fix: renamed to `_preserve_worker_artifacts` and it now copies both files.
- **Stale worktree**: Workers started from a stale snapshot of the epic branch (commits that merged after the worker branch was created were invisible). Fix: `_rebase_worktree_from_base` runs `git fetch && git rebase origin/<base_branch>` after worktree creation; warns on failure rather than aborting.

Root cause found by analyzing WOR-121 run: 84 turns, $2.85, duplicate PRs (#223 worker-created, #224 watcher-created), no result artifact, 572-line test file churn from stale worktree.

## Test plan
- [ ] `pytest tests/test_watcher.py` — 52 tests, includes 3 new tests for `_preserve_worker_artifacts` and `_rebase_worktree_from_base`
- [ ] Full suite: 259 tests, 83.78% coverage
- [ ] Run watcher with a cloud ticket and verify: single PR, result.json present in `.claude/artifacts/`, worker starts from latest epic state

🤖 Generated with [Claude Code](https://claude.com/claude-code)