### PR TITLE
WOR-57 Epic: UI Testing & Test Infrastructure

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -76,6 +76,14 @@ def _build_parser() -> argparse.ArgumentParser:
         ),
     )
     gen.add_argument(
+        "--playwright",
+        action="store_true",
+        help=(
+            "Include Playwright browser-test scaffold (full_agentic only — "
+            "for web-facing repos, not PySide6 desktop apps)."
+        ),
+    )
+    gen.add_argument(
         "--git-init", action="store_true", help="Run git init in the output directory."
     )
     gen.add_argument(
@@ -241,6 +249,7 @@ def _run_generate(args: argparse.Namespace) -> int:
             include_codeowners=args.codeowners,
             include_claude_files=args.claude_files,
             include_linear_mcp=include_linear_mcp,
+            include_playwright=args.playwright,
             git_init=args.git_init,
             install_precommit=args.install_precommit,
         )

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -16,6 +16,7 @@ class RepoConfig(BaseModel):
     include_codeowners: bool = False
     include_claude_files: bool = False
     include_linear_mcp: bool = False
+    include_playwright: bool = False
 
     git_init: bool = False
     install_precommit: bool = False

--- a/app/core/presets.py
+++ b/app/core/presets.py
@@ -67,6 +67,8 @@ _PRESETS: dict[str, Preset] = {
             "app/main.py",
             "app/ui/__init__.py",
             _F_TESTS_INIT,
+            "tests/conftest.py",
+            "tests/test_ui_smoke.py",
         ),
         optional_files={
             "include_precommit": (_F_PRECOMMIT,),

--- a/app/core/presets.py
+++ b/app/core/presets.py
@@ -118,6 +118,7 @@ _PRESETS: dict[str, Preset] = {
                 _F_MCP_JSON,
                 ".claude/settings.json",
             ),
+            "include_playwright": ("tests/test_web_smoke.py",),
         },
     ),
 }

--- a/templates/full_agentic/pyproject.toml.j2
+++ b/templates/full_agentic/pyproject.toml.j2
@@ -8,7 +8,7 @@ authors = [{name = "{{ author_name }}", email = "{{ author_email }}"}]
 dependencies = []
 
 [project.optional-dependencies]
-dev = ["pytest", "pytest-cov", "ruff", "bandit", "mypy", "lint-imports"]
+dev = ["pytest", "pytest-cov", "ruff", "bandit", "mypy", "lint-imports", "pytest-mock>=3.0", "pytest-snapshot>=0.9", "pytest-qt>=4.0", "pytest-asyncio>=0.23", "pytest-httpx>=0.30", "hypothesis>=6.0"]
 
 [tool.ruff]
 line-length = 88
