### PR TITLE
WOR-72 UI smoke test template and conftest for python_desktop

### DIFF
--- a/app/core/presets.py
+++ b/app/core/presets.py
@@ -67,6 +67,8 @@ _PRESETS: dict[str, Preset] = {
             "app/main.py",
             "app/ui/__init__.py",
             _F_TESTS_INIT,
+            "tests/conftest.py",
+            "tests/test_ui_smoke.py",
         ),
         optional_files={
             "include_precommit": (_F_PRECOMMIT,),

--- a/templates/python_desktop/tests/conftest.py.j2
+++ b/templates/python_desktop/tests/conftest.py.j2
@@ -1,0 +1,8 @@
+import pytest
+from PySide6.QtWidgets import QApplication
+
+
+@pytest.fixture(scope="session")
+def qapp():
+    app = QApplication.instance() or QApplication([])
+    yield app

--- a/templates/python_desktop/tests/test_ui_smoke.py.j2
+++ b/templates/python_desktop/tests/test_ui_smoke.py.j2
@@ -1,0 +1,8 @@
+# Smoke test: verify {{ repo_name }} main window opens without crashing.
+# Uncomment and extend once MainWindow is implemented.
+
+# def test_main_window_opens(qtbot):
+#     from app.ui.main_window import MainWindow
+#     window = MainWindow()
+#     qtbot.addWidget(window)
+#     assert window.isVisible() is False  # not shown until window.show()

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -461,3 +461,30 @@ def test_full_agentic_asyncio_mode_auto(output_dir):
     generate(config, output_dir)
     content = (output_dir / "pyproject.toml").read_text(encoding="utf-8")
     assert 'asyncio_mode = "auto"' in content
+
+
+def test_python_desktop_generates_conftest(output_dir):
+    config = RepoConfig(repo_name="my-desktop-app", preset="python_desktop")
+    generate(config, output_dir)
+    assert (output_dir / "tests" / "conftest.py").exists()
+
+
+def test_python_desktop_conftest_has_qapp_fixture(output_dir):
+    config = RepoConfig(repo_name="my-desktop-app", preset="python_desktop")
+    generate(config, output_dir)
+    content = (output_dir / "tests" / "conftest.py").read_text(encoding="utf-8")
+    assert "qapp" in content
+    assert "QApplication" in content
+
+
+def test_python_desktop_generates_ui_smoke_test(output_dir):
+    config = RepoConfig(repo_name="my-desktop-app", preset="python_desktop")
+    generate(config, output_dir)
+    assert (output_dir / "tests" / "test_ui_smoke.py").exists()
+
+
+def test_python_desktop_ui_smoke_contains_repo_name(output_dir):
+    config = RepoConfig(repo_name="my-desktop-app", preset="python_desktop")
+    generate(config, output_dir)
+    content = (output_dir / "tests" / "test_ui_smoke.py").read_text(encoding="utf-8")
+    assert "my-desktop-app" in content

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -89,3 +89,9 @@ def test_non_agentic_presets_have_no_skills_config():
         preset = get_preset(name)
         assert preset.skills_source is None
         assert preset.skills_version is None
+
+
+def test_python_desktop_required_files_include_conftest_and_smoke():
+    preset = get_preset("python_desktop")
+    assert "tests/conftest.py" in preset.required_files
+    assert "tests/test_ui_smoke.py" in preset.required_files


### PR DESCRIPTION
- Adds `templates/python_desktop/tests/conftest.py.j2` with a session-scoped `QApplication` (`qapp`) fixture for pytest-qt
- Adds `templates/python_desktop/tests/test_ui_smoke.py.j2` with a commented smoke test skeleton that renders `{{ repo_name }}`
- Registers both as required files in the `python_desktop` preset so every generated repo includes them automatically

**Milestone:** Agentic Scaffolding
**Epic:** WOR-57 — Epic: UI Testing & Test Infrastructure

## Test plan
- [x] `test_python_desktop_generates_conftest` — conftest.py exists in output
- [x] `test_python_desktop_conftest_has_qapp_fixture` — fixture content verified
- [x] `test_python_desktop_generates_ui_smoke_test` — test_ui_smoke.py exists in output
- [x] `test_python_desktop_ui_smoke_contains_repo_name` — repo_name rendered correctly
- [x] `test_python_desktop_required_files_include_conftest_and_smoke` — preset registry verified
- [x] All 315 tests pass; coverage 84.47%

Closes WOR-72

🤖 Generated with [Claude Code](https://claude.com/claude-code)