### PR TITLE
WOR-139 Wire EscalationPolicy into watcher._finalize_worker()

### DIFF
--- a/app/core/watcher.py
+++ b/app/core/watcher.py
@@ -31,6 +31,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import IO, Any, Protocol
 
+from app.core.escalation_policy import EscalationPolicy
 from app.core.linear_client import DONE_STATE_TYPES, LinearError
 from app.core.manifest import ExecutionManifest
 from app.core.metrics import ImplementationMode, MetricsStore, Outcome, TicketMetrics
@@ -243,6 +244,26 @@ def _tee_worker_output(
         log_file.close()
 
 
+_POLICY_FLAGS = (
+    "scope_drift",
+    "forbidden_path_touched",
+    "import_linter_violation",
+    "security_blocker",
+)
+
+
+def _read_result_flags(result_path: Path) -> dict[str, bool]:
+    """Load result.json and return the four escalation-policy boolean flags.
+
+    Returns all-False defaults when the file is missing or malformed.
+    """
+    try:
+        raw = json.loads(result_path.read_text(encoding="utf-8"))
+    except Exception:
+        return dict.fromkeys(_POLICY_FLAGS, False)
+    return {f: bool(raw.get(f, False)) for f in _POLICY_FLAGS}
+
+
 # ---------------------------------------------------------------------------
 # Watcher
 # ---------------------------------------------------------------------------
@@ -284,6 +305,7 @@ class Watcher:
         self._worker_counter = 0
         self._worker_counter_lock = threading.Lock()
         self._retry_counters: dict[str, int] = {}
+        self._escalation_policy = EscalationPolicy.from_toml()
 
     # ------------------------------------------------------------------
     # Public entry point
@@ -577,6 +599,7 @@ class Watcher:
 
         outcome: Outcome
         escalated = False
+        artifacts_preserved = False
 
         if returncode != 0:
             logger.error("Worker %s exited non-zero (%d)", ticket_id, returncode)
@@ -595,7 +618,48 @@ class Watcher:
                     linear_id, manifest.ticket_state_map.failed, ticket_id
                 )
             else:
-                outcome = self._attempt_pr(manifest, worker, ticket_id, linear_id)
+                self._preserve_worker_artifacts(worker)
+                artifacts_preserved = True
+
+                result_path = self._repo_root / manifest.artifact_paths.result_json
+                flags = _read_result_flags(result_path)
+                action = self._escalation_policy.classify_result(**flags)
+
+                if action == "escalate":
+                    triggering = next(
+                        (f for f in _POLICY_FLAGS if flags.get(f)), "unknown"
+                    )
+                    logger.info(
+                        "Escalating %s to cloud (flag=%s)", ticket_id, triggering
+                    )
+                    escalated = True
+                    self._safe_set_state(linear_id, "In Progress", ticket_id)
+                    try:
+                        self._linear.post_comment(
+                            linear_id,
+                            f"Local worker escalating `{ticket_id}` to cloud. "
+                            f"Triggering flag: `{triggering}`.",
+                        )
+                    except Exception:
+                        logger.warning(
+                            "Could not post escalation comment for %s", ticket_id
+                        )
+                    outcome = "escalated"
+                elif action == "human":
+                    logger.info("Human review required for %s per policy", ticket_id)
+                    try:
+                        self._linear.post_comment(
+                            linear_id,
+                            f"Human review required for `{ticket_id}` before "
+                            f"proceeding. Please inspect the result artifact.",
+                        )
+                    except Exception:
+                        logger.warning(
+                            "Could not post human review comment for %s", ticket_id
+                        )
+                    outcome = "aborted"
+                else:  # fix_locally
+                    outcome = self._attempt_pr(manifest, worker, ticket_id, linear_id)
 
         sonar_count = self._fetch_sonar_findings(manifest.worker_branch)
 
@@ -624,7 +688,8 @@ class Watcher:
         )
 
         self._restore_plan_files(worker.backed_up_plans)
-        self._preserve_worker_artifacts(worker)
+        if not artifacts_preserved:
+            self._preserve_worker_artifacts(worker)
         self._cleanup_worktree(worker.worktree_path)
 
     # ------------------------------------------------------------------

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -1400,3 +1400,117 @@ def test_cloud_pool_full_does_not_block_local_dispatch(tmp_path: Path) -> None:
     # Cloud pool unchanged
     assert len(watcher._cloud_active) == 1
     assert watcher._cloud_active[0].ticket_id == "WOR-99"
