### PR TITLE
WOR-133 Parameterize skills repo command files for linear_project and repo_name

### DIFF
--- a/.claude/commands/close-epic.md
+++ b/.claude/commands/close-epic.md
@@ -149,7 +149,7 @@ This PR requires **human review and approval** — no auto-merge.
 
 ### 8. Update Linear
 1. Mark the epic issue **In Review**: `save_issue(id: "$ARGUMENTS", state: "In Review")`
-2. Check milestone progress with `list_milestones(project: "repo-scaffold-desktop")`. If 100%, note: "🎉 Milestone '<name>' is now complete."
+2. Check milestone progress with `list_milestones(project: "{{ linear_project }}")`. If 100%, note: "🎉 Milestone '<name>' is now complete."
 
 ### 9. Clean up worktrees
 List any worktrees for sub-tickets that have already been merged into the epic branch:

--- a/.claude/commands/finalize-ticket.md
+++ b/.claude/commands/finalize-ticket.md
@@ -78,10 +78,10 @@ What "In Review" means depends on the PR target:
 - **Sub-ticket → epic branch (auto-merge):** "In Review" = PR is open and will merge automatically when CI passes. `/close-epic` will repair this to Done once the PR is confirmed merged. If CI fails, the PR stays open and `/close-epic` will catch and report it.
 - **Ticket → main (human review):** "In Review" = PR is open, awaiting human approval.
 
-Fetch the milestone this issue belongs to with `list_milestones(project: "repo-scaffold-desktop")`. If the milestone's progress has reached 100%, note it explicitly: "🎉 Milestone '<name>' is now complete."
+Fetch the milestone this issue belongs to with `list_milestones(project: "{{ linear_project }}")`. If the milestone's progress has reached 100%, note it explicitly: "🎉 Milestone '<name>' is now complete."
 
 ### 5. Update the project page
-Update the **repo-scaffold-desktop** project summary to reflect what just shipped.
+Update the **{{ linear_project }}** project summary to reflect what just shipped.
 
 Call `save_project(id: "87ca9685-f2e6-493f-a022-03ef2425d2ab")` with an updated `summary` (max 255 chars) capturing the current state. Example format:
 `MVP Build 88% | WOR-NNN just merged | In Review: WOR-X | Next: WOR-Y`