@@ -20,3 +20,4 @@ select = ["E", "F", "I", "UP"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = "--cov=app --cov-report=term-missing"
+asyncio_mode = "auto"

--- a/templates/full_agentic/pyproject.toml.j2
+++ b/templates/full_agentic/pyproject.toml.j2
@@ -8,7 +8,7 @@ authors = [{name = "{{ author_name }}", email = "{{ author_email }}"}]
 dependencies = []
 
 [project.optional-dependencies]
-dev = ["pytest", "pytest-cov", "ruff", "bandit", "mypy", "lint-imports", "pytest-mock>=3.0", "pytest-snapshot>=0.9", "pytest-qt>=4.0", "pytest-asyncio>=0.23", "pytest-httpx>=0.30", "hypothesis>=6.0"]
+dev = ["pytest", "pytest-cov", "ruff", "bandit", "mypy", "lint-imports", "pytest-mock>=3.0", "pytest-snapshot>=0.9", "pytest-qt>=4.0", "pytest-asyncio>=0.23", "pytest-httpx>=0.30", "hypothesis>=6.0"{% if include_playwright %}, "playwright>=1.40", "pytest-playwright>=0.4"{% endif %}]
 
 [tool.ruff]
 line-length = 88

--- a/templates/full_agentic/tests/test_web_smoke.py.j2
+++ b/templates/full_agentic/tests/test_web_smoke.py.j2
@@ -1,0 +1,23 @@
+# Web smoke tests using Playwright.
+# Run: pytest tests/test_web_smoke.py --headed   (or headless by default)
+#
+# Prerequisites:
+#   pip install playwright pytest-playwright
+#   playwright install chromium
+
+# import pytest
+# from playwright.sync_api import Page
+#
+#
+# BASE_URL = "http://localhost:8000"
+#
+#
+# def test_home_page_loads(page: Page) -> None:
+#     page.goto(BASE_URL)
+#     assert page.title() != ""
+#
+#
+# def test_home_page_has_content(page: Page) -> None:
+#     page.goto(BASE_URL)
+#     # Replace with a selector that exists on your home page.
+#     assert page.locator("body").is_visible()

--- a/templates/python_basic/pyproject.toml.j2
+++ b/templates/python_basic/pyproject.toml.j2
@@ -8,7 +8,7 @@ authors = [{name = "{{ author_name }}", email = "{{ author_email }}"}]
 dependencies = []
 
 [project.optional-dependencies]
-dev = ["pytest", "pytest-cov", "ruff"]
+dev = ["pytest", "pytest-cov", "ruff", "pytest-mock>=3.0", "pytest-snapshot>=0.9"]
 
 [tool.ruff]
 line-length = 88

--- a/templates/python_basic/pyproject.toml.j2
+++ b/templates/python_basic/pyproject.toml.j2
@@ -8,7 +8,7 @@ authors = [{name = "{{ author_name }}", email = "{{ author_email }}"}]
 dependencies = []
 
 [project.optional-dependencies]
-dev = ["pytest", "pytest-cov", "ruff", "pytest-mock>=3.0", "pytest-snapshot>=0.9"]
+dev = ["pytest", "pytest-cov", "ruff", "pytest-mock>=3.0", "pytest-snapshot>=0.9", "hypothesis>=6.0"]
 
 [tool.ruff]
 line-length = 88

--- a/templates/python_desktop/pyproject.toml.j2
+++ b/templates/python_desktop/pyproject.toml.j2
@@ -8,7 +8,7 @@ authors = [{name = "{{ author_name }}", email = "{{ author_email }}"}]
 dependencies = ["pyside6"]
 
 [project.optional-dependencies]
-dev = ["pytest", "pytest-cov", "ruff", "pytest-mock>=3.0", "pytest-snapshot>=0.9", "pytest-qt>=4.0"]
+dev = ["pytest", "pytest-cov", "ruff", "pytest-mock>=3.0", "pytest-snapshot>=0.9", "pytest-qt>=4.0", "hypothesis>=6.0"]
 
 [tool.ruff]
 line-length = 88

--- a/templates/python_desktop/pyproject.toml.j2
+++ b/templates/python_desktop/pyproject.toml.j2
@@ -8,7 +8,7 @@ authors = [{name = "{{ author_name }}", email = "{{ author_email }}"}]
 dependencies = ["pyside6"]
 
 [project.optional-dependencies]
-dev = ["pytest", "pytest-cov", "ruff"]
+dev = ["pytest", "pytest-cov", "ruff", "pytest-mock>=3.0", "pytest-snapshot>=0.9", "pytest-qt>=4.0"]
 
 [tool.ruff]
 line-length = 88

--- a/templates/python_desktop/tests/conftest.py.j2
+++ b/templates/python_desktop/tests/conftest.py.j2
@@ -1,0 +1,8 @@
+import pytest
+from PySide6.QtWidgets import QApplication
+
+
+@pytest.fixture(scope="session")
+def qapp():
+    app = QApplication.instance() or QApplication([])
+    yield app

--- a/templates/python_desktop/tests/test_ui_smoke.py.j2
+++ b/templates/python_desktop/tests/test_ui_smoke.py.j2
@@ -1,0 +1,8 @@
+# Smoke test: verify {{ repo_name }} main window opens without crashing.
+# Uncomment and extend once MainWindow is implemented.
+
+# def test_main_window_opens(qtbot):
+#     from app.ui.main_window import MainWindow
+#     window = MainWindow()
+#     qtbot.addWidget(window)
+#     assert window.isVisible() is False  # not shown until window.show()

--- a/templates/shared/.mcp.json.j2
+++ b/templates/shared/.mcp.json.j2
@@ -5,7 +5,12 @@
     "linear": {
       "type": "http",
       "url": "https://mcp.linear.app/mcp"
-    }
+    }{% if include_playwright %},
+    "playwright": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["@playwright/mcp"]
+    }{% endif %}
   }
 }
 {%- else -%}

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -73,3 +73,8 @@ def test_all_valid_presets_accepted():
 def test_invalid_preset_rejected():
     with pytest.raises(ValidationError):
         RepoConfig(repo_name="my-repo", preset="nonexistent_preset")
+
+
+def test_include_playwright_defaults_false():
+    config = RepoConfig(repo_name="my-repo", preset="full_agentic")
+    assert config.include_playwright is False

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -488,3 +488,62 @@ def test_python_desktop_ui_smoke_contains_repo_name(output_dir):
     generate(config, output_dir)
     content = (output_dir / "tests" / "test_ui_smoke.py").read_text(encoding="utf-8")
     assert "my-desktop-app" in content
