### PR TITLE
Fix start-ticket: document ticket_id_lower path normalization rule

### DIFF
--- a/.claude/commands/start-ticket.md
+++ b/.claude/commands/start-ticket.md
@@ -194,6 +194,8 @@ Construct the manifest from the planning context gathered in steps 1–4:
 
 Write this JSON to `.claude/artifacts/<ticket_id_lower>/manifest.json` (e.g. `.claude/artifacts/wor_80/manifest.json`). Create parent dirs as needed.
 
+> **Path normalization:** `<ticket_id_lower>` is `ticket_id.lower().replace("-", "_")` — hyphens become underscores (e.g. `WOR-127` → `wor_127`). This matches `ArtifactPaths.from_ticket_id()` in `app/core/manifest.py`. Using `wor-127` (hyphen) will cause a "No such file or directory" error at watcher startup.
+
 Then:
 1. Set the ticket to **ReadyForLocal** in Linear: `save_issue(id: "$ARGUMENTS", state: "ReadyForLocal")`
 2. Post a Linear comment with the manifest path: `save_comment(issueId: "$ARGUMENTS", body: "Execution manifest written to .claude/artifacts/<ticket_id_lower>/manifest.json — watcher may now pick up.")`


### PR DESCRIPTION
## Summary
- Adds a callout block in the manifest-writing section of `start-ticket.md`
- Documents that `ticket_id_lower` uses underscores (`wor_127`), not hyphens (`wor-127`)
- Prevents watcher startup errors from malformed manifest paths

## Test plan
- [ ] No code changes — documentation only
- [ ] Verify callout renders correctly in markdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)