### PR TITLE
WOR-165 Refactor: split watcher.py into cohesive sub-modules

### DIFF
--- a/.importlinter
+++ b/.importlinter
@@ -25,3 +25,33 @@ source_modules =
 forbidden_modules =
     app.cli
     app.main
+
+[importlinter:contract:watcher-layers]
+name = watcher sub-modules form a strict dependency layer
+type = layers
+# watcher (orchestrator) imports all sub-modules.
+# watcher_subprocess, watcher_worktrees, watcher_services may import from
+# watcher_types and watcher_helpers — not from each other or from watcher.
+# watcher_helpers may import from watcher_types only.
+# watcher_types is a leaf: imports nothing from watcher siblings.
+# CONTRACT OWNER: cloud LLM only — do not modify without explicit approval.
+layers =
+    app.core.watcher
+    app.core.watcher_subprocess : app.core.watcher_worktrees : app.core.watcher_services
+    app.core.watcher_helpers
+    app.core.watcher_types
+
+[importlinter:contract:watcher-types-is-leaf]
+name = watcher_types must not import from sibling watcher modules
+type = forbidden
+# Belt-and-suspenders for watcher-layers: explicitly forbid the leaf from
+# importing any sibling watcher module.
+# CONTRACT OWNER: cloud LLM only — do not modify without explicit approval.
+source_modules =
+    app.core.watcher_types
+forbidden_modules =
+    app.core.watcher
+    app.core.watcher_helpers
+    app.core.watcher_subprocess
+    app.core.watcher_worktrees
+    app.core.watcher_services

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,12 @@ Module responsibilities:
 - `escalation_policy.py` — `EscalationPolicy` Pydantic model: loads `config/escalation_policy.toml`, classifies result-artifact flags and Sonar findings into watcher actions
 - `linear_client.py` — thin Linear GraphQL client (stdlib `urllib` only, no third-party HTTP deps); requires `LINEAR_API_KEY` env var
 - `metrics.py` — SQLite-backed store for per-ticket cost and execution metrics; watcher is sole writer, workers emit JSON result files only
-- `watcher.py` — orchestrator daemon: polls Linear for `ReadyForLocal` tickets, manages git worktrees, launches worker sessions, collects result artifacts, creates PRs, updates Linear state
+- `watcher_types.py` — constants, `LinearClientProtocol`, `ActiveWorker` dataclass, `is_watcher_running`, `_to_metrics_mode`
+- `watcher_helpers.py` — pure stateless functions: `check_allowed_paths_overlap`, `build_worker_env`, `build_worker_cmd`, `resolve_effective_mode`, `_tee_worker_output`, `_parse_worker_usage`, `_parse_ollama_model`
+- `watcher_subprocess.py` — worker subprocess lifecycle: `launch_worker`, `run_checks`, `fetch_sonar_findings`, `create_pr`, `build_snippet_tool_restrictions`
+- `watcher_worktrees.py` — git worktree lifecycle: `setup_worktree`, `teardown_worktree`, `rebase_worktree_from_base`, `preserve_worker_artifacts`
+- `watcher_services.py` — `ServiceManager` class: LiteLLM proxy and Ollama process management
+- `watcher.py` — orchestrator only: polls Linear for `ReadyForLocal` tickets, delegates to sub-modules above
 - `main.py` — PySide6 `QApplication` entry point
 
 Data flows one way: UI → config model → generator → disk. Post-setup runs after generation.

--- a/app/core/watcher.py
+++ b/app/core/watcher.py
@@ -21,7 +21,6 @@ import json
 import logging
 import os
 import shlex
-import shutil
 import signal
 import subprocess  # nosec B404
 import sys
@@ -52,7 +51,6 @@ from app.core.watcher_types import (
     _CLAUDE_DIR,
     _LOCAL_MODEL,
     _PID_FILE,
-    _WORKTREE_BASE,
     ActiveWorker,
     _to_metrics_mode,
 )
@@ -61,6 +59,16 @@ from app.core.watcher_types import (
 )
 from app.core.watcher_types import (
     is_watcher_running as is_watcher_running,  # noqa: F401 — backward-compat re-export
+)
+from app.core.watcher_worktrees import (
+    backup_plan_files,
+    cleanup_worktree,
+    copy_manifest_to_worktree,
+    create_worktree,
+    preserve_worker_artifacts,
+    rebase_worktree_from_base,
+    restore_plan_files,
+    write_worker_pytest_config,
 )
 
 logger = logging.getLogger(__name__)
@@ -605,172 +613,38 @@ class Watcher:
         return ExecutionManifest.from_json(manifest_path)
 
     # ------------------------------------------------------------------
-    # Worktree management
+    # Worktree management — shims delegating to watcher_worktrees
     # ------------------------------------------------------------------
 
     def _create_worktree(self, manifest: ExecutionManifest) -> Path:
-        worktree_name = manifest.worktree_name or manifest.worker_branch
-        if ".." in Path(worktree_name).parts:
-            raise ValueError(f"Invalid worktree name: {worktree_name!r}")
-        worktree_path = self._repo_root.parent / _WORKTREE_BASE / worktree_name
-        subprocess.run(  # nosec B603 B607
-            [
-                "git",
-                "-C",
-                str(self._repo_root),
-                "worktree",
-                "add",
-                str(worktree_path),
-                manifest.worker_branch,
-            ],
-            check=True,
-            capture_output=True,
-            text=True,
-        )
-        logger.info("Worktree created at %s", worktree_path)
-        self._rebase_worktree_from_base(worktree_path, manifest.base_branch)
-        return worktree_path
+        return create_worktree(self._repo_root, manifest)
 
     def _rebase_worktree_from_base(self, worktree_path: Path, base_branch: str) -> None:
-        """Fetch and rebase the worktree from origin/<base_branch>.
-
-        Ensures the worker starts from the latest epic state, not a stale
-        snapshot from when the branch was created.  Logs a warning on failure
-        rather than raising — a stale start is preferable to no start at all.
-        """
-        try:
-            subprocess.run(  # nosec B603 B607
-                ["git", "-C", str(worktree_path), "fetch", "origin", base_branch],
-                check=True,
-                capture_output=True,
-                text=True,
-            )
-            subprocess.run(  # nosec B603 B607
-                [
-                    "git",
-                    "-C",
-                    str(worktree_path),
-                    "rebase",
-                    f"origin/{base_branch}",
-                ],
-                check=True,
-                capture_output=True,
-                text=True,
-            )
-            logger.debug(
-                "Worktree at %s rebased onto origin/%s", worktree_path, base_branch
-            )
-        except subprocess.CalledProcessError as exc:
-            logger.warning(
-                "Could not rebase worktree onto origin/%s (worker will start from "
-                "branch tip instead): %s",
-                base_branch,
-                (exc.stderr or exc.stdout or str(exc)).strip(),
-            )
+        rebase_worktree_from_base(worktree_path, base_branch)
 
     def _copy_manifest_to_worktree(
         self, manifest: ExecutionManifest, worktree_path: Path
     ) -> None:
-        src = self._repo_root / manifest.artifact_paths.manifest_copy
-        dest = worktree_path / manifest.artifact_paths.manifest_copy
-        dest.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(src, dest)
+        copy_manifest_to_worktree(self._repo_root, manifest, worktree_path)
 
     def _backup_plan_files(self) -> list[Path]:
-        """Move ~/.claude/plans/*.md aside so the worker doesn't enter plan mode.
-
-        Claude Code enters plan mode whenever it finds a plan file in the plans
-        directory at startup. Workers must never enter plan mode — they run
-        non-interactively and ExitPlanMode would silently terminate the session.
-        Returns the list of backup paths so the caller can restore them later.
-        """
-        plans_dir = Path.home() / _CLAUDE_DIR / "plans"
-        if not plans_dir.exists():
-            return []
-        backup_dir = plans_dir.parent / "plans_worker_backup"
-        backup_dir.mkdir(exist_ok=True)
-        moved: list[Path] = []
-        for plan_file in plans_dir.glob("*.md"):
-            dest = backup_dir / plan_file.name
-            shutil.move(str(plan_file), dest)
-            moved.append(dest)
-        if moved:
-            logger.debug("Backed up %d plan file(s) to %s", len(moved), backup_dir)
-        return moved
+        return backup_plan_files()
 
     def _restore_plan_files(self, backed_up: list[Path]) -> None:
-        """Restore plan files moved by _backup_plan_files."""
-        if not backed_up:
-            return
-        plans_dir = Path.home() / _CLAUDE_DIR / "plans"
-        plans_dir.mkdir(exist_ok=True)
-        for plan_file in backed_up:
-            shutil.move(str(plan_file), plans_dir / plan_file.name)
-        logger.debug("Restored %d plan file(s)", len(backed_up))
+        restore_plan_files(backed_up)
 
     def _write_worker_pytest_config(self, worktree_path: Path) -> None:
-        """Write pytest.ini overriding pyproject.toml addopts in the worktree.
-
-        pytest.ini takes precedence over pyproject.toml, so this strips
-        --cov-fail-under from every pytest call the worker makes. Coverage
-        is still enforced by CI on the PR.
-        """
-        (worktree_path / "pytest.ini").write_text("[pytest]\naddopts = --tb=short\n")
+        write_worker_pytest_config(worktree_path)
 
     def _preserve_worker_artifacts(self, worker: ActiveWorker) -> None:
-        """Copy worker log and result.json from the worktree to the repo artifact dir.
-
-        The worktree is removed after this call, so any file not copied here is lost.
-        """
-        artifact_dir = (
-            self._repo_root / worker.manifest.artifact_paths.result_json
-        ).parent
-        artifact_dir.mkdir(parents=True, exist_ok=True)
-
-        log_src = (
-            worker.worktree_path / f".claude/worker_{worker.ticket_id.lower()}.log"
-        )
-        if log_src.exists():
-            shutil.copy2(log_src, artifact_dir / log_src.name)
-            logger.info("Worker log preserved at %s", artifact_dir / log_src.name)
-
-        result_src = worker.worktree_path / worker.manifest.artifact_paths.result_json
-        if result_src.exists():
-            shutil.copy2(result_src, artifact_dir / result_src.name)
-            logger.info(
-                "Result artifact preserved at %s", artifact_dir / result_src.name
-            )
-        else:
-            logger.warning(
-                "No result artifact found at %s for %s",
-                result_src,
-                worker.ticket_id,
-            )
+        preserve_worker_artifacts(self._repo_root, worker)
 
     def _cleanup_worktree(self, worktree_path: Path) -> None:
-        try:
-            subprocess.run(  # nosec B603 B607
-                [
-                    "git",
-                    "-C",
-                    str(self._repo_root),
-                    "worktree",
-                    "remove",
-                    "--force",
-                    str(worktree_path),
-                ],
-                check=True,
-                capture_output=True,
-                text=True,
-            )
-            logger.info("Worktree removed: %s", worktree_path)
-        except subprocess.CalledProcessError as exc:
-            logger.warning(
-                "Failed to remove worktree %s: %s", worktree_path, exc.stderr
-            )
+        cleanup_worktree(self._repo_root, worktree_path)
 
     def _cleanup_orphaned_worktrees(self) -> None:
-        """Remove any leftover watcher-managed worktrees from a prior run."""
+        from app.core.watcher_types import _WORKTREE_BASE
+
         base = self._repo_root.parent / _WORKTREE_BASE
         if not base.exists():
             return

--- a/app/core/watcher.py
+++ b/app/core/watcher.py
@@ -34,10 +34,19 @@ from app.core.escalation_policy import EscalationPolicy
 from app.core.linear_client import DONE_STATE_TYPES, LinearError
 from app.core.manifest import ExecutionManifest
 from app.core.metrics import MetricsStore, Outcome, TicketMetrics