+
+
+# ---------------------------------------------------------------------------
+# _finalize_worker — EscalationPolicy flag routing
+# ---------------------------------------------------------------------------
+
+
+def _make_finalize_worker_for_policy(
+    tmp_path: Path,
+    flags: dict[str, bool],
+) -> tuple[Watcher, MagicMock, ActiveWorker]:
+    """Return (watcher, linear_mock, worker) with result.json pre-written."""
+    manifest = _make_manifest(ticket_id="WOR-10", worker_branch="wor-10-test-ticket")
+    linear_mock = MagicMock()
+    w = Watcher(linear_client=linear_mock, repo_root=tmp_path)
+
+    result_path = tmp_path / ".claude" / "artifacts" / "wor_10" / "result.json"
+    result_path.parent.mkdir(parents=True, exist_ok=True)
+    result_path.write_text(json.dumps({"status": "success", **flags}), encoding="utf-8")
+
+    worker = ActiveWorker(
+        ticket_id="WOR-10",
+        linear_id="fake-linear-id",
+        manifest=manifest,
+        worktree_path=tmp_path,
+        process=MagicMock(spec=subprocess.Popen),
+    )
+    return w, linear_mock, worker
+
+
+def test_finalize_worker_scope_drift_escalates(tmp_path: Path) -> None:
+    w, linear_mock, worker = _make_finalize_worker_for_policy(
+        tmp_path, {"scope_drift": True}
+    )
+    with (
+        patch.object(w, "_run_checks", return_value=True),
+        patch.object(w, "_preserve_worker_artifacts"),
+        patch.object(w, "_create_pr") as mock_create_pr,
+        patch.object(w, "_cleanup_worktree"),
+        patch.object(w, "_metrics") as metrics_mock,
+    ):
+        w._finalize_worker(worker, returncode=0, wall_time=1.0)
+
+    mock_create_pr.assert_not_called()
+    linear_mock.set_state.assert_called_with("fake-linear-id", "In Progress")
+    comment_body: str = linear_mock.post_comment.call_args[0][1]
+    assert "scope_drift" in comment_body
+    m = metrics_mock.record.call_args[0][0]
+    assert m.escalated_to_cloud is True
+    assert m.outcome == "escalated"
+
+
+def test_finalize_worker_forbidden_path_touched_escalates(tmp_path: Path) -> None:
+    w, linear_mock, worker = _make_finalize_worker_for_policy(
+        tmp_path, {"forbidden_path_touched": True}
+    )
+    with (
+        patch.object(w, "_run_checks", return_value=True),
+        patch.object(w, "_preserve_worker_artifacts"),
+        patch.object(w, "_create_pr") as mock_create_pr,
+        patch.object(w, "_cleanup_worktree"),
+        patch.object(w, "_metrics") as metrics_mock,
+    ):
+        w._finalize_worker(worker, returncode=0, wall_time=1.0)
+
+    mock_create_pr.assert_not_called()
+    linear_mock.set_state.assert_called_with("fake-linear-id", "In Progress")
+    comment_body: str = linear_mock.post_comment.call_args[0][1]
+    assert "forbidden_path_touched" in comment_body
+    m = metrics_mock.record.call_args[0][0]
+    assert m.escalated_to_cloud is True
+    assert m.outcome == "escalated"
+
+
+def test_finalize_worker_no_flags_proceeds_normally(tmp_path: Path) -> None:
+    w, _linear_mock, worker = _make_finalize_worker_for_policy(tmp_path, {})
+    with (
+        patch.object(w, "_run_checks", return_value=True),
+        patch.object(w, "_preserve_worker_artifacts"),
+        patch.object(w, "_create_pr", return_value="https://github.com/example/pr/1"),
+        patch.object(w, "_cleanup_worktree"),
+        patch.object(w, "_metrics") as metrics_mock,
+    ):
+        w._finalize_worker(worker, returncode=0, wall_time=1.0)
+
+    m = metrics_mock.record.call_args[0][0]
+    assert m.outcome == "success"
+    assert m.escalated_to_cloud is False
+
+
+def test_finalize_worker_missing_result_json_proceeds_normally(tmp_path: Path) -> None:
+    manifest = _make_manifest(ticket_id="WOR-10", worker_branch="wor-10-test-ticket")
+    linear_mock = MagicMock()
+    w = Watcher(linear_client=linear_mock, repo_root=tmp_path)
+
+    worker = ActiveWorker(
+        ticket_id="WOR-10",
+        linear_id="fake-linear-id",
+        manifest=manifest,
+        worktree_path=tmp_path,
+        process=MagicMock(spec=subprocess.Popen),
+    )
+    with (
+        patch.object(w, "_run_checks", return_value=True),
+        patch.object(w, "_preserve_worker_artifacts"),
+        patch.object(w, "_create_pr", return_value="https://github.com/example/pr/1"),
+        patch.object(w, "_cleanup_worktree"),
+        patch.object(w, "_metrics") as metrics_mock,
+    ):
+        w._finalize_worker(worker, returncode=0, wall_time=1.0)
+
+    m = metrics_mock.record.call_args[0][0]
+    assert m.outcome == "success"
+    assert m.escalated_to_cloud is False


### PR DESCRIPTION
Closes WOR-139

EscalationPolicy is loaded at __init__ and called in _finalize_worker(); all four flags from result.json are wired to their policy actions; missing result.json is handled gracefully; unit tests for each branch pass; mypy and ruff clean.