### PR TITLE
WOR-140 Wire Sonar severity into escalation classification in watcher

### DIFF
--- a/app/core/watcher.py
+++ b/app/core/watcher.py
@@ -600,6 +600,7 @@ class Watcher:
         outcome: Outcome
         escalated = False
         artifacts_preserved = False
+        sonar_findings: list[str] | None = None
 
         if returncode != 0:
             logger.error("Worker %s exited non-zero (%d)", ticket_id, returncode)
@@ -658,10 +659,43 @@ class Watcher:
                             "Could not post human review comment for %s", ticket_id
                         )
                     outcome = "aborted"
-                else:  # fix_locally
-                    outcome = self._attempt_pr(manifest, worker, ticket_id, linear_id)
-
-        sonar_count = self._fetch_sonar_findings(manifest.worker_branch)
+                else:  # fix_locally — classify Sonar severities before creating PR
+                    sonar_findings = self._fetch_sonar_findings(manifest.worker_branch)
+                    sonar_escalate = False
+                    if sonar_findings:
+                        for severity in sonar_findings:
+                            sonar_action = (
+                                self._escalation_policy.classify_sonar_finding(
+                                    severity.lower()
+                                )
+                            )
+                            if sonar_action == "escalate":
+                                sonar_escalate = True
+                            else:
+                                logger.warning(
+                                    "Sonar finding for %s: severity=%s — fix_locally",
+                                    ticket_id,
+                                    severity,
+                                )
+                    if sonar_escalate:
+                        escalated = True
+                        self._safe_set_state(linear_id, "In Progress", ticket_id)
+                        try:
+                            self._linear.post_comment(
+                                linear_id,
+                                f"Local worker escalating `{ticket_id}` to cloud due "
+                                f"to Sonar finding requiring immediate action.",
+                            )
+                        except Exception:
+                            logger.warning(
+                                "Could not post Sonar escalation comment for %s",
+                                ticket_id,
+                            )
+                        outcome = "escalated"
+                    else:
+                        outcome = self._attempt_pr(
+                            manifest, worker, ticket_id, linear_id
+                        )
 
         log_path = (
             worker.worktree_path / f".claude/worker_{worker.ticket_id.lower()}.log"
@@ -683,7 +717,9 @@ class Watcher:
                 outcome=outcome,
                 retry_count=worker.retry_count,
                 context_compactions=context_compactions,
-                sonar_findings_count=sonar_count,
+                sonar_findings_count=(
+                    len(sonar_findings) if sonar_findings is not None else None
+                ),
             )
         )
 
@@ -1014,16 +1050,12 @@ class Watcher:
     # SonarCloud findings count (Option B: REST API, best-effort)
     # ------------------------------------------------------------------
 
-    def _fetch_sonar_findings(self, branch: str) -> int | None:
-        # Calls the SonarCloud measures API for the worker branch right after PR
-        # creation.  The CI scan usually hasn't run yet at this point, so None is
-        # the common case for new branches; this becomes non-NULL once SonarCloud
-        # has processed a previous push to the same branch.  Requires SONAR_TOKEN
-        # and SONAR_PROJECT_KEY env vars; returns None silently if either is absent
-        # or if the API call fails for any reason.
-        #
-        # Uses http.client.HTTPSConnection (always TLS) rather than urlopen so that
-        # the scheme is statically known and not subject to file:// redirection.
+    def _fetch_sonar_findings(self, branch: str) -> list[str] | None:
+        # Calls the SonarCloud issues API for the worker branch to get per-severity
+        # issue data for escalation classification.  Returns a list of severity
+        # strings (e.g. ['BLOCKER', 'CRITICAL']) or None when SONAR_TOKEN /
+        # SONAR_PROJECT_KEY are absent or the API call fails.  An empty list means
+        # the branch was scanned and has no open issues.
         import base64
         import ssl
         import urllib.parse
@@ -1035,9 +1067,14 @@ class Watcher:
             return None
 
         params = urllib.parse.urlencode(
-            {"component": project_key, "branch": branch, "metricKeys": "violations"}
+            {
+                "componentKeys": project_key,
+                "branch": branch,
+                "resolved": "false",
+                "ps": "500",
+            }
         )
