### PR TITLE
WOR-127 Watcher: log gh pr merge --auto failures instead of silently swallowing them

### DIFF
--- a/app/core/watcher.py
+++ b/app/core/watcher.py
@@ -919,13 +919,21 @@ class Watcher:
             check=True,
         )
         pr_url = result.stdout.strip()
-        subprocess.run(  # nosec B603 B607
+        merge_result = subprocess.run(  # nosec B603 B607
             ["gh", "pr", "merge", "--auto", "--squash", pr_url],
             cwd=str(worktree_path),
             capture_output=True,
             text=True,
             check=False,
         )
+        if merge_result.returncode != 0:
+            output = (merge_result.stderr or merge_result.stdout).strip()
+            logger.warning(
+                "gh pr merge --auto failed for %s (rc=%d): %s",
+                pr_url,
+                merge_result.returncode,
+                output,
+            )
         return pr_url
 
     # ------------------------------------------------------------------

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -6,6 +6,7 @@ this file covers the unit-testable, I/O-free helpers.
 
 from __future__ import annotations
 
+import logging
 import os
 import subprocess
 from pathlib import Path
@@ -426,6 +427,51 @@ def test_create_pr_pushes_branch_before_gh_pr(tmp_path: Path) -> None:
         w._create_pr(manifest, tmp_path)
 
     assert call_order == ["push", "gh_pr"]
+
+
+def test_create_pr_logs_warning_on_auto_merge_failure(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    manifest = _make_manifest(
+        ticket_id="WOR-10",
+        worker_branch="wor-10-test-ticket",
+        base_branch="main",
+        title="Test ticket",
+        done_definition="It works.",
+    )
+    pr_url = "https://github.com/example/pr/1"
+
+    def fake_run(cmd: list[str], **_kwargs: object) -> MagicMock:
+        result = MagicMock()
+        result.returncode = 0
+        result.stderr = ""
+        if cmd[:3] == ["gh", "pr", "merge"]:
+            result.returncode = 1
+            result.stderr = "auto-merge is not enabled for this repository"
+            result.stdout = ""
+        elif cmd[:3] == ["gh", "pr", "create"]:
+            result.stdout = pr_url
+        elif cmd[:2] == ["git", "log"]:
+            result.stdout = "abc1234 some commit"
+        else:
+            result.stdout = pr_url
+        return result
+
+    w = Watcher(linear_client=MagicMock())
+    with (
+        patch("app.core.watcher.subprocess.run", side_effect=fake_run),
+        caplog.at_level(logging.WARNING, logger="app.core.watcher"),
+    ):
+        returned_url = w._create_pr(manifest, tmp_path)
+
+    assert returned_url == pr_url
+    assert any(
+        "gh pr merge --auto failed" in msg
+        and pr_url in msg
+        and "rc=1" in msg
+        and "auto-merge is not enabled" in msg
+        for msg in caplog.messages
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes WOR-127

The `_create_pr` method captures the return value of `gh pr merge --auto --squash` and logs a WARNING (including PR URL, rc, and stderr) when it exits non-zero. At least one new test verifies the warning is emitted on failure. All required checks pass.