### PR TITLE
WOR-141 Fix Linear client: safe GraphQL response handling and retry with backoff

### DIFF
--- a/app/core/linear_client.py
+++ b/app/core/linear_client.py
@@ -6,14 +6,23 @@ No third-party HTTP dependencies — uses only urllib.request from stdlib.
 
 from __future__ import annotations
 
+import http.client
 import json
+import logging
 import os
+import time
+import urllib.error
 import urllib.request
 from typing import Any, cast
 
 _LINEAR_API_URL = "https://api.linear.app/graphql"
 
 DONE_STATE_TYPES = frozenset({"completed", "cancelled"})
+
+_RETRY_DELAYS = (1, 2, 4)
+_RETRYABLE_HTTP_CODES = frozenset({429, 500, 502, 503})
+
+logger = logging.getLogger(__name__)
 
 
 class LinearError(Exception):
@@ -206,8 +215,39 @@ class LinearClient:
             },
             method="POST",
         )
-        with urllib.request.urlopen(req, timeout=30) as resp:  # nosec B310
-            body = json.loads(resp.read())
-        if "errors" in body:
-            raise LinearError(f"Linear API error: {body['errors']}")
-        return body["data"]  # type: ignore[no-any-return]
+        last_exc: Exception | None = None
+        max_retries = len(_RETRY_DELAYS)
+        for attempt in range(max_retries + 1):
+            try:
+                with urllib.request.urlopen(req, timeout=30) as resp:  # nosec B310
+                    body: dict[str, Any] = json.loads(resp.read())
+                errors = body.get("errors")
+                if errors:
+                    raise LinearError(f"Linear API error: {errors}")
+                data = body.get("data")
+                if data is None:
+                    raise LinearError(f"Linear API returned no data: {body!r}")
+                return cast(dict[str, Any], data)
+            except LinearError:
+                raise
+            except urllib.error.HTTPError as exc:
+                if exc.code not in _RETRYABLE_HTTP_CODES:
+                    raise LinearError(
+                        f"Linear API HTTP {exc.code}: {exc.reason}"
+                    ) from exc
+                last_exc = exc
+            except (urllib.error.URLError, http.client.RemoteDisconnected) as exc:
+                last_exc = exc
+            if attempt < max_retries:
+                delay = _RETRY_DELAYS[attempt]
+                logger.warning(
+                    "Linear API transient error on attempt %d/%d — retrying in %ds: %s",
+                    attempt + 1,
+                    max_retries + 1,
+                    delay,
+                    last_exc,
+                )
+                time.sleep(delay)
+        raise LinearError(
+            f"Linear API failed after {max_retries + 1} attempts: {last_exc}"
+        ) from last_exc

--- a/tests/test_linear_client.py
+++ b/tests/test_linear_client.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import json
-from unittest.mock import MagicMock, patch
+import urllib.error
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 
@@ -288,3 +289,62 @@ def test_get_issue_state_type_raises_on_api_error() -> None:
     with patch("urllib.request.urlopen", return_value=_mock_response(response)):
         with pytest.raises(LinearError):
             _client().get_issue_state_type("WOR-45")
+
+
+# ---------------------------------------------------------------------------
+# _query retry and safe access
+# ---------------------------------------------------------------------------
+
+
+def test_query_clean_success() -> None:
+    response = {"data": {"foo": "bar"}}
+    with patch("urllib.request.urlopen", return_value=_mock_response(response)):
+        result = _client()._query("query { foo }")
+    assert result == {"foo": "bar"}
+
+
+def test_query_missing_data_key_raises() -> None:
+    response = {"something": "else"}
+    with patch("urllib.request.urlopen", return_value=_mock_response(response)):
+        with pytest.raises(LinearError, match="no data"):
+            _client()._query("query { foo }")
+
+
+def test_query_429_retries_three_times_then_raises() -> None:
+    exc = urllib.error.HTTPError(
+        url="", code=429, msg="Too Many Requests", hdrs=None, fp=None
+    )
+    with (
+        patch("urllib.request.urlopen", side_effect=exc) as mock_urlopen,
+        patch("app.core.linear_client.time.sleep") as mock_sleep,
+    ):
+        with pytest.raises(LinearError):
+            _client()._query("query { foo }")
+    assert mock_urlopen.call_count == 4
+    assert mock_sleep.call_args_list == [call(1), call(2), call(4)]
+
+
+def test_query_400_raises_immediately_without_retry() -> None:
+    exc = urllib.error.HTTPError(
+        url="", code=400, msg="Bad Request", hdrs=None, fp=None
+    )
+    with (
+        patch("urllib.request.urlopen", side_effect=exc) as mock_urlopen,
+        patch("app.core.linear_client.time.sleep") as mock_sleep,
+    ):
+        with pytest.raises(LinearError, match="400"):
+            _client()._query("query { foo }")
+    assert mock_urlopen.call_count == 1
+    mock_sleep.assert_not_called()
+
+
+def test_query_url_error_retries_with_backoff() -> None:
+    exc = urllib.error.URLError(reason="connection refused")
+    with (
+        patch("urllib.request.urlopen", side_effect=exc) as mock_urlopen,
+        patch("app.core.linear_client.time.sleep") as mock_sleep,
+    ):
+        with pytest.raises(LinearError):
+            _client()._query("query { foo }")
+    assert mock_urlopen.call_count == 4
+    assert mock_sleep.call_args_list == [call(1), call(2), call(4)]


### PR DESCRIPTION
Closes WOR-141

_query() guards all dict accesses and retries transient errors with backoff; non-retryable errors fail immediately; unit tests for all cases pass; mypy and ruff clean.