### PR TITLE
WOR-138 Epic: Watcher Reliability & Escalation Enforcement

### DIFF
--- a/app/core/linear_client.py
+++ b/app/core/linear_client.py
@@ -6,14 +6,23 @@ No third-party HTTP dependencies — uses only urllib.request from stdlib.
 
 from __future__ import annotations
 
+import http.client
 import json
+import logging
 import os
+import time
+import urllib.error
 import urllib.request
 from typing import Any, cast
 
 _LINEAR_API_URL = "https://api.linear.app/graphql"
 
 DONE_STATE_TYPES = frozenset({"completed", "cancelled"})
+
+_RETRY_DELAYS = (1, 2, 4)
+_RETRYABLE_HTTP_CODES = frozenset({429, 500, 502, 503})
+
+logger = logging.getLogger(__name__)
 
 
 class LinearError(Exception):
@@ -206,8 +215,39 @@ class LinearClient:
             },
             method="POST",
         )
-        with urllib.request.urlopen(req, timeout=30) as resp:  # nosec B310
-            body = json.loads(resp.read())
-        if "errors" in body:
-            raise LinearError(f"Linear API error: {body['errors']}")
-        return body["data"]  # type: ignore[no-any-return]
+        last_exc: Exception | None = None
+        max_retries = len(_RETRY_DELAYS)
+        for attempt in range(max_retries + 1):
+            try:
+                with urllib.request.urlopen(req, timeout=30) as resp:  # nosec B310
+                    body: dict[str, Any] = json.loads(resp.read())
+                errors = body.get("errors")
+                if errors:
+                    raise LinearError(f"Linear API error: {errors}")
+                data = body.get("data")
+                if data is None:
+                    raise LinearError(f"Linear API returned no data: {body!r}")
+                return cast(dict[str, Any], data)
+            except LinearError:
+                raise
+            except urllib.error.HTTPError as exc:
+                if exc.code not in _RETRYABLE_HTTP_CODES:
+                    raise LinearError(
+                        f"Linear API HTTP {exc.code}: {exc.reason}"
+                    ) from exc
+                last_exc = exc
+            except (urllib.error.URLError, http.client.RemoteDisconnected) as exc:
+                last_exc = exc
+            if attempt < max_retries:
+                delay = _RETRY_DELAYS[attempt]
+                logger.warning(
+                    "Linear API transient error on attempt %d/%d — retrying in %ds: %s",
+                    attempt + 1,
+                    max_retries + 1,
+                    delay,
+                    last_exc,
+                )
+                time.sleep(delay)
+        raise LinearError(
+            f"Linear API failed after {max_retries + 1} attempts: {last_exc}"
+        ) from last_exc

