### PR TITLE
WOR-73 Add Playwright and Playwright MCP as optional toggle for full_agentic

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -76,6 +76,14 @@ def _build_parser() -> argparse.ArgumentParser:
         ),
     )
     gen.add_argument(
+        "--playwright",
+        action="store_true",
+        help=(
+            "Include Playwright browser-test scaffold (full_agentic only — "
+            "for web-facing repos, not PySide6 desktop apps)."
+        ),
+    )
+    gen.add_argument(
         "--git-init", action="store_true", help="Run git init in the output directory."
     )
     gen.add_argument(
@@ -241,6 +249,7 @@ def _run_generate(args: argparse.Namespace) -> int:
             include_codeowners=args.codeowners,
             include_claude_files=args.claude_files,
             include_linear_mcp=include_linear_mcp,
+            include_playwright=args.playwright,
             git_init=args.git_init,
             install_precommit=args.install_precommit,
         )

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -16,6 +16,7 @@ class RepoConfig(BaseModel):
     include_codeowners: bool = False
     include_claude_files: bool = False
     include_linear_mcp: bool = False
+    include_playwright: bool = False
 
     git_init: bool = False
     install_precommit: bool = False

--- a/app/core/presets.py
+++ b/app/core/presets.py
@@ -118,6 +118,7 @@ _PRESETS: dict[str, Preset] = {
                 _F_MCP_JSON,
                 ".claude/settings.json",
             ),
+            "include_playwright": ("tests/test_web_smoke.py",),
         },
     ),
 }

--- a/templates/full_agentic/pyproject.toml.j2
+++ b/templates/full_agentic/pyproject.toml.j2
@@ -8,7 +8,7 @@ authors = [{name = "{{ author_name }}", email = "{{ author_email }}"}]
 dependencies = []
 
 [project.optional-dependencies]
-dev = ["pytest", "pytest-cov", "ruff", "bandit", "mypy", "lint-imports", "pytest-mock>=3.0", "pytest-snapshot>=0.9", "pytest-qt>=4.0", "pytest-asyncio>=0.23", "pytest-httpx>=0.30", "hypothesis>=6.0"]
+dev = ["pytest", "pytest-cov", "ruff", "bandit", "mypy", "lint-imports", "pytest-mock>=3.0", "pytest-snapshot>=0.9", "pytest-qt>=4.0", "pytest-asyncio>=0.23", "pytest-httpx>=0.30", "hypothesis>=6.0"{% if include_playwright %}, "playwright>=1.40", "pytest-playwright>=0.4"{% endif %}]
 
 [tool.ruff]
 line-length = 88

--- a/templates/full_agentic/tests/test_web_smoke.py.j2
+++ b/templates/full_agentic/tests/test_web_smoke.py.j2
@@ -1,0 +1,23 @@
+# Web smoke tests using Playwright.
+# Run: pytest tests/test_web_smoke.py --headed   (or headless by default)
+#
+# Prerequisites:
+#   pip install playwright pytest-playwright
+#   playwright install chromium
+
+# import pytest
+# from playwright.sync_api import Page
+#
+#
+# BASE_URL = "http://localhost:8000"
+#
+#
+# def test_home_page_loads(page: Page) -> None:
+#     page.goto(BASE_URL)
+#     assert page.title() != ""
+#
+#
+# def test_home_page_has_content(page: Page) -> None:
+#     page.goto(BASE_URL)
+#     # Replace with a selector that exists on your home page.
+#     assert page.locator("body").is_visible()

--- a/templates/shared/.mcp.json.j2
+++ b/templates/shared/.mcp.json.j2
@@ -5,7 +5,12 @@
     "linear": {
       "type": "http",
       "url": "https://mcp.linear.app/mcp"
-    }
+    }{% if include_playwright %},
+    "playwright": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["@playwright/mcp"]
+    }{% endif %}
   }
 }
 {%- else -%}

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -73,3 +73,8 @@ def test_all_valid_presets_accepted():
 def test_invalid_preset_rejected():
     with pytest.raises(ValidationError):
         RepoConfig(repo_name="my-repo", preset="nonexistent_preset")
