### PR TITLE
WOR-142 Fix LiteLLM proxy process orphaning on watcher shutdown

### DIFF
--- a/app/core/watcher.py
+++ b/app/core/watcher.py
@@ -338,6 +338,7 @@ class Watcher:
                 time.sleep(self._POLL_INTERVAL)
         finally:
             self._wait_for_active_workers()
+            self._stop_litellm_proxy()
             self._remove_pid_file()
             logger.info("Watcher stopped cleanly")
 
@@ -1255,6 +1256,18 @@ class Watcher:
             f"Check .claude/litellm.log for details."
         )
 
+    def _stop_litellm_proxy(self) -> None:
+        if not self._litellm_proc:
+            return
+        logger.info("Stopping LiteLLM proxy (pid=%d)…", self._litellm_proc.pid)
+        self._litellm_proc.terminate()
+        try:
+            self._litellm_proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            logger.info("LiteLLM proxy did not exit after 5s — sending kill")
+            self._litellm_proc.kill()
+        self._litellm_proc = None
+
     # ------------------------------------------------------------------
     # Graceful shutdown
     # ------------------------------------------------------------------
@@ -1268,6 +1281,7 @@ class Watcher:
         logger.info(
             "Signal %d received — finishing active workers then exiting", signum
         )
+        self._stop_litellm_proxy()
         self._running = False
 
     def _wait_for_active_workers(self) -> None:

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -827,6 +827,47 @@ def test_promote_writes_updated_manifest_to_disk(tmp_path: Path) -> None:
     assert reloaded.ticket_id == "WOR-46"
 
 
+# ---------------------------------------------------------------------------
+# _stop_litellm_proxy
+# ---------------------------------------------------------------------------
+
+
+def test_stop_litellm_proxy_terminate_on_clean_exit() -> None:
+    mock_proc = MagicMock(spec=subprocess.Popen)
+    mock_proc.pid = 12345
+    mock_proc.wait.return_value = 0
+
+    w = Watcher(linear_client=MagicMock())
+    w._litellm_proc = mock_proc
+
+    w._stop_litellm_proxy()
+
+    mock_proc.terminate.assert_called_once()
+    mock_proc.kill.assert_not_called()
+    assert w._litellm_proc is None
+
+
+def test_stop_litellm_proxy_kill_when_terminate_hangs() -> None:
+    mock_proc = MagicMock(spec=subprocess.Popen)
+    mock_proc.pid = 12345
+    mock_proc.wait.side_effect = subprocess.TimeoutExpired(cmd="litellm", timeout=5)
+
+    w = Watcher(linear_client=MagicMock())
+    w._litellm_proc = mock_proc
+
+    w._stop_litellm_proxy()
+
+    mock_proc.terminate.assert_called_once()
+    mock_proc.kill.assert_called_once()
+    assert w._litellm_proc is None
+
+
+def test_stop_litellm_proxy_noop_when_none() -> None:
+    w = Watcher(linear_client=MagicMock())
+    assert w._litellm_proc is None
+    w._stop_litellm_proxy()  # must not raise
+
+
 def test_promote_no_artifacts_root_no_error(tmp_path: Path) -> None:
     watcher, _ = _make_watcher_with_mock_linear(tmp_path)
     watcher._promote_waiting_tickets()  # should not raise


### PR DESCRIPTION
Closes WOR-142

_stop_litellm_proxy() added; called from finally and _handle_signal(); process terminated with kill fallback; nil-safe; tests pass; mypy and ruff clean.