--- a/app/core/watcher.py
+++ b/app/core/watcher.py
@@ -362,11 +362,9 @@ class Watcher:
 
         Scans .claude/artifacts/*/manifest.json each poll cycle. For each manifest
         with status=='WaitingForDeps', checks whether all blocked_by_tickets have
-        reached a completed/cancelled state in Linear. If so, writes the manifest
-        back to disk with status='ReadyForLocal' and advances the Linear ticket.
-
-        # TODO: detect when a predecessor goes to 'Blocked' (failed) and surface it
-        # as a comment rather than waiting forever.
+        reached a completed state in Linear. If so, writes the manifest back to disk
+        with status='ReadyForLocal' and advances the Linear ticket. If any blocker
+        is cancelled, posts a comment and moves the dependent ticket to Backlog.
         """
         artifacts_root = self._repo_root / _CLAUDE_DIR / "artifacts"
         if not artifacts_root.exists():
@@ -394,6 +392,14 @@ class Watcher:
                 self._notify_promotion(manifest)
                 continue
 
+            cancelled = self._find_cancelled_blocker(manifest)
+            if cancelled is not None:
+                blocker_id, state_type = cancelled
+                self._handle_cancelled_predecessor(
+                    manifest, manifest_path, blocker_id, state_type
+                )
+                continue
+
             if self._all_blockers_satisfied(manifest):
                 logger.info(
                     "All blockers for %s satisfied — promoting to ReadyForLocal",
@@ -403,6 +409,56 @@ class Watcher:
                     manifest, manifest_path, "ReadyForLocal"
                 )
                 self._notify_promotion(manifest)
+
+    def _find_cancelled_blocker(
+        self, manifest: ExecutionManifest
+    ) -> tuple[str, str] | None:
+        """Return (blocker_id, state_type) for the first cancelled blocker, or None."""
+        for blocker_id in manifest.blocked_by_tickets:
+            try:
+                state_type = self._linear.get_issue_state_type(blocker_id)
+            except Exception as exc:
+                logger.debug(
+                    "Could not fetch state for blocker %s while scanning for "
+                    "cancellations in %s: %s",
+                    blocker_id,
+                    manifest.ticket_id,
+                    exc,
+                )
+                continue
+            if state_type == "cancelled":
+                return blocker_id, state_type
+        return None
+
+    def _handle_cancelled_predecessor(
+        self,
+        manifest: ExecutionManifest,
+        manifest_path: Path,
+        blocker_id: str,
+        state_type: str,
+    ) -> None:
+        logger.warning(
+            "Blocker %s for %s is %s — moving dependent to Backlog",
+            blocker_id,
+            manifest.ticket_id,
+            state_type,
+        )
+        self._transition_waiting_manifest(manifest, manifest_path, "Backlog")
+        if not manifest.linear_id:
+            return
+        self._safe_set_state(manifest.linear_id, "Backlog", manifest.ticket_id)
+        try:
+            msg = (
+                f"Predecessor {blocker_id} moved to {state_type}"
+                " — manual intervention required."
+            )
+            self._linear.post_comment(manifest.linear_id, msg)
+        except Exception as exc:
+            logger.warning(
+                "Could not post predecessor-cancelled comment for %s: %s",
+                manifest.ticket_id,
+                exc,
+            )
 
     def _all_blockers_satisfied(self, manifest: ExecutionManifest) -> bool:
         for blocker_id in manifest.blocked_by_tickets:
@@ -417,6 +473,8 @@ class Watcher:
                 )
                 return False
             if state_type is None or state_type not in DONE_STATE_TYPES:
+                return False
+            if state_type == "cancelled":
                 return False
         return True
 

--- a/app/core/watcher.py
+++ b/app/core/watcher.py
@@ -31,6 +31,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import IO, Any, Protocol
 
+from app.core.escalation_policy import EscalationPolicy
 from app.core.linear_client import DONE_STATE_TYPES, LinearError
 from app.core.manifest import ExecutionManifest
 from app.core.metrics import ImplementationMode, MetricsStore, Outcome, TicketMetrics
@@ -243,6 +244,26 @@ def _tee_worker_output(
         log_file.close()
 
 
+_POLICY_FLAGS = (
+    "scope_drift",
+    "forbidden_path_touched",
+    "import_linter_violation",
+    "security_blocker",
+)
+
+
+def _read_result_flags(result_path: Path) -> dict[str, bool]:
+    """Load result.json and return the four escalation-policy boolean flags.
+
+    Returns all-False defaults when the file is missing or malformed.
+    """
+    try:
+        raw = json.loads(result_path.read_text(encoding="utf-8"))
+    except Exception:
+        return dict.fromkeys(_POLICY_FLAGS, False)
+    return {f: bool(raw.get(f, False)) for f in _POLICY_FLAGS}
+
+
 # ---------------------------------------------------------------------------
 # Watcher
 # ---------------------------------------------------------------------------
@@ -284,6 +305,7 @@ class Watcher:
         self._worker_counter = 0
         self._worker_counter_lock = threading.Lock()
         self._retry_counters: dict[str, int] = {}
+        self._escalation_policy = EscalationPolicy.from_toml()
 
     # ------------------------------------------------------------------
     # Public entry point
@@ -577,6 +599,7 @@ class Watcher:
 
         outcome: Outcome
         escalated = False
+        artifacts_preserved = False
 
         if returncode != 0:
             logger.error("Worker %s exited non-zero (%d)", ticket_id, returncode)
@@ -595,7 +618,48 @@ class Watcher:
                     linear_id, manifest.ticket_state_map.failed, ticket_id
                 )
             else:
-                outcome = self._attempt_pr(manifest, worker, ticket_id, linear_id)
+                self._preserve_worker_artifacts(worker)
+                artifacts_preserved = True
+
+                result_path = self._repo_root / manifest.artifact_paths.result_json
+                flags = _read_result_flags(result_path)
+                action = self._escalation_policy.classify_result(**flags)
+
+                if action == "escalate":
+                    triggering = next(
+                        (f for f in _POLICY_FLAGS if flags.get(f)), "unknown"
+                    )
+                    logger.info(
+                        "Escalating %s to cloud (flag=%s)", ticket_id, triggering
+                    )
+                    escalated = True
+                    self._safe_set_state(linear_id, "In Progress", ticket_id)
+                    try:
+                        self._linear.post_comment(
+                            linear_id,
+                            f"Local worker escalating `{ticket_id}` to cloud. "
+                            f"Triggering flag: `{triggering}`.",
+                        )
+                    except Exception:
+                        logger.warning(
+                            "Could not post escalation comment for %s", ticket_id
+                        )
+                    outcome = "escalated"
+                elif action == "human":
+                    logger.info("Human review required for %s per policy", ticket_id)
+                    try:
+                        self._linear.post_comment(
+                            linear_id,
+                            f"Human review required for `{ticket_id}` before "
+                            f"proceeding. Please inspect the result artifact.",
+                        )
+                    except Exception:
+                        logger.warning(
+                            "Could not post human review comment for %s", ticket_id
+                        )
+                    outcome = "aborted"
+                else:  # fix_locally
+                    outcome = self._attempt_pr(manifest, worker, ticket_id, linear_id)
 
         sonar_count = self._fetch_sonar_findings(manifest.worker_branch)
 
@@ -624,7 +688,8 @@ class Watcher:
         )
 
         self._restore_plan_files(worker.backed_up_plans)
-        self._preserve_worker_artifacts(worker)
+        if not artifacts_preserved:
+            self._preserve_worker_artifacts(worker)
         self._cleanup_worktree(worker.worktree_path)
 
     # ------------------------------------------------------------------

--- a/app/core/watcher.py
+++ b/app/core/watcher.py
@@ -600,6 +600,7 @@ class Watcher:
         outcome: Outcome
         escalated = False
         artifacts_preserved = False
+        sonar_findings: list[str] | None = None
 
         if returncode != 0:
             logger.error("Worker %s exited non-zero (%d)", ticket_id, returncode)
@@ -658,10 +659,43 @@ class Watcher:
                             "Could not post human review comment for %s", ticket_id
                         )
                     outcome = "aborted"
-                else:  # fix_locally
-                    outcome = self._attempt_pr(manifest, worker, ticket_id, linear_id)
-
-        sonar_count = self._fetch_sonar_findings(manifest.worker_branch)
+                else:  # fix_locally — classify Sonar severities before creating PR
+                    sonar_findings = self._fetch_sonar_findings(manifest.worker_branch)
+                    sonar_escalate = False
+                    if sonar_findings:
+                        for severity in sonar_findings:
+                            sonar_action = (
+                                self._escalation_policy.classify_sonar_finding(
+                                    severity.lower()
+                                )
+                            )
+                            if sonar_action == "escalate":
+                                sonar_escalate = True
+                            else:
+                                logger.warning(
+                                    "Sonar finding for %s: severity=%s — fix_locally",
+                                    ticket_id,
+                                    severity,
+                                )
+                    if sonar_escalate:
+                        escalated = True
+                        self._safe_set_state(linear_id, "In Progress", ticket_id)
+                        try:
+                            self._linear.post_comment(
+                                linear_id,
+                                f"Local worker escalating `{ticket_id}` to cloud due "
+                                f"to Sonar finding requiring immediate action.",
+                            )
+                        except Exception:
+                            logger.warning(
+                                "Could not post Sonar escalation comment for %s",
+                                ticket_id,
+                            )
+                        outcome = "escalated"
+                    else:
+                        outcome = self._attempt_pr(
+                            manifest, worker, ticket_id, linear_id
+                        )
 
         log_path = (
             worker.worktree_path / f".claude/worker_{worker.ticket_id.lower()}.log"
@@ -683,7 +717,9 @@ class Watcher:
                 outcome=outcome,
                 retry_count=worker.retry_count,
                 context_compactions=context_compactions,
-                sonar_findings_count=sonar_count,
+                sonar_findings_count=(
+                    len(sonar_findings) if sonar_findings is not None else None
+                ),
             )
         )
 
@@ -1014,16 +1050,12 @@ class Watcher:
     # SonarCloud findings count (Option B: REST API, best-effort)
     # ------------------------------------------------------------------
 
-    def _fetch_sonar_findings(self, branch: str) -> int | None:
-        # Calls the SonarCloud measures API for the worker branch right after PR
-        # creation.  The CI scan usually hasn't run yet at this point, so None is
-        # the common case for new branches; this becomes non-NULL once SonarCloud
-        # has processed a previous push to the same branch.  Requires SONAR_TOKEN
-        # and SONAR_PROJECT_KEY env vars; returns None silently if either is absent
-        # or if the API call fails for any reason.
-        #
-        # Uses http.client.HTTPSConnection (always TLS) rather than urlopen so that
-        # the scheme is statically known and not subject to file:// redirection.
+    def _fetch_sonar_findings(self, branch: str) -> list[str] | None:
+        # Calls the SonarCloud issues API for the worker branch to get per-severity
+        # issue data for escalation classification.  Returns a list of severity
+        # strings (e.g. ['BLOCKER', 'CRITICAL']) or None when SONAR_TOKEN /
+        # SONAR_PROJECT_KEY are absent or the API call fails.  An empty list means
+        # the branch was scanned and has no open issues.
         import base64
         import ssl
         import urllib.parse
@@ -1035,9 +1067,14 @@ class Watcher:
             return None
 
         params = urllib.parse.urlencode(
-            {"component": project_key, "branch": branch, "metricKeys": "violations"}
+            {
+                "componentKeys": project_key,
+                "branch": branch,
+                "resolved": "false",
+                "ps": "500",
+            }
         )
-        url = f"https://sonarcloud.io/api/measures/component?{params}"
+        url = f"https://sonarcloud.io/api/issues/search?{params}"
         creds = base64.b64encode(f"{token}:".encode()).decode()
         req = urllib.request.Request(url, headers={"Authorization": f"Basic {creds}"})
         ctx = ssl.create_default_context()
@@ -1046,13 +1083,12 @@ class Watcher:
                 req, timeout=10, context=ctx
             ) as resp:
                 data: dict[str, object] = json.loads(resp.read())
-            component = data.get("component") or {}
-            measures = (component if isinstance(component, dict) else {}).get(
-                "measures", []
-            )
-            for m in measures if isinstance(measures, list) else []:
-                if isinstance(m, dict) and m.get("metric") == "violations":
-                    return int(m["value"])
+            issues = data.get("issues") or []
+            return [
+                str(issue["severity"])
+                for issue in (issues if isinstance(issues, list) else [])
+                if isinstance(issue, dict) and issue.get("severity")
+            ]
         except Exception:
             logger.debug(
                 "Could not fetch Sonar findings for branch %s", branch, exc_info=True

--- a/app/core/watcher.py
+++ b/app/core/watcher.py
@@ -338,6 +338,7 @@ class Watcher:
                 time.sleep(self._POLL_INTERVAL)
         finally:
             self._wait_for_active_workers()
+            self._stop_litellm_proxy()
             self._remove_pid_file()
             logger.info("Watcher stopped cleanly")
 
@@ -1255,6 +1256,18 @@ class Watcher:
             f"Check .claude/litellm.log for details."
         )
 
+    def _stop_litellm_proxy(self) -> None:
+        if not self._litellm_proc:
+            return
+        logger.info("Stopping LiteLLM proxy (pid=%d)…", self._litellm_proc.pid)
+        self._litellm_proc.terminate()
+        try:
+            self._litellm_proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            logger.info("LiteLLM proxy did not exit after 5s — sending kill")
+            self._litellm_proc.kill()
+        self._litellm_proc = None
+
     # ------------------------------------------------------------------
     # Graceful shutdown
     # ------------------------------------------------------------------
@@ -1268,6 +1281,7 @@ class Watcher:
         logger.info(
             "Signal %d received — finishing active workers then exiting", signum
         )
+        self._stop_litellm_proxy()
         self._running = False
 
     def _wait_for_active_workers(self) -> None:

--- a/tests/test_linear_client.py
+++ b/tests/test_linear_client.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import json
-from unittest.mock import MagicMock, patch
+import urllib.error
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 
@@ -288,3 +289,62 @@ def test_get_issue_state_type_raises_on_api_error() -> None:
     with patch("urllib.request.urlopen", return_value=_mock_response(response)):
         with pytest.raises(LinearError):
             _client().get_issue_state_type("WOR-45")
+
+
+# ---------------------------------------------------------------------------
+# _query retry and safe access
+# ---------------------------------------------------------------------------
+
+
+def test_query_clean_success() -> None:
+    response = {"data": {"foo": "bar"}}
+    with patch("urllib.request.urlopen", return_value=_mock_response(response)):
+        result = _client()._query("query { foo }")
+    assert result == {"foo": "bar"}
+
+
+def test_query_missing_data_key_raises() -> None:
+    response = {"something": "else"}
+    with patch("urllib.request.urlopen", return_value=_mock_response(response)):
+        with pytest.raises(LinearError, match="no data"):
+            _client()._query("query { foo }")
+
+
+def test_query_429_retries_three_times_then_raises() -> None:
+    exc = urllib.error.HTTPError(
+        url="", code=429, msg="Too Many Requests", hdrs=None, fp=None
+    )
+    with (
+        patch("urllib.request.urlopen", side_effect=exc) as mock_urlopen,
+        patch("app.core.linear_client.time.sleep") as mock_sleep,
+    ):
+        with pytest.raises(LinearError):
+            _client()._query("query { foo }")
+    assert mock_urlopen.call_count == 4
+    assert mock_sleep.call_args_list == [call(1), call(2), call(4)]
+
+
+def test_query_400_raises_immediately_without_retry() -> None:
+    exc = urllib.error.HTTPError(
+        url="", code=400, msg="Bad Request", hdrs=None, fp=None
+    )
+    with (
+        patch("urllib.request.urlopen", side_effect=exc) as mock_urlopen,
+        patch("app.core.linear_client.time.sleep") as mock_sleep,
+    ):
+        with pytest.raises(LinearError, match="400"):
+            _client()._query("query { foo }")
+    assert mock_urlopen.call_count == 1
+    mock_sleep.assert_not_called()
+
+
+def test_query_url_error_retries_with_backoff() -> None:
+    exc = urllib.error.URLError(reason="connection refused")
+    with (
+        patch("urllib.request.urlopen", side_effect=exc) as mock_urlopen,
+        patch("app.core.linear_client.time.sleep") as mock_sleep,
+    ):
+        with pytest.raises(LinearError):
+            _client()._query("query { foo }")
+    assert mock_urlopen.call_count == 4
+    assert mock_sleep.call_args_list == [call(1), call(2), call(4)]

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -1238,40 +1238,44 @@ def _make_sonar_resp_mock(payload: bytes) -> MagicMock:
     return mock_resp
 
 
-def test_fetch_sonar_findings_returns_count(
+def test_fetch_sonar_findings_returns_severities(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("SONAR_TOKEN", "fake-token")
     monkeypatch.setenv("SONAR_PROJECT_KEY", "my-org_my-project")
     api_payload = json.dumps(
-        {"component": {"measures": [{"metric": "violations", "value": "7"}]}}
+        {
+            "issues": [
+                {"key": "A", "severity": "MAJOR"},
+                {"key": "B", "severity": "MINOR"},
+                {"key": "C", "severity": "BLOCKER"},
+            ]
+        }
     ).encode()
 
     w = Watcher(linear_client=MagicMock())
     mock_resp = _make_sonar_resp_mock(api_payload)
     with patch("urllib.request.urlopen", return_value=mock_resp):
-        count = w._fetch_sonar_findings("wor-10-some-branch")
+        findings = w._fetch_sonar_findings("wor-10-some-branch")
 
-    assert count == 7
+    assert findings == ["MAJOR", "MINOR", "BLOCKER"]
 
 
-def test_fetch_sonar_findings_returns_none_when_metric_absent(
+def test_fetch_sonar_findings_returns_empty_list_when_no_issues(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("SONAR_TOKEN", "fake-token")
     monkeypatch.setenv("SONAR_PROJECT_KEY", "my-project")
-    api_payload = json.dumps(
-        {"component": {"measures": [{"metric": "coverage", "value": "80.0"}]}}
-    ).encode()
+    api_payload = json.dumps({"issues": [], "total": 0}).encode()
 
     w = Watcher(linear_client=MagicMock())
     with patch(
         "urllib.request.urlopen",
         return_value=_make_sonar_resp_mock(api_payload),
     ):
-        count = w._fetch_sonar_findings("wor-10-some-branch")
+        findings = w._fetch_sonar_findings("wor-10-some-branch")
 
-    assert count is None
+    assert findings == []
 
 
 def test_fetch_sonar_findings_returns_none_on_api_error(
@@ -1309,7 +1313,9 @@ def test_finalize_worker_sonar_count_wired_to_metrics(tmp_path: Path) -> None:
         patch.object(w, "_run_checks", return_value=True),
         patch.object(w, "_create_pr", return_value="https://github.com/example/pr/1"),
         patch.object(w, "_cleanup_worktree"),
-        patch.object(w, "_fetch_sonar_findings", return_value=3),
+        patch.object(
+            w, "_fetch_sonar_findings", return_value=["MAJOR", "MINOR", "MINOR"]
+        ),
         patch.object(w, "_metrics") as metrics_mock,
     ):
         w._finalize_worker(worker, returncode=0, wall_time=1.0)
@@ -1338,6 +1344,92 @@ def test_finalize_worker_sonar_count_none_when_unavailable(tmp_path: Path) -> No
         w._finalize_worker(worker, returncode=0, wall_time=1.0)
 
     m = metrics_mock.record.call_args[0][0]
+    assert m.sonar_findings_count is None
+
+
+# ---------------------------------------------------------------------------
+# _finalize_worker — Sonar severity escalation classification
+# ---------------------------------------------------------------------------
+
+
+def _make_finalize_worker_with_empty_result(
+    tmp_path: Path,
+) -> tuple[Watcher, MagicMock, ActiveWorker]:
+    manifest = _make_manifest(ticket_id="WOR-10", worker_branch="wor-10-test-ticket")
+    linear_mock = MagicMock()
+    w = Watcher(linear_client=linear_mock, repo_root=tmp_path)
+
+    result_path = tmp_path / ".claude" / "artifacts" / "wor_10" / "result.json"
+    result_path.parent.mkdir(parents=True, exist_ok=True)
+    result_path.write_text(json.dumps({"status": "success"}), encoding="utf-8")
+
+    worker = ActiveWorker(
+        ticket_id="WOR-10",
+        linear_id="fake-linear-id",
+        manifest=manifest,
+        worktree_path=tmp_path,
+        process=MagicMock(spec=subprocess.Popen),
+    )
+    return w, linear_mock, worker
+
+
+def test_finalize_worker_sonar_blocker_escalates(tmp_path: Path) -> None:
+    w, linear_mock, worker = _make_finalize_worker_with_empty_result(tmp_path)
+    with (
+        patch.object(w, "_run_checks", return_value=True),
+        patch.object(w, "_preserve_worker_artifacts"),
+        patch.object(w, "_fetch_sonar_findings", return_value=["BLOCKER"]),
+        patch.object(w, "_create_pr") as mock_create_pr,
+        patch.object(w, "_cleanup_worktree"),
+        patch.object(w, "_metrics") as metrics_mock,
+    ):
+        w._finalize_worker(worker, returncode=0, wall_time=1.0)
+
+    mock_create_pr.assert_not_called()
+    linear_mock.set_state.assert_called_with("fake-linear-id", "In Progress")
+    m = metrics_mock.record.call_args[0][0]
+    assert m.escalated_to_cloud is True
+    assert m.outcome == "escalated"
+    assert m.sonar_findings_count == 1
+
+
+def test_finalize_worker_sonar_major_advisory_warning(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    w, _linear_mock, worker = _make_finalize_worker_with_empty_result(tmp_path)
+    with (
+        patch.object(w, "_run_checks", return_value=True),
+        patch.object(w, "_preserve_worker_artifacts"),
+        patch.object(w, "_fetch_sonar_findings", return_value=["MAJOR"]),
+        patch.object(w, "_create_pr", return_value="https://github.com/example/pr/1"),
+        patch.object(w, "_cleanup_worktree"),
+        patch.object(w, "_metrics") as metrics_mock,
+        caplog.at_level(logging.WARNING, logger="app.core.watcher"),
+    ):
+        w._finalize_worker(worker, returncode=0, wall_time=1.0)
+
+    m = metrics_mock.record.call_args[0][0]
+    assert m.escalated_to_cloud is False
+    assert m.outcome == "success"
+    assert m.sonar_findings_count == 1
+    assert any("MAJOR" in msg and "fix_locally" in msg for msg in caplog.messages)
+
+
+def test_finalize_worker_sonar_none_no_escalation(tmp_path: Path) -> None:
+    w, _linear_mock, worker = _make_finalize_worker_with_empty_result(tmp_path)
+    with (
+        patch.object(w, "_run_checks", return_value=True),
+        patch.object(w, "_preserve_worker_artifacts"),
+        patch.object(w, "_fetch_sonar_findings", return_value=None),
+        patch.object(w, "_create_pr", return_value="https://github.com/example/pr/1"),
+        patch.object(w, "_cleanup_worktree"),
+        patch.object(w, "_metrics") as metrics_mock,
+    ):
+        w._finalize_worker(worker, returncode=0, wall_time=1.0)
+
+    m = metrics_mock.record.call_args[0][0]
+    assert m.escalated_to_cloud is False
+    assert m.outcome == "success"
     assert m.sonar_findings_count is None
 
 

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -827,6 +827,47 @@ def test_promote_writes_updated_manifest_to_disk(tmp_path: Path) -> None:
     assert reloaded.ticket_id == "WOR-46"
 
 
+# ---------------------------------------------------------------------------
+# _stop_litellm_proxy
+# ---------------------------------------------------------------------------
+
+
+def test_stop_litellm_proxy_terminate_on_clean_exit() -> None:
+    mock_proc = MagicMock(spec=subprocess.Popen)
+    mock_proc.pid = 12345
+    mock_proc.wait.return_value = 0
+
+    w = Watcher(linear_client=MagicMock())
+    w._litellm_proc = mock_proc
+
+    w._stop_litellm_proxy()
+
+    mock_proc.terminate.assert_called_once()
+    mock_proc.kill.assert_not_called()
+    assert w._litellm_proc is None
+
+
+def test_stop_litellm_proxy_kill_when_terminate_hangs() -> None:
+    mock_proc = MagicMock(spec=subprocess.Popen)
+    mock_proc.pid = 12345
+    mock_proc.wait.side_effect = subprocess.TimeoutExpired(cmd="litellm", timeout=5)
+
+    w = Watcher(linear_client=MagicMock())
+    w._litellm_proc = mock_proc
+
+    w._stop_litellm_proxy()
+
+    mock_proc.terminate.assert_called_once()
+    mock_proc.kill.assert_called_once()
+    assert w._litellm_proc is None
+
+
+def test_stop_litellm_proxy_noop_when_none() -> None:
+    w = Watcher(linear_client=MagicMock())
+    assert w._litellm_proc is None
+    w._stop_litellm_proxy()  # must not raise
+
+
 def test_promote_no_artifacts_root_no_error(tmp_path: Path) -> None:
     watcher, _ = _make_watcher_with_mock_linear(tmp_path)
     watcher._promote_waiting_tickets()  # should not raise

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -1400,3 +1400,117 @@ def test_cloud_pool_full_does_not_block_local_dispatch(tmp_path: Path) -> None:
     # Cloud pool unchanged
     assert len(watcher._cloud_active) == 1
     assert watcher._cloud_active[0].ticket_id == "WOR-99"
+
+
+# ---------------------------------------------------------------------------
+# _finalize_worker — EscalationPolicy flag routing
+# ---------------------------------------------------------------------------
+
+
+def _make_finalize_worker_for_policy(
+    tmp_path: Path,
+    flags: dict[str, bool],
+) -> tuple[Watcher, MagicMock, ActiveWorker]:
+    """Return (watcher, linear_mock, worker) with result.json pre-written."""
+    manifest = _make_manifest(ticket_id="WOR-10", worker_branch="wor-10-test-ticket")
+    linear_mock = MagicMock()
+    w = Watcher(linear_client=linear_mock, repo_root=tmp_path)
+
+    result_path = tmp_path / ".claude" / "artifacts" / "wor_10" / "result.json"
+    result_path.parent.mkdir(parents=True, exist_ok=True)
+    result_path.write_text(json.dumps({"status": "success", **flags}), encoding="utf-8")
+
+    worker = ActiveWorker(
+        ticket_id="WOR-10",
+        linear_id="fake-linear-id",
+        manifest=manifest,
+        worktree_path=tmp_path,
+        process=MagicMock(spec=subprocess.Popen),
+    )
+    return w, linear_mock, worker
+
+
+def test_finalize_worker_scope_drift_escalates(tmp_path: Path) -> None:
+    w, linear_mock, worker = _make_finalize_worker_for_policy(
+        tmp_path, {"scope_drift": True}
+    )
+    with (
+        patch.object(w, "_run_checks", return_value=True),
+        patch.object(w, "_preserve_worker_artifacts"),
+        patch.object(w, "_create_pr") as mock_create_pr,
+        patch.object(w, "_cleanup_worktree"),
+        patch.object(w, "_metrics") as metrics_mock,
+    ):
+        w._finalize_worker(worker, returncode=0, wall_time=1.0)
+
+    mock_create_pr.assert_not_called()
+    linear_mock.set_state.assert_called_with("fake-linear-id", "In Progress")
+    comment_body: str = linear_mock.post_comment.call_args[0][1]
+    assert "scope_drift" in comment_body
+    m = metrics_mock.record.call_args[0][0]
+    assert m.escalated_to_cloud is True
+    assert m.outcome == "escalated"
+
+
+def test_finalize_worker_forbidden_path_touched_escalates(tmp_path: Path) -> None:
+    w, linear_mock, worker = _make_finalize_worker_for_policy(
+        tmp_path, {"forbidden_path_touched": True}
+    )
+    with (
+        patch.object(w, "_run_checks", return_value=True),
+        patch.object(w, "_preserve_worker_artifacts"),
+        patch.object(w, "_create_pr") as mock_create_pr,
+        patch.object(w, "_cleanup_worktree"),
+        patch.object(w, "_metrics") as metrics_mock,
+    ):
+        w._finalize_worker(worker, returncode=0, wall_time=1.0)
+
+    mock_create_pr.assert_not_called()
+    linear_mock.set_state.assert_called_with("fake-linear-id", "In Progress")
+    comment_body: str = linear_mock.post_comment.call_args[0][1]
+    assert "forbidden_path_touched" in comment_body
+    m = metrics_mock.record.call_args[0][0]
+    assert m.escalated_to_cloud is True
+    assert m.outcome == "escalated"
+
+
+def test_finalize_worker_no_flags_proceeds_normally(tmp_path: Path) -> None:
+    w, _linear_mock, worker = _make_finalize_worker_for_policy(tmp_path, {})
+    with (
+        patch.object(w, "_run_checks", return_value=True),
+        patch.object(w, "_preserve_worker_artifacts"),
+        patch.object(w, "_create_pr", return_value="https://github.com/example/pr/1"),
+        patch.object(w, "_cleanup_worktree"),
+        patch.object(w, "_metrics") as metrics_mock,
+    ):
+        w._finalize_worker(worker, returncode=0, wall_time=1.0)
+
+    m = metrics_mock.record.call_args[0][0]
+    assert m.outcome == "success"
+    assert m.escalated_to_cloud is False
+
+
+def test_finalize_worker_missing_result_json_proceeds_normally(tmp_path: Path) -> None:
+    manifest = _make_manifest(ticket_id="WOR-10", worker_branch="wor-10-test-ticket")
+    linear_mock = MagicMock()
+    w = Watcher(linear_client=linear_mock, repo_root=tmp_path)
+
+    worker = ActiveWorker(
+        ticket_id="WOR-10",
+        linear_id="fake-linear-id",
+        manifest=manifest,
+        worktree_path=tmp_path,
+        process=MagicMock(spec=subprocess.Popen),
+    )
+    with (
+        patch.object(w, "_run_checks", return_value=True),
+        patch.object(w, "_preserve_worker_artifacts"),
+        patch.object(w, "_create_pr", return_value="https://github.com/example/pr/1"),
+        patch.object(w, "_cleanup_worktree"),
+        patch.object(w, "_metrics") as metrics_mock,
+    ):
+        w._finalize_worker(worker, returncode=0, wall_time=1.0)
+
+    m = metrics_mock.record.call_args[0][0]
+    assert m.outcome == "success"
+    assert m.escalated_to_cloud is False

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -760,7 +760,7 @@ def test_promote_partial_blockers_skips(tmp_path: Path) -> None:
     mock_linear.set_state.assert_not_called()
 
 
-def test_promote_cancelled_blocker_counts_as_done(tmp_path: Path) -> None:
+def test_promote_cancelled_blocker_moves_to_backlog(tmp_path: Path) -> None:
     artifacts = tmp_path / ".claude" / "artifacts"
     manifest = _make_waiting_manifest()
     _write_manifest(manifest, artifacts)
@@ -771,7 +771,43 @@ def test_promote_cancelled_blocker_counts_as_done(tmp_path: Path) -> None:
     watcher._promote_waiting_tickets()
 
     on_disk = ExecutionManifest.from_json(artifacts / "wor_46" / "manifest.json")
-    assert on_disk.status == "ReadyForLocal"
+    assert on_disk.status == "Backlog"
+    mock_linear.set_state.assert_called_once_with("fake-linear-uuid", "Backlog")
+    comment_body: str = mock_linear.post_comment.call_args[0][1]
+    assert "WOR-45" in comment_body
+    assert "manual intervention" in comment_body
+
+
+def test_promote_cancelled_blocker_does_not_promote_to_ready(tmp_path: Path) -> None:
+    artifacts = tmp_path / ".claude" / "artifacts"
+    manifest = _make_waiting_manifest()
+    _write_manifest(manifest, artifacts)
+
+    watcher, mock_linear = _make_watcher_with_mock_linear(
+        tmp_path, {"WOR-45": "cancelled"}
+    )
+    watcher._promote_waiting_tickets()
+
+    on_disk = ExecutionManifest.from_json(artifacts / "wor_46" / "manifest.json")
+    assert on_disk.status != "ReadyForLocal"
+
+
+def test_promote_cancelled_blocker_no_linear_id_updates_disk_only(
+    tmp_path: Path,
+) -> None:
+    artifacts = tmp_path / ".claude" / "artifacts"
+    manifest = _make_waiting_manifest(linear_id=None)
+    _write_manifest(manifest, artifacts)
+
+    watcher, mock_linear = _make_watcher_with_mock_linear(
+        tmp_path, {"WOR-45": "cancelled"}
+    )
+    watcher._promote_waiting_tickets()
+
+    on_disk = ExecutionManifest.from_json(artifacts / "wor_46" / "manifest.json")
+    assert on_disk.status == "Backlog"
+    mock_linear.set_state.assert_not_called()
+    mock_linear.post_comment.assert_not_called()
 
 
 def test_promote_empty_blocked_by_promotes_immediately(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Wire `EscalationPolicy.classify_result()` into `_finalize_worker()` so result-artifact flags (`scope_drift`, `forbidden_path_touched`, `import_linter_violation`, `security_blocker`) actually trigger cloud escalation
- Wire `classify_sonar_finding()` per Sonar severity — BLOCKER/CRITICAL escalate to cloud, MAJOR/MINOR log advisory; switch `_fetch_sonar_findings()` from count-based to severity-list API (`issues/search`)
- Harden `LinearClient._query()` with safe `dict.get()` response access and exponential backoff retry (3 attempts: 1s/2s/4s) for 429/5xx/timeout errors
- Fix LiteLLM proxy orphaning: `_stop_litellm_proxy()` added to both `_handle_shutdown()` signal handler and `finally` cleanup in `run()`
- Handle cancelled predecessor in `WaitingForDeps`: posts Linear comment + moves dependent ticket to Backlog instead of hanging indefinitely

## Sub-tickets included
- WOR-139 Wire EscalationPolicy into watcher._finalize_worker()
- WOR-140 Wire Sonar severity into escalation classification in watcher
- WOR-141 Fix Linear client: safe GraphQL response handling and retry with backoff
- WOR-142 Fix LiteLLM proxy process orphaning on watcher shutdown
- WOR-143 Surface predecessor failure in WaitingForDeps instead of hanging

## Test plan
- [x] pytest passes: 339 tests, 84.69% coverage (≥ 80% threshold)
- [x] Security scan: PASS (bandit — no new findings; existing `nosec` annotations on reviewed subprocess calls)
- [x] UI tests: not yet present — noted for future epic
- [ ] Manual: verify signal handler path (`SIGTERM` → `_stop_litellm_proxy`) terminates LiteLLM before production rollout
- [ ] Manual: confirm SonarCloud `issues/search` API works with your org/project key configuration

## Reviewer attention points
- Signal handler end-to-end test gap (lines 316–343 in watcher.py): defensive `try/except` in place, but no automated test for the SIGTERM path
- `_fetch_sonar_findings()` changed endpoint — no batching past 500 active issues; follow-up ticket if needed
- Narrow TOCTOU race in `_promote_waiting_tickets()` between `_find_cancelled_blocker()` and `_all_blockers_satisfied()` — acceptable given narrow window

**Milestone:** Watcher Hardening

Closes WOR-138
Closes WOR-139
Closes WOR-140
Closes WOR-141
Closes WOR-142
Closes WOR-143