### PR TITLE
fix: watcher immediate-merge fallback for epic branches

### DIFF
--- a/app/core/watcher.py
+++ b/app/core/watcher.py
@@ -1057,12 +1057,35 @@ class Watcher:
         )
         if merge_result.returncode != 0:
             output = (merge_result.stderr or merge_result.stdout).strip()
-            logger.warning(
-                "gh pr merge --auto failed for %s (rc=%d): %s",
-                pr_url,
-                merge_result.returncode,
-                output,
-            )
+            # "clean status" means no required checks on the target branch (e.g. epic
+            # branches) — PR is already mergeable, so fall back to immediate merge.
+            if "enablePullRequestAutoMerge" in output or "clean status" in output:
+                logger.info(
+                    "No required checks on target branch — merging %s immediately",
+                    pr_url,
+                )
+                immediate = subprocess.run(  # nosec B603 B607
+                    ["gh", "pr", "merge", "--squash", pr_url],
+                    cwd=str(worktree_path),
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                )
+                if immediate.returncode != 0:
+                    imm_output = (immediate.stderr or immediate.stdout).strip()
+                    logger.warning(
+                        "gh pr merge --squash also failed for %s (rc=%d): %s",
+                        pr_url,
+                        immediate.returncode,
+                        imm_output,
+                    )
+            else:
+                logger.warning(
+                    "gh pr merge --auto failed for %s (rc=%d): %s",
+                    pr_url,
+                    merge_result.returncode,
+                    output,
+                )
         return pr_url
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `gh pr merge --auto` fails on epic branches because they have no required status checks (sub→epic CI is `continue-on-error: true` — informational only)
- GitHub rejects the call with `enablePullRequestAutoMerge / Pull request is in clean status`
- Fix: detect that error string and fall back to `gh pr merge --squash` for an immediate merge
- Unrecognised auto-merge failures still log a WARNING as before

## Test plan

- [ ] Existing 81 watcher tests pass
- [ ] Next watcher run against an epic-branch PR merges immediately instead of warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)