@@ -95,6 +95,20 @@ If this session entered a worktree via `EnterWorktree`, call `ExitWorktree` now 
 git checkout main
 ```
 
+### 6.5. Skills drift check
+
+Check whether any `.claude/commands/` files were modified in this PR:
+```bash
+git diff $(git merge-base HEAD origin/<base-branch>)..HEAD --name-only | grep '^\\.claude/commands/'
+```
+
+If any command files appear in the output, list them and print:
+```
+Command files changed — run `/contribute-skill <file>` for each to sync upstream, then update `.claude/skills_version.txt`.
+```
+
+Skip silently if no command files were changed.
+
 ---
 
 ### 7. Opportunistic issue capture
@@ -106,7 +120,7 @@ Now that implementation is complete, you have the deepest context on this area o
 
 **Rules:**
 - Only surface things genuinely encountered during implementation — no extra scans
-- Check existing Linear issues first (`list_issues` with `project: "repo-scaffold-desktop"`) to avoid duplicates
+- Check existing Linear issues first (`list_issues` with `project: "{{ linear_project }}"`) to avoid duplicates
 - Maximum 3 suggestions; keep only the most impactful
 - Present suggestions and wait for approval before creating anything
 

--- a/.claude/commands/groom-ticket.md
+++ b/.claude/commands/groom-ticket.md
@@ -13,10 +13,10 @@ Before anything else, run a non-blocking skills staleness check:
 
 ---
 
-Look up the Linear issue with identifier $ARGUMENTS in the repo-scaffold-desktop project using the Linear MCP server. Run these in parallel:
+Look up the Linear issue with identifier $ARGUMENTS in the {{ linear_project }} project using the Linear MCP server. Run these in parallel:
 - `get_issue($ARGUMENTS, includeRelations: true)` — see existing labels, milestone, parent epic, priority, blocking relations
-- `list_milestones(project: "repo-scaffold-desktop")` — check milestone progress before suggesting assignment
-- `list_issues(project: "repo-scaffold-desktop", state: "In Progress")` combined with issues that have no parentId — to get current active epics
+- `list_milestones(project: "{{ linear_project }}")` — check milestone progress before suggesting assignment
+- `list_issues(project: "{{ linear_project }}", state: "In Progress")` combined with issues that have no parentId — to get current active epics
 
 Then spawn the **repo-investigator** subagent, passing the ticket title and description as the prompt. Use its returned summary as context for the analysis below — do not read any source files yourself.
 
@@ -52,7 +52,7 @@ After the human approves, take all of the following actions in Linear:
 
 1. **Labels** — set the Type and Stream labels on the issue using `save_issue` (use label names, not IDs). If `local-ready` was recommended, add it to the labels list too.
 2. **Epic** — set `parentId` to the approved epic identifier using `save_issue`. If a new epic was proposed and approved, create it first with `save_issue` (no parentId, with Type+Stream labels), then set it as parent on this issue
-3. **Milestone** — assign with `save_issue`. If a new milestone was approved, create it first with `save_milestone(project: "repo-scaffold-desktop", name: "...", description: "...")`, then assign
+3. **Milestone** — assign with `save_issue`. If a new milestone was approved, create it first with `save_milestone(project: "{{ linear_project }}", name: "...", description: "...")`, then assign
 4. **Priority** — update if the current value is wrong or missing
 5. **Blockers** — add any missing `blockedBy` relations (append-only; existing relations are never removed)
 6. **Sub-issues** — if splitting was recommended and approved, create each sub-issue with `save_issue` using `parentId: "$ARGUMENTS"`, then set the same labels, epic, and milestone on each

--- a/.claude/commands/prioritize.md
+++ b/.claude/commands/prioritize.md
@@ -1,7 +1,7 @@
-Pull all open issues from the **repo-scaffold-desktop** project using the Linear MCP server. Run these fetches in parallel:
+Pull all open issues from the **{{ linear_project }}** project using the Linear MCP server. Run these fetches in parallel:
 
-- `list_issues` with `project: "repo-scaffold-desktop"` — exclude Done/Cancelled
-- `list_milestones` with `project: "repo-scaffold-desktop"` — get progress % on each
+- `list_issues` with `project: "{{ linear_project }}"` — exclude Done/Cancelled
+- `list_milestones` with `project: "{{ linear_project }}"` — get progress % on each
 
 Then for every issue that has or appears to have blocking relations, fetch `get_issue(id, includeRelations: true)` to get the **actual Linear blocker chain** (do not infer from titles).
 
@@ -72,7 +72,7 @@ Based on the milestone overview and current issue distribution, recommend any of
 
 ### 7. Update the Linear project page
 
-After presenting sections 1–5, update the **repo-scaffold-desktop** project in Linear to reflect current state. Do both of these:
+After presenting sections 1–5, update the **{{ linear_project }}** project in Linear to reflect current state. Do both of these:
 
 **A. Update `summary`** (max 255 chars) — a single sentence capturing the current milestone and what's in flight. Example format:
 `MVP Build 88% → Test/polish 40% | In flight: WOR-X, WOR-Y | Next: WOR-Z`

--- a/.claude/commands/start-epic.md
+++ b/.claude/commands/start-epic.md
@@ -40,7 +40,7 @@ git branch --merged main | grep -v '^\*\? *main$' | xargs -r git branch -d
 
 Fetch all children of the epic:
 ```
-list_issues(project: "repo-scaffold-desktop", parentId: "$ARGUMENTS")
+list_issues(project: "{{ linear_project }}", parentId: "$ARGUMENTS")
 ```
 
 Keep only tickets in state `Groomed` or `Todo`. Skip anything already `ReadyForLocal`, `InProgressLocal`, `In Progress`, `In Review`, `MergedToEpic`, or `Done`.
@@ -185,8 +185,6 @@ Write to `.claude/artifacts/<ticket_id_lower>/manifest.json`:
   },
   "ticket_state_map": {
     "in_progress_local": "InProgressLocal",
-    "merged_to_epic": "MergedToEpic",
-    "ready_for_review": "EpicReadyForCloudReview",
     "failed": "Blocked"
   },
   "artifact_paths": {

--- a/.claude/commands/start-ticket.md
+++ b/.claude/commands/start-ticket.md
@@ -1,4 +1,4 @@
-Look up the Linear issue with identifier $ARGUMENTS in the repo-scaffold-desktop project using the Linear MCP server. Also fetch `get_issue($ARGUMENTS, includeRelations: true)` to see its milestone, labels, priority, parent epic, and any blocking relations.
+Look up the Linear issue with identifier $ARGUMENTS in the {{ linear_project }} project using the Linear MCP server. Also fetch `get_issue($ARGUMENTS, includeRelations: true)` to see its milestone, labels, priority, parent epic, and any blocking relations.
 
 Work through these phases in order:
 
@@ -77,7 +77,7 @@ Check whether this ticket has a parent epic (`parentId` from `get_issue` relatio
 ### 0.6. Coordination check
 Query Linear for sibling tickets in the same epic that are currently In Progress:
 ```