+from app.core.watcher_helpers import (
+    _POLICY_FLAGS,
+    _parse_ollama_model,
+    _parse_worker_usage,
+    _read_result_flags,
+    _tee_worker_output,
+    build_worker_cmd,
+    build_worker_env,
+    check_allowed_paths_overlap,
+    resolve_effective_mode,
+)
 from app.core.watcher_types import (
     _CLAUDE_DIR,
-    _ENV_VARS_TO_STRIP_FOR_CLOUD,
-    _LITELLM_BASE_URL,
     _LITELLM_CONFIG,
     _LITELLM_PORT,
     _LOCAL_MODEL,
@@ -56,213 +65,6 @@ from app.core.watcher_types import (
 )
 
 logger = logging.getLogger(__name__)
-
-
-# ---------------------------------------------------------------------------
-# Active worker tracking
-# ---------------------------------------------------------------------------
-
-
-def _parse_worker_usage(log_path: Path) -> tuple[int | None, int | None]:
-    """Read stream-json worker log and return (local_tokens, context_compactions)."""
-    try:
-        with log_path.open(encoding="utf-8") as f:
-            for raw in f:
-                line = raw.strip()
-                if not line:
-                    continue
-                try:
-                    obj = json.loads(line)
-                except json.JSONDecodeError:
-                    continue
-                if obj.get("type") == "result":
-                    usage = obj.get("usage") or {}
-                    local_tokens = (usage.get("input_tokens") or 0) + (
-                        usage.get("output_tokens") or 0
-                    )
-                    context_compactions = obj.get("context_compactions")
-                    return local_tokens, context_compactions
-    except Exception:
-        return None, None
-    return None, None
-
-
-# ---------------------------------------------------------------------------
-# Pure helper functions (unit-testable, no I/O)
-# ---------------------------------------------------------------------------
-
-
-def check_allowed_paths_overlap(
-    active: list[ActiveWorker], candidate: ExecutionManifest
-) -> list[str]:
-    """Return identifiers of active workers whose allowed_paths overlap with candidate.
-
-    Two manifests overlap when they share at least one allowed_path pattern.
-    An empty allowed_paths list means "no restriction" — treated as overlap with
-    everything to be safe.
-    """
-    if not candidate.allowed_paths:
-        return [w.manifest.ticket_id for w in active]
-
-    conflicts: list[str] = []
-    candidate_set = set(candidate.allowed_paths)
-    for worker in active:
-        if not worker.manifest.allowed_paths or candidate_set & set(
-            worker.manifest.allowed_paths
-        ):
-            conflicts.append(worker.manifest.ticket_id)
-    return conflicts
-
-
-def build_worker_env(
-    mode: str,
-    base_env: dict[str, str],
-) -> dict[str, str]:
-    """Return a subprocess environment dict for the given worker mode.
-
-    cloud   — strips ANTHROPIC_BASE_URL and related vars so the process routes
-              to the real Anthropic API.
-    local   — injects ANTHROPIC_BASE_URL pointing to the LiteLLM proxy and sets
-              ANTHROPIC_API_KEY=sk-dummy if not already present (LiteLLM doesn't
-              validate the key; this satisfies Claude Code's auth check).
-    default — passes base_env unchanged.
-    """
-    env = dict(base_env)
-    if mode == "cloud":
-        for var in _ENV_VARS_TO_STRIP_FOR_CLOUD:
-            env.pop(var, None)
-    elif mode == "local":
-        env["ANTHROPIC_BASE_URL"] = _LITELLM_BASE_URL
-        env.setdefault("ANTHROPIC_API_KEY", "sk-dummy")
-    return env
-
-
-def build_worker_cmd(
-    ticket_id: str,
-    mode: str,
-    worktree_path: Path,
-    prompt: str | None = None,
-    disallowed_tools: list[str] | None = None,
-) -> list[str]:
-    """Return the claude subprocess command list for the given mode.
-
-    prompt — pre-expanded skill content; defaults to the /implement-ticket
-    slash-command shortcut (requires commands to be loaded by Claude Code).
-    In --bare mode the shortcut is unavailable, so callers should pass the
-    expanded implement-ticket.md content with $ARGUMENTS substituted.
-
-    disallowed_tools — list of tool-call patterns passed to --disallowed-tools
-    (e.g. ["Read(*watcher.py)", "Read(*metrics.py)"]) to enforce context_snippets.
-    """
-    if prompt is None:
-        prompt = f"/implement-ticket {ticket_id}"
-    # --bare strips auto-memory, hooks, and CLAUDE.md auto-discovery, keeping
-    # the system prompt lean. --add-dir re-adds the worktree CLAUDE.md.
-    # --strict-mcp-config + empty config prevents the Linear HTTP MCP server
-    # from blocking ~180s on OAuth in non-interactive mode.
-    # NOTE: --bare also strips OAuth credential loading, so it must NOT be used
-    # for cloud mode where the worker authenticates via OAuth (Claude Max).
-    # Local mode uses a dummy API key via LiteLLM, so --bare is safe there.
-    base = [
-        "claude",
-        "--dangerously-skip-permissions",
-        "--add-dir",
-        str(worktree_path),
-        "--strict-mcp-config",
-        "--mcp-config",
-        '{"mcpServers":{}}',
-        "--effort",
-        "max",
-        "--verbose",
-        "--output-format",
-        "stream-json",
-    ]
-    if mode == "local":
-        base.insert(2, "--bare")
-    if disallowed_tools:
-        base += ["--disallowed-tools", ",".join(disallowed_tools)]
-    if mode == "local":
-        return base + ["--model", _LOCAL_MODEL, "-p", prompt]
-    return base + ["-p", prompt]
-
-
-def resolve_effective_mode(worker_mode: str, manifest_mode: str) -> str:
-    """Return the effective implementation mode.
-
-    worker_mode takes precedence when it is not 'default'.
-    Falls back to manifest_mode ('local', 'cloud', or 'hybrid').
-    Hybrid is treated as 'cloud' for subprocess purposes.
-    """
-    if worker_mode != "default":
-        return worker_mode
-    if manifest_mode == "hybrid":
-        return "cloud"
-    return manifest_mode
-
-
-def _tee_worker_output(
-    pipe: IO[bytes],
-    log_file: IO[bytes],
-    prefix: bytes,
-    dest: IO[bytes],
-) -> None:
-    """Read *pipe* line-by-line, writing each line to *log_file* and *dest*.
-
-    Runs in a daemon thread; returns when the pipe reaches EOF (worker exit).
-    Closes *log_file* in the finally block — ownership transfers from the
-    caller to this thread in verbose mode.
-    """
-    try:
-        for raw_line in pipe:
-            log_file.write(raw_line)
-            log_file.flush()
-            dest.write(prefix + raw_line)
-            dest.flush()
-    finally:
-        log_file.close()
-
-
-_POLICY_FLAGS = (
-    "scope_drift",
-    "forbidden_path_touched",
-    "import_linter_violation",
-    "security_blocker",
-)
-
-
-def _read_result_flags(result_path: Path) -> dict[str, bool]:
-    """Load result.json and return the four escalation-policy boolean flags.
-
-    Returns all-False defaults when the file is missing or malformed.
-    """
-    try:
-        raw = json.loads(result_path.read_text(encoding="utf-8"))
-    except Exception:
-        return dict.fromkeys(_POLICY_FLAGS, False)
-    return {f: bool(raw.get(f, False)) for f in _POLICY_FLAGS}
-
-
-def _parse_ollama_model(config_path: Path) -> str:
-    """Return the bare Ollama model name from a LiteLLM YAML config.
-
-    Scans for the first 'model: ollama_chat/<name>' line and returns <name>.
-    Raises ValueError if none is found, FileNotFoundError if the file is absent.
-    """
-    import re
-
-    if not config_path.exists():
-        raise FileNotFoundError(
-            f"LiteLLM config not found: {config_path}. "
-            "Copy litellm-local.yaml.example to litellm-local.yaml and configure it."
-        )
-    text = config_path.read_text(encoding="utf-8")
-    match = re.search(r"model:\s+ollama_chat/(\S+)", text)
-    if match is None:
-        raise ValueError(
-            f"No ollama_chat/ model found in {config_path}. "
-            "Add a model_list entry with litellm_params.model = 'ollama_chat/<model>'."
-        )
-    return match.group(1)
 
 
 # ---------------------------------------------------------------------------

--- a/app/core/watcher.py
+++ b/app/core/watcher.py
@@ -27,47 +27,35 @@ import subprocess  # nosec B404
 import sys
 import threading
 import time
-from dataclasses import dataclass, field
 from pathlib import Path
-from typing import IO, Any, Protocol
+from typing import IO
 
 from app.core.escalation_policy import EscalationPolicy
 from app.core.linear_client import DONE_STATE_TYPES, LinearError
 from app.core.manifest import ExecutionManifest
-from app.core.metrics import ImplementationMode, MetricsStore, Outcome, TicketMetrics
-
-logger = logging.getLogger(__name__)
-
-_CLAUDE_DIR = ".claude"
-_PID_FILE = Path(_CLAUDE_DIR) / "watcher.pid"
-_LITELLM_PORT = 8082
-_LITELLM_CONFIG = "litellm-local.yaml"
-_LOCAL_MODEL = "qwen3-coder:30b"
-_LITELLM_BASE_URL = f"http://localhost:{_LITELLM_PORT}"
-_OLLAMA_PORT = 11434
-_OLLAMA_KEEPALIVE = "120m"
-_WORKTREE_BASE = Path("worktrees")
-
-_ENV_VARS_TO_STRIP_FOR_CLOUD = frozenset(
-    {
-        "ANTHROPIC_BASE_URL",
-        "ANTHROPIC_MODEL",
-        "OPENAI_API_BASE",
-    }
+from app.core.metrics import MetricsStore, Outcome, TicketMetrics
+from app.core.watcher_types import (
+    _CLAUDE_DIR,
+    _ENV_VARS_TO_STRIP_FOR_CLOUD,
+    _LITELLM_BASE_URL,
+    _LITELLM_CONFIG,
+    _LITELLM_PORT,
+    _LOCAL_MODEL,
+    _OLLAMA_KEEPALIVE,
+    _OLLAMA_PORT,
+    _PID_FILE,
+    _WORKTREE_BASE,
+    ActiveWorker,
+    _to_metrics_mode,
+)
+from app.core.watcher_types import (
+    LinearClientProtocol as LinearClientProtocol,  # noqa: F401 — backward-compat re-export
+)
+from app.core.watcher_types import (
+    is_watcher_running as is_watcher_running,  # noqa: F401 — backward-compat re-export
 )
 
-
-# ---------------------------------------------------------------------------
-# Protocol for dependency injection (testability)
-# ---------------------------------------------------------------------------
-
-
-class LinearClientProtocol(Protocol):
-    def list_ready_for_local(self) -> list[dict[str, Any]]: ...
-    def get_open_blockers(self, issue_id: str) -> list[str]: ...
-    def set_state(self, issue_id: str, state_name: str) -> None: ...
-    def post_comment(self, issue_id: str, body: str) -> None: ...
-    def get_issue_state_type(self, identifier: str) -> str | None: ...
+logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
@@ -97,18 +85,6 @@ def _parse_worker_usage(log_path: Path) -> tuple[int | None, int | None]:
     except Exception:
         return None, None
     return None, None
-
-
-@dataclass
-class ActiveWorker:
-    ticket_id: str
-    linear_id: str
-    manifest: ExecutionManifest
-    worktree_path: Path
-    process: subprocess.Popen[bytes]
-    start_time: float = field(default_factory=time.monotonic)
-    backed_up_plans: list[Path] = field(default_factory=list)
-    retry_count: int = 0
 
 
 # ---------------------------------------------------------------------------
@@ -1448,39 +1424,3 @@ class Watcher:
             _PID_FILE.unlink()
         except FileNotFoundError:
             pass
-
-
-# ---------------------------------------------------------------------------
-# Utilities
-# ---------------------------------------------------------------------------
-
-
-def is_watcher_running(pid_file: Path = _PID_FILE) -> bool:
-    """Return True if a watcher process is currently running."""
-    if not pid_file.exists():
-        return False
-    try:
-        pid = int(pid_file.read_text(encoding="utf-8").strip())
-    except (ValueError, OSError):
-        return False
-    # Check if process is alive (cross-platform)
-    if sys.platform == "win32":
-        import ctypes
-
-        handle = ctypes.windll.kernel32.OpenProcess(0x00100000, False, pid)
-        if not handle:
-            return False
-        ctypes.windll.kernel32.CloseHandle(handle)
-        return True
-    else:
-        try:
-            os.kill(pid, 0)
-            return True
-        except (ProcessLookupError, PermissionError):
-            return False
-
-
-def _to_metrics_mode(mode: str) -> ImplementationMode:
-    if mode in ("local", "cloud", "hybrid"):
-        return mode  # type: ignore[return-value]
-    return "cloud"

--- a/app/core/watcher.py
+++ b/app/core/watcher.py
@@ -17,17 +17,12 @@ Worker modes:
 
 from __future__ import annotations
 
-import json
 import logging
 import os
-import shlex
 import signal
 import subprocess  # nosec B404
-import sys
-import threading
 import time
 from pathlib import Path
-from typing import IO
 
 from app.core.escalation_policy import EscalationPolicy
 from app.core.linear_client import DONE_STATE_TYPES, LinearError
@@ -37,16 +32,29 @@ from app.core.watcher_helpers import (
     _POLICY_FLAGS,
     _parse_worker_usage,
     _read_result_flags,
-    _tee_worker_output,
-    build_worker_cmd,
-    build_worker_env,
     check_allowed_paths_overlap,
     resolve_effective_mode,
 )
 from app.core.watcher_helpers import (
     _parse_ollama_model as _parse_ollama_model,  # noqa: F401 — backward-compat re-export
 )
+from app.core.watcher_helpers import (
+    _tee_worker_output as _tee_worker_output,  # noqa: F401 — backward-compat re-export
+)
+from app.core.watcher_helpers import (
+    build_worker_cmd as build_worker_cmd,  # noqa: F401 — backward-compat re-export
+)
+from app.core.watcher_helpers import (
+    build_worker_env as build_worker_env,  # noqa: F401 — backward-compat re-export
+)
 from app.core.watcher_services import ServiceManager
+from app.core.watcher_subprocess import (
+    build_snippet_tool_restrictions,
+    expand_skill,
+    fetch_sonar_findings,
+    launch_worker,
+    run_checks,
+)
 from app.core.watcher_types import (
     _CLAUDE_DIR,
     _LOCAL_MODEL,
@@ -112,8 +120,6 @@ class Watcher:
         self._running = True
         self._services = ServiceManager(self._repo_root)
         self._verbose = verbose
-        self._worker_counter = 0
-        self._worker_counter_lock = threading.Lock()
         self._retry_counters: dict[str, int] = {}
         self._escalation_policy = EscalationPolicy.from_toml()
 
@@ -655,47 +661,15 @@ class Watcher:
             self._cleanup_worktree(worktree_dir)
 
     # ------------------------------------------------------------------
-    # Worker subprocess
+    # Worker subprocess — shims delegating to watcher_subprocess
     # ------------------------------------------------------------------
 
     def _expand_skill(self, ticket_id: str) -> str | None:
-        """Return the implement-ticket skill content with $ARGUMENTS substituted.
-
-        Returns None if the skill file cannot be read (caller falls back to
-        the /implement-ticket shortcut).
-        """
-        skill_path = self._repo_root / _CLAUDE_DIR / "commands" / "implement-ticket.md"
-        try:
-            return skill_path.read_text(encoding="utf-8").replace(
-                "$ARGUMENTS", ticket_id
-            )
-        except OSError:
-            logger.warning("Could not read skill file %s; using shortcut", skill_path)
-            return None
+        return expand_skill(self._repo_root, ticket_id)
 
     @staticmethod
     def _build_snippet_tool_restrictions(snippets: list[str]) -> list[str]:
-        """Return --disallowed-tools patterns derived from context_snippets headers.
-
-        Each snippet starts with a comment line like:
-            # app/core/watcher.py lines 574-589
-        We extract the basename and return glob patterns that block Read on those
-        files regardless of the absolute path the worker uses.
-        """
-        import re
-
-        seen: set[str] = set()
-        patterns: list[str] = []
-        header_re = re.compile(r"^#\s+(\S+)\s+lines?\s+\d")
-        for snippet in snippets:
-            first_line = snippet.splitlines()[0] if snippet else ""
-            m = header_re.match(first_line)
-            if m:
-                basename = Path(m.group(1)).name
-                if basename not in seen:
-                    seen.add(basename)
-                    patterns.append(f"Read(*{basename})")
-        return patterns
+        return build_snippet_tool_restrictions(snippets)
 
     def _launch_worker(
         self,
@@ -703,136 +677,15 @@ class Watcher:
         worktree_path: Path,
         effective_mode: str,
     ) -> subprocess.Popen[bytes]:
-        prompt = self._expand_skill(manifest.ticket_id)
-
-        disallowed_tools: list[str] | None = None
-        if manifest.context_snippets and effective_mode == "cloud":
-            disallowed_tools = self._build_snippet_tool_restrictions(
-                manifest.context_snippets
-            )
-            if disallowed_tools and prompt:
-                file_list = ", ".join(
-                    p.removeprefix("Read(*").removesuffix(")") for p in disallowed_tools
-                )
-                warning = (
-                    f"CRITICAL: The following files are pre-loaded as context_snippets "
-                    f"in the manifest: {file_list}. "
-                    f"DO NOT use the Read tool on these files — "
-                    f"the tool is blocked and attempting to read them will "
-                    f"abort the task. "
-                    f"Use only the snippets already provided.\n\n"
-                )
-                prompt = warning + (prompt or "")
-
-        cmd = build_worker_cmd(
-            manifest.ticket_id, effective_mode, worktree_path, prompt, disallowed_tools
+        return launch_worker(
+            self._repo_root, manifest, worktree_path, effective_mode, self._verbose
         )
-        env = build_worker_env(effective_mode, dict(os.environ))
-
-        log_path = worktree_path / f".claude/worker_{manifest.ticket_id.lower()}.log"
-        log_path.parent.mkdir(parents=True, exist_ok=True)
-        log_file = open(log_path, "wb")  # noqa: SIM115
-
-        if self._verbose:
-            with self._worker_counter_lock:
-                self._worker_counter += 1
-            prefix = f"[{manifest.ticket_id}] ".encode()
-            process = subprocess.Popen(  # nosec B603 B607
-                cmd,
-                cwd=str(worktree_path),
-                env=env,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
-            )
-            assert process.stdout is not None  # guaranteed by stdout=PIPE  # nosec B101
-            stderr_buf: IO[bytes] = (
-                getattr(sys.stderr, "buffer", None) or sys.stderr.buffer
-            )
-            threading.Thread(
-                target=_tee_worker_output,
-                args=(process.stdout, log_file, prefix, stderr_buf),
-                daemon=True,
-                name=f"tee-{manifest.ticket_id}",
-            ).start()
-            return process
-
-        return subprocess.Popen(  # nosec B603 B607
-            cmd,
-            cwd=str(worktree_path),
-            env=env,
-            stdout=log_file,
-            stderr=subprocess.STDOUT,
-        )
-
-    # ------------------------------------------------------------------
-    # Check runner
-    # ------------------------------------------------------------------
 
     def _run_checks(self, manifest: ExecutionManifest, worktree_path: Path) -> bool:
-        all_passed = True
-        for check_cmd in manifest.required_checks:
-            logger.info("Running check: %s", check_cmd)
-            result = subprocess.run(  # nosec B603
-                shlex.split(check_cmd),
-                cwd=str(worktree_path),
-                capture_output=True,
-                text=True,
-            )
-            if result.returncode != 0:
-                logger.error(
-                    "Check failed: %s\n%s", check_cmd, result.stdout + result.stderr
-                )
-                all_passed = False
-        return all_passed
-
-    # ------------------------------------------------------------------
-    # SonarCloud findings count (Option B: REST API, best-effort)
-    # ------------------------------------------------------------------
+        return run_checks(manifest, worktree_path)
 
     def _fetch_sonar_findings(self, branch: str) -> list[str] | None:
-        # Calls the SonarCloud issues API for the worker branch to get per-severity
-        # issue data for escalation classification.  Returns a list of severity
-        # strings (e.g. ['BLOCKER', 'CRITICAL']) or None when SONAR_TOKEN /
-        # SONAR_PROJECT_KEY are absent or the API call fails.  An empty list means
-        # the branch was scanned and has no open issues.
-        import base64
-        import ssl
-        import urllib.parse
-        import urllib.request
-
-        token = os.environ.get("SONAR_TOKEN")
-        project_key = os.environ.get("SONAR_PROJECT_KEY")
-        if not token or not project_key:
-            return None
-
-        params = urllib.parse.urlencode(
-            {
-                "componentKeys": project_key,
-                "branch": branch,
-                "resolved": "false",
-                "ps": "500",
-            }
-        )
-        url = f"https://sonarcloud.io/api/issues/search?{params}"
-        creds = base64.b64encode(f"{token}:".encode()).decode()
-        req = urllib.request.Request(url, headers={"Authorization": f"Basic {creds}"})
-        ctx = ssl.create_default_context()
-        try:
-            with urllib.request.urlopen(  # nosec B310  # nosemgrep
-                req, timeout=10, context=ctx
-            ) as resp:
-                data: dict[str, object] = json.loads(resp.read())
-            issues = data.get("issues") or []
-            return [
-                str(issue["severity"])
-                for issue in (issues if isinstance(issues, list) else [])
-                if isinstance(issue, dict) and issue.get("severity")
-            ]
-        except Exception:
-            logger.debug(
-                "Could not fetch Sonar findings for branch %s", branch, exc_info=True
-            )
-        return None
+        return fetch_sonar_findings(branch)
 
     # ------------------------------------------------------------------
     # PR creation

--- a/app/core/watcher.py
+++ b/app/core/watcher.py
@@ -36,7 +36,6 @@ from app.core.manifest import ExecutionManifest
 from app.core.metrics import MetricsStore, Outcome, TicketMetrics
 from app.core.watcher_helpers import (
     _POLICY_FLAGS,
-    _parse_ollama_model,
     _parse_worker_usage,
     _read_result_flags,
     _tee_worker_output,
@@ -45,13 +44,13 @@ from app.core.watcher_helpers import (
     check_allowed_paths_overlap,
     resolve_effective_mode,
 )
+from app.core.watcher_helpers import (
+    _parse_ollama_model as _parse_ollama_model,  # noqa: F401 — backward-compat re-export
+)
+from app.core.watcher_services import ServiceManager
 from app.core.watcher_types import (
     _CLAUDE_DIR,
-    _LITELLM_CONFIG,
-    _LITELLM_PORT,
     _LOCAL_MODEL,
-    _OLLAMA_KEEPALIVE,
-    _OLLAMA_PORT,
     _PID_FILE,
     _WORKTREE_BASE,
     ActiveWorker,
@@ -103,7 +102,7 @@ class Watcher:
         self._local_active: list[ActiveWorker] = []
         self._cloud_active: list[ActiveWorker] = []
         self._running = True
-        self._litellm_proc: subprocess.Popen[bytes] | None = None
+        self._services = ServiceManager(self._repo_root)
         self._verbose = verbose
         self._worker_counter = 0
         self._worker_counter_lock = threading.Lock()
@@ -121,7 +120,7 @@ class Watcher:
         self._cleanup_orphaned_worktrees()
 
         if self._mode == "local":
-            self._ensure_litellm_running()
+            self._services.ensure_litellm_running()
 
         logger.info(
             "Watcher started (mode=%s, max_local_workers=%d, max_cloud_workers=%d)",
@@ -141,7 +140,7 @@ class Watcher:
                 time.sleep(self._POLL_INTERVAL)
         finally:
             self._wait_for_active_workers()
-            self._stop_litellm_proxy()
+            self._services.stop()
             self._remove_pid_file()
             logger.info("Watcher stopped cleanly")
 
@@ -1055,135 +1054,25 @@ class Watcher:
         return pr_url
 
     # ------------------------------------------------------------------
-    # LiteLLM proxy
+    # Service shims — delegate to self._services; removed in test-split step
     # ------------------------------------------------------------------
 
     def _ensure_ollama_running(self) -> None:
-        """Start Ollama with the configured model if not already on _OLLAMA_PORT."""
-        import socket
-
-        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-            already_up = sock.connect_ex(("localhost", _OLLAMA_PORT)) == 0
-
-        if already_up:
-            logger.info("Ollama already running on port %d", _OLLAMA_PORT)
-            return
-
-        config_path = self._repo_root / _LITELLM_CONFIG
-        model = _parse_ollama_model(config_path)
-        logger.info(
-            "Starting Ollama (model=%s, keepalive=%s)…", model, _OLLAMA_KEEPALIVE
-        )
-        if sys.platform == "win32":
-            creation_flags = subprocess.CREATE_NEW_CONSOLE
-        else:
-            creation_flags = 0
-        subprocess.Popen(  # nosec B603 B607
-            ["ollama", "run", model, "--keepalive", _OLLAMA_KEEPALIVE],
-            creationflags=creation_flags,
-        )
-        self._wait_for_ollama_ready()
-
-    def _wait_for_ollama_ready(self, timeout: float = 120.0) -> None:
-        """Poll TCP until Ollama's port accepts connections."""
-        import socket
-
-        deadline = time.monotonic() + timeout
-        while time.monotonic() < deadline:
-            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-                sock.settimeout(2)
-                if sock.connect_ex(("localhost", _OLLAMA_PORT)) == 0:
-                    return
-            time.sleep(0.5)
-        raise TimeoutError(f"Ollama not ready after {timeout}s.")
+        self._services.ensure_ollama_running()
 
     def _ensure_litellm_running(self) -> None:
-        """Start the LiteLLM proxy if not already listening on _LITELLM_PORT."""
-        import socket
-
-        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-            already_up = sock.connect_ex(("localhost", _LITELLM_PORT)) == 0
-
-        if already_up:
-            logger.info("LiteLLM proxy already running on port %d", _LITELLM_PORT)
-            return
-
-        config_path = self._repo_root / _LITELLM_CONFIG
-        if not config_path.exists():
-            raise FileNotFoundError(
-                f"LiteLLM config not found: {config_path}. "
-                "Copy litellm-local.yaml.example to litellm-local.yaml "
-                "and configure it."
-            )
-
-        logger.info("Starting LiteLLM proxy (port %d)…", _LITELLM_PORT)
-        env = {**os.environ, "PYTHONUTF8": "1"}
-        if sys.platform == "win32":
-            self._litellm_proc = subprocess.Popen(  # nosec B603 B607
-                [
-                    "litellm",
-                    "--config",
-                    str(config_path),
-                    "--port",
-                    str(_LITELLM_PORT),
-                    "--drop_params",
-                ],
-                creationflags=subprocess.CREATE_NEW_CONSOLE,
-                env=env,
-            )
-        else:
-            log_path = self._repo_root / _CLAUDE_DIR / "litellm.log"
-            log_path.parent.mkdir(parents=True, exist_ok=True)
-            log_file = open(log_path, "wb")  # noqa: SIM115
-            logger.info("LiteLLM log: %s", log_path)
-            self._litellm_proc = subprocess.Popen(  # nosec B603 B607
-                [
-                    "litellm",
-                    "--config",
-                    str(config_path),
-                    "--port",
-                    str(_LITELLM_PORT),
-                    "--drop_params",
-                ],
-                stdout=log_file,
-                stderr=log_file,
-                env=env,
-            )
-        self._wait_for_litellm_ready()
-
-    def _wait_for_litellm_ready(self, timeout: float = 60.0) -> None:
-        """Poll TCP until LiteLLM's port accepts connections or process dies."""
-        import socket
-
-        deadline = time.monotonic() + timeout
-        while time.monotonic() < deadline:
-            if self._litellm_proc and self._litellm_proc.poll() is not None:
-                rc = self._litellm_proc.returncode
-                raise RuntimeError(
-                    f"LiteLLM proxy exited (rc={rc}). "
-                    f"Check .claude/litellm.log for details."
-                )
-            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-                sock.settimeout(2)
-                if sock.connect_ex(("localhost", _LITELLM_PORT)) == 0:
-                    return
-            time.sleep(0.5)
-        raise TimeoutError(
-            f"LiteLLM proxy not ready after {timeout}s. "
-            f"Check .claude/litellm.log for details."
-        )
+        self._services.ensure_litellm_running()
 
     def _stop_litellm_proxy(self) -> None:
-        if not self._litellm_proc:
-            return
-        logger.info("Stopping LiteLLM proxy (pid=%d)…", self._litellm_proc.pid)
-        self._litellm_proc.terminate()
-        try:
-            self._litellm_proc.wait(timeout=5)
-        except subprocess.TimeoutExpired:
-            logger.info("LiteLLM proxy did not exit after 5s — sending kill")
-            self._litellm_proc.kill()
-        self._litellm_proc = None
+        self._services.stop()
+
+    @property
+    def _litellm_proc(self) -> subprocess.Popen[bytes] | None:
+        return self._services._litellm_proc
+
+    @_litellm_proc.setter
+    def _litellm_proc(self, value: subprocess.Popen[bytes] | None) -> None:
+        self._services._litellm_proc = value
 
     # ------------------------------------------------------------------
     # Graceful shutdown
@@ -1198,7 +1087,7 @@ class Watcher:
         logger.info(
             "Signal %d received — finishing active workers then exiting", signum
         )
-        self._stop_litellm_proxy()
+        self._services.stop()
         self._running = False
 
     def _wait_for_active_workers(self) -> None:

--- a/app/core/watcher_helpers.py
+++ b/app/core/watcher_helpers.py
@@ -1,4 +1,243 @@
 """Pure helper functions for the watcher sub-system (no I/O, unit-testable).
 
-Populated in WOR-165 step 2.
+All functions in this module are stateless and have no self-dependencies.
+This module may import from watcher_types only (no other watcher siblings).
 """
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import IO
+
+from app.core.manifest import ExecutionManifest
+from app.core.watcher_types import (
+    _ENV_VARS_TO_STRIP_FOR_CLOUD,
+    _LITELLM_BASE_URL,
+    _LOCAL_MODEL,
+    ActiveWorker,
+)
+
+# ---------------------------------------------------------------------------
+# Worker log parsing
+# ---------------------------------------------------------------------------
+
+
+def _parse_worker_usage(log_path: Path) -> tuple[int | None, int | None]:
+    """Read stream-json worker log and return (local_tokens, context_compactions)."""
+    try:
+        with log_path.open(encoding="utf-8") as f:
+            for raw in f:
+                line = raw.strip()
+                if not line:
+                    continue
+                try:
+                    obj = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if obj.get("type") == "result":
+                    usage = obj.get("usage") or {}
+                    local_tokens = (usage.get("input_tokens") or 0) + (
+                        usage.get("output_tokens") or 0
+                    )
+                    context_compactions = obj.get("context_compactions")
+                    return local_tokens, context_compactions
+    except Exception:
+        return None, None
+    return None, None
+
+
+# ---------------------------------------------------------------------------
+# Escalation-policy flag names (also used by watcher.py orchestrator)
+# ---------------------------------------------------------------------------
+
+_POLICY_FLAGS = (
+    "scope_drift",
+    "forbidden_path_touched",
+    "import_linter_violation",
+    "security_blocker",
+)
+
+
+def _read_result_flags(result_path: Path) -> dict[str, bool]:
+    """Load result.json and return the four escalation-policy boolean flags.
+
+    Returns all-False defaults when the file is missing or malformed.
+    """
+    try:
+        raw = json.loads(result_path.read_text(encoding="utf-8"))
+    except Exception:
+        return dict.fromkeys(_POLICY_FLAGS, False)
+    return {f: bool(raw.get(f, False)) for f in _POLICY_FLAGS}
+
+
+# ---------------------------------------------------------------------------
+# Allowed-paths overlap check
+# ---------------------------------------------------------------------------
+
+
+def check_allowed_paths_overlap(
+    active: list[ActiveWorker], candidate: ExecutionManifest
+) -> list[str]:
+    """Return identifiers of active workers whose allowed_paths overlap with candidate.
+
+    Two manifests overlap when they share at least one allowed_path pattern.
+    An empty allowed_paths list means "no restriction" — treated as overlap with
+    everything to be safe.
+    """
+    if not candidate.allowed_paths:
+        return [w.manifest.ticket_id for w in active]
+
+    conflicts: list[str] = []
+    candidate_set = set(candidate.allowed_paths)
+    for worker in active:
+        if not worker.manifest.allowed_paths or candidate_set & set(
+            worker.manifest.allowed_paths
+        ):
+            conflicts.append(worker.manifest.ticket_id)
+    return conflicts
+
+
+# ---------------------------------------------------------------------------
+# Worker environment and command builders
+# ---------------------------------------------------------------------------
+
+
+def build_worker_env(
+    mode: str,
+    base_env: dict[str, str],
+) -> dict[str, str]:
+    """Return a subprocess environment dict for the given worker mode.
+
+    cloud   — strips ANTHROPIC_BASE_URL and related vars so the process routes
+              to the real Anthropic API.
+    local   — injects ANTHROPIC_BASE_URL pointing to the LiteLLM proxy and sets
+              ANTHROPIC_API_KEY=sk-dummy if not already present (LiteLLM doesn't
+              validate the key; this satisfies Claude Code's auth check).
+    default — passes base_env unchanged.
+    """
+    env = dict(base_env)
+    if mode == "cloud":
+        for var in _ENV_VARS_TO_STRIP_FOR_CLOUD:
+            env.pop(var, None)
+    elif mode == "local":
+        env["ANTHROPIC_BASE_URL"] = _LITELLM_BASE_URL
+        env.setdefault("ANTHROPIC_API_KEY", "sk-dummy")
+    return env
+
+
+def build_worker_cmd(
+    ticket_id: str,
+    mode: str,
+    worktree_path: Path,
+    prompt: str | None = None,
+    disallowed_tools: list[str] | None = None,
+) -> list[str]:
+    """Return the claude subprocess command list for the given mode.
+
+    prompt — pre-expanded skill content; defaults to the /implement-ticket
+    slash-command shortcut (requires commands to be loaded by Claude Code).
+    In --bare mode the shortcut is unavailable, so callers should pass the
+    expanded implement-ticket.md content with $ARGUMENTS substituted.
+
+    disallowed_tools — list of tool-call patterns passed to --disallowed-tools
+    (e.g. ["Read(*watcher.py)", "Read(*metrics.py)"]) to enforce context_snippets.
+    """
+    if prompt is None:
+        prompt = f"/implement-ticket {ticket_id}"
+    # --bare strips auto-memory, hooks, and CLAUDE.md auto-discovery, keeping
+    # the system prompt lean. --add-dir re-adds the worktree CLAUDE.md.
+    # --strict-mcp-config + empty config prevents the Linear HTTP MCP server
+    # from blocking ~180s on OAuth in non-interactive mode.
+    # NOTE: --bare also strips OAuth credential loading, so it must NOT be used
+    # for cloud mode where the worker authenticates via OAuth (Claude Max).
+    # Local mode uses a dummy API key via LiteLLM, so --bare is safe there.
+    base = [
+        "claude",
+        "--dangerously-skip-permissions",
+        "--add-dir",
+        str(worktree_path),
+        "--strict-mcp-config",
+        "--mcp-config",
+        '{"mcpServers":{}}',
+        "--effort",
+        "max",
+        "--verbose",
+        "--output-format",
+        "stream-json",
+    ]
+    if mode == "local":
+        base.insert(2, "--bare")
+    if disallowed_tools:
+        base += ["--disallowed-tools", ",".join(disallowed_tools)]
+    if mode == "local":
+        return base + ["--model", _LOCAL_MODEL, "-p", prompt]
+    return base + ["-p", prompt]
+
+
+def resolve_effective_mode(worker_mode: str, manifest_mode: str) -> str:
+    """Return the effective implementation mode.
+
+    worker_mode takes precedence when it is not 'default'.
+    Falls back to manifest_mode ('local', 'cloud', or 'hybrid').
+    Hybrid is treated as 'cloud' for subprocess purposes.
+    """
+    if worker_mode != "default":
+        return worker_mode
+    if manifest_mode == "hybrid":
+        return "cloud"
+    return manifest_mode
+
+
+# ---------------------------------------------------------------------------
+# Worker output tee (runs in a daemon thread)
+# ---------------------------------------------------------------------------
+
+
+def _tee_worker_output(
+    pipe: IO[bytes],
+    log_file: IO[bytes],
+    prefix: bytes,
+    dest: IO[bytes],
+) -> None:
+    """Read *pipe* line-by-line, writing each line to *log_file* and *dest*.
+
+    Runs in a daemon thread; returns when the pipe reaches EOF (worker exit).
+    Closes *log_file* in the finally block — ownership transfers from the
+    caller to this thread in verbose mode.
+    """
+    try:
+        for raw_line in pipe:
+            log_file.write(raw_line)
+            log_file.flush()
+            dest.write(prefix + raw_line)
+            dest.flush()
+    finally:
+        log_file.close()
+
+
+# ---------------------------------------------------------------------------
+# Ollama config parsing
+# ---------------------------------------------------------------------------
+
+
+def _parse_ollama_model(config_path: Path) -> str:
+    """Return the bare Ollama model name from a LiteLLM YAML config.
+
+    Scans for the first 'model: ollama_chat/<name>' line and returns <name>.
+    Raises ValueError if none is found, FileNotFoundError if the file is absent.
+    """
+    if not config_path.exists():
+        raise FileNotFoundError(
+            f"LiteLLM config not found: {config_path}. "
+            "Copy litellm-local.yaml.example to litellm-local.yaml and configure it."
+        )
+    text = config_path.read_text(encoding="utf-8")
+    match = re.search(r"model:\s+ollama_chat/(\S+)", text)
+    if match is None:
+        raise ValueError(
+            f"No ollama_chat/ model found in {config_path}. "
+            "Add a model_list entry with litellm_params.model = 'ollama_chat/<model>'."
+        )
+    return match.group(1)

--- a/app/core/watcher_helpers.py
+++ b/app/core/watcher_helpers.py
@@ -1,0 +1,4 @@
+"""Pure helper functions for the watcher sub-system (no I/O, unit-testable).
+
+Populated in WOR-165 step 2.
+"""

--- a/app/core/watcher_services.py
+++ b/app/core/watcher_services.py
@@ -1,0 +1,4 @@
+"""LiteLLM and Ollama process management for the watcher sub-system.
+
+Populated in WOR-165 step 3.
+"""

--- a/app/core/watcher_services.py
+++ b/app/core/watcher_services.py
@@ -1,4 +1,154 @@
 """LiteLLM and Ollama process management for the watcher sub-system.
 
-Populated in WOR-165 step 3.
+ServiceManager owns the shared _litellm_proc handle; two methods depend on it
+(_ensure_litellm_running stores it, _stop_litellm_proxy uses it) which makes a
+class boundary cleaner than threading a Popen handle through function signatures.
 """
+
+from __future__ import annotations
+
+import logging
+import os
+import socket
+import subprocess  # nosec B404
+import sys
+import time
+from pathlib import Path
+
+from app.core.watcher_helpers import _parse_ollama_model
+from app.core.watcher_types import (
+    _LITELLM_CONFIG,
+    _LITELLM_PORT,
+    _OLLAMA_KEEPALIVE,
+    _OLLAMA_PORT,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class ServiceManager:
+    """Manages the LiteLLM proxy and Ollama processes for local-mode workers."""
+
+    def __init__(self, repo_root: Path) -> None:
+        self._repo_root = repo_root
+        self._litellm_proc: subprocess.Popen[bytes] | None = None
+
+    def ensure_ollama_running(self) -> None:
+        """Start Ollama with the configured model if not already on _OLLAMA_PORT."""
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            already_up = sock.connect_ex(("localhost", _OLLAMA_PORT)) == 0
+
+        if already_up:
+            logger.info("Ollama already running on port %d", _OLLAMA_PORT)
+            return
+
+        config_path = self._repo_root / _LITELLM_CONFIG
+        model = _parse_ollama_model(config_path)
+        logger.info(
+            "Starting Ollama (model=%s, keepalive=%s)…", model, _OLLAMA_KEEPALIVE
+        )
+        if sys.platform == "win32":
+            creation_flags = subprocess.CREATE_NEW_CONSOLE
+        else:
+            creation_flags = 0
+        subprocess.Popen(  # nosec B603 B607
+            ["ollama", "run", model, "--keepalive", _OLLAMA_KEEPALIVE],
+            creationflags=creation_flags,
+        )
+        self._wait_for_ollama_ready()
+
+    def _wait_for_ollama_ready(self, timeout: float = 120.0) -> None:
+        """Poll TCP until Ollama's port accepts connections."""
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+                sock.settimeout(2)
+                if sock.connect_ex(("localhost", _OLLAMA_PORT)) == 0:
+                    return
+            time.sleep(0.5)
+        raise TimeoutError(f"Ollama not ready after {timeout}s.")
+
+    def ensure_litellm_running(self) -> None:
+        """Start the LiteLLM proxy if not already listening on _LITELLM_PORT."""
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            already_up = sock.connect_ex(("localhost", _LITELLM_PORT)) == 0
+
+        if already_up:
+            logger.info("LiteLLM proxy already running on port %d", _LITELLM_PORT)
+            return
+
+        config_path = self._repo_root / _LITELLM_CONFIG
+        if not config_path.exists():
+            raise FileNotFoundError(
+                f"LiteLLM config not found: {config_path}. "
+                "Copy litellm-local.yaml.example to litellm-local.yaml "
+                "and configure it."
+            )
+
+        logger.info("Starting LiteLLM proxy (port %d)…", _LITELLM_PORT)
+        env = {**os.environ, "PYTHONUTF8": "1"}
+        if sys.platform == "win32":
+            self._litellm_proc = subprocess.Popen(  # nosec B603 B607
+                [
+                    "litellm",
+                    "--config",
+                    str(config_path),
+                    "--port",
+                    str(_LITELLM_PORT),
+                    "--drop_params",
+                ],
+                creationflags=subprocess.CREATE_NEW_CONSOLE,
+                env=env,
+            )
+        else:
+            log_path = self._repo_root / ".claude" / "litellm.log"
+            log_path.parent.mkdir(parents=True, exist_ok=True)
+            log_file = open(log_path, "wb")  # noqa: SIM115
+            logger.info("LiteLLM log: %s", log_path)
+            self._litellm_proc = subprocess.Popen(  # nosec B603 B607
+                [
+                    "litellm",
+                    "--config",
+                    str(config_path),
+                    "--port",
+                    str(_LITELLM_PORT),
+                    "--drop_params",
+                ],
+                stdout=log_file,
+                stderr=log_file,
+                env=env,
+            )
+        self._wait_for_litellm_ready()
+
+    def _wait_for_litellm_ready(self, timeout: float = 60.0) -> None:
+        """Poll TCP until LiteLLM's port accepts connections or process dies."""
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if self._litellm_proc and self._litellm_proc.poll() is not None:
+                rc = self._litellm_proc.returncode
+                raise RuntimeError(
+                    f"LiteLLM proxy exited (rc={rc}). "
+                    f"Check .claude/litellm.log for details."
+                )
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+                sock.settimeout(2)
+                if sock.connect_ex(("localhost", _LITELLM_PORT)) == 0:
+                    return
+            time.sleep(0.5)
+        raise TimeoutError(
+            f"LiteLLM proxy not ready after {timeout}s. "
+            f"Check .claude/litellm.log for details."
+        )
+
+    def stop(self) -> None:
+        """Terminate the LiteLLM proxy if it was started by this manager."""
+        if not self._litellm_proc:
+            return
+        logger.info("Stopping LiteLLM proxy (pid=%d)…", self._litellm_proc.pid)
+        self._litellm_proc.terminate()
+        try:
+            self._litellm_proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            logger.info("LiteLLM proxy did not exit after 5s — sending kill")
+            self._litellm_proc.kill()
+        self._litellm_proc = None

--- a/app/core/watcher_subprocess.py
+++ b/app/core/watcher_subprocess.py
@@ -1,4 +1,195 @@
-"""Subprocess and I/O functions for the watcher sub-system.
+"""Worker subprocess management for the watcher sub-system.
 
-Populated in WOR-165 step 5.
+Stateless functions that launch and query worker processes. No persistent
+state — each function takes all inputs as parameters.
+This module may import from watcher_helpers and watcher_types (no other siblings).
 """
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import shlex
+import subprocess  # nosec B404
+import sys
+import threading
+from pathlib import Path
+from typing import IO
+
+from app.core.manifest import ExecutionManifest
+from app.core.watcher_helpers import (
+    _tee_worker_output,
+    build_worker_cmd,
+    build_worker_env,
+)
+from app.core.watcher_types import _CLAUDE_DIR
+
+logger = logging.getLogger(__name__)
+
+
+def expand_skill(repo_root: Path, ticket_id: str) -> str | None:
+    """Return the implement-ticket skill content with $ARGUMENTS substituted.
+
+    Returns None if the skill file cannot be read (caller falls back to
+    the /implement-ticket shortcut).
+    """
+    skill_path = repo_root / _CLAUDE_DIR / "commands" / "implement-ticket.md"
+    try:
+        return skill_path.read_text(encoding="utf-8").replace("$ARGUMENTS", ticket_id)
+    except OSError:
+        logger.warning("Could not read skill file %s; using shortcut", skill_path)
+        return None
+
+
+def build_snippet_tool_restrictions(snippets: list[str]) -> list[str]:
+    """Return --disallowed-tools patterns derived from context_snippets headers.
+
+    Each snippet starts with a comment line like:
+        # app/core/watcher.py lines 574-589
+    We extract the basename and return glob patterns that block Read on those
+    files regardless of the absolute path the worker uses.
+    """
+    seen: set[str] = set()
+    patterns: list[str] = []
+    header_re = re.compile(r"^#\s+(\S+)\s+lines?\s+\d")
+    for snippet in snippets:
+        first_line = snippet.splitlines()[0] if snippet else ""
+        m = header_re.match(first_line)
+        if m:
+            basename = Path(m.group(1)).name
+            if basename not in seen:
+                seen.add(basename)
+                patterns.append(f"Read(*{basename})")
+    return patterns
+
+
+def launch_worker(
+    repo_root: Path,
+    manifest: ExecutionManifest,
+    worktree_path: Path,
+    effective_mode: str,
+    verbose: bool = False,
+) -> subprocess.Popen[bytes]:
+    """Launch a worker subprocess and return the Popen handle."""
+    prompt = expand_skill(repo_root, manifest.ticket_id)
+
+    disallowed_tools: list[str] | None = None
+    if manifest.context_snippets and effective_mode == "cloud":
+        disallowed_tools = build_snippet_tool_restrictions(manifest.context_snippets)
+        if disallowed_tools and prompt:
+            file_list = ", ".join(
+                p.removeprefix("Read(*").removesuffix(")") for p in disallowed_tools
+            )
+            warning = (
+                f"CRITICAL: The following files are pre-loaded as context_snippets "
+                f"in the manifest: {file_list}. "
+                f"DO NOT use the Read tool on these files — "
+                f"the tool is blocked and attempting to read them will "
+                f"abort the task. "
+                f"Use only the snippets already provided.\n\n"
+            )
+            prompt = warning + (prompt or "")
+
+    cmd = build_worker_cmd(
+        manifest.ticket_id, effective_mode, worktree_path, prompt, disallowed_tools
+    )
+    env = build_worker_env(effective_mode, dict(os.environ))
+
+    log_path = worktree_path / f".claude/worker_{manifest.ticket_id.lower()}.log"
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    log_file = open(log_path, "wb")  # noqa: SIM115
+
+    if verbose:
+        prefix = f"[{manifest.ticket_id}] ".encode()
+        process = subprocess.Popen(  # nosec B603 B607
+            cmd,
+            cwd=str(worktree_path),
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+        )
+        assert process.stdout is not None  # guaranteed by stdout=PIPE  # nosec B101
+        stderr_buf: IO[bytes] = getattr(sys.stderr, "buffer", None) or sys.stderr.buffer
+        threading.Thread(
+            target=_tee_worker_output,
+            args=(process.stdout, log_file, prefix, stderr_buf),
+            daemon=True,
+            name=f"tee-{manifest.ticket_id}",
+        ).start()
+        return process
+
+    return subprocess.Popen(  # nosec B603 B607
+        cmd,
+        cwd=str(worktree_path),
+        env=env,
+        stdout=log_file,
+        stderr=subprocess.STDOUT,
+    )
+
+
+def run_checks(manifest: ExecutionManifest, worktree_path: Path) -> bool:
+    """Run manifest.required_checks in the worktree. Returns True if all pass."""
+    all_passed = True
+    for check_cmd in manifest.required_checks:
+        logger.info("Running check: %s", check_cmd)
+        result = subprocess.run(  # nosec B603
+            shlex.split(check_cmd),
+            cwd=str(worktree_path),
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            logger.error(
+                "Check failed: %s\n%s", check_cmd, result.stdout + result.stderr
+            )
+            all_passed = False
+    return all_passed
+
+
+def fetch_sonar_findings(branch: str) -> list[str] | None:
+    """Return per-severity finding list from SonarCloud for *branch*, or None.
+
+    Returns a list of severity strings (e.g. ['BLOCKER', 'CRITICAL']) or None
+    when SONAR_TOKEN / SONAR_PROJECT_KEY are absent or the API call fails. An
+    empty list means the branch was scanned and has no open issues.
+    """
+    import base64
+    import ssl
+    import urllib.parse
+    import urllib.request
+
+    token = os.environ.get("SONAR_TOKEN")
+    project_key = os.environ.get("SONAR_PROJECT_KEY")
+    if not token or not project_key:
+        return None
+
+    params = urllib.parse.urlencode(
+        {
+            "componentKeys": project_key,
+            "branch": branch,
+            "resolved": "false",
+            "ps": "500",
+        }
+    )
+    url = f"https://sonarcloud.io/api/issues/search?{params}"
+    creds = base64.b64encode(f"{token}:".encode()).decode()
+    req = urllib.request.Request(url, headers={"Authorization": f"Basic {creds}"})
+    ctx = ssl.create_default_context()
+    try:
+        with urllib.request.urlopen(  # nosec B310  # nosemgrep
+            req, timeout=10, context=ctx
+        ) as resp:
+            data: dict[str, object] = json.loads(resp.read())
+        issues = data.get("issues") or []
+        return [
+            str(issue["severity"])
+            for issue in (issues if isinstance(issues, list) else [])
+            if isinstance(issue, dict) and issue.get("severity")
+        ]
+    except Exception:
+        logger.debug(
+            "Could not fetch Sonar findings for branch %s", branch, exc_info=True
+        )
+    return None

--- a/app/core/watcher_subprocess.py
+++ b/app/core/watcher_subprocess.py
@@ -1,0 +1,4 @@
+"""Subprocess and I/O functions for the watcher sub-system.
+
+Populated in WOR-165 step 5.
+"""

--- a/app/core/watcher_types.py
+++ b/app/core/watcher_types.py
@@ -1,0 +1,100 @@
+"""Shared types, constants, and protocol definitions for the watcher sub-system.
+
+This module is a leaf — it must not import from any sibling watcher module.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess  # nosec B404
+import sys
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Protocol
+
+from app.core.manifest import ExecutionManifest
+from app.core.metrics import ImplementationMode
+
+_CLAUDE_DIR = ".claude"
+_PID_FILE = Path(_CLAUDE_DIR) / "watcher.pid"
+_LITELLM_PORT = 8082
+_LITELLM_CONFIG = "litellm-local.yaml"
+_LOCAL_MODEL = "qwen3-coder:30b"
+_LITELLM_BASE_URL = f"http://localhost:{_LITELLM_PORT}"
+_OLLAMA_PORT = 11434
+_OLLAMA_KEEPALIVE = "120m"
+_WORKTREE_BASE = Path("worktrees")
+
+_ENV_VARS_TO_STRIP_FOR_CLOUD = frozenset(
+    {
+        "ANTHROPIC_BASE_URL",
+        "ANTHROPIC_MODEL",
+        "OPENAI_API_BASE",
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# Protocol for dependency injection (testability)
+# ---------------------------------------------------------------------------
+
+
+class LinearClientProtocol(Protocol):
+    def list_ready_for_local(self) -> list[dict[str, Any]]: ...
+    def get_open_blockers(self, issue_id: str) -> list[str]: ...
+    def set_state(self, issue_id: str, state_name: str) -> None: ...
+    def post_comment(self, issue_id: str, body: str) -> None: ...
+    def get_issue_state_type(self, identifier: str) -> str | None: ...
+
+
+# ---------------------------------------------------------------------------
+# Active worker tracking
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ActiveWorker:
+    ticket_id: str
+    linear_id: str
+    manifest: ExecutionManifest
+    worktree_path: Path
+    process: subprocess.Popen[bytes]
+    start_time: float = field(default_factory=time.monotonic)
+    backed_up_plans: list[Path] = field(default_factory=list)
+    retry_count: int = 0
+
+
+# ---------------------------------------------------------------------------
+# Module-level utilities
+# ---------------------------------------------------------------------------
+
+
+def is_watcher_running(pid_file: Path = _PID_FILE) -> bool:
+    """Return True if a watcher process is currently running."""
+    if not pid_file.exists():
+        return False
+    try:
+        pid = int(pid_file.read_text(encoding="utf-8").strip())
+    except (ValueError, OSError):
+        return False
+    if sys.platform == "win32":
+        import ctypes
+
+        handle = ctypes.windll.kernel32.OpenProcess(0x00100000, False, pid)
+        if not handle:
+            return False
+        ctypes.windll.kernel32.CloseHandle(handle)
+        return True
+    else:
+        try:
+            os.kill(pid, 0)
+            return True
+        except (ProcessLookupError, PermissionError):
+            return False
+
+
+def _to_metrics_mode(mode: str) -> ImplementationMode:
+    if mode in ("local", "cloud", "hybrid"):
+        return mode  # type: ignore[return-value]
+    return "cloud"

--- a/app/core/watcher_worktrees.py
+++ b/app/core/watcher_worktrees.py
@@ -1,4 +1,198 @@
 """Worktree lifecycle functions for the watcher sub-system.
 
-Populated in WOR-165 step 4.
+All functions take repo_root as an explicit parameter — no persistent state
+is needed, so a class boundary would add no value here.
+This module may import from watcher_types only (no other watcher siblings).
 """
+
+from __future__ import annotations
+
+import logging
+import shutil
+import subprocess  # nosec B404
+from pathlib import Path
+
+from app.core.manifest import ExecutionManifest
+from app.core.watcher_types import (
+    _CLAUDE_DIR,
+    _WORKTREE_BASE,
+    ActiveWorker,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def create_worktree(repo_root: Path, manifest: ExecutionManifest) -> Path:
+    """Add a git worktree for *manifest* and rebase it onto its base branch."""
+    worktree_name = manifest.worktree_name or manifest.worker_branch
+    if ".." in Path(worktree_name).parts:
+        raise ValueError(f"Invalid worktree name: {worktree_name!r}")
+    worktree_path = repo_root.parent / _WORKTREE_BASE / worktree_name
+    subprocess.run(  # nosec B603 B607
+        [
+            "git",
+            "-C",
+            str(repo_root),
+            "worktree",
+            "add",
+            str(worktree_path),
+            manifest.worker_branch,
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    logger.info("Worktree created at %s", worktree_path)
+    rebase_worktree_from_base(worktree_path, manifest.base_branch)
+    return worktree_path
+
+
+def rebase_worktree_from_base(worktree_path: Path, base_branch: str) -> None:
+    """Fetch and rebase the worktree from origin/<base_branch>.
+
+    Ensures the worker starts from the latest epic state, not a stale
+    snapshot from when the branch was created.  Logs a warning on failure
+    rather than raising — a stale start is preferable to no start at all.
+    """
+    try:
+        subprocess.run(  # nosec B603 B607
+            ["git", "-C", str(worktree_path), "fetch", "origin", base_branch],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        subprocess.run(  # nosec B603 B607
+            [
+                "git",
+                "-C",
+                str(worktree_path),
+                "rebase",
+                f"origin/{base_branch}",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        logger.debug(
+            "Worktree at %s rebased onto origin/%s", worktree_path, base_branch
+        )
+    except subprocess.CalledProcessError as exc:
+        logger.warning(
+            "Could not rebase worktree onto origin/%s (worker will start from "
+            "branch tip instead): %s",
+            base_branch,
+            (exc.stderr or exc.stdout or str(exc)).strip(),
+        )
+
+
+def copy_manifest_to_worktree(
+    repo_root: Path, manifest: ExecutionManifest, worktree_path: Path
+) -> None:
+    """Copy the manifest JSON into the worktree artifact directory."""
+    src = repo_root / manifest.artifact_paths.manifest_copy
+    dest = worktree_path / manifest.artifact_paths.manifest_copy
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(src, dest)
+
+
+def backup_plan_files() -> list[Path]:
+    """Move ~/.claude/plans/*.md aside so the worker doesn't enter plan mode.
+
+    Claude Code enters plan mode whenever it finds a plan file in the plans
+    directory at startup. Workers must never enter plan mode — they run
+    non-interactively and ExitPlanMode would silently terminate the session.
+    Returns the list of backup paths so the caller can restore them later.
+    """
+    plans_dir = Path.home() / _CLAUDE_DIR / "plans"
+    if not plans_dir.exists():
+        return []
+    backup_dir = plans_dir.parent / "plans_worker_backup"
+    backup_dir.mkdir(exist_ok=True)
+    moved: list[Path] = []
+    for plan_file in plans_dir.glob("*.md"):
+        dest = backup_dir / plan_file.name
+        shutil.move(str(plan_file), dest)
+        moved.append(dest)
+    if moved:
+        logger.debug("Backed up %d plan file(s) to %s", len(moved), backup_dir)
+    return moved
+
+
+def restore_plan_files(backed_up: list[Path]) -> None:
+    """Restore plan files moved by backup_plan_files."""
+    if not backed_up:
+        return
+    plans_dir = Path.home() / _CLAUDE_DIR / "plans"
+    plans_dir.mkdir(exist_ok=True)
+    for plan_file in backed_up:
+        shutil.move(str(plan_file), plans_dir / plan_file.name)
+    logger.debug("Restored %d plan file(s)", len(backed_up))
+
+
+def write_worker_pytest_config(worktree_path: Path) -> None:
+    """Write pytest.ini overriding pyproject.toml addopts in the worktree.
+
+    pytest.ini takes precedence over pyproject.toml, so this strips
+    --cov-fail-under from every pytest call the worker makes. Coverage
+    is still enforced by CI on the PR.
+    """
+    (worktree_path / "pytest.ini").write_text("[pytest]\naddopts = --tb=short\n")
+
+
+def preserve_worker_artifacts(repo_root: Path, worker: ActiveWorker) -> None:
+    """Copy worker log and result.json from the worktree to the repo artifact dir.
+
+    The worktree is removed after this call, so any file not copied here is lost.
+    """
+    artifact_dir = (repo_root / worker.manifest.artifact_paths.result_json).parent
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+
+    log_src = worker.worktree_path / f".claude/worker_{worker.ticket_id.lower()}.log"
+    if log_src.exists():
+        shutil.copy2(log_src, artifact_dir / log_src.name)
+        logger.info("Worker log preserved at %s", artifact_dir / log_src.name)
+
+    result_src = worker.worktree_path / worker.manifest.artifact_paths.result_json
+    if result_src.exists():
+        shutil.copy2(result_src, artifact_dir / result_src.name)
+        logger.info("Result artifact preserved at %s", artifact_dir / result_src.name)
+    else:
+        logger.warning(
+            "No result artifact found at %s for %s",
+            result_src,
+            worker.ticket_id,
+        )
+
+
+def cleanup_worktree(repo_root: Path, worktree_path: Path) -> None:
+    """Remove a git worktree, logging a warning on failure."""
+    try:
+        subprocess.run(  # nosec B603 B607
+            [
+                "git",
+                "-C",
+                str(repo_root),
+                "worktree",
+                "remove",
+                "--force",
+                str(worktree_path),
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        logger.info("Worktree removed: %s", worktree_path)
+    except subprocess.CalledProcessError as exc:
+        logger.warning("Failed to remove worktree %s: %s", worktree_path, exc.stderr)
+
+
+def cleanup_orphaned_worktrees(repo_root: Path) -> None:
+    """Remove any leftover watcher-managed worktrees from a prior run."""
+    base = repo_root.parent / _WORKTREE_BASE
+    if not base.exists():
+        return
+    for worktree_dir in base.iterdir():
+        if not worktree_dir.is_dir():
+            continue
+        logger.warning("Orphaned worktree detected: %s — removing", worktree_dir)
+        cleanup_worktree(repo_root, worktree_dir)

--- a/app/core/watcher_worktrees.py
+++ b/app/core/watcher_worktrees.py
@@ -1,0 +1,4 @@
+"""Worktree lifecycle functions for the watcher sub-system.
+
+Populated in WOR-165 step 4.
+"""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,53 @@
+"""Shared test fixtures for watcher sub-module tests."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from app.core.manifest import ArtifactPaths, ExecutionManifest
+from app.core.watcher_types import ActiveWorker
+
+
+def make_manifest(**overrides: object) -> ExecutionManifest:
+    defaults: dict[str, object] = {
+        "ticket_id": "WOR-10",
+        "epic_id": "WOR-96",
+        "title": "Test ticket",
+        "priority": 2,
+        "status": "ReadyForLocal",
+        "parallel_safe": True,
+        "risk_level": "low",
+        "implementation_mode": "local",
+        "review_mode": "auto",
+        "base_branch": "wor-96-local-worker-engine",
+        "worker_branch": "wor-10-test-ticket",
+        "objective": "Do the thing.",
+        "artifact_paths": ArtifactPaths.from_ticket_id("WOR-10"),
+        "allowed_paths": ["app/core/foo.py"],
+    }
+    defaults.update(overrides)
+    return ExecutionManifest(**defaults)  # type: ignore[arg-type]
+
+
+_SENTINEL: list[str] = ["app/core/bar.py"]
+
+
+def make_active_worker(
+    ticket_id: str = "WOR-11", allowed_paths: list[str] | None = None
+) -> ActiveWorker:
+    paths = _SENTINEL if allowed_paths is None else allowed_paths
+    manifest = make_manifest(
+        ticket_id=ticket_id,
+        worker_branch=f"wor-{ticket_id.lower().replace('-', '')}-branch",
+        artifact_paths=ArtifactPaths.from_ticket_id(ticket_id),
+        allowed_paths=paths,
+    )
+    return ActiveWorker(
+        ticket_id=ticket_id,
+        linear_id="fake-linear-id",
+        manifest=manifest,
+        worktree_path=Path(f"/tmp/{ticket_id}"),
+        process=MagicMock(spec=subprocess.Popen),
+    )

--- a/tests/test_watcher_helpers.py
+++ b/tests/test_watcher_helpers.py
@@ -1,0 +1,299 @@
+"""Tests for app.core.watcher_helpers."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from app.core.watcher_helpers import (
+    _parse_ollama_model,
+    _parse_worker_usage,
+    build_worker_cmd,
+    build_worker_env,
+    check_allowed_paths_overlap,
+    resolve_effective_mode,
+)
+from tests.conftest import make_active_worker, make_manifest
+
+# ---------------------------------------------------------------------------
+# check_allowed_paths_overlap
+# ---------------------------------------------------------------------------
+
+
+def test_overlap_when_paths_share_entry() -> None:
+    active = [make_active_worker("WOR-11", allowed_paths=["app/core/foo.py"])]
+    candidate = make_manifest(allowed_paths=["app/core/foo.py"])
+    assert check_allowed_paths_overlap(active, candidate) == ["WOR-11"]
+
+
+def test_no_overlap_when_paths_are_disjoint() -> None:
+    active = [make_active_worker("WOR-11", allowed_paths=["app/core/bar.py"])]
+    candidate = make_manifest(allowed_paths=["app/core/foo.py"])
+    assert check_allowed_paths_overlap(active, candidate) == []
+
+
+def test_empty_candidate_paths_conflicts_with_all() -> None:
+    active = [make_active_worker("WOR-11", allowed_paths=["app/core/bar.py"])]
+    candidate = make_manifest(allowed_paths=[])
+    assert check_allowed_paths_overlap(active, candidate) == ["WOR-11"]
+
+
+def test_empty_active_paths_conflicts_with_candidate() -> None:
+    active = [make_active_worker("WOR-11", allowed_paths=[])]
+    candidate = make_manifest(allowed_paths=["app/core/foo.py"])
+    assert check_allowed_paths_overlap(active, candidate) == ["WOR-11"]
+
+
+def test_multiple_active_partial_overlap() -> None:
+    active = [
+        make_active_worker("WOR-11", allowed_paths=["app/core/foo.py"]),
+        make_active_worker("WOR-12", allowed_paths=["app/core/baz.py"]),
+    ]
+    candidate = make_manifest(allowed_paths=["app/core/foo.py"])
+    assert check_allowed_paths_overlap(active, candidate) == ["WOR-11"]
+
+
+# ---------------------------------------------------------------------------
+# build_worker_env
+# ---------------------------------------------------------------------------
+
+
+def test_cloud_mode_strips_base_url() -> None:
+    base = {
+        "ANTHROPIC_BASE_URL": "http://localhost:8082",
+        "PATH": "/usr/bin",
+        "HOME": "/root",
+    }
+    env = build_worker_env("cloud", base)
+    assert "ANTHROPIC_BASE_URL" not in env
+    assert env["PATH"] == "/usr/bin"
+
+
+def test_cloud_mode_strips_model_var() -> None:
+    base = {"ANTHROPIC_MODEL": "qwen3-coder:30b", "PATH": "/usr/bin"}
+    env = build_worker_env("cloud", base)
+    assert "ANTHROPIC_MODEL" not in env
+
+
+def test_local_mode_injects_base_url() -> None:
+    base = {"PATH": "/usr/bin"}
+    env = build_worker_env("local", base)
+    assert env["ANTHROPIC_BASE_URL"] == "http://localhost:8082"
+
+
+def test_default_mode_passes_env_unchanged() -> None:
+    base = {"ANTHROPIC_BASE_URL": "http://localhost:8082", "PATH": "/usr/bin"}
+    env = build_worker_env("default", base)
+    assert env == base
+
+
+def test_cloud_mode_does_not_inject_base_url_if_absent() -> None:
+    base = {"PATH": "/usr/bin"}
+    env = build_worker_env("cloud", base)
+    assert "ANTHROPIC_BASE_URL" not in env
+
+
+# ---------------------------------------------------------------------------
+# build_worker_cmd
+# ---------------------------------------------------------------------------
+
+
+def test_cloud_cmd_has_no_model_flag(tmp_path: Path) -> None:
+    cmd = build_worker_cmd("WOR-10", "cloud", tmp_path)
+    assert "--model" not in cmd
+    assert "/implement-ticket WOR-10" in " ".join(cmd)
+
+
+def test_local_cmd_includes_model_flag(tmp_path: Path) -> None:
+    cmd = build_worker_cmd("WOR-10", "local", tmp_path)
+    assert "--model" in cmd
+    idx = cmd.index("--model")
+    assert cmd[idx + 1] == "qwen3-coder:30b"
+
+
+def test_cmd_includes_dangerously_skip_permissions(tmp_path: Path) -> None:
+    for mode in ("cloud", "local"):
+        cmd = build_worker_cmd("WOR-10", mode, tmp_path)
+        assert "--dangerously-skip-permissions" in cmd
+
+
+def test_cmd_bare_mode_uses_worktree_path(tmp_path: Path) -> None:
+    cmd = build_worker_cmd("WOR-10", "local", tmp_path)
+    assert "--bare" in cmd
+    idx = cmd.index("--add-dir")
+    assert cmd[idx + 1] == str(tmp_path)
+
+
+def test_cloud_cmd_has_no_bare_flag(tmp_path: Path) -> None:
+    cmd = build_worker_cmd("WOR-10", "cloud", tmp_path)
+    assert "--bare" not in cmd
+
+
+def test_cmd_disallowed_tools_appended(tmp_path: Path) -> None:
+    tools = ["Read(*watcher.py)", "Read(*metrics.py)"]
+    cmd = build_worker_cmd("WOR-10", "cloud", tmp_path, disallowed_tools=tools)
+    assert "--disallowed-tools" in cmd
+    idx = cmd.index("--disallowed-tools")
+    assert cmd[idx + 1] == "Read(*watcher.py),Read(*metrics.py)"
+
+
+def test_cmd_no_disallowed_tools_when_none(tmp_path: Path) -> None:
+    cmd = build_worker_cmd("WOR-10", "cloud", tmp_path, disallowed_tools=None)
+    assert "--disallowed-tools" not in cmd
+
+
+# ---------------------------------------------------------------------------
+# resolve_effective_mode
+# ---------------------------------------------------------------------------
+
+
+def test_worker_mode_overrides_manifest_local() -> None:
+    assert resolve_effective_mode("cloud", "local") == "cloud"
+
+
+def test_worker_mode_overrides_manifest_cloud() -> None:
+    assert resolve_effective_mode("local", "cloud") == "local"
+
+
+def test_default_defers_to_manifest() -> None:
+    assert resolve_effective_mode("default", "local") == "local"
+    assert resolve_effective_mode("default", "cloud") == "cloud"
+
+
+def test_default_hybrid_becomes_cloud() -> None:
+    assert resolve_effective_mode("default", "hybrid") == "cloud"
+
+
+# ---------------------------------------------------------------------------
+# _parse_worker_usage
+# ---------------------------------------------------------------------------
+
+
+def _write_log(tmp_path: Path, lines: list[str]) -> Path:
+    log = tmp_path / "worker_wor-99.log"
+    log.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return log
+
+
+def test_parse_worker_usage_success(tmp_path: Path) -> None:
+    result_line = json.dumps(
+        {
+            "type": "result",
+            "subtype": "success",
+            "usage": {
+                "input_tokens": 1000,
+                "output_tokens": 200,
+                "cache_read_input_tokens": 0,
+            },
+            "context_compactions": 3,
+        }
+    )
+    log = _write_log(tmp_path, ['{"type":"other","x":1}', result_line])
+    tokens, compactions = _parse_worker_usage(log)
+    assert tokens == 1200
+    assert compactions == 3
+
+
+def test_parse_worker_usage_no_context_compactions(tmp_path: Path) -> None:
+    result_line = json.dumps(
+        {"type": "result", "usage": {"input_tokens": 500, "output_tokens": 50}}
+    )
+    log = _write_log(tmp_path, [result_line])
+    tokens, compactions = _parse_worker_usage(log)
+    assert tokens == 550
+    assert compactions is None
+
+
+def test_parse_worker_usage_missing_log(tmp_path: Path) -> None:
+    tokens, compactions = _parse_worker_usage(tmp_path / "no_such_file.log")
+    assert tokens is None
+    assert compactions is None
+
+
+def test_parse_worker_usage_no_result_line(tmp_path: Path) -> None:
+    log = _write_log(
+        tmp_path,
+        [
+            json.dumps({"type": "tool_use", "name": "Bash"}),
+            json.dumps({"type": "assistant", "content": "hello"}),
+        ],
+    )
+    tokens, compactions = _parse_worker_usage(log)
+    assert tokens is None
+    assert compactions is None
+
+
+def test_parse_worker_usage_malformed_json(tmp_path: Path) -> None:
+    log = tmp_path / "worker.log"
+    log.write_text("not json at all\n{broken\n", encoding="utf-8")
+    tokens, compactions = _parse_worker_usage(log)
+    assert tokens is None
+    assert compactions is None
+
+
+def test_parse_worker_usage_mixed_valid_invalid_lines(tmp_path: Path) -> None:
+    result_line = json.dumps(
+        {
+            "type": "result",
+            "usage": {"input_tokens": 300, "output_tokens": 100},
+            "context_compactions": 1,
+        }
+    )
+    log = tmp_path / "worker.log"
+    log.write_text("garbage line\n" + result_line + "\n", encoding="utf-8")
+    tokens, compactions = _parse_worker_usage(log)
+    assert tokens == 400
+    assert compactions == 1
+
+
+def test_parse_worker_usage_returns_first_result_line(tmp_path: Path) -> None:
+    first = json.dumps(
+        {"type": "result", "usage": {"input_tokens": 10, "output_tokens": 5}}
+    )
+    second = json.dumps(
+        {"type": "result", "usage": {"input_tokens": 999, "output_tokens": 999}}
+    )
+    log = _write_log(tmp_path, [first, second])
+    tokens, _ = _parse_worker_usage(log)
+    assert tokens == 15
+
+
+def test_parse_worker_usage_empty_file(tmp_path: Path) -> None:
+    log = tmp_path / "empty.log"
+    log.write_text("", encoding="utf-8")
+    tokens, compactions = _parse_worker_usage(log)
+    assert tokens is None
+    assert compactions is None
+
+
+# ---------------------------------------------------------------------------
+# _parse_ollama_model
+# ---------------------------------------------------------------------------
+
+
+def test_parse_ollama_model_returns_bare_model_name(tmp_path: Path) -> None:
+    cfg = tmp_path / "litellm-local.yaml"
+    cfg.write_text(
+        "model_list:\n"
+        "  - model_name: claude-sonnet-4-6\n"
+        "    litellm_params:\n"
+        "      model: ollama_chat/qwen3-coder:30b\n"
+        "      api_base: http://localhost:11434\n"
+    )
+    assert _parse_ollama_model(cfg) == "qwen3-coder:30b"
+
+
+def test_parse_ollama_model_raises_when_no_ollama_entry(tmp_path: Path) -> None:
+    import pytest
+
+    cfg = tmp_path / "litellm-local.yaml"
+    cfg.write_text("model_list:\n  - model_name: gpt-4\n")
+    with pytest.raises(ValueError, match="No ollama_chat/"):
+        _parse_ollama_model(cfg)
+
+
+def test_parse_ollama_model_raises_when_file_missing(tmp_path: Path) -> None:
+    import pytest
+
+    with pytest.raises(FileNotFoundError):
+        _parse_ollama_model(tmp_path / "nonexistent.yaml")

--- a/tests/test_watcher_services.py
+++ b/tests/test_watcher_services.py
@@ -1,0 +1,112 @@
+"""Tests for app.core.watcher_services (ServiceManager)."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from app.core.watcher_services import ServiceManager
+
+# ---------------------------------------------------------------------------
+# ServiceManager.stop  (formerly _stop_litellm_proxy via Watcher shim)
+# ---------------------------------------------------------------------------
+
+
+def test_stop_terminates_on_clean_exit(tmp_path: Path) -> None:
+    mock_proc = MagicMock(spec=subprocess.Popen)
+    mock_proc.pid = 12345
+    mock_proc.wait.return_value = 0
+
+    mgr = ServiceManager(tmp_path)
+    mgr._litellm_proc = mock_proc
+
+    mgr.stop()
+
+    mock_proc.terminate.assert_called_once()
+    mock_proc.kill.assert_not_called()
+    assert mgr._litellm_proc is None
+
+
+def test_stop_kills_when_terminate_hangs(tmp_path: Path) -> None:
+    mock_proc = MagicMock(spec=subprocess.Popen)
+    mock_proc.pid = 12345
+    mock_proc.wait.side_effect = subprocess.TimeoutExpired(cmd="litellm", timeout=5)
+
+    mgr = ServiceManager(tmp_path)
+    mgr._litellm_proc = mock_proc
+
+    mgr.stop()
+
+    mock_proc.terminate.assert_called_once()
+    mock_proc.kill.assert_called_once()
+    assert mgr._litellm_proc is None
+
+
+def test_stop_noop_when_no_proc(tmp_path: Path) -> None:
+    mgr = ServiceManager(tmp_path)
+    assert mgr._litellm_proc is None
+    mgr.stop()  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# ServiceManager.ensure_ollama_running
+# ---------------------------------------------------------------------------
+
+
+def test_ensure_ollama_running_already_up(tmp_path: Path) -> None:
+    mgr = ServiceManager(tmp_path)
+    with (
+        patch("socket.socket") as mock_sock_cls,
+        patch("subprocess.Popen") as mock_popen,
+    ):
+        mock_sock = MagicMock()
+        mock_sock.__enter__ = lambda s: s
+        mock_sock.__exit__ = MagicMock(return_value=False)
+        mock_sock.connect_ex.return_value = 0  # already up
+        mock_sock_cls.return_value = mock_sock
+
+        mgr.ensure_ollama_running()
+
+    mock_popen.assert_not_called()
+
+
+def test_ensure_ollama_running_starts_process(tmp_path: Path) -> None:
+    cfg = tmp_path / "litellm-local.yaml"
+    cfg.write_text(
+        "model_list:\n"
+        "  - model_name: claude-sonnet-4-6\n"
+        "    litellm_params:\n"
+        "      model: ollama_chat/qwen3-coder:30b\n"
+        "      api_base: http://localhost:11434\n"
+    )
+    mgr = ServiceManager(tmp_path)
+
+    call_count = 0
+
+    def _probe_side_effect(*args: Any, **kwargs: Any) -> int:
+        nonlocal call_count
+        call_count += 1
+        # First call (already-up check) -> not up; subsequent calls (wait loop) -> up
+        return 1 if call_count == 1 else 0
+
+    with (
+        patch("socket.socket") as mock_sock_cls,
+        patch("subprocess.Popen") as mock_popen,
+    ):
+        mock_sock = MagicMock()
+        mock_sock.__enter__ = lambda s: s
+        mock_sock.__exit__ = MagicMock(return_value=False)
+        mock_sock.connect_ex.side_effect = _probe_side_effect
+        mock_sock_cls.return_value = mock_sock
+
+        mgr.ensure_ollama_running()
+
+    mock_popen.assert_called_once()
+    cmd = mock_popen.call_args[0][0]
+    assert cmd[0] == "ollama"
+    assert cmd[1] == "run"
+    assert cmd[2] == "qwen3-coder:30b"
+    assert "--keepalive" in cmd
+    assert "120m" in cmd

--- a/tests/test_watcher_subprocess.py
+++ b/tests/test_watcher_subprocess.py
@@ -1,0 +1,178 @@
+"""Tests for app.core.watcher_subprocess."""
+
+from __future__ import annotations
+
+import io
+from unittest.mock import patch
+
+import pytest
+
+from app.core.watcher_helpers import _tee_worker_output
+from app.core.watcher_subprocess import (
+    build_snippet_tool_restrictions,
+    fetch_sonar_findings,
+)
+
+# ---------------------------------------------------------------------------
+# _tee_worker_output (lives in watcher_helpers; tested here as subprocess I/O)
+# ---------------------------------------------------------------------------
+
+
+class _CaptureSink:
+    """Byte sink that accumulates writes and tracks close without discarding data."""
+
+    def __init__(self) -> None:
+        self.data = b""
+        self.closed = False
+
+    def write(self, b: bytes) -> int:
+        self.data += b
+        return len(b)
+
+    def flush(self) -> None:
+        pass
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def test_tee_writes_prefixed_lines_to_dest() -> None:
+    pipe = io.BytesIO(b"hello\nsecond line\n")
+    log_sink: _CaptureSink = _CaptureSink()
+    dest_sink = io.BytesIO()
+
+    _tee_worker_output(pipe, log_sink, b"[WOR-62] ", dest_sink)  # type: ignore[arg-type]
+
+    assert log_sink.data == b"hello\nsecond line\n"
+    assert dest_sink.getvalue() == b"[WOR-62] hello\n[WOR-62] second line\n"
+
+
+def test_tee_closes_log_file() -> None:
+    pipe = io.BytesIO(b"line\n")
+    log_sink = _CaptureSink()
+    dest_sink = io.BytesIO()
+
+    _tee_worker_output(pipe, log_sink, b"", dest_sink)  # type: ignore[arg-type]
+
+    assert log_sink.closed
+
+
+def test_tee_empty_pipe() -> None:
+    pipe = io.BytesIO(b"")
+    log_sink = _CaptureSink()
+    dest_sink = io.BytesIO()
+
+    _tee_worker_output(pipe, log_sink, b"[X] ", dest_sink)  # type: ignore[arg-type]
+
+    assert log_sink.data == b""
+    assert dest_sink.getvalue() == b""
+
+
+# ---------------------------------------------------------------------------
+# build_snippet_tool_restrictions
+# ---------------------------------------------------------------------------
+
+
+def test_build_snippet_tool_restrictions_extracts_basenames() -> None:
+    snippets = [
+        "# app/core/watcher.py lines 574-589\nsome code",
+        "# app/core/metrics.py lines 1-20\nmore code",
+        "# app/core/watcher.py lines 600-620\nduplicate file",
+    ]
+    patterns = build_snippet_tool_restrictions(snippets)
+    assert patterns == ["Read(*watcher.py)", "Read(*metrics.py)"]
+
+
+def test_build_snippet_tool_restrictions_ignores_malformed() -> None:
+    snippets = ["no header here", "# missing path\ncode"]
+    patterns = build_snippet_tool_restrictions(snippets)
+    assert patterns == []
+
+
+# ---------------------------------------------------------------------------
+# fetch_sonar_findings
+# ---------------------------------------------------------------------------
+
+
+def _make_sonar_resp_mock(payload: bytes) -> object:
+    """Return a context-manager mock whose .read() returns payload."""
+    from unittest.mock import MagicMock
+
+    mock_resp = MagicMock()
+    mock_resp.read.return_value = payload
+    mock_resp.__enter__ = lambda s: s
+    mock_resp.__exit__ = MagicMock(return_value=False)
+    return mock_resp
+
+
+def test_fetch_sonar_findings_returns_none_without_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("SONAR_TOKEN", raising=False)
+    monkeypatch.delenv("SONAR_PROJECT_KEY", raising=False)
+    assert fetch_sonar_findings("wor-10-some-branch") is None
+
+
+def test_fetch_sonar_findings_returns_none_without_project_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SONAR_TOKEN", "fake-token")
+    monkeypatch.delenv("SONAR_PROJECT_KEY", raising=False)
+    assert fetch_sonar_findings("wor-10-some-branch") is None
+
+
+def test_fetch_sonar_findings_returns_severities(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import json
+
+    monkeypatch.setenv("SONAR_TOKEN", "fake-token")
+    monkeypatch.setenv("SONAR_PROJECT_KEY", "my-org_my-project")
+    api_payload = json.dumps(
+        {
+            "issues": [
+                {"key": "A", "severity": "MAJOR"},
+                {"key": "B", "severity": "MINOR"},
+                {"key": "C", "severity": "BLOCKER"},
+            ]
+        }
+    ).encode()
+
+    mock_resp = _make_sonar_resp_mock(api_payload)
+    with patch("urllib.request.urlopen", return_value=mock_resp):
+        findings = fetch_sonar_findings("wor-10-some-branch")
+
+    assert findings == ["MAJOR", "MINOR", "BLOCKER"]
+
+
+def test_fetch_sonar_findings_returns_empty_list_when_no_issues(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import json
+
+    monkeypatch.setenv("SONAR_TOKEN", "fake-token")
+    monkeypatch.setenv("SONAR_PROJECT_KEY", "my-project")
+    api_payload = json.dumps({"issues": [], "total": 0}).encode()
+
+    with patch(
+        "urllib.request.urlopen",
+        return_value=_make_sonar_resp_mock(api_payload),
+    ):
+        findings = fetch_sonar_findings("wor-10-some-branch")
+
+    assert findings == []
+
+
+def test_fetch_sonar_findings_returns_none_on_api_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import urllib.error
+
+    monkeypatch.setenv("SONAR_TOKEN", "fake-token")
+    monkeypatch.setenv("SONAR_PROJECT_KEY", "my-project")
+    with patch(
+        "urllib.request.urlopen",
+        side_effect=urllib.error.URLError("connection refused"),
+    ):
+        count = fetch_sonar_findings("wor-10-some-branch")
+    assert count is None

--- a/tests/test_watcher_types.py
+++ b/tests/test_watcher_types.py
@@ -1,0 +1,28 @@
+"""Tests for app.core.watcher_types."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from app.core.watcher_types import is_watcher_running
+
+
+def test_is_watcher_running_no_pid_file(tmp_path: Path) -> None:
+    pid_file = tmp_path / "watcher.pid"
+    assert not is_watcher_running(pid_file)
+
+
+def test_is_watcher_running_stale_pid(tmp_path: Path) -> None:
+    pid_file = tmp_path / "watcher.pid"
+    pid_file.write_text("9999999", encoding="utf-8")  # very unlikely to be real
+    # Should return False (process not running) or True on very unlucky collision;
+    # just verify no exception is raised
+    result = is_watcher_running(pid_file)
+    assert isinstance(result, bool)
+
+
+def test_is_watcher_running_own_pid(tmp_path: Path) -> None:
+    pid_file = tmp_path / "watcher.pid"
+    pid_file.write_text(str(os.getpid()), encoding="utf-8")
+    assert is_watcher_running(pid_file)

--- a/tests/test_watcher_worktrees.py
+++ b/tests/test_watcher_worktrees.py
@@ -1,0 +1,91 @@
+"""Tests for app.core.watcher_worktrees."""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.core.watcher_types import ActiveWorker
+from app.core.watcher_worktrees import (
+    preserve_worker_artifacts,
+    rebase_worktree_from_base,
+)
+from tests.conftest import make_manifest
+
+# ---------------------------------------------------------------------------
+# rebase_worktree_from_base
+# ---------------------------------------------------------------------------
+
+
+def test_rebase_worktree_from_base_warns_on_failure(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    def _raise(*args: object, **kwargs: object) -> None:
+        raise subprocess.CalledProcessError(1, "git", stderr="conflict")
+
+    with (
+        patch("subprocess.run", side_effect=_raise),
+        caplog.at_level(logging.WARNING, logger="app.core.watcher_worktrees"),
+    ):
+        rebase_worktree_from_base(tmp_path, "some-epic-branch")
+
+    assert any("Could not rebase" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# preserve_worker_artifacts
+# ---------------------------------------------------------------------------
+
+
+def test_preserve_worker_artifacts_copies_log_and_result(tmp_path: Path) -> None:
+    manifest = make_manifest(ticket_id="WOR-10", worker_branch="wor-10-test-ticket")
+
+    worktree = tmp_path / "worktrees" / "wor-10"
+    worktree.mkdir(parents=True)
+
+    log_src = worktree / ".claude" / "worker_wor-10.log"
+    log_src.parent.mkdir(parents=True)
+    log_src.write_text("log content")
+
+    result_src = worktree / ".claude" / "artifacts" / "wor_10" / "result.json"
+    result_src.parent.mkdir(parents=True)
+    result_src.write_text('{"status": "success"}')
+
+    worker = ActiveWorker(
+        ticket_id="WOR-10",
+        linear_id="fake-id",
+        manifest=manifest,
+        worktree_path=worktree,
+        process=MagicMock(spec=subprocess.Popen),
+    )
+    preserve_worker_artifacts(tmp_path, worker)
+
+    artifact_dir = tmp_path / ".claude" / "artifacts" / "wor_10"
+    assert (artifact_dir / "worker_wor-10.log").read_text() == "log content"
+    assert (artifact_dir / "result.json").read_text() == '{"status": "success"}'
+
+
+def test_preserve_worker_artifacts_missing_result_warns(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    manifest = make_manifest(ticket_id="WOR-10", worker_branch="wor-10-test-ticket")
+
+    worktree = tmp_path / "worktrees" / "wor-10"
+    worktree.mkdir(parents=True)
+
+    worker = ActiveWorker(
+        ticket_id="WOR-10",
+        linear_id="fake-id",
+        manifest=manifest,
+        worktree_path=worktree,
+        process=MagicMock(spec=subprocess.Popen),
+    )
+
+    with caplog.at_level(logging.WARNING, logger="app.core.watcher_worktrees"):
+        preserve_worker_artifacts(tmp_path, worker)
+
+    assert any("No result artifact" in r.message for r in caplog.records)


### PR DESCRIPTION
- Splits the 1,486-LOC `watcher.py` monolith into 5 focused sub-modules (`watcher_types`, `watcher_helpers`, `watcher_services`, `watcher_worktrees`, `watcher_subprocess`), reducing `watcher.py` to 387 LOC (orchestration only)
- Adds two Import Linter architecture contracts enforcing the strict dependency layer between sub-modules
- Adds 53 new tests across 5 test files; overall coverage 85%

**Milestone:** Post-MVP Explorations
**Epic:** code refactoring / auto split (WOR-160)

## Test plan
- [x] `pytest` — 399 passed, 85% coverage (threshold 80%)
- [x] `mypy app/` — no errors
- [x] `lint-imports` — both new contracts pass
- [x] `ruff check .` — clean
- [x] All sub-modules ≤300 LOC; `watcher.py` ≤600 LOC
- [x] `LinearClientProtocol` backward-compat re-export in `watcher.py`
- [x] No behavioural changes to watcher daemon

Closes WOR-165