### PR TITLE
WOR-126 Spike tickets bypass watcher — always implement interactively

### DIFF
--- a/.claude/commands/start-ticket.md
+++ b/.claude/commands/start-ticket.md
@@ -2,6 +2,27 @@ Look up the Linear issue with identifier $ARGUMENTS in the repo-scaffold-desktop
 
 Work through these phases in order:
 
+### Spike gate
+Check whether the issue carries a label whose name matches **Spike** (case-insensitive).
+
+If the Spike label is present:
+1. Set state to In Progress: `save_issue(id: "$ARGUMENTS", state: "In Progress")`
+2. Post a comment: `save_comment(issueId: "$ARGUMENTS", body: "Spike ticket — implementing interactively (no watcher manifest). See CLAUDE.md spike workflow.")`
+3. Print the following and **STOP** — do not create a branch, do not write a manifest:
+
+```
+This ticket is labelled Spike — interactive implementation required.
+
+Spike tickets bypass the watcher. Implement them interactively:
+  1. Create a branch: git checkout -b <branch-name>
+  2. Investigate and document findings in docs/spikes/<name>.md
+  3. Commit findings with: git commit -m "Part of $ARGUMENTS: ..."
+  4. Run /finalize-ticket to open a PR (review_mode: human — no auto-merge)
+  5. Human reviews before merge; close the Linear ticket manually after merge
+```
+
+**Do not write a ReadyForLocal manifest for Spike tickets.**
+
 ### Watcher status check
 Check whether the watcher daemon is running by reading `.claude/watcher.pid`:
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -266,6 +266,39 @@ To change escalation rules, edit `config/escalation_policy.toml` and commit — 
 
 ---
 
+## Spike workflow
+
+Spike tickets are investigative — findings must be reviewed by a human before merging. They bypass the watcher entirely.
+
+**Detecting a spike:** Any ticket with the **Spike** label (case-insensitive).
+
+**`/start-ticket` behaviour:** If the Spike label is present, the command sets state to `In Progress` and prints the interactive workflow below. It does **not** write a ReadyForLocal manifest.
+
+**`watcher` behaviour:** Any `ReadyForLocal` ticket that still carries the Spike label is skipped with a WARNING log. This is a safety net — `/start-ticket` should have caught it first.
+
+**Interactive spike workflow:**
+```bash
+# 1. Create a branch (use Linear's "Copy branch name")
+git checkout -b wor-NNN-spike-slug
+
+# 2. Investigate and document findings
+mkdir -p docs/spikes
+# write findings to docs/spikes/<slug>.md
+
+# 3. Commit findings
+git commit -m "Part of WOR-NNN: spike findings — <topic>"
+
+# 4. Open a PR for human review (no auto-merge)
+# Run /finalize-ticket — it will open a PR targeting main (or epic branch)
+# The PR requires human review before merge
+
+# 5. After merge, close the Linear ticket manually
+```
+
+Spike PRs always require human review. Do not enable auto-merge on spike PRs.
+
+---
+
 ## Immediate milestone
 
 **Generate a local repository skeleton from a selected preset and write all files to disk.**

--- a/app/core/linear_client.py
+++ b/app/core/linear_client.py
@@ -51,6 +51,11 @@ class LinearClient:
                   id
                   identifier
                   title
+                  labels {
+                    nodes {
+                      name
+                    }
+                  }
                   relations {
                     nodes {
                       type

--- a/app/core/watcher.py
+++ b/app/core/watcher.py
@@ -398,6 +398,15 @@ class Watcher:
             ticket_id: str = ticket["identifier"]
             if any(w.ticket_id == ticket_id for w in self._active):
                 continue
+            labels = [
+                node["name"] for node in ticket.get("labels", {}).get("nodes", [])
+            ]
+            if any(label.lower() == "spike" for label in labels):
+                logger.warning(
+                    "Skipping %s — Spike label detected; implement interactively",
+                    ticket_id,
+                )
+                continue
             try:
                 self._start_ticket(ticket_id, ticket["id"])
                 return  # one ticket per dispatch cycle

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -849,6 +849,84 @@ def test_rebase_worktree_from_base_warns_on_failure(
 
 
 # ---------------------------------------------------------------------------
+# _dispatch_next_ticket — Spike label guard
+# ---------------------------------------------------------------------------
+
+
+def _spike_ticket(label_name: str = "Spike") -> dict[str, Any]:
+    return {
+        "id": "fake-linear-id",
+        "identifier": "WOR-99",
+        "title": "Some spike",
+        "labels": {"nodes": [{"name": label_name}]},
+    }
+
+
+def _regular_ticket() -> dict[str, Any]:
+    return {
+        "id": "fake-linear-id",
+        "identifier": "WOR-99",
+        "title": "Regular ticket",
+        "labels": {"nodes": [{"name": "local-ready"}]},
+    }
+
+
+def test_dispatch_skips_spike_labelled_ticket(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    mock_linear = MagicMock()
+    mock_linear.list_ready_for_local.return_value = [_spike_ticket("Spike")]
+    w = Watcher(linear_client=mock_linear, repo_root=tmp_path)
+
+    with (
+        patch.object(w, "_start_ticket") as mock_start,
+        caplog.at_level(logging.WARNING, logger="app.core.watcher"),
+    ):
+        w._dispatch_next_ticket()
+
+    mock_start.assert_not_called()
+    assert any("Spike" in msg and "WOR-99" in msg for msg in caplog.messages)
+
+
+@pytest.mark.parametrize("label_name", ["spike", "SPIKE", "Spike"])
+def test_dispatch_skips_spike_label_case_insensitive(
+    tmp_path: Path, label_name: str
+) -> None:
+    mock_linear = MagicMock()
+    mock_linear.list_ready_for_local.return_value = [_spike_ticket(label_name)]
+    w = Watcher(linear_client=mock_linear, repo_root=tmp_path)
+
+    with patch.object(w, "_start_ticket") as mock_start:
+        w._dispatch_next_ticket()
+
+    mock_start.assert_not_called()
+
+
+def test_dispatch_proceeds_for_non_spike_ticket(tmp_path: Path) -> None:
+    mock_linear = MagicMock()
+    mock_linear.list_ready_for_local.return_value = [_regular_ticket()]
+    w = Watcher(linear_client=mock_linear, repo_root=tmp_path)
+
+    with patch.object(w, "_start_ticket") as mock_start:
+        w._dispatch_next_ticket()
+
+    mock_start.assert_called_once_with("WOR-99", "fake-linear-id")
+
+
+def test_dispatch_missing_labels_field_no_crash(tmp_path: Path) -> None:
+    mock_linear = MagicMock()
+    mock_linear.list_ready_for_local.return_value = [
+        {"id": "fake-linear-id", "identifier": "WOR-99", "title": "No labels"}
+    ]
+    w = Watcher(linear_client=mock_linear, repo_root=tmp_path)
+
+    with patch.object(w, "_start_ticket") as mock_start:
+        w._dispatch_next_ticket()
+
+    mock_start.assert_called_once_with("WOR-99", "fake-linear-id")
+
+
+# ---------------------------------------------------------------------------
 # _promote_waiting_tickets — context_snippets cleared on promotion
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes WOR-126

list_ready_for_local GraphQL query includes labels; _dispatch_next_ticket skips Spike-labelled tickets with a warning log; /start-ticket sets In Progress and posts a comment instead of writing a manifest when Spike label is present; CLAUDE.md spike workflow section exists; tests pass for both the skip and non-skip paths in the watcher.