### PR TITLE
WOR-154 Fix hybrid/default watcher mode: start Ollama and LiteLLM proxy for local dispatch

### DIFF
--- a/app/core/watcher.py
+++ b/app/core/watcher.py
@@ -44,6 +44,8 @@ _LITELLM_PORT = 8082
 _LITELLM_CONFIG = "litellm-local.yaml"
 _LOCAL_MODEL = "qwen3-coder:30b"
 _LITELLM_BASE_URL = f"http://localhost:{_LITELLM_PORT}"
+_OLLAMA_PORT = 11434
+_OLLAMA_KEEPALIVE = "120m"
 _WORKTREE_BASE = Path("worktrees")
 
 _ENV_VARS_TO_STRIP_FOR_CLOUD = frozenset(
@@ -262,6 +264,29 @@ def _read_result_flags(result_path: Path) -> dict[str, bool]:
     except Exception:
         return dict.fromkeys(_POLICY_FLAGS, False)
     return {f: bool(raw.get(f, False)) for f in _POLICY_FLAGS}
+
+
+def _parse_ollama_model(config_path: Path) -> str:
+    """Return the bare Ollama model name from a LiteLLM YAML config.
+
+    Scans for the first 'model: ollama_chat/<name>' line and returns <name>.
+    Raises ValueError if none is found, FileNotFoundError if the file is absent.
+    """
+    import re
+
+    if not config_path.exists():
+        raise FileNotFoundError(
+            f"LiteLLM config not found: {config_path}. "
+            "Copy litellm-local.yaml.example to litellm-local.yaml and configure it."
+        )
+    text = config_path.read_text(encoding="utf-8")
+    match = re.search(r"model:\s+ollama_chat/(\S+)", text)
+    if match is None:
+        raise ValueError(
+            f"No ollama_chat/ model found in {config_path}. "
+            "Add a model_list entry with litellm_params.model = 'ollama_chat/<model>'."
+        )
+    return match.group(1)
 
 
 # ---------------------------------------------------------------------------
@@ -576,6 +601,10 @@ class Watcher:
             linear_id, manifest.ticket_state_map.in_progress_local, ticket_id
         )
         logger.info("Launching worker for %s (mode=%s)", ticket_id, effective_mode)
+
+        if effective_mode == "local":
+            self._ensure_ollama_running()
+            self._ensure_litellm_running()
 
         backed_up_plans = self._backup_plan_files()
         process = self._launch_worker(manifest, worktree_path, effective_mode)
@@ -1251,6 +1280,45 @@ class Watcher:
     # LiteLLM proxy
     # ------------------------------------------------------------------
 
+    def _ensure_ollama_running(self) -> None:
+        """Start Ollama with the configured model if not already on _OLLAMA_PORT."""
+        import socket
+
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            already_up = sock.connect_ex(("localhost", _OLLAMA_PORT)) == 0
+
+        if already_up:
+            logger.info("Ollama already running on port %d", _OLLAMA_PORT)
+            return
+
+        config_path = self._repo_root / _LITELLM_CONFIG
+        model = _parse_ollama_model(config_path)
+        logger.info(
+            "Starting Ollama (model=%s, keepalive=%s)…", model, _OLLAMA_KEEPALIVE
+        )
+        if sys.platform == "win32":
+            creation_flags = subprocess.CREATE_NEW_CONSOLE
+        else:
+            creation_flags = 0
+        subprocess.Popen(  # nosec B603 B607
+            ["ollama", "run", model, "--keepalive", _OLLAMA_KEEPALIVE],
+            creationflags=creation_flags,
+        )
+        self._wait_for_ollama_ready()
+
+    def _wait_for_ollama_ready(self, timeout: float = 120.0) -> None:
+        """Poll TCP until Ollama's port accepts connections."""
+        import socket
+
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+                sock.settimeout(2)
+                if sock.connect_ex(("localhost", _OLLAMA_PORT)) == 0:
+                    return
+            time.sleep(0.5)
+        raise TimeoutError(f"Ollama not ready after {timeout}s.")
+
     def _ensure_litellm_running(self) -> None:
         """Start the LiteLLM proxy if not already listening on _LITELLM_PORT."""
         import socket
