### PR TITLE
WOR-166 Add file-size advisory gate to /finalize-ticket and /close-epic

### DIFF
--- a/.claude/commands/close-epic.md
+++ b/.claude/commands/close-epic.md
@@ -57,6 +57,68 @@ git checkout epic/<epic-slug>
 git pull origin epic/<epic-slug>
 ```
 
+### 2.5. File-size gate
+
+Thresholds derived from local model context window (qwen3-coder:30b, 32k tokens, ~9.7 tokens/LOC):
+
+```
+ADVISORY_LOC = 500   # ~22% of working context (21,600 tokens available)
+RECOMMEND_LOC = 700  # ~31% of working context
+BLOCK_LOC = 1000     # ~45% of working context — local model effectiveness degrades sharply
+```
+
+Check the LOC of every `.py` file modified across the full epic diff (all sub-tickets combined):
+
+```bash
+MODIFIED_PY=$(git diff --name-only main..<epic-branch> | grep '\.py$')
+for f in $MODIFIED_PY; do
+  [ -f "$f" ] && echo "$f: $(wc -l < "$f") LOC"
+done
+```
+
+Skip files that no longer exist in the working tree (deleted). Classify each file by LOC and emit the appropriate message:
+
+**Advisory (≥ 500 LOC):**
+```
+Note: <filename> is <N> LOC (≥ 500 — advisory). Consider splitting before this file grows further.
+```
+Continue — non-blocking.
+
+**Recommend (≥ 700 LOC):**
+```
+Warning: <filename> is <N> LOC (≥ 700 — recommend). Large enough to reduce local model effectiveness.
+Include a splitting recommendation in the epic PR description.
+```
+Continue — but flag the file in the PR body.
+
+**Block (≥ 1,000 LOC):**
+```
+BLOCKED: <filename> is <N> LOC (≥ 1,000 — block threshold).
+This file consumes ~45% of the local model's working context budget.
+Split <filename> before creating the epic → main PR.
+```
+**Stop here. Do not proceed to step 3 or create the PR.** Ask the user how to proceed.
+
+This block is unconditional — it applies regardless of implementation mode.
+
+### 2.6. Import Linter review
+
+Check whether any new `.py` files were added across the entire epic diff (an indicator that a file split may have occurred):
+
+```bash
+git diff --diff-filter=A --name-only main..<epic-branch> | grep '\.py$'
+```
+
+If any new `.py` files appear in the output, print:
+
+```
+New Python module(s) detected: <list of files>
+If these were created by splitting an existing module, review .importlinter and consider
+adding contracts to enforce the new module boundaries. See existing contracts for examples.
+```
+
+Skip silently if no new `.py` files were added.
+
 ### 3. Security check
 Run a full security scan against main:
 ```bash

--- a/.claude/commands/finalize-ticket.md
+++ b/.claude/commands/finalize-ticket.md
@@ -18,6 +18,75 @@ Check if any of the following need updating:
 
 Only update docs if the change is meaningful — do not document implementation details.
 
+### 2.5. File-size gate
+
+Thresholds derived from local model context window (qwen3-coder:30b, 32k tokens, ~9.7 tokens/LOC):
+
+```
+ADVISORY_LOC = 500   # ~22% of working context (21,600 tokens available)
+RECOMMEND_LOC = 700  # ~31% of working context
+BLOCK_LOC = 1000     # ~45% of working context — local model effectiveness degrades sharply
+```
+
+Determine the base branch (epic branch or `main`) from the PR target established in step 1. Find every modified `.py` file in this branch's diff:
+
+```bash
+BASE=$(git merge-base HEAD origin/<base-branch>)
+MODIFIED_PY=$(git diff --name-only "$BASE" HEAD | grep '\.py$')
+```
+
+For each file in `$MODIFIED_PY`, skip it if it no longer exists in the working tree (deleted). Otherwise count its lines:
+
+```bash
+for f in $MODIFIED_PY; do
+  [ -f "$f" ] && echo "$f: $(wc -l < "$f") LOC"
+done
+```
+
+Classify each file by LOC and emit the appropriate message:
+
+**Advisory (≥ 500 LOC):**
+```
+Note: <filename> is <N> LOC (≥ 500 — advisory). Consider splitting before this file grows further.
+```
+Continue — non-blocking.
+
+**Recommend (≥ 700 LOC):**
+```
+Warning: <filename> is <N> LOC (≥ 700 — recommend). Large enough to reduce local model effectiveness.
+Include a splitting recommendation in the PR description.
+```
+Continue — but flag the file in the PR body.
+
+**Block (≥ 1,000 LOC):**
+```
+BLOCKED: <filename> is <N> LOC (≥ 1,000 — block threshold).
+This file consumes ~45% of the local model's working context budget.
+Split <filename> before creating this PR.
+```
+**Stop here. Do not proceed to step 3 or create a PR.** Ask the user how to proceed.
+
+This block is unconditional — it applies regardless of implementation mode.
+
+### 2.6. Import Linter review
+
+Check whether any new `.py` files were added in this branch's diff (an indicator that a file split may have occurred):
+
+```bash
+BASE=$(git merge-base HEAD origin/<base-branch>)
+git diff --diff-filter=A --name-only "$BASE" HEAD | grep '\.py$'
+```
+
+If any new `.py` files appear in the output, print:
+
+```
+New Python module(s) detected: <list of files>
+If these were created by splitting an existing module, review .importlinter and consider
+adding contracts to enforce the new module boundaries. See existing contracts for examples.
+```
+
+Skip silently if no new `.py` files were added.
+
 ### 3. Finalize Reviewer subagent
 Gather the following three inputs:
 ```bash


### PR DESCRIPTION
## Summary

- Adds a file-size gate (step 2.5) to `/finalize-ticket` and `/close-epic` that checks LOC of every modified `.py` file (including `tests/`) against three threshold constants derived from the local model context window
- Three output levels: advisory note (≥ 500 LOC), recommend warning (≥ 700 LOC), unconditional block (≥ 1,000 LOC) — block stops PR creation regardless of implementation mode
- Adds an Import Linter review step (step 2.6) that detects newly added `.py` files and prompts to review `.importlinter` for new module boundary contracts

**Milestone:** Post-MVP Explorations
**Epic:** WOR-160 code refactoring / auto split

## Test plan

- [ ] `/finalize-ticket` on a branch with no modified `.py` files — gate passes silently
- [ ] `/finalize-ticket` on a branch with a `.py` file 500–699 LOC — advisory note printed, PR proceeds
- [ ] `/finalize-ticket` on a branch with a `.py` file 700–999 LOC — recommend warning printed, PR proceeds
- [ ] `/finalize-ticket` on a branch with a `.py` file ≥ 1,000 LOC — blocked, PR not created
- [ ] `/finalize-ticket` on a branch that adds a new `.py` file — Import Linter review prompt printed
- [ ] `/close-epic` runs same checks against full epic diff

Closes WOR-166