### PR TITLE
WOR-169 Refactor: remove backward-compat shims from watcher.py and extract _create_pr

### DIFF
--- a/app/core/watcher.py
+++ b/app/core/watcher.py
@@ -35,22 +35,9 @@ from app.core.watcher_helpers import (
     check_allowed_paths_overlap,
     resolve_effective_mode,
 )
-from app.core.watcher_helpers import (
-    _parse_ollama_model as _parse_ollama_model,  # noqa: F401 — backward-compat re-export
-)
-from app.core.watcher_helpers import (
-    _tee_worker_output as _tee_worker_output,  # noqa: F401 — backward-compat re-export
-)
-from app.core.watcher_helpers import (
-    build_worker_cmd as build_worker_cmd,  # noqa: F401 — backward-compat re-export
-)
-from app.core.watcher_helpers import (
-    build_worker_env as build_worker_env,  # noqa: F401 — backward-compat re-export
-)
 from app.core.watcher_services import ServiceManager
 from app.core.watcher_subprocess import (
-    build_snippet_tool_restrictions,
-    expand_skill,
+    create_pr,
     fetch_sonar_findings,
     launch_worker,
     run_checks,
@@ -60,13 +47,8 @@ from app.core.watcher_types import (
     _LOCAL_MODEL,
     _PID_FILE,
     ActiveWorker,
+    LinearClientProtocol,
     _to_metrics_mode,
-)
-from app.core.watcher_types import (
-    LinearClientProtocol as LinearClientProtocol,  # noqa: F401 — backward-compat re-export
-)
-from app.core.watcher_types import (
-    is_watcher_running as is_watcher_running,  # noqa: F401 — backward-compat re-export
 )
 from app.core.watcher_worktrees import (
     backup_plan_files,
@@ -74,7 +56,6 @@ from app.core.watcher_worktrees import (
     copy_manifest_to_worktree,
     create_worktree,
     preserve_worker_artifacts,
-    rebase_worktree_from_base,
     restore_plan_files,
     write_worker_pytest_config,
 )
@@ -157,6 +138,18 @@ class Watcher:
             self._services.stop()
             self._remove_pid_file()
             logger.info("Watcher stopped cleanly")
+
+    def _cleanup_orphaned_worktrees(self) -> None:
+        from app.core.watcher_types import _WORKTREE_BASE
+
+        base = self._repo_root.parent / _WORKTREE_BASE
+        if not base.exists():
+            return
+        for worktree_dir in base.iterdir():
+            if not worktree_dir.is_dir():
+                continue
+            logger.warning("Orphaned worktree detected: %s — removing", worktree_dir)
+            cleanup_worktree(self._repo_root, worktree_dir)
 
     # ------------------------------------------------------------------
     # WaitingForDeps promotion
@@ -384,9 +377,9 @@ class Watcher:
                 )
                 return
 
-        worktree_path = self._create_worktree(manifest)
-        self._copy_manifest_to_worktree(manifest, worktree_path)
-        self._write_worker_pytest_config(worktree_path)
+        worktree_path = create_worktree(self._repo_root, manifest)
+        copy_manifest_to_worktree(self._repo_root, manifest, worktree_path)
+        write_worker_pytest_config(worktree_path)
 
         self._safe_set_state(
             linear_id, manifest.ticket_state_map.in_progress_local, ticket_id
@@ -394,11 +387,13 @@ class Watcher:
         logger.info("Launching worker for %s (mode=%s)", ticket_id, effective_mode)
 
         if effective_mode == "local":
-            self._ensure_ollama_running()
-            self._ensure_litellm_running()
+            self._services.ensure_ollama_running()
+            self._services.ensure_litellm_running()
 
-        backed_up_plans = self._backup_plan_files()
-        process = self._launch_worker(manifest, worktree_path, effective_mode)
+        backed_up_plans = backup_plan_files()
+        process = launch_worker(
+            self._repo_root, manifest, worktree_path, effective_mode, self._verbose
+        )
         worker = ActiveWorker(
             ticket_id=ticket_id,
             linear_id=linear_id,
@@ -453,7 +448,7 @@ class Watcher:
         linear_id: str,
     ) -> Outcome:
         try:
-            pr_url = self._create_pr(manifest, worker.worktree_path)
+            pr_url = create_pr(manifest, worker.worktree_path)
         except subprocess.CalledProcessError as exc:
             err_detail = (exc.stderr or exc.stdout or str(exc)).strip()
             logger.error("PR creation failed for %s: %s", ticket_id, err_detail)
@@ -489,7 +484,7 @@ class Watcher:
                 escalated = True
             self._safe_set_state(linear_id, manifest.ticket_state_map.failed, ticket_id)
         else:
-            checks_ok = self._run_checks(manifest, worker.worktree_path)
+            checks_ok = run_checks(manifest, worker.worktree_path)
             if not checks_ok:
                 worker.retry_count += 1
             if not checks_ok and manifest.failure_policy.on_check_failure == "abort":
@@ -498,7 +493,7 @@ class Watcher:
                     linear_id, manifest.ticket_state_map.failed, ticket_id
                 )
             else:
-                self._preserve_worker_artifacts(worker)
+                preserve_worker_artifacts(self._repo_root, worker)
                 artifacts_preserved = True
 
                 result_path = self._repo_root / manifest.artifact_paths.result_json
@@ -539,7 +534,7 @@ class Watcher:
                         )
                     outcome = "aborted"
                 else:  # fix_locally — classify Sonar severities before creating PR
