### PR TITLE
WOR-123 Add separate concurrency limits for cloud and local workers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,10 @@ python -m app.cli watcher                        # respects each manifest's impl
 python -m app.cli watcher --worker-mode cloud    # force cloud (Anthropic API) for all tickets
 python -m app.cli watcher --worker-mode local    # force local (LiteLLM proxy + RTX 5090)
 # Also: WORKER_MODE=cloud python -m app.cli watcher
+# Concurrency (pools are independent — local is never starved by cloud burst):
+python -m app.cli watcher --max-local-workers 1  # default 1; GPU serial bottleneck
+python -m app.cli watcher --max-cloud-workers 3  # default 3; parallelisable
+python -m app.cli watcher --max-workers 2        # backward-compat alias: sets both to 2
 
 
 # CLI — metrics

--- a/app/cli.py
+++ b/app/cli.py
@@ -95,10 +95,25 @@ def _build_parser() -> argparse.ArgumentParser:
         ),
     )
     watcher.add_argument(
-        "--max-workers",
+        "--max-local-workers",
         type=int,
         default=1,
-        help="Maximum number of concurrent worker sessions (default: 1).",
+        help="Maximum concurrent local worker sessions (default: 1).",
+    )
+    watcher.add_argument(
+        "--max-cloud-workers",
+        type=int,
+        default=3,
+        help="Maximum concurrent cloud worker sessions (default: 3).",
+    )
+    watcher.add_argument(
+        "--max-workers",
+        type=int,
+        default=None,
+        help=(
+            "Backward-compatible alias: sets both --max-local-workers and "
+            "--max-cloud-workers to the same value."
+        ),
     )
     watcher.add_argument(
         "--verbose",
@@ -124,8 +139,16 @@ def _run_watcher(args: argparse.Namespace) -> int:
         stream=sys.stderr,
     )
     mode = args.worker_mode or os.environ.get("WORKER_MODE", "default")
+    max_local = args.max_local_workers
+    max_cloud = args.max_cloud_workers
+    if args.max_workers is not None:
+        max_local = args.max_workers
+        max_cloud = args.max_workers
     watcher = Watcher(
-        worker_mode=mode, max_workers=args.max_workers, verbose=args.verbose
+        worker_mode=mode,
+        max_local_workers=max_local,
+        max_cloud_workers=max_cloud,
+        verbose=args.verbose,
     )
     try:
         watcher.run()