@@ -1270,26 +1338,39 @@ class Watcher:
                 "and configure it."
             )
 
-        log_path = self._repo_root / _CLAUDE_DIR / "litellm.log"
-        log_path.parent.mkdir(parents=True, exist_ok=True)
-        log_file = open(log_path, "wb")  # noqa: SIM115
-        logger.info(
-            "Starting LiteLLM proxy (port %d)… (log: %s)", _LITELLM_PORT, log_path
-        )
+        logger.info("Starting LiteLLM proxy (port %d)…", _LITELLM_PORT)
         env = {**os.environ, "PYTHONUTF8": "1"}
-        self._litellm_proc = subprocess.Popen(  # nosec B603 B607
-            [
-                "litellm",
-                "--config",
-                str(config_path),
-                "--port",
-                str(_LITELLM_PORT),
-                "--drop_params",
-            ],
-            stdout=log_file,
-            stderr=log_file,
-            env=env,
-        )
+        if sys.platform == "win32":
+            self._litellm_proc = subprocess.Popen(  # nosec B603 B607
+                [
+                    "litellm",
+                    "--config",
+                    str(config_path),
+                    "--port",
+                    str(_LITELLM_PORT),
+                    "--drop_params",
+                ],
+                creationflags=subprocess.CREATE_NEW_CONSOLE,
+                env=env,
+            )
+        else:
+            log_path = self._repo_root / _CLAUDE_DIR / "litellm.log"
+            log_path.parent.mkdir(parents=True, exist_ok=True)
+            log_file = open(log_path, "wb")  # noqa: SIM115
+            logger.info("LiteLLM log: %s", log_path)
+            self._litellm_proc = subprocess.Popen(  # nosec B603 B607
+                [
+                    "litellm",
+                    "--config",
+                    str(config_path),
+                    "--port",
+                    str(_LITELLM_PORT),
+                    "--drop_params",
+                ],
+                stdout=log_file,
+                stderr=log_file,
+                env=env,
+            )
         self._wait_for_litellm_ready()
 
     def _wait_for_litellm_ready(self, timeout: float = 60.0) -> None:

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -21,6 +21,7 @@ from app.core.manifest import ArtifactPaths, ExecutionManifest
 from app.core.watcher import (
     ActiveWorker,
     Watcher,
+    _parse_ollama_model,
     _parse_worker_usage,
     _tee_worker_output,
     build_worker_cmd,
@@ -666,6 +667,8 @@ def test_start_ticket_set_state_failure_worker_still_starts(tmp_path: Path) -> N
         patch.object(w, "_create_worktree", return_value=tmp_path),
         patch.object(w, "_copy_manifest_to_worktree"),
         patch.object(w, "_launch_worker", return_value=fake_process),
+        patch.object(w, "_ensure_ollama_running"),
+        patch.object(w, "_ensure_litellm_running"),
     ):
         # set_state raises — worker must still be launched and added to _local_active
         w._start_ticket("WOR-10", "fake-linear-id")
@@ -1683,3 +1686,170 @@ def test_finalize_worker_missing_result_json_proceeds_normally(tmp_path: Path) -
     m = metrics_mock.record.call_args[0][0]
     assert m.outcome == "success"
     assert m.escalated_to_cloud is False