-        url = f"https://sonarcloud.io/api/measures/component?{params}"
+        url = f"https://sonarcloud.io/api/issues/search?{params}"
         creds = base64.b64encode(f"{token}:".encode()).decode()
         req = urllib.request.Request(url, headers={"Authorization": f"Basic {creds}"})
         ctx = ssl.create_default_context()
@@ -1046,13 +1083,12 @@ class Watcher:
                 req, timeout=10, context=ctx
             ) as resp:
                 data: dict[str, object] = json.loads(resp.read())
-            component = data.get("component") or {}
-            measures = (component if isinstance(component, dict) else {}).get(
-                "measures", []
-            )
-            for m in measures if isinstance(measures, list) else []:
-                if isinstance(m, dict) and m.get("metric") == "violations":
-                    return int(m["value"])
+            issues = data.get("issues") or []
+            return [
+                str(issue["severity"])
+                for issue in (issues if isinstance(issues, list) else [])
+                if isinstance(issue, dict) and issue.get("severity")
+            ]
         except Exception:
             logger.debug(
                 "Could not fetch Sonar findings for branch %s", branch, exc_info=True

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -1238,40 +1238,44 @@ def _make_sonar_resp_mock(payload: bytes) -> MagicMock:
     return mock_resp
 
 
-def test_fetch_sonar_findings_returns_count(
+def test_fetch_sonar_findings_returns_severities(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("SONAR_TOKEN", "fake-token")
     monkeypatch.setenv("SONAR_PROJECT_KEY", "my-org_my-project")
     api_payload = json.dumps(
-        {"component": {"measures": [{"metric": "violations", "value": "7"}]}}
+        {
+            "issues": [
+                {"key": "A", "severity": "MAJOR"},
+                {"key": "B", "severity": "MINOR"},
+                {"key": "C", "severity": "BLOCKER"},
+            ]
+        }
     ).encode()
 
     w = Watcher(linear_client=MagicMock())
     mock_resp = _make_sonar_resp_mock(api_payload)
     with patch("urllib.request.urlopen", return_value=mock_resp):
-        count = w._fetch_sonar_findings("wor-10-some-branch")
+        findings = w._fetch_sonar_findings("wor-10-some-branch")
 
-    assert count == 7
+    assert findings == ["MAJOR", "MINOR", "BLOCKER"]
 
 
-def test_fetch_sonar_findings_returns_none_when_metric_absent(
+def test_fetch_sonar_findings_returns_empty_list_when_no_issues(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("SONAR_TOKEN", "fake-token")
     monkeypatch.setenv("SONAR_PROJECT_KEY", "my-project")
-    api_payload = json.dumps(
-        {"component": {"measures": [{"metric": "coverage", "value": "80.0"}]}}
-    ).encode()
+    api_payload = json.dumps({"issues": [], "total": 0}).encode()
 
     w = Watcher(linear_client=MagicMock())
     with patch(
         "urllib.request.urlopen",
         return_value=_make_sonar_resp_mock(api_payload),
     ):
-        count = w._fetch_sonar_findings("wor-10-some-branch")
+        findings = w._fetch_sonar_findings("wor-10-some-branch")
 
-    assert count is None
+    assert findings == []
 
 
 def test_fetch_sonar_findings_returns_none_on_api_error(
@@ -1309,7 +1313,9 @@ def test_finalize_worker_sonar_count_wired_to_metrics(tmp_path: Path) -> None:
         patch.object(w, "_run_checks", return_value=True),
         patch.object(w, "_create_pr", return_value="https://github.com/example/pr/1"),
         patch.object(w, "_cleanup_worktree"),
-        patch.object(w, "_fetch_sonar_findings", return_value=3),
+        patch.object(
+            w, "_fetch_sonar_findings", return_value=["MAJOR", "MINOR", "MINOR"]
+        ),
         patch.object(w, "_metrics") as metrics_mock,
     ):
         w._finalize_worker(worker, returncode=0, wall_time=1.0)
@@ -1338,6 +1344,92 @@ def test_finalize_worker_sonar_count_none_when_unavailable(tmp_path: Path) -> No
         w._finalize_worker(worker, returncode=0, wall_time=1.0)
 
     m = metrics_mock.record.call_args[0][0]
+    assert m.sonar_findings_count is None
+
+
+# ---------------------------------------------------------------------------
+# _finalize_worker — Sonar severity escalation classification
+# ---------------------------------------------------------------------------
+
+
+def _make_finalize_worker_with_empty_result(
+    tmp_path: Path,
+) -> tuple[Watcher, MagicMock, ActiveWorker]:
+    manifest = _make_manifest(ticket_id="WOR-10", worker_branch="wor-10-test-ticket")
+    linear_mock = MagicMock()
+    w = Watcher(linear_client=linear_mock, repo_root=tmp_path)
+
+    result_path = tmp_path / ".claude" / "artifacts" / "wor_10" / "result.json"
+    result_path.parent.mkdir(parents=True, exist_ok=True)
+    result_path.write_text(json.dumps({"status": "success"}), encoding="utf-8")
+
+    worker = ActiveWorker(
+        ticket_id="WOR-10",
+        linear_id="fake-linear-id",
+        manifest=manifest,
+        worktree_path=tmp_path,
+        process=MagicMock(spec=subprocess.Popen),
+    )
+    return w, linear_mock, worker
+
+
+def test_finalize_worker_sonar_blocker_escalates(tmp_path: Path) -> None:
+    w, linear_mock, worker = _make_finalize_worker_with_empty_result(tmp_path)
+    with (
+        patch.object(w, "_run_checks", return_value=True),
+        patch.object(w, "_preserve_worker_artifacts"),
+        patch.object(w, "_fetch_sonar_findings", return_value=["BLOCKER"]),
+        patch.object(w, "_create_pr") as mock_create_pr,
+        patch.object(w, "_cleanup_worktree"),
+        patch.object(w, "_metrics") as metrics_mock,
+    ):
+        w._finalize_worker(worker, returncode=0, wall_time=1.0)
+
+    mock_create_pr.assert_not_called()
+    linear_mock.set_state.assert_called_with("fake-linear-id", "In Progress")
+    m = metrics_mock.record.call_args[0][0]
+    assert m.escalated_to_cloud is True
+    assert m.outcome == "escalated"
+    assert m.sonar_findings_count == 1
+
+
+def test_finalize_worker_sonar_major_advisory_warning(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    w, _linear_mock, worker = _make_finalize_worker_with_empty_result(tmp_path)
+    with (
+        patch.object(w, "_run_checks", return_value=True),
+        patch.object(w, "_preserve_worker_artifacts"),
+        patch.object(w, "_fetch_sonar_findings", return_value=["MAJOR"]),
+        patch.object(w, "_create_pr", return_value="https://github.com/example/pr/1"),
+        patch.object(w, "_cleanup_worktree"),
+        patch.object(w, "_metrics") as metrics_mock,
+        caplog.at_level(logging.WARNING, logger="app.core.watcher"),
+    ):
+        w._finalize_worker(worker, returncode=0, wall_time=1.0)
+
+    m = metrics_mock.record.call_args[0][0]
+    assert m.escalated_to_cloud is False
+    assert m.outcome == "success"
+    assert m.sonar_findings_count == 1
+    assert any("MAJOR" in msg and "fix_locally" in msg for msg in caplog.messages)
+
+
+def test_finalize_worker_sonar_none_no_escalation(tmp_path: Path) -> None:
+    w, _linear_mock, worker = _make_finalize_worker_with_empty_result(tmp_path)
+    with (
+        patch.object(w, "_run_checks", return_value=True),
+        patch.object(w, "_preserve_worker_artifacts"),
+        patch.object(w, "_fetch_sonar_findings", return_value=None),
+        patch.object(w, "_create_pr", return_value="https://github.com/example/pr/1"),
+        patch.object(w, "_cleanup_worktree"),
+        patch.object(w, "_metrics") as metrics_mock,
+    ):
+        w._finalize_worker(worker, returncode=0, wall_time=1.0)
+
+    m = metrics_mock.record.call_args[0][0]
+    assert m.escalated_to_cloud is False
+    assert m.outcome == "success"
     assert m.sonar_findings_count is None
 
 


### PR DESCRIPTION
Closes WOR-140

_fetch_sonar_findings() returns per-severity list; _finalize_worker() classifies each severity; BLOCKER/CRITICAL trigger cloud escalation; MAJOR/MINOR/INFO log and continue; tests pass; mypy and ruff clean.