### PR TITLE
WOR-59 Populate .mcp.json.j2 with Linear MCP server config

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -67,6 +67,15 @@ def _build_parser() -> argparse.ArgumentParser:
         "--claude-files", action="store_true", help="Include Claude Code files."
     )
     gen.add_argument(
+        "--linear-mcp",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help=(
+            "Include Linear MCP server in .mcp.json. "
+            "full_agentic preset defaults to True; all others default to False."
+        ),
+    )
+    gen.add_argument(
         "--git-init", action="store_true", help="Run git init in the output directory."
     )
     gen.add_argument(
@@ -216,6 +225,11 @@ def _run_config(args: argparse.Namespace) -> int:
 
 
 def _run_generate(args: argparse.Namespace) -> int:
+    include_linear_mcp: bool = args.linear_mcp
+    if include_linear_mcp is None:
+        include_linear_mcp = get_preset(args.preset).context_defaults.get(
+            "include_linear_mcp", False
+        )
     try:
         config = RepoConfig(
             repo_name=args.repo_name,
@@ -226,6 +240,7 @@ def _run_generate(args: argparse.Namespace) -> int:
             include_issue_templates=args.issue_templates,
             include_codeowners=args.codeowners,
             include_claude_files=args.claude_files,
+            include_linear_mcp=include_linear_mcp,
             git_init=args.git_init,
             install_precommit=args.install_precommit,
         )

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -15,6 +15,7 @@ class RepoConfig(BaseModel):
     include_issue_templates: bool = False
     include_codeowners: bool = False
     include_claude_files: bool = False
+    include_linear_mcp: bool = False
 
     git_init: bool = False
     install_precommit: bool = False

--- a/app/core/presets.py
+++ b/app/core/presets.py
@@ -24,6 +24,8 @@ class Preset:
     optional_files: dict[str, tuple[str, ...]] = field(default_factory=dict)
     skills_source: str | None = None
     skills_version: str | None = None
+    # Template context overrides applied by the CLI when no explicit flag is given
+    context_defaults: dict[str, bool] = field(default_factory=dict)
 
 
 _PRESETS: dict[str, Preset] = {
@@ -87,6 +89,7 @@ _PRESETS: dict[str, Preset] = {
         ),
         skills_source="github:virppa/repo-scaffold-skills",
         skills_version="v1.0.0",
+        context_defaults={"include_linear_mcp": True},
         required_files=(
             _F_PYPROJECT,
             _F_README,

--- a/templates/shared/.mcp.json.j2
+++ b/templates/shared/.mcp.json.j2
@@ -1,3 +1,15 @@
+{%- if include_linear_mcp -%}
+{
+  "_comment": "Run /mcp in Claude Code to authenticate with Linear.",
+  "mcpServers": {
+    "linear": {
+      "type": "http",
+      "url": "https://mcp.linear.app/mcp"
+    }
+  }
+}
+{%- else -%}
 {
   "mcpServers": {}
 }
+{%- endif %}

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 
 from app.core.config import RepoConfig
@@ -304,3 +306,25 @@ def test_generate_no_authors_section_when_prefs_empty(output_dir):
     generate(config, output_dir, prefs=prefs)
     content = (output_dir / "pyproject.toml").read_text(encoding="utf-8")
     assert "authors" not in content
+
+
+def test_mcp_json_has_linear_mcp_when_enabled(output_dir):
+    config = RepoConfig(
+        repo_name="my-agentic-project", preset="full_agentic", include_linear_mcp=True
+    )
+    generate(config, output_dir)
+    raw = (output_dir / ".mcp.json").read_text(encoding="utf-8")
+    data = json.loads(raw)
+    assert "_comment" in data
+    assert "linear" in data["mcpServers"]
+    assert data["mcpServers"]["linear"]["url"] == "https://mcp.linear.app/mcp"
+
+
+def test_mcp_json_has_empty_mcp_servers_when_disabled(output_dir):
+    config = RepoConfig(
+        repo_name="my-project", preset="python_basic", include_claude_files=True
+    )
+    generate(config, output_dir)
+    raw = (output_dir / ".mcp.json").read_text(encoding="utf-8")
+    data = json.loads(raw)
+    assert data["mcpServers"] == {}


### PR DESCRIPTION
Closes WOR-59

templates/shared/.mcp.json.j2 emits the Linear MCP server entry when include_linear_mcp=True and an empty mcpServers object when False; RepoConfig carries the field; full_agentic preset sets it to True; CLI exposes the flag; tests pass for both states.