+
+
+def test_playwright_generates_smoke_test(output_dir):
+    config = RepoConfig(
+        repo_name="my-web-app", preset="full_agentic", include_playwright=True
+    )
+    generate(config, output_dir)
+    assert (output_dir / "tests" / "test_web_smoke.py").exists()
+
+
+def test_playwright_adds_deps_to_pyproject(output_dir):
+    config = RepoConfig(
+        repo_name="my-web-app", preset="full_agentic", include_playwright=True
+    )
+    generate(config, output_dir)
+    content = (output_dir / "pyproject.toml").read_text(encoding="utf-8")
+    assert "playwright>=1.40" in content
+    assert "pytest-playwright>=0.4" in content
+
+
+def test_playwright_mcp_in_mcp_json(output_dir):
+    config = RepoConfig(
+        repo_name="my-web-app",
+        preset="full_agentic",
+        include_linear_mcp=True,
+        include_playwright=True,
+    )
+    generate(config, output_dir)
+    raw = (output_dir / ".mcp.json").read_text(encoding="utf-8")
+    data = json.loads(raw)
+    assert "playwright" in data["mcpServers"]
+    assert data["mcpServers"]["playwright"]["command"] == "npx"
+    assert "@playwright/mcp" in data["mcpServers"]["playwright"]["args"]
+
+
+def test_playwright_mcp_absent_without_linear_mcp(output_dir):
+    config = RepoConfig(
+        repo_name="my-web-app",
+        preset="full_agentic",
+        include_linear_mcp=False,
+        include_playwright=True,
+    )
+    generate(config, output_dir)
+    raw = (output_dir / ".mcp.json").read_text(encoding="utf-8")
+    data = json.loads(raw)
+    assert "playwright" not in data["mcpServers"]
+
+
+def test_playwright_disabled_by_default_no_smoke_file(output_dir):
+    config = RepoConfig(repo_name="my-web-app", preset="full_agentic")
+    generate(config, output_dir)
+    assert not (output_dir / "tests" / "test_web_smoke.py").exists()
+
+
+def test_playwright_deps_absent_when_disabled(output_dir):
+    config = RepoConfig(repo_name="my-web-app", preset="full_agentic")
+    generate(config, output_dir)
+    content = (output_dir / "pyproject.toml").read_text(encoding="utf-8")
+    assert "playwright" not in content

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -461,3 +461,30 @@ def test_full_agentic_asyncio_mode_auto(output_dir):
     generate(config, output_dir)
     content = (output_dir / "pyproject.toml").read_text(encoding="utf-8")
     assert 'asyncio_mode = "auto"' in content
+
+
+def test_python_desktop_generates_conftest(output_dir):
+    config = RepoConfig(repo_name="my-desktop-app", preset="python_desktop")
+    generate(config, output_dir)
+    assert (output_dir / "tests" / "conftest.py").exists()
+
+
+def test_python_desktop_conftest_has_qapp_fixture(output_dir):
+    config = RepoConfig(repo_name="my-desktop-app", preset="python_desktop")
+    generate(config, output_dir)
+    content = (output_dir / "tests" / "conftest.py").read_text(encoding="utf-8")
+    assert "qapp" in content
+    assert "QApplication" in content
+
+
+def test_python_desktop_generates_ui_smoke_test(output_dir):
+    config = RepoConfig(repo_name="my-desktop-app", preset="python_desktop")
+    generate(config, output_dir)
+    assert (output_dir / "tests" / "test_ui_smoke.py").exists()
+
+
+def test_python_desktop_ui_smoke_contains_repo_name(output_dir):
+    config = RepoConfig(repo_name="my-desktop-app", preset="python_desktop")
+    generate(config, output_dir)
+    content = (output_dir / "tests" / "test_ui_smoke.py").read_text(encoding="utf-8")
+    assert "my-desktop-app" in content

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -421,6 +421,7 @@ def test_python_basic_dev_deps_include_mock_and_snapshot(output_dir):
     content = (output_dir / "pyproject.toml").read_text(encoding="utf-8")
     assert "pytest-mock" in content
     assert "pytest-snapshot" in content
+    assert "hypothesis" in content
 
 
 def test_python_basic_dev_deps_exclude_qt_and_asyncio(output_dir):
@@ -438,6 +439,7 @@ def test_python_desktop_dev_deps_include_qt(output_dir):
     assert "pytest-mock" in content
     assert "pytest-snapshot" in content
     assert "pytest-qt" in content