-                    sonar_findings = self._fetch_sonar_findings(manifest.worker_branch)
+                    sonar_findings = fetch_sonar_findings(manifest.worker_branch)
                     sonar_escalate = False
                     if sonar_findings:
                         for severity in sonar_findings:
@@ -602,10 +597,10 @@ class Watcher:
             )
         )
 
-        self._restore_plan_files(worker.backed_up_plans)
+        restore_plan_files(worker.backed_up_plans)
         if not artifacts_preserved:
-            self._preserve_worker_artifacts(worker)
-        self._cleanup_worktree(worker.worktree_path)
+            preserve_worker_artifacts(self._repo_root, worker)
+        cleanup_worktree(self._repo_root, worker.worktree_path)
 
     # ------------------------------------------------------------------
     # Manifest loading
@@ -617,189 +612,6 @@ class Watcher:
         artifact = ArtifactPaths.from_ticket_id(ticket_id)
         manifest_path = self._repo_root / artifact.manifest_copy
         return ExecutionManifest.from_json(manifest_path)
-
-    # ------------------------------------------------------------------
-    # Worktree management — shims delegating to watcher_worktrees
-    # ------------------------------------------------------------------
-
-    def _create_worktree(self, manifest: ExecutionManifest) -> Path:
-        return create_worktree(self._repo_root, manifest)
-
-    def _rebase_worktree_from_base(self, worktree_path: Path, base_branch: str) -> None:
-        rebase_worktree_from_base(worktree_path, base_branch)
-
-    def _copy_manifest_to_worktree(
-        self, manifest: ExecutionManifest, worktree_path: Path
-    ) -> None:
-        copy_manifest_to_worktree(self._repo_root, manifest, worktree_path)
-
-    def _backup_plan_files(self) -> list[Path]:
-        return backup_plan_files()
-
-    def _restore_plan_files(self, backed_up: list[Path]) -> None:
-        restore_plan_files(backed_up)
-
-    def _write_worker_pytest_config(self, worktree_path: Path) -> None:
-        write_worker_pytest_config(worktree_path)
-
-    def _preserve_worker_artifacts(self, worker: ActiveWorker) -> None:
-        preserve_worker_artifacts(self._repo_root, worker)
-
-    def _cleanup_worktree(self, worktree_path: Path) -> None:
-        cleanup_worktree(self._repo_root, worktree_path)
-
-    def _cleanup_orphaned_worktrees(self) -> None:
-        from app.core.watcher_types import _WORKTREE_BASE
-
-        base = self._repo_root.parent / _WORKTREE_BASE
-        if not base.exists():
-            return
-        for worktree_dir in base.iterdir():
-            if not worktree_dir.is_dir():
-                continue
-            logger.warning("Orphaned worktree detected: %s — removing", worktree_dir)
-            self._cleanup_worktree(worktree_dir)
-
-    # ------------------------------------------------------------------
-    # Worker subprocess — shims delegating to watcher_subprocess
-    # ------------------------------------------------------------------
-
-    def _expand_skill(self, ticket_id: str) -> str | None:
-        return expand_skill(self._repo_root, ticket_id)
-
-    @staticmethod
-    def _build_snippet_tool_restrictions(snippets: list[str]) -> list[str]:
-        return build_snippet_tool_restrictions(snippets)
-
-    def _launch_worker(
-        self,
-        manifest: ExecutionManifest,
-        worktree_path: Path,
-        effective_mode: str,
-    ) -> subprocess.Popen[bytes]:
-        return launch_worker(
-            self._repo_root, manifest, worktree_path, effective_mode, self._verbose
-        )
-
-    def _run_checks(self, manifest: ExecutionManifest, worktree_path: Path) -> bool:
-        return run_checks(manifest, worktree_path)
-
-    def _fetch_sonar_findings(self, branch: str) -> list[str] | None:
-        return fetch_sonar_findings(branch)
-
-    # ------------------------------------------------------------------
-    # PR creation
-    # ------------------------------------------------------------------
-
-    def _create_pr(self, manifest: ExecutionManifest, worktree_path: Path) -> str:
-        subprocess.run(  # nosec B603 B607
-            ["git", "push", "-u", "origin", manifest.worker_branch],
-            cwd=str(worktree_path),
-            check=True,
-            capture_output=True,
-            text=True,
-        )
-        ahead = subprocess.run(  # nosec B603 B607
-            [
-                "git",
-                "log",
-                f"origin/{manifest.base_branch}..{manifest.worker_branch}",
-                "--oneline",
-            ],
-            cwd=str(worktree_path),
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-        if not ahead.stdout.strip():
-            raise subprocess.CalledProcessError(
-                1,
-                "git log",
-                stderr=(
-                    f"No commits on {manifest.worker_branch} ahead of "
-                    f"{manifest.base_branch} — worker did not commit any changes"
-                ),
-            )
-        result = subprocess.run(  # nosec B603 B607
-            [
-                "gh",
-                "pr",
-                "create",
-                "--base",
-                manifest.base_branch,
-                "--head",
-                manifest.worker_branch,
-                "--title",
-                f"{manifest.ticket_id} {manifest.title}",
-                "--body",
-                f"Closes {manifest.ticket_id}\n\n{manifest.done_definition}",
-            ],
-            cwd=str(worktree_path),
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-        pr_url = result.stdout.strip()
-        merge_result = subprocess.run(  # nosec B603 B607
-            ["gh", "pr", "merge", "--auto", "--squash", pr_url],
-            cwd=str(worktree_path),
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-        if merge_result.returncode != 0:
-            output = (merge_result.stderr or merge_result.stdout).strip()
-            # "clean status" means no required checks on the target branch (e.g. epic
-            # branches) — PR is already mergeable, so fall back to immediate merge.
-            if "enablePullRequestAutoMerge" in output or "clean status" in output:
-                logger.info(
-                    "No required checks on target branch — merging %s immediately",
-                    pr_url,
-                )
-                immediate = subprocess.run(  # nosec B603 B607
-                    ["gh", "pr", "merge", "--squash", pr_url],
-                    cwd=str(worktree_path),
-                    capture_output=True,
-                    text=True,
-                    check=False,
-                )
-                if immediate.returncode != 0:
-                    imm_output = (immediate.stderr or immediate.stdout).strip()
-                    logger.warning(
-                        "gh pr merge --squash also failed for %s (rc=%d): %s",
-                        pr_url,
-                        immediate.returncode,
-                        imm_output,
-                    )
-            else:
-                logger.warning(
-                    "gh pr merge --auto failed for %s (rc=%d): %s",
-                    pr_url,
-                    merge_result.returncode,
-                    output,
-                )
-        return pr_url
-
-    # ------------------------------------------------------------------
-    # Service shims — delegate to self._services; removed in test-split step
-    # ------------------------------------------------------------------
-
-    def _ensure_ollama_running(self) -> None:
-        self._services.ensure_ollama_running()
-
-    def _ensure_litellm_running(self) -> None:
-        self._services.ensure_litellm_running()
-
-    def _stop_litellm_proxy(self) -> None:
-        self._services.stop()
-
-    @property
-    def _litellm_proc(self) -> subprocess.Popen[bytes] | None:
-        return self._services._litellm_proc
-
-    @_litellm_proc.setter
-    def _litellm_proc(self, value: subprocess.Popen[bytes] | None) -> None:
-        self._services._litellm_proc = value
 
     # ------------------------------------------------------------------
     # Graceful shutdown

--- a/app/core/watcher_subprocess.py
+++ b/app/core/watcher_subprocess.py
@@ -148,6 +148,97 @@ def run_checks(manifest: ExecutionManifest, worktree_path: Path) -> bool:
     return all_passed
 
 
+def create_pr(manifest: ExecutionManifest, worktree_path: Path) -> str:
+    """Push the worker branch and open a GitHub PR, enabling auto-merge."""
+    subprocess.run(  # nosec B603 B607
+        ["git", "push", "-u", "origin", manifest.worker_branch],
+        cwd=str(worktree_path),
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    ahead = subprocess.run(  # nosec B603 B607
+        [
+            "git",
+            "log",
+            f"origin/{manifest.base_branch}..{manifest.worker_branch}",
+            "--oneline",
+        ],
+        cwd=str(worktree_path),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if not ahead.stdout.strip():
+        raise subprocess.CalledProcessError(
+            1,
+            "git log",
+            stderr=(
+                f"No commits on {manifest.worker_branch} ahead of "
+                f"{manifest.base_branch} — worker did not commit any changes"
+            ),
+        )
+    result = subprocess.run(  # nosec B603 B607
+        [
+            "gh",
+            "pr",
+            "create",
+            "--base",
+            manifest.base_branch,
+            "--head",
+            manifest.worker_branch,
+            "--title",
+            f"{manifest.ticket_id} {manifest.title}",
+            "--body",
+            f"Closes {manifest.ticket_id}\n\n{manifest.done_definition}",
+        ],
+        cwd=str(worktree_path),
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    pr_url = result.stdout.strip()
+    merge_result = subprocess.run(  # nosec B603 B607
+        ["gh", "pr", "merge", "--auto", "--squash", pr_url],
+        cwd=str(worktree_path),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if merge_result.returncode != 0:
+        output = (merge_result.stderr or merge_result.stdout).strip()
+        # "clean status" means no required checks on the target branch (e.g. epic
+        # branches) — PR is already mergeable, so fall back to immediate merge.
+        if "enablePullRequestAutoMerge" in output or "clean status" in output:
+            logger.info(
+                "No required checks on target branch — merging %s immediately",
+                pr_url,
+            )
+            immediate = subprocess.run(  # nosec B603 B607
+                ["gh", "pr", "merge", "--squash", pr_url],
+                cwd=str(worktree_path),
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            if immediate.returncode != 0:
+                imm_output = (immediate.stderr or immediate.stdout).strip()
+                logger.warning(
+                    "gh pr merge --squash also failed for %s (rc=%d): %s",
+                    pr_url,
+                    immediate.returncode,
+                    imm_output,
+                )
+        else:
+            logger.warning(
+                "gh pr merge --auto failed for %s (rc=%d): %s",
+                pr_url,
+                merge_result.returncode,
+                output,
+            )
+    return pr_url
+
+
 def fetch_sonar_findings(branch: str) -> list[str] | None:
     """Return per-severity finding list from SonarCloud for *branch*, or None.
 

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -85,82 +85,6 @@ def test_watcher_stores_verbose_true() -> None:
 
 
 # ---------------------------------------------------------------------------
-# _create_pr — push before gh pr create
-# ---------------------------------------------------------------------------
-
-
-def test_create_pr_pushes_branch_before_gh_pr(tmp_path: Path) -> None:
-    manifest = _make_manifest(
-        ticket_id="WOR-10",
-        worker_branch="wor-10-test-ticket",
-        base_branch="main",
-        title="Test ticket",
-        done_definition="It works.",
-    )
-    call_order: list[str] = []
-
-    def fake_run(cmd: list[str], **_kwargs: object) -> MagicMock:
-        if cmd[:2] == ["git", "push"]:
-            call_order.append("push")
-        elif cmd[:3] == ["gh", "pr", "create"]:
-            call_order.append("gh_pr")
-        result = MagicMock()
-        result.stdout = "https://github.com/example/pr/1"
-        return result
-
-    w = Watcher(linear_client=MagicMock())
-    with patch("app.core.watcher.subprocess.run", side_effect=fake_run):
-        w._create_pr(manifest, tmp_path)
-
-    assert call_order == ["push", "gh_pr"]
-
-
-def test_create_pr_logs_warning_on_auto_merge_failure(
-    tmp_path: Path, caplog: pytest.LogCaptureFixture
-) -> None:
-    manifest = _make_manifest(
-        ticket_id="WOR-10",
-        worker_branch="wor-10-test-ticket",
-        base_branch="main",
-        title="Test ticket",
-        done_definition="It works.",
-    )
-    pr_url = "https://github.com/example/pr/1"
-
-    def fake_run(cmd: list[str], **_kwargs: object) -> MagicMock:
-        result = MagicMock()
-        result.returncode = 0
-        result.stderr = ""
-        if cmd[:3] == ["gh", "pr", "merge"]:
-            result.returncode = 1
-            result.stderr = "auto-merge is not enabled for this repository"
-            result.stdout = ""
-        elif cmd[:3] == ["gh", "pr", "create"]:
-            result.stdout = pr_url
-        elif cmd[:2] == ["git", "log"]:
-            result.stdout = "abc1234 some commit"
-        else:
-            result.stdout = pr_url
-        return result
-
-    w = Watcher(linear_client=MagicMock())
-    with (
-        patch("app.core.watcher.subprocess.run", side_effect=fake_run),
-        caplog.at_level(logging.WARNING, logger="app.core.watcher"),
-    ):
-        returned_url = w._create_pr(manifest, tmp_path)
-
-    assert returned_url == pr_url
-    assert any(
-        "gh pr merge --auto failed" in msg
-        and pr_url in msg
-        and "rc=1" in msg
-        and "auto-merge is not enabled" in msg
-        for msg in caplog.messages
-    )
-
-
-# ---------------------------------------------------------------------------
 # _safe_set_state — daemon survives LinearError at _start_ticket
 # ---------------------------------------------------------------------------
 
@@ -177,11 +101,11 @@ def test_start_ticket_set_state_failure_worker_still_starts(tmp_path: Path) -> N
 
     with (
         patch.object(w, "_load_manifest", return_value=manifest),
-        patch.object(w, "_create_worktree", return_value=tmp_path),
-        patch.object(w, "_copy_manifest_to_worktree"),
-        patch.object(w, "_launch_worker", return_value=fake_process),
-        patch.object(w, "_ensure_ollama_running"),
-        patch.object(w, "_ensure_litellm_running"),
+        patch("app.core.watcher.create_worktree", return_value=tmp_path),
+        patch("app.core.watcher.copy_manifest_to_worktree"),
+        patch("app.core.watcher.launch_worker", return_value=fake_process),
+        patch.object(w._services, "ensure_ollama_running"),
+        patch.object(w._services, "ensure_litellm_running"),
     ):
         w._start_ticket("WOR-10", "fake-linear-id")
 
@@ -311,12 +235,12 @@ def test_cloud_pool_full_does_not_block_local_dispatch(tmp_path: Path) -> None:
 
     with (
         patch.object(watcher, "_load_manifest", return_value=local_manifest),
-        patch.object(watcher, "_create_worktree", return_value=tmp_path),
-        patch.object(watcher, "_copy_manifest_to_worktree"),
-        patch.object(watcher, "_write_worker_pytest_config"),
-        patch.object(watcher, "_ensure_ollama_running"),
-        patch.object(watcher, "_ensure_litellm_running"),
-        patch.object(watcher, "_launch_worker", return_value=fake_local_process),
+        patch("app.core.watcher.create_worktree", return_value=tmp_path),
+        patch("app.core.watcher.copy_manifest_to_worktree"),
+        patch("app.core.watcher.write_worker_pytest_config"),
+        patch.object(watcher._services, "ensure_ollama_running"),
+        patch.object(watcher._services, "ensure_litellm_running"),
+        patch("app.core.watcher.launch_worker", return_value=fake_local_process),
     ):
         watcher._start_ticket("WOR-10", "fake-local-id")
 
@@ -350,14 +274,14 @@ def test_dispatch_calls_ensure_ollama_and_litellm_for_local_effective_mode(
 
     with (
         patch.object(w, "_load_manifest", return_value=manifest),
-        patch.object(w, "_create_worktree", return_value=tmp_path),
-        patch.object(w, "_copy_manifest_to_worktree"),
-        patch.object(w, "_write_worker_pytest_config"),
+        patch("app.core.watcher.create_worktree", return_value=tmp_path),
+        patch("app.core.watcher.copy_manifest_to_worktree"),
+        patch("app.core.watcher.write_worker_pytest_config"),
         patch.object(w, "_safe_set_state"),
-        patch.object(w, "_backup_plan_files", return_value=[]),
-        patch.object(w, "_launch_worker", return_value=fake_process),
-        patch.object(w, "_ensure_ollama_running") as mock_ollama,
-        patch.object(w, "_ensure_litellm_running") as mock_litellm,
+        patch("app.core.watcher.backup_plan_files", return_value=[]),
+        patch("app.core.watcher.launch_worker", return_value=fake_process),
+        patch.object(w._services, "ensure_ollama_running") as mock_ollama,
+        patch.object(w._services, "ensure_litellm_running") as mock_litellm,
     ):
         w._dispatch_next_ticket()
 
@@ -382,14 +306,14 @@ def test_dispatch_skips_ensure_for_cloud_effective_mode(tmp_path: Path) -> None:
 
     with (
         patch.object(w, "_load_manifest", return_value=manifest),
-        patch.object(w, "_create_worktree", return_value=tmp_path),
-        patch.object(w, "_copy_manifest_to_worktree"),
-        patch.object(w, "_write_worker_pytest_config"),
+        patch("app.core.watcher.create_worktree", return_value=tmp_path),
+        patch("app.core.watcher.copy_manifest_to_worktree"),
+        patch("app.core.watcher.write_worker_pytest_config"),
         patch.object(w, "_safe_set_state"),
-        patch.object(w, "_backup_plan_files", return_value=[]),
-        patch.object(w, "_launch_worker", return_value=fake_process),
-        patch.object(w, "_ensure_ollama_running") as mock_ollama,
-        patch.object(w, "_ensure_litellm_running") as mock_litellm,
+        patch("app.core.watcher.backup_plan_files", return_value=[]),
+        patch("app.core.watcher.launch_worker", return_value=fake_process),
+        patch.object(w._services, "ensure_ollama_running") as mock_ollama,
+        patch.object(w._services, "ensure_litellm_running") as mock_litellm,
     ):
         w._dispatch_next_ticket()
 

--- a/tests/test_watcher_finalize.py
+++ b/tests/test_watcher_finalize.py
@@ -40,9 +40,9 @@ def test_finalize_worker_pr_failure_marks_blocked(tmp_path: Path) -> None:
     exc = subprocess.CalledProcessError(1, "gh", stderr="Head sha can't be blank")
 
     with (
-        patch.object(w, "_run_checks", return_value=True),
-        patch.object(w, "_create_pr", side_effect=exc),
-        patch.object(w, "_cleanup_worktree"),
+        patch("app.core.watcher.run_checks", return_value=True),
+        patch("app.core.watcher.create_pr", side_effect=exc),
+        patch("app.core.watcher.cleanup_worktree"),
         patch.object(w, "_metrics") as metrics_mock,
     ):
         w._finalize_worker(worker, returncode=0, wall_time=1.0)
@@ -71,9 +71,11 @@ def test_finalize_worker_retry_count_zero_on_success(tmp_path: Path) -> None:
         process=MagicMock(spec=subprocess.Popen),
     )
     with (
-        patch.object(w, "_run_checks", return_value=True),
-        patch.object(w, "_create_pr", return_value="https://github.com/example/pr/1"),
-        patch.object(w, "_cleanup_worktree"),
+        patch("app.core.watcher.run_checks", return_value=True),
+        patch(
+            "app.core.watcher.create_pr", return_value="https://github.com/example/pr/1"
+        ),
+        patch("app.core.watcher.cleanup_worktree"),
         patch.object(w, "_metrics") as metrics_mock,
     ):
         w._finalize_worker(worker, returncode=0, wall_time=1.0)
@@ -96,8 +98,8 @@ def test_finalize_worker_retry_count_increments_on_check_failure(
         process=MagicMock(spec=subprocess.Popen),
     )
     with (
-        patch.object(w, "_run_checks", return_value=False),
-        patch.object(w, "_cleanup_worktree"),
+        patch("app.core.watcher.run_checks", return_value=False),
+        patch("app.core.watcher.cleanup_worktree"),
         patch.object(w, "_metrics"),
     ):
         w._finalize_worker(worker, returncode=0, wall_time=1.0)
@@ -120,9 +122,11 @@ def test_finalize_worker_retry_count_two_failures_then_success(
     )
     check_results = [False, False, True]
     with (
-        patch.object(w, "_run_checks", side_effect=check_results),
-        patch.object(w, "_create_pr", return_value="https://github.com/example/pr/1"),
-        patch.object(w, "_cleanup_worktree"),
+        patch("app.core.watcher.run_checks", side_effect=check_results),
+        patch(
+            "app.core.watcher.create_pr", return_value="https://github.com/example/pr/1"
+        ),
+        patch("app.core.watcher.cleanup_worktree"),
         patch.object(w, "_metrics") as metrics_mock,
     ):
         w._finalize_worker(worker, returncode=0, wall_time=1.0)
@@ -153,7 +157,7 @@ def test_finalize_worker_set_state_failure_nonzero_no_crash(tmp_path: Path) -> N
     )
 
     with (
-        patch.object(w, "_cleanup_worktree"),
+        patch("app.core.watcher.cleanup_worktree"),
         patch.object(w, "_metrics"),
     ):
         w._finalize_worker(worker, returncode=1, wall_time=1.0)
@@ -176,9 +180,11 @@ def test_finalize_worker_set_state_failure_success_path_no_crash(
     )
 
     with (
-        patch.object(w, "_run_checks", return_value=True),
-        patch.object(w, "_create_pr", return_value="https://github.com/example/pr/1"),
-        patch.object(w, "_cleanup_worktree"),
+        patch("app.core.watcher.run_checks", return_value=True),
+        patch(
+            "app.core.watcher.create_pr", return_value="https://github.com/example/pr/1"
+        ),
+        patch("app.core.watcher.cleanup_worktree"),
         patch.object(w, "_metrics"),
     ):
         w._finalize_worker(worker, returncode=0, wall_time=1.0)
@@ -217,9 +223,11 @@ def test_finalize_worker_passes_usage_to_metrics(tmp_path: Path) -> None:
     )
 
     with (
-        patch.object(w, "_run_checks", return_value=True),
-        patch.object(w, "_create_pr", return_value="https://github.com/example/pr/1"),
-        patch.object(w, "_cleanup_worktree"),
+        patch("app.core.watcher.run_checks", return_value=True),
+        patch(
+            "app.core.watcher.create_pr", return_value="https://github.com/example/pr/1"
+        ),
+        patch("app.core.watcher.cleanup_worktree"),
         patch.object(w, "_metrics") as metrics_mock,
     ):
         w._finalize_worker(worker, returncode=0, wall_time=1.0)
@@ -242,9 +250,11 @@ def test_finalize_worker_usage_none_when_no_log(tmp_path: Path) -> None:
     )
 
     with (
-        patch.object(w, "_run_checks", return_value=True),
-        patch.object(w, "_create_pr", return_value="https://github.com/example/pr/1"),
-        patch.object(w, "_cleanup_worktree"),
+        patch("app.core.watcher.run_checks", return_value=True),
+        patch(
+            "app.core.watcher.create_pr", return_value="https://github.com/example/pr/1"
+        ),
+        patch("app.core.watcher.cleanup_worktree"),
         patch.object(w, "_metrics") as metrics_mock,
     ):
         w._finalize_worker(worker, returncode=0, wall_time=1.0)
@@ -270,11 +280,14 @@ def test_finalize_worker_sonar_count_wired_to_metrics(tmp_path: Path) -> None:
         process=MagicMock(spec=subprocess.Popen),
     )
     with (
-        patch.object(w, "_run_checks", return_value=True),
-        patch.object(w, "_create_pr", return_value="https://github.com/example/pr/1"),
-        patch.object(w, "_cleanup_worktree"),
-        patch.object(
-            w, "_fetch_sonar_findings", return_value=["MAJOR", "MINOR", "MINOR"]
+        patch("app.core.watcher.run_checks", return_value=True),
+        patch(
+            "app.core.watcher.create_pr", return_value="https://github.com/example/pr/1"
+        ),
+        patch("app.core.watcher.cleanup_worktree"),
+        patch(
+            "app.core.watcher.fetch_sonar_findings",
+            return_value=["MAJOR", "MINOR", "MINOR"],
         ),
         patch.object(w, "_metrics") as metrics_mock,
     ):
@@ -295,10 +308,12 @@ def test_finalize_worker_sonar_count_none_when_unavailable(tmp_path: Path) -> No
         process=MagicMock(spec=subprocess.Popen),
     )
     with (
-        patch.object(w, "_run_checks", return_value=True),
-        patch.object(w, "_create_pr", return_value="https://github.com/example/pr/1"),
-        patch.object(w, "_cleanup_worktree"),
-        patch.object(w, "_fetch_sonar_findings", return_value=None),
+        patch("app.core.watcher.run_checks", return_value=True),
+        patch(
+            "app.core.watcher.create_pr", return_value="https://github.com/example/pr/1"
+        ),
+        patch("app.core.watcher.cleanup_worktree"),
+        patch("app.core.watcher.fetch_sonar_findings", return_value=None),
         patch.object(w, "_metrics") as metrics_mock,
     ):
         w._finalize_worker(worker, returncode=0, wall_time=1.0)
@@ -336,11 +351,11 @@ def _make_finalize_worker_with_empty_result(
 def test_finalize_worker_sonar_blocker_escalates(tmp_path: Path) -> None:
     w, linear_mock, worker = _make_finalize_worker_with_empty_result(tmp_path)
     with (
-        patch.object(w, "_run_checks", return_value=True),
-        patch.object(w, "_preserve_worker_artifacts"),
-        patch.object(w, "_fetch_sonar_findings", return_value=["BLOCKER"]),
-        patch.object(w, "_create_pr") as mock_create_pr,
-        patch.object(w, "_cleanup_worktree"),
+        patch("app.core.watcher.run_checks", return_value=True),
+        patch("app.core.watcher.preserve_worker_artifacts"),
+        patch("app.core.watcher.fetch_sonar_findings", return_value=["BLOCKER"]),
+        patch("app.core.watcher.create_pr") as mock_create_pr,
+        patch("app.core.watcher.cleanup_worktree"),
         patch.object(w, "_metrics") as metrics_mock,
     ):
         w._finalize_worker(worker, returncode=0, wall_time=1.0)
@@ -358,11 +373,13 @@ def test_finalize_worker_sonar_major_advisory_warning(
 ) -> None:
     w, _linear_mock, worker = _make_finalize_worker_with_empty_result(tmp_path)
     with (
-        patch.object(w, "_run_checks", return_value=True),
-        patch.object(w, "_preserve_worker_artifacts"),
-        patch.object(w, "_fetch_sonar_findings", return_value=["MAJOR"]),
-        patch.object(w, "_create_pr", return_value="https://github.com/example/pr/1"),
-        patch.object(w, "_cleanup_worktree"),
+        patch("app.core.watcher.run_checks", return_value=True),
+        patch("app.core.watcher.preserve_worker_artifacts"),
+        patch("app.core.watcher.fetch_sonar_findings", return_value=["MAJOR"]),
+        patch(
+            "app.core.watcher.create_pr", return_value="https://github.com/example/pr/1"
+        ),
+        patch("app.core.watcher.cleanup_worktree"),
         patch.object(w, "_metrics") as metrics_mock,
         caplog.at_level(logging.WARNING, logger="app.core.watcher"),
     ):
@@ -378,11 +395,13 @@ def test_finalize_worker_sonar_major_advisory_warning(
 def test_finalize_worker_sonar_none_no_escalation(tmp_path: Path) -> None:
     w, _linear_mock, worker = _make_finalize_worker_with_empty_result(tmp_path)
     with (
-        patch.object(w, "_run_checks", return_value=True),
-        patch.object(w, "_preserve_worker_artifacts"),
-        patch.object(w, "_fetch_sonar_findings", return_value=None),
-        patch.object(w, "_create_pr", return_value="https://github.com/example/pr/1"),
-        patch.object(w, "_cleanup_worktree"),
+        patch("app.core.watcher.run_checks", return_value=True),
+        patch("app.core.watcher.preserve_worker_artifacts"),
+        patch("app.core.watcher.fetch_sonar_findings", return_value=None),
+        patch(
+            "app.core.watcher.create_pr", return_value="https://github.com/example/pr/1"
+        ),
+        patch("app.core.watcher.cleanup_worktree"),
         patch.object(w, "_metrics") as metrics_mock,
     ):
         w._finalize_worker(worker, returncode=0, wall_time=1.0)
@@ -425,10 +444,10 @@ def test_finalize_worker_scope_drift_escalates(tmp_path: Path) -> None:
         tmp_path, {"scope_drift": True}
     )
     with (
-        patch.object(w, "_run_checks", return_value=True),
-        patch.object(w, "_preserve_worker_artifacts"),
-        patch.object(w, "_create_pr") as mock_create_pr,
-        patch.object(w, "_cleanup_worktree"),
+        patch("app.core.watcher.run_checks", return_value=True),
+        patch("app.core.watcher.preserve_worker_artifacts"),
+        patch("app.core.watcher.create_pr") as mock_create_pr,
+        patch("app.core.watcher.cleanup_worktree"),
         patch.object(w, "_metrics") as metrics_mock,
     ):
         w._finalize_worker(worker, returncode=0, wall_time=1.0)
@@ -447,10 +466,10 @@ def test_finalize_worker_forbidden_path_touched_escalates(tmp_path: Path) -> Non
         tmp_path, {"forbidden_path_touched": True}
     )
     with (
-        patch.object(w, "_run_checks", return_value=True),
-        patch.object(w, "_preserve_worker_artifacts"),
-        patch.object(w, "_create_pr") as mock_create_pr,
-        patch.object(w, "_cleanup_worktree"),
+        patch("app.core.watcher.run_checks", return_value=True),
+        patch("app.core.watcher.preserve_worker_artifacts"),
+        patch("app.core.watcher.create_pr") as mock_create_pr,
+        patch("app.core.watcher.cleanup_worktree"),
         patch.object(w, "_metrics") as metrics_mock,
     ):
         w._finalize_worker(worker, returncode=0, wall_time=1.0)
@@ -467,10 +486,12 @@ def test_finalize_worker_forbidden_path_touched_escalates(tmp_path: Path) -> Non
 def test_finalize_worker_no_flags_proceeds_normally(tmp_path: Path) -> None:
     w, _linear_mock, worker = _make_finalize_worker_for_policy(tmp_path, {})
     with (
-        patch.object(w, "_run_checks", return_value=True),
-        patch.object(w, "_preserve_worker_artifacts"),
-        patch.object(w, "_create_pr", return_value="https://github.com/example/pr/1"),
-        patch.object(w, "_cleanup_worktree"),
+        patch("app.core.watcher.run_checks", return_value=True),
+        patch("app.core.watcher.preserve_worker_artifacts"),
+        patch(
+            "app.core.watcher.create_pr", return_value="https://github.com/example/pr/1"
+        ),
+        patch("app.core.watcher.cleanup_worktree"),
         patch.object(w, "_metrics") as metrics_mock,
     ):
         w._finalize_worker(worker, returncode=0, wall_time=1.0)
@@ -493,10 +514,12 @@ def test_finalize_worker_missing_result_json_proceeds_normally(tmp_path: Path) -
         process=MagicMock(spec=subprocess.Popen),
     )
     with (
-        patch.object(w, "_run_checks", return_value=True),
-        patch.object(w, "_preserve_worker_artifacts"),
-        patch.object(w, "_create_pr", return_value="https://github.com/example/pr/1"),
-        patch.object(w, "_cleanup_worktree"),
+        patch("app.core.watcher.run_checks", return_value=True),
+        patch("app.core.watcher.preserve_worker_artifacts"),
+        patch(
+            "app.core.watcher.create_pr", return_value="https://github.com/example/pr/1"
+        ),
+        patch("app.core.watcher.cleanup_worktree"),
         patch.object(w, "_metrics") as metrics_mock,
     ):
         w._finalize_worker(worker, returncode=0, wall_time=1.0)

--- a/tests/test_watcher_subprocess.py
+++ b/tests/test_watcher_subprocess.py
@@ -3,15 +3,110 @@
 from __future__ import annotations
 
 import io
-from unittest.mock import patch
+import logging
+from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
 
+from app.core.manifest import ArtifactPaths, ExecutionManifest
 from app.core.watcher_helpers import _tee_worker_output
 from app.core.watcher_subprocess import (
     build_snippet_tool_restrictions,
+    create_pr,
     fetch_sonar_findings,
 )
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_manifest(**overrides: object) -> ExecutionManifest:
+    from typing import Any
+
+    defaults: dict[str, Any] = {
+        "ticket_id": "WOR-10",
+        "epic_id": "WOR-96",
+        "title": "Test ticket",
+        "priority": 2,
+        "status": "ReadyForLocal",
+        "parallel_safe": True,
+        "risk_level": "low",
+        "implementation_mode": "local",
+        "review_mode": "auto",
+        "base_branch": "main",
+        "worker_branch": "wor-10-test-ticket",
+        "objective": "Do the thing.",
+        "artifact_paths": ArtifactPaths.from_ticket_id("WOR-10"),
+        "allowed_paths": ["app/core/foo.py"],
+        "done_definition": "It works.",
+    }
+    defaults.update(overrides)
+    return ExecutionManifest(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# create_pr
+# ---------------------------------------------------------------------------
+
+
+def test_create_pr_pushes_branch_before_gh_pr(tmp_path: Path) -> None:
+    manifest = _make_manifest()
+    call_order: list[str] = []
+
+    def fake_run(cmd: list[str], **_kwargs: object) -> MagicMock:
+        if cmd[:2] == ["git", "push"]:
+            call_order.append("push")
+        elif cmd[:3] == ["gh", "pr", "create"]:
+            call_order.append("gh_pr")
+        result = MagicMock()
+        result.stdout = "https://github.com/example/pr/1"
+        return result
+
+    with patch("app.core.watcher_subprocess.subprocess.run", side_effect=fake_run):
+        create_pr(manifest, tmp_path)
+
+    assert call_order == ["push", "gh_pr"]
+
+
+def test_create_pr_logs_warning_on_auto_merge_failure(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    manifest = _make_manifest()
+    pr_url = "https://github.com/example/pr/1"
+
+    def fake_run(cmd: list[str], **_kwargs: object) -> MagicMock:
+        result = MagicMock()
+        result.returncode = 0
+        result.stderr = ""
+        if cmd[:3] == ["gh", "pr", "merge"]:
+            result.returncode = 1
+            result.stderr = "auto-merge is not enabled for this repository"
+            result.stdout = ""
+        elif cmd[:3] == ["gh", "pr", "create"]:
+            result.stdout = pr_url
+        elif cmd[:2] == ["git", "log"]:
+            result.stdout = "abc1234 some commit"
+        else:
+            result.stdout = pr_url
+        return result
+
+    with (
+        patch("app.core.watcher_subprocess.subprocess.run", side_effect=fake_run),
+        caplog.at_level(logging.WARNING, logger="app.core.watcher_subprocess"),
+    ):
+        returned_url = create_pr(manifest, tmp_path)
+
+    assert returned_url == pr_url
+    assert any(
+        "gh pr merge --auto failed" in msg
+        and pr_url in msg
+        and "rc=1" in msg
+        and "auto-merge is not enabled" in msg
+        for msg in caplog.messages
+    )
+
 
 # ---------------------------------------------------------------------------
 # _tee_worker_output (lives in watcher_helpers; tested here as subprocess I/O)

--- a/tests/test_watcher_worktrees.py
+++ b/tests/test_watcher_worktrees.py
@@ -107,9 +107,9 @@ def test_cleanup_orphaned_worktrees_removes_dirs(tmp_path: Path) -> None:
         repo_root=tmp_path,
     )
 
-    with patch.object(watcher, "_cleanup_worktree") as mock_cleanup:
+    with patch("app.core.watcher.cleanup_worktree") as mock_cleanup:
         watcher._cleanup_orphaned_worktrees()
-        mock_cleanup.assert_called_once_with(worktree_dir)
+        mock_cleanup.assert_called_once_with(watcher._repo_root, worktree_dir)
 
 
 def test_cleanup_orphaned_worktrees_skips_when_base_absent(tmp_path: Path) -> None:


### PR DESCRIPTION
- Remove 6 `# noqa: F401` backward-compat re-export lines and 17 delegation/service shim methods from `watcher.py`; all call-sites now invoke sub-module functions directly
- Move `_create_pr` (88 LOC) to `watcher_subprocess.create_pr()` free function alongside the other subprocess operations
- Update all test patches from `patch.object(w, "_shim")` to `patch("app.core.watcher.<function>")` across `test_watcher.py`, `test_watcher_finalize.py`, and `test_watcher_worktrees.py`; two `_create_pr` tests relocated to `test_watcher_subprocess.py`

**Result:** `watcher.py` 844 → 656 LOC (Advisory tier ✓)

**Milestone:** Post-MVP Explorations
**Epic:** WOR-160 code refactoring / auto split

## Test plan
- [x] `pytest` — 346 passed, 85% coverage
- [x] `ruff check` — clean
- [x] `mypy app/` — no issues
- [x] `lint-imports` — 4/4 contracts kept
- [x] All `patch.object(w, "_shim")` targets updated to module-level patches; verified no `AttributeError` on removed methods

Closes WOR-169