--- a/app/core/watcher.py
+++ b/app/core/watcher.py
@@ -255,7 +255,8 @@ class Watcher:
     def __init__(
         self,
         worker_mode: str = "default",
-        max_workers: int = 1,
+        max_local_workers: int = 1,
+        max_cloud_workers: int = 3,
         linear_client: LinearClientProtocol | None = None,
         metrics_store: MetricsStore | None = None,
         repo_root: Path | None = None,
@@ -268,12 +269,14 @@ class Watcher:
             linear_client = LinearClient()
 
         self._mode = worker_mode
-        self._max_workers = max_workers
+        self._max_local_workers = max_local_workers
+        self._max_cloud_workers = max_cloud_workers
         self._linear = linear_client
         self._metrics = metrics_store or MetricsStore()
         self._repo_root = (repo_root or Path.cwd()).resolve()
         self._project_id = project_id
-        self._active: list[ActiveWorker] = []
+        self._local_active: list[ActiveWorker] = []
+        self._cloud_active: list[ActiveWorker] = []
         self._running = True
         self._litellm_proc: subprocess.Popen[bytes] | None = None
         self._verbose = verbose
@@ -295,16 +298,19 @@ class Watcher:
             self._ensure_litellm_running()
 
         logger.info(
-            "Watcher started (mode=%s, max_workers=%d)",
+            "Watcher started (mode=%s, max_local_workers=%d, max_cloud_workers=%d)",
             self._mode,
-            self._max_workers,
+            self._max_local_workers,
+            self._max_cloud_workers,
         )
 
         try:
             while self._running:
                 self._reap_finished_workers()
                 self._promote_waiting_tickets()
-                if len(self._active) < self._max_workers:
+                local_has_capacity = len(self._local_active) < self._max_local_workers
+                cloud_has_capacity = len(self._cloud_active) < self._max_cloud_workers
+                if local_has_capacity or cloud_has_capacity:
                     self._dispatch_next_ticket()
                 time.sleep(self._POLL_INTERVAL)
         finally:
@@ -422,7 +428,8 @@ class Watcher:
 
         for ticket in tickets:
             ticket_id: str = ticket["identifier"]
-            if any(w.ticket_id == ticket_id for w in self._active):
+            all_active = self._local_active + self._cloud_active
+            if any(w.ticket_id == ticket_id for w in all_active):
                 continue
             try:
                 self._start_ticket(ticket_id, ticket["id"])
@@ -439,7 +446,8 @@ class Watcher:
             logger.info("Skipping %s — open blockers: %s", ticket_id, open_blockers)
             return
 
-        conflicts = check_allowed_paths_overlap(self._active, manifest)
+        all_active = self._local_active + self._cloud_active
+        conflicts = check_allowed_paths_overlap(all_active, manifest)
         if conflicts:
             logger.info(
                 "Deferring %s — allowed_paths overlap with active workers: %s",
@@ -451,6 +459,26 @@ class Watcher:
         effective_mode = resolve_effective_mode(
             self._mode, manifest.implementation_mode
         )
+
+        if effective_mode == "local":
+            if len(self._local_active) >= self._max_local_workers:
+                logger.info(
+                    "Deferring %s — local pool full (%d/%d)",
+                    ticket_id,
+                    len(self._local_active),
+                    self._max_local_workers,
+                )
+                return
+        else:
+            if len(self._cloud_active) >= self._max_cloud_workers:
+                logger.info(
+                    "Deferring %s — cloud pool full (%d/%d)",
+                    ticket_id,
+                    len(self._cloud_active),
+                    self._max_cloud_workers,
+                )
+                return
+
         worktree_path = self._create_worktree(manifest)
         self._copy_manifest_to_worktree(manifest, worktree_path)
         self._write_worker_pytest_config(worktree_path)
@@ -462,24 +490,26 @@ class Watcher:
 
         backed_up_plans = self._backup_plan_files()
         process = self._launch_worker(manifest, worktree_path, effective_mode)
-        self._active.append(
-            ActiveWorker(
-                ticket_id=ticket_id,
-                linear_id=linear_id,
-                manifest=manifest,
-                worktree_path=worktree_path,
-                process=process,
-                backed_up_plans=backed_up_plans,
-            )
+        worker = ActiveWorker(
+            ticket_id=ticket_id,
+            linear_id=linear_id,
+            manifest=manifest,
+            worktree_path=worktree_path,
+            process=process,
+            backed_up_plans=backed_up_plans,
         )
+        if effective_mode == "local":
+            self._local_active.append(worker)
+        else:
+            self._cloud_active.append(worker)
 
     # ------------------------------------------------------------------
     # Worker lifecycle
     # ------------------------------------------------------------------
 
-    def _reap_finished_workers(self) -> None:
+    def _reap_pool(self, workers: list[ActiveWorker]) -> list[ActiveWorker]:
         still_running: list[ActiveWorker] = []
-        for worker in self._active:
+        for worker in workers:
             rc = worker.process.poll()
             if rc is None:
                 still_running.append(worker)
@@ -492,7 +522,11 @@ class Watcher:
                 elapsed,
             )
             self._finalize_worker(worker, returncode=rc, wall_time=elapsed)
-        self._active = still_running
+        return still_running
+
+    def _reap_finished_workers(self) -> None:
+        self._local_active = self._reap_pool(self._local_active)
+        self._cloud_active = self._reap_pool(self._cloud_active)
 
     def _safe_set_state(self, linear_id: str, state: str, ticket_id: str) -> None:
         try:
@@ -1046,10 +1080,11 @@ class Watcher:
         self._running = False
 
     def _wait_for_active_workers(self) -> None:
-        if not self._active:
+        all_active = self._local_active + self._cloud_active
+        if not all_active:
             return
-        logger.info("Waiting for %d active worker(s) to finish…", len(self._active))
-        for worker in self._active:
+        logger.info("Waiting for %d active worker(s) to finish…", len(all_active))
+        for worker in all_active:
             try:
                 worker.process.wait(timeout=600)
             except subprocess.TimeoutExpired:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -280,3 +280,29 @@ def test_watcher_verbose_flag_forwarded(tmp_path):
     assert rc == 0
     _, kwargs = MockWatcher.call_args
     assert kwargs.get("verbose") is True
+
+
+def test_watcher_max_local_and_cloud_workers_forwarded():
+    from unittest.mock import MagicMock, patch
+
+    mock_instance = MagicMock()
+    mock_instance.run.return_value = None
+    with patch("app.core.watcher.Watcher", return_value=mock_instance) as MockWatcher:
+        rc = main(["watcher", "--max-local-workers", "2", "--max-cloud-workers", "5"])
+    assert rc == 0
+    _, kwargs = MockWatcher.call_args
+    assert kwargs.get("max_local_workers") == 2
+    assert kwargs.get("max_cloud_workers") == 5
+
+
+def test_watcher_max_workers_alias_sets_both():
+    from unittest.mock import MagicMock, patch
+
+    mock_instance = MagicMock()
+    mock_instance.run.return_value = None
+    with patch("app.core.watcher.Watcher", return_value=mock_instance) as MockWatcher:
+        rc = main(["watcher", "--max-workers", "4"])
+    assert rc == 0
+    _, kwargs = MockWatcher.call_args
+    assert kwargs.get("max_local_workers") == 4
+    assert kwargs.get("max_cloud_workers") == 4

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -621,11 +621,11 @@ def test_start_ticket_set_state_failure_worker_still_starts(tmp_path: Path) -> N
         patch.object(w, "_copy_manifest_to_worktree"),
         patch.object(w, "_launch_worker", return_value=fake_process),
     ):
-        # set_state raises — worker must still be launched and added to _active
+        # set_state raises — worker must still be launched and added to _local_active
         w._start_ticket("WOR-10", "fake-linear-id")
 
-    assert len(w._active) == 1
-    assert w._active[0].ticket_id == "WOR-10"
+    assert len(w._local_active) == 1
+    assert w._local_active[0].ticket_id == "WOR-10"
 
 
 # ---------------------------------------------------------------------------
@@ -1075,3 +1075,64 @@ def test_finalize_worker_usage_none_when_no_log(tmp_path: Path) -> None:
     m = metrics_mock.record.call_args[0][0]
     assert m.local_tokens is None
     assert m.context_compactions is None
+
+
+# ---------------------------------------------------------------------------
+# Per-type concurrency — cloud pool full does not block local dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_cloud_pool_full_does_not_block_local_dispatch(tmp_path: Path) -> None:
+    """A saturated cloud pool must not prevent a local ticket from being dispatched."""
+    local_manifest = _make_manifest(
+        ticket_id="WOR-10",
+        worker_branch="wor-10-test-ticket",
+        implementation_mode="local",
+        allowed_paths=["app/core/local_only.py"],
+    )
+    cloud_manifest = _make_manifest(
+        ticket_id="WOR-99",
+        worker_branch="wor-99-cloud-ticket",
+        implementation_mode="cloud",
+        artifact_paths=ArtifactPaths.from_ticket_id("WOR-99"),
+        allowed_paths=["app/core/cloud_only.py"],
+    )
+
+    mock_linear = MagicMock()
+    mock_linear.get_open_blockers.return_value = []
+
+    # max_cloud_workers=1 so one occupant fills the cloud pool; local cap=1
+    watcher = Watcher(
+        linear_client=mock_linear,
+        max_local_workers=1,
+        max_cloud_workers=1,
+    )
+
+    # Pre-fill the cloud pool
+    watcher._cloud_active.append(
+        ActiveWorker(
+            ticket_id="WOR-99",
+            linear_id="fake-cloud-id",
+            manifest=cloud_manifest,
+            worktree_path=tmp_path,
+            process=MagicMock(spec=subprocess.Popen),
+        )
+    )
+
+    fake_local_process = MagicMock(spec=subprocess.Popen)
+
+    with (
+        patch.object(watcher, "_load_manifest", return_value=local_manifest),
+        patch.object(watcher, "_create_worktree", return_value=tmp_path),
+        patch.object(watcher, "_copy_manifest_to_worktree"),
+        patch.object(watcher, "_write_worker_pytest_config"),
+        patch.object(watcher, "_launch_worker", return_value=fake_local_process),
+    ):
+        watcher._start_ticket("WOR-10", "fake-local-id")
+
+    # Local ticket dispatched despite cloud pool being full
+    assert len(watcher._local_active) == 1
+    assert watcher._local_active[0].ticket_id == "WOR-10"
+    # Cloud pool unchanged
+    assert len(watcher._cloud_active) == 1
+    assert watcher._cloud_active[0].ticket_id == "WOR-99"


### PR DESCRIPTION
Closes WOR-123

Watcher uses independent per-type concurrency counters. Cloud and local worker pools gate independently. --max-cloud-workers and --max-local-workers CLI flags are available. All tests pass including new mixed-mode saturation test.