+
+
+def test_include_playwright_defaults_false():
+    config = RepoConfig(repo_name="my-repo", preset="full_agentic")
+    assert config.include_playwright is False

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -488,3 +488,62 @@ def test_python_desktop_ui_smoke_contains_repo_name(output_dir):
     generate(config, output_dir)
     content = (output_dir / "tests" / "test_ui_smoke.py").read_text(encoding="utf-8")
     assert "my-desktop-app" in content
+
+
+def test_playwright_generates_smoke_test(output_dir):
+    config = RepoConfig(
+        repo_name="my-web-app", preset="full_agentic", include_playwright=True
+    )
+    generate(config, output_dir)
+    assert (output_dir / "tests" / "test_web_smoke.py").exists()
+
+
+def test_playwright_adds_deps_to_pyproject(output_dir):
+    config = RepoConfig(
+        repo_name="my-web-app", preset="full_agentic", include_playwright=True
+    )
+    generate(config, output_dir)
+    content = (output_dir / "pyproject.toml").read_text(encoding="utf-8")
+    assert "playwright>=1.40" in content
+    assert "pytest-playwright>=0.4" in content
+
+
+def test_playwright_mcp_in_mcp_json(output_dir):
+    config = RepoConfig(
+        repo_name="my-web-app",
+        preset="full_agentic",
+        include_linear_mcp=True,
+        include_playwright=True,
+    )
+    generate(config, output_dir)
+    raw = (output_dir / ".mcp.json").read_text(encoding="utf-8")
+    data = json.loads(raw)
+    assert "playwright" in data["mcpServers"]
+    assert data["mcpServers"]["playwright"]["command"] == "npx"
+    assert "@playwright/mcp" in data["mcpServers"]["playwright"]["args"]
+
+
+def test_playwright_mcp_absent_without_linear_mcp(output_dir):
+    config = RepoConfig(
+        repo_name="my-web-app",
+        preset="full_agentic",
+        include_linear_mcp=False,
+        include_playwright=True,
+    )
+    generate(config, output_dir)
+    raw = (output_dir / ".mcp.json").read_text(encoding="utf-8")
+    data = json.loads(raw)
+    assert "playwright" not in data["mcpServers"]
+
+
+def test_playwright_disabled_by_default_no_smoke_file(output_dir):
+    config = RepoConfig(repo_name="my-web-app", preset="full_agentic")
+    generate(config, output_dir)
+    assert not (output_dir / "tests" / "test_web_smoke.py").exists()
+
+
+def test_playwright_deps_absent_when_disabled(output_dir):
+    config = RepoConfig(repo_name="my-web-app", preset="full_agentic")
+    generate(config, output_dir)
+    content = (output_dir / "pyproject.toml").read_text(encoding="utf-8")
+    assert "playwright" not in content


### PR DESCRIPTION
## Summary

- Adds `include_playwright: bool = False` to `RepoConfig` and `--playwright` CLI flag (web-facing repos only — not for PySide6 desktop apps)
- When enabled: scaffolds `playwright>=1.40`/`pytest-playwright>=0.4` in `pyproject.toml`, a `tests/test_web_smoke.py` commented skeleton, and a playwright MCP entry in `.mcp.json` (only when `--linear-mcp` is also set)
- Flag defaults to False; all existing presets and tests are unaffected

**Milestone:** Agentic Scaffolding
**Epic:** WOR-57 — Epic: UI Testing & Test Infrastructure

## Test plan

- [x] `test_playwright_generates_smoke_test` — `tests/test_web_smoke.py` present when flag set
- [x] `test_playwright_adds_deps_to_pyproject` — playwright deps in pyproject.toml
- [x] `test_playwright_mcp_in_mcp_json` — playwright MCP entry with both flags enabled
- [x] `test_playwright_mcp_absent_without_linear_mcp` — MCP entry absent when `--linear-mcp` off
- [x] `test_playwright_disabled_by_default_no_smoke_file` — no smoke file when flag not set
- [x] `test_playwright_deps_absent_when_disabled` — no playwright deps when flag not set
- [x] `test_include_playwright_defaults_false` — config default verified
- [x] 322 tests pass, 84.49% coverage

Closes WOR-73