+    assert "hypothesis" in content
     assert "pytest-asyncio" not in content
 
 

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -413,3 +413,51 @@ def test_full_agentic_no_unrendered_jinja_variables(output_dir, agentic_prefs):
     for rel_path in written:
         content = (output_dir / rel_path).read_text(encoding="utf-8", errors="replace")
         assert "{{" not in content, f"Unrendered Jinja2 variable in {rel_path}"
+
+
+def test_python_basic_dev_deps_include_mock_and_snapshot(output_dir):
+    config = RepoConfig(repo_name="my-project", preset="python_basic")
+    generate(config, output_dir)
+    content = (output_dir / "pyproject.toml").read_text(encoding="utf-8")
+    assert "pytest-mock" in content
+    assert "pytest-snapshot" in content
+
+
+def test_python_basic_dev_deps_exclude_qt_and_asyncio(output_dir):
+    config = RepoConfig(repo_name="my-project", preset="python_basic")
+    generate(config, output_dir)
+    content = (output_dir / "pyproject.toml").read_text(encoding="utf-8")
+    assert "pytest-qt" not in content
+    assert "pytest-asyncio" not in content
+
+
+def test_python_desktop_dev_deps_include_qt(output_dir):
+    config = RepoConfig(repo_name="my-desktop-app", preset="python_desktop")
+    generate(config, output_dir)
+    content = (output_dir / "pyproject.toml").read_text(encoding="utf-8")
+    assert "pytest-mock" in content
+    assert "pytest-snapshot" in content
+    assert "pytest-qt" in content
+    assert "pytest-asyncio" not in content
+
+
+def test_full_agentic_dev_deps_include_all_plugins(output_dir):
+    config = RepoConfig(repo_name="my-agentic-project", preset="full_agentic")
+    generate(config, output_dir)
+    content = (output_dir / "pyproject.toml").read_text(encoding="utf-8")
+    for plugin in (
+        "pytest-mock",
+        "pytest-snapshot",
+        "pytest-qt",
+        "pytest-asyncio",
+        "pytest-httpx",
+        "hypothesis",
+    ):
+        assert plugin in content, f"pyproject.toml missing test plugin: {plugin}"
+
+
+def test_full_agentic_asyncio_mode_auto(output_dir):
+    config = RepoConfig(repo_name="my-agentic-project", preset="full_agentic")
+    generate(config, output_dir)
+    content = (output_dir / "pyproject.toml").read_text(encoding="utf-8")
+    assert 'asyncio_mode = "auto"' in content

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -89,3 +89,9 @@ def test_non_agentic_presets_have_no_skills_config():
         preset = get_preset(name)
         assert preset.skills_source is None
         assert preset.skills_version is None
+
+
+def test_python_desktop_required_files_include_conftest_and_smoke():
+    preset = get_preset("python_desktop")
+    assert "tests/conftest.py" in preset.required_files
+    assert "tests/test_ui_smoke.py" in preset.required_files


### PR DESCRIPTION
## Summary
- Scaffolds appropriate test plugins into generated repos by preset type: `pytest-mock` + `pytest-snapshot` + `hypothesis` for all presets, `pytest-qt` for python_desktop, and the full async/HTTP/property-based suite for full_agentic
- Adds `conftest.py` (QApplication fixture) and `test_ui_smoke.py` (commented skeleton) to the `python_desktop` template so generated repos have GUI test infrastructure ready from day one
- Adds an optional `--playwright` flag for `full_agentic` that scaffolds browser-test deps, a `test_web_smoke.py` skeleton, and the Playwright MCP server entry in `.mcp.json` (web-facing repos only)

## Sub-tickets included
- WOR-71 Scaffold test plugins into generated presets by type
- WOR-72 UI smoke test template and conftest for generated repos
- WOR-73 Add Playwright and Playwright MCP as optional toggle for full_agentic
- WOR-136 Add hypothesis to python_basic and python_desktop dev deps

## Test plan
- [x] pytest passes — 322 tests, 84% coverage (≥ 80%)
- [x] Security scan: PASS (bandit clean, no OWASP findings in diff)
- [x] UI tests: not yet present — tracked under WOR-137 (Epic: Desktop UI)
- [x] All 16 acceptance criteria verified by dedicated test assertions
- [x] Integration risks reviewed: Playwright MCP conditional logic, conftest fixture, hypothesis consistency across presets — all covered

**Milestone:** Agentic Scaffolding

Closes WOR-57
Closes WOR-71
Closes WOR-72
Closes WOR-73
Closes WOR-136