### PR TITLE
WOR-109 Jinja2-aware fetch_skills for parametrized command generation

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -259,10 +259,17 @@ def _run_generate(args: argparse.Namespace) -> int:
 
     preset = get_preset(config.preset)
     if preset.skills_source is not None and preset.skills_version is not None:
+        ctx = config.model_dump()
+        skills_context = (
+            {k: ctx[k] for k in preset.skills_context_fields}
+            if preset.skills_context_fields
+            else None
+        )
         skills_written = fetch_skills(
             args.output,
             skills_source=preset.skills_source,
             skills_version=preset.skills_version,
+            context=skills_context,
         )
         for path in skills_written:
             print(f"✓ {path}")

--- a/app/core/post_setup.py
+++ b/app/core/post_setup.py
@@ -5,14 +5,22 @@ import urllib.error
 import urllib.request
 from pathlib import Path
 
+from jinja2 import Environment, Undefined
+
 _GITHUB_SOURCE_RE = re.compile(r"^github:([A-Za-z0-9_.-]+)/([A-Za-z0-9_.-]+)$")
 _SAFE_PATH_RE = re.compile(r"^[A-Za-z0-9_.\-/]+$")
 
 
 def fetch_skills(
-    output_path: Path, skills_source: str, skills_version: str
+    output_path: Path,
+    skills_source: str,
+    skills_version: str,
+    context: dict[str, object] | None = None,
 ) -> list[str]:
     """Fetch .claude/commands/ from a versioned skills repo and write to output_path.
+
+    When context is provided each downloaded file is rendered through Jinja2 using
+    non-strict Undefined so missing variables produce an empty string, not an error.
 
     Returns the list of relative paths written. On network or API errors, logs a
     warning and returns an empty list — fetch failure is intentionally non-fatal.
@@ -45,6 +53,15 @@ def fetch_skills(
 
     commands_prefix = ".claude/commands/"
     written: list[str] = []
+    _jinja_env: Environment | None = (
+        Environment(  # nosec B701  # nosemgrep: python.flask.security.xss.audit.direct-use-of-jinja2.direct-use-of-jinja2
+            undefined=Undefined,
+            keep_trailing_newline=True,
+            autoescape=False,
+        )
+        if context is not None
+        else None
+    )
 
     for entry in tree.get("tree", []):
         path: str = entry.get("path", "")
@@ -63,6 +80,11 @@ def fetch_skills(
         except OSError as exc:
             print(f"[skills] Warning: could not download {path}: {exc}")
             continue
+
+        if _jinja_env is not None and context is not None:
+            text = content.decode("utf-8", errors="replace")
+            rendered = _jinja_env.from_string(text).render(**context)  # nosec  # nosemgrep: python.flask.security.xss.audit.direct-use-of-jinja2.direct-use-of-jinja2
+            content = rendered.encode("utf-8")
 
         dest = output_path / path
         dest.parent.mkdir(parents=True, exist_ok=True)

--- a/app/core/presets.py
+++ b/app/core/presets.py
@@ -24,6 +24,8 @@ class Preset:
     optional_files: dict[str, tuple[str, ...]] = field(default_factory=dict)
     skills_source: str | None = None
     skills_version: str | None = None
+    # Keys from the generator context to forward to fetch_skills for Jinja2 rendering
+    skills_context_fields: tuple[str, ...] = ()
     # Template context overrides applied by the CLI when no explicit flag is given
     context_defaults: dict[str, bool] = field(default_factory=dict)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -245,6 +245,7 @@ def test_full_agentic_preset_calls_fetch_skills(output_dir):
         output_dir,
         skills_source=preset.skills_source,
         skills_version=preset.skills_version,
+        context=None,
     )
 
 

--- a/tests/test_post_setup.py
+++ b/tests/test_post_setup.py
@@ -128,6 +128,62 @@ class TestFetchSkills:
         assert "unsafe" in captured.out
 
 
+class TestFetchSkillsJinja2:
+    def test_renders_template_variables_in_skill_files(self, tmp_path):
+        entries = [{"path": ".claude/commands/foo.md", "type": "blob"}]
+        template = b"# skill for {{ linear_project }} in {{ repo_name }}"
+        with patch(
+            "app.core.post_setup.urllib.request.urlopen",
+            side_effect=_make_urlopen_mock(entries, template),
+        ):
+            written = fetch_skills(
+                tmp_path,
+                "github:virppa/repo-scaffold-skills",
+                "v1.0.0",
+                context={"linear_project": "MY_PROJECT", "repo_name": "my-repo"},
+            )
+
+        assert written == [".claude/commands/foo.md"]
+        content = (tmp_path / ".claude/commands/foo.md").read_text(encoding="utf-8")
+        assert "MY_PROJECT" in content
+        assert "my-repo" in content
+
+    def test_missing_context_key_renders_as_empty_string(self, tmp_path):
+        entries = [{"path": ".claude/commands/foo.md", "type": "blob"}]
+        template = b"# skill for {{ linear_project }}"
+        with patch(
+            "app.core.post_setup.urllib.request.urlopen",
+            side_effect=_make_urlopen_mock(entries, template),
+        ):
+            written = fetch_skills(
+                tmp_path,
+                "github:virppa/repo-scaffold-skills",
+                "v1.0.0",
+                context={},
+            )
+
+        assert written == [".claude/commands/foo.md"]
+        content = (tmp_path / ".claude/commands/foo.md").read_text(encoding="utf-8")
+        assert "{{ linear_project }}" not in content
+        assert content == "# skill for "
+
+    def test_no_context_writes_raw_bytes_unchanged(self, tmp_path):
+        entries = [{"path": ".claude/commands/foo.md", "type": "blob"}]
+        raw = b"# skill for {{ linear_project }}"
+        with patch(
+            "app.core.post_setup.urllib.request.urlopen",
+            side_effect=_make_urlopen_mock(entries, raw),
+        ):
+            written = fetch_skills(
+                tmp_path,
+                "github:virppa/repo-scaffold-skills",
+                "v1.0.0",
+            )
+
+        assert written == [".claude/commands/foo.md"]
+        assert (tmp_path / ".claude/commands/foo.md").read_bytes() == raw
+
+
 class TestRunGitInit:
     def test_invokes_subprocess_with_correct_args(self, repo_dir):
         with patch("app.core.post_setup.subprocess.run") as mock_run:


### PR DESCRIPTION
Closes WOR-109

fetch_skills in post_setup.py accepts context: dict | None; renders downloaded files through Jinja2 when context is provided; Preset has skills_context_fields; CLI passes the subset of context through; tests for substitution and graceful degradation pass.