+
+
+# ---------------------------------------------------------------------------
+# _parse_ollama_model
+# ---------------------------------------------------------------------------
+
+
+def test_parse_ollama_model_returns_bare_model_name(tmp_path: Path) -> None:
+    cfg = tmp_path / "litellm-local.yaml"
+    cfg.write_text(
+        "model_list:\n"
+        "  - model_name: claude-sonnet-4-6\n"
+        "    litellm_params:\n"
+        "      model: ollama_chat/qwen3-coder:30b\n"
+        "      api_base: http://localhost:11434\n"
+    )
+    assert _parse_ollama_model(cfg) == "qwen3-coder:30b"
+
+
+def test_parse_ollama_model_raises_when_no_ollama_entry(tmp_path: Path) -> None:
+    cfg = tmp_path / "litellm-local.yaml"
+    cfg.write_text(
+        "model_list:\n"
+        "  - model_name: gpt-4\n"
+        "    litellm_params:\n"
+        "      model: openai/gpt-4\n"
+    )
+    with pytest.raises(ValueError, match="No ollama_chat/"):
+        _parse_ollama_model(cfg)
+
+
+def test_parse_ollama_model_raises_when_file_missing(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        _parse_ollama_model(tmp_path / "nonexistent.yaml")
+
+
+# ---------------------------------------------------------------------------
+# _ensure_ollama_running
+# ---------------------------------------------------------------------------
+
+
+def test_ensure_ollama_running_already_up() -> None:
+    w = Watcher(linear_client=MagicMock())
+    with (
+        patch("socket.socket") as mock_sock_cls,
+        patch("subprocess.Popen") as mock_popen,
+    ):
+        mock_sock = MagicMock()
+        mock_sock.__enter__ = lambda s: s
+        mock_sock.__exit__ = MagicMock(return_value=False)
+        mock_sock.connect_ex.return_value = 0  # already up
+        mock_sock_cls.return_value = mock_sock
+
+        w._ensure_ollama_running()
+
+    mock_popen.assert_not_called()
+
+
+def test_ensure_ollama_running_starts_process(tmp_path: Path) -> None:
+    cfg = tmp_path / "litellm-local.yaml"
+    cfg.write_text(
+        "model_list:\n"
+        "  - model_name: claude-sonnet-4-6\n"
+        "    litellm_params:\n"
+        "      model: ollama_chat/qwen3-coder:30b\n"
+        "      api_base: http://localhost:11434\n"
+    )
+    w = Watcher(linear_client=MagicMock(), repo_root=tmp_path)
+
+    call_count = 0
+
+    def _probe_side_effect(*args: Any, **kwargs: Any) -> int:
+        nonlocal call_count
+        call_count += 1
+        # First call (already-up check) -> not up; subsequent calls (wait loop) -> up
+        return 1 if call_count == 1 else 0
+
+    with (
+        patch("socket.socket") as mock_sock_cls,
+        patch("subprocess.Popen") as mock_popen,
+    ):
+        mock_sock = MagicMock()
+        mock_sock.__enter__ = lambda s: s
+        mock_sock.__exit__ = MagicMock(return_value=False)
+        mock_sock.connect_ex.side_effect = _probe_side_effect
+        mock_sock_cls.return_value = mock_sock
+
+        w._ensure_ollama_running()
+
+    mock_popen.assert_called_once()
+    cmd = mock_popen.call_args[0][0]
+    assert cmd[0] == "ollama"
+    assert cmd[1] == "run"
+    assert cmd[2] == "qwen3-coder:30b"
+    assert "--keepalive" in cmd
+    assert "120m" in cmd
+
+
+# ---------------------------------------------------------------------------
+# _dispatch_next_ticket — ollama/litellm wiring
+# ---------------------------------------------------------------------------
+
+
+def test_dispatch_calls_ensure_ollama_and_litellm_for_local_effective_mode(
+    tmp_path: Path,
+) -> None:
+    manifest = _make_manifest(
+        ticket_id="WOR-10",
+        worker_branch="wor-10-test-ticket",
+        implementation_mode="local",
+    )
+    linear_mock = MagicMock()
+    linear_mock.get_open_blockers.return_value = []
+    linear_mock.list_ready_for_local.return_value = [
+        {"identifier": "WOR-10", "id": "fake-linear-id", "labels": {"nodes": []}}
+    ]
+
+    w = Watcher(linear_client=linear_mock, repo_root=tmp_path, worker_mode="default")
+    fake_process = MagicMock(spec=subprocess.Popen)
+
+    with (
+        patch.object(w, "_load_manifest", return_value=manifest),
+        patch.object(w, "_create_worktree", return_value=tmp_path),
+        patch.object(w, "_copy_manifest_to_worktree"),
+        patch.object(w, "_write_worker_pytest_config"),
+        patch.object(w, "_safe_set_state"),
+        patch.object(w, "_backup_plan_files", return_value=[]),
+        patch.object(w, "_launch_worker", return_value=fake_process),
+        patch.object(w, "_ensure_ollama_running") as mock_ollama,
+        patch.object(w, "_ensure_litellm_running") as mock_litellm,
+    ):
+        w._dispatch_next_ticket()
+
+    mock_ollama.assert_called_once()
+    mock_litellm.assert_called_once()
+
+
+def test_dispatch_skips_ensure_for_cloud_effective_mode(tmp_path: Path) -> None:
+    manifest = _make_manifest(
+        ticket_id="WOR-10",
+        worker_branch="wor-10-test-ticket",
+        implementation_mode="cloud",
+    )
+    linear_mock = MagicMock()
+    linear_mock.get_open_blockers.return_value = []
+    linear_mock.list_ready_for_local.return_value = [
+        {"identifier": "WOR-10", "id": "fake-linear-id", "labels": {"nodes": []}}
+    ]
+
+    w = Watcher(linear_client=linear_mock, repo_root=tmp_path, worker_mode="default")
+    fake_process = MagicMock(spec=subprocess.Popen)
+
+    with (
+        patch.object(w, "_load_manifest", return_value=manifest),
+        patch.object(w, "_create_worktree", return_value=tmp_path),
+        patch.object(w, "_copy_manifest_to_worktree"),
+        patch.object(w, "_write_worker_pytest_config"),
+        patch.object(w, "_safe_set_state"),
+        patch.object(w, "_backup_plan_files", return_value=[]),
+        patch.object(w, "_launch_worker", return_value=fake_process),
+        patch.object(w, "_ensure_ollama_running") as mock_ollama,
+        patch.object(w, "_ensure_litellm_running") as mock_litellm,
+    ):
+        w._dispatch_next_ticket()
+
+    mock_ollama.assert_not_called()
+    mock_litellm.assert_not_called()


### PR DESCRIPTION
- Add `_ensure_ollama_running()`: TCP-probes port 11434, runs `ollama run <model> --keepalive 120m` in a new visible terminal (CREATE_NEW_CONSOLE on Windows) if not already up; polls until ready (120s timeout)
- Add `_parse_ollama_model()`: extracts bare model name from `litellm-local.yaml` via regex on `ollama_chat/<model>` entries
- Update `_ensure_litellm_running()`: opens proxy in a new visible terminal on Windows (CREATE_NEW_CONSOLE) instead of hidden subprocess; retains process handle for clean shutdown via `_stop_litellm_proxy()`; non-Windows keeps existing log-file behaviour
- Wire both calls into `_start_ticket()` before `_launch_worker()` when `effective_mode == "local"`, fixing hybrid/default mode where local workers previously failed to connect

**Milestone:** Watcher Hardening
**Epic:** WOR-138 — Watcher Reliability & Escalation Enforcement

## Test plan

- [x] `test_parse_ollama_model_returns_bare_model_name` — happy path parses `ollama_chat/qwen3-coder:30b` → `qwen3-coder:30b`
- [x] `test_parse_ollama_model_raises_when_no_ollama_entry` — ValueError on missing ollama_chat entry
- [x] `test_parse_ollama_model_raises_when_file_missing` — FileNotFoundError
- [x] `test_ensure_ollama_running_already_up` — TCP probe succeeds → Popen never called
- [x] `test_ensure_ollama_running_starts_process` — cold start → Popen called with `ollama run qwen3-coder:30b --keepalive 120m`
- [x] `test_dispatch_calls_ensure_ollama_and_litellm_for_local_effective_mode` — default/hybrid + local manifest → both ensure methods called before _launch_worker
- [x] `test_dispatch_skips_ensure_for_cloud_effective_mode` — cloud manifest → neither called
- [x] All 346 tests pass, 86% coverage

Closes WOR-154