### PR TITLE
WOR-136 Add hypothesis to python_basic and python_desktop dev deps

### DIFF
--- a/templates/python_basic/pyproject.toml.j2
+++ b/templates/python_basic/pyproject.toml.j2
@@ -8,7 +8,7 @@ authors = [{name = "{{ author_name }}", email = "{{ author_email }}"}]
 dependencies = []
 
 [project.optional-dependencies]
-dev = ["pytest", "pytest-cov", "ruff", "pytest-mock>=3.0", "pytest-snapshot>=0.9"]
+dev = ["pytest", "pytest-cov", "ruff", "pytest-mock>=3.0", "pytest-snapshot>=0.9", "hypothesis>=6.0"]
 
 [tool.ruff]
 line-length = 88

--- a/templates/python_desktop/pyproject.toml.j2
+++ b/templates/python_desktop/pyproject.toml.j2
@@ -8,7 +8,7 @@ authors = [{name = "{{ author_name }}", email = "{{ author_email }}"}]
 dependencies = ["pyside6"]
 
 [project.optional-dependencies]
-dev = ["pytest", "pytest-cov", "ruff", "pytest-mock>=3.0", "pytest-snapshot>=0.9", "pytest-qt>=4.0"]
+dev = ["pytest", "pytest-cov", "ruff", "pytest-mock>=3.0", "pytest-snapshot>=0.9", "pytest-qt>=4.0", "hypothesis>=6.0"]
 
 [tool.ruff]
 line-length = 88

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -421,6 +421,7 @@ def test_python_basic_dev_deps_include_mock_and_snapshot(output_dir):
     content = (output_dir / "pyproject.toml").read_text(encoding="utf-8")
     assert "pytest-mock" in content
     assert "pytest-snapshot" in content
+    assert "hypothesis" in content
 
 
 def test_python_basic_dev_deps_exclude_qt_and_asyncio(output_dir):
@@ -438,6 +439,7 @@ def test_python_desktop_dev_deps_include_qt(output_dir):
     assert "pytest-mock" in content
     assert "pytest-snapshot" in content
     assert "pytest-qt" in content
+    assert "hypothesis" in content
     assert "pytest-asyncio" not in content
 
 


### PR DESCRIPTION
- Appends `hypothesis>=6.0` to dev deps in `templates/python_basic/pyproject.toml.j2` and `templates/python_desktop/pyproject.toml.j2` to match the epic design that WOR-71 fulfilled for `full_agentic` only
- Extends `test_python_basic_dev_deps_include_mock_and_snapshot` and `test_python_desktop_dev_deps_include_qt` to assert `hypothesis` is present in the generated output

**Milestone:** Agentic Scaffolding
**Epic:** WOR-57 — UI Testing / Test Infrastructure

## Test plan
- [x] `ruff check .` — passed
- [x] `mypy app/` — passed
- [x] `pytest` — 322 passed, 84% coverage
- [x] `test_python_basic_dev_deps_include_mock_and_snapshot` asserts hypothesis
- [x] `test_python_desktop_dev_deps_include_qt` asserts hypothesis

Closes WOR-136