-list_issues(project: "repo-scaffold-desktop", state: "In Progress", parentId: <epicId>)
+list_issues(project: "{{ linear_project }}", state: "In Progress", parentId: <epicId>)
 ```
 For each In-Progress sibling:
 - Show ticket ID, title, branch name
@@ -134,7 +134,7 @@ Same reason — leave main checked out so the watcher can worktree the sub-ticke
 
 **If the parent epic was previously Backlog** (i.e., this is the first sub-ticket being started in this epic), also promote all other Backlog children to **Todo**:
 ```
-list_issues(project: "repo-scaffold-desktop", parentId: <epicId>, state: "Backlog")
+list_issues(project: "{{ linear_project }}", parentId: <epicId>, state: "Backlog")
 → for each result (excluding the current ticket): save_issue(id: "WOR-X", state: "Todo")
 ```
 "Todo" signals "actively queued in this epic, not yet started" — distinguishes from Backlog items that aren't in scope yet. Skip this step if the epic was already In Progress.
@@ -253,7 +253,7 @@ While reading the codebase to plan this ticket you may have noticed things outsi
 
 **Rules:**
 - Only surface things genuinely encountered while reading — no extra scans
-- Check existing Linear issues first (`list_issues` with `project: "repo-scaffold-desktop"`) to avoid duplicates
+- Check existing Linear issues first (`list_issues` with `project: "{{ linear_project }}"`) to avoid duplicates
 - Maximum 3 suggestions; if you spotted more, keep only the most impactful
 - Do not create anything — present suggestions and wait for approval
 

--- a/.claude/commands/update-skills.md
+++ b/.claude/commands/update-skills.md
@@ -35,7 +35,13 @@ Fetch the latest `.claude/commands/` files from the upstream skills repo and upd
    "
    ```
 
-8. Print a summary:
+8. Write the upstream version to `.claude/skills_version.txt` so the last-synced state is tracked:
+   ```bash
+   echo "<latest-tag>" > .claude/skills_version.txt
+   ```
+   This file is the marker that `finalize-ticket` and `/contribute-skill` use to detect drift.
+
+9. Print a summary:
    ```
    Updated skills from <old-version> → <latest-tag>
    ✓ .claude/commands/update-skills.md

--- a/.claude/skills_version.txt
+++ b/.claude/skills_version.txt
@@ -1,0 +1,1 @@
+local-snapshot-2026-04-23


### PR DESCRIPTION
## Summary
- Replace all hardcoded `repo-scaffold-desktop` references in 6 command files (groom-ticket, start-ticket, finalize-ticket, close-epic, prioritize, start-epic) with `{{ linear_project }}` — enabling `fetch_skills` to render the correct project name at scaffold time
- Add drift-warning step 6.5 to `finalize-ticket.md`: when `.claude/commands/` files change in a PR, remind to run `/contribute-skill` and update `skills_version.txt`
- Bonus fix: remove stale `merged_to_epic` / `ready_for_review` fields from the manifest template in `start-epic.md` (deleted from `TicketStateMap` by WOR-128 but missed in the skill file)

**Milestone:** Agentic Scaffolding
**Epic:** WOR-55 Epic: Agentic Scaffolding

## Test plan
- [x] `grep -r "repo-scaffold-desktop" .claude/commands/` returns CLEAN
- [x] ruff, mypy, pytest all pass (84.6% coverage)
- [x] Drift-warning step added to finalize-ticket.md (step 6.5)
- [x] `update-skills.md` now writes upstream tag to `.claude/skills_version.txt`
- [x] `.claude/skills_version.txt` created as initial marker
- [ ] After merge: run `/contribute-skill` for each changed command file to sync `virppa/repo-scaffold-skills`

Closes WOR-133