### PR TITLE
WOR-161 Fix _wait_for_ollama_ready(): add HTTP health check after TCP probe

### DIFF
--- a/app/core/watcher_services.py
+++ b/app/core/watcher_services.py
@@ -7,6 +7,7 @@ class boundary cleaner than threading a Popen handle through function signatures
 
 from __future__ import annotations
 
+import http.client
 import logging
 import os
 import socket
@@ -58,13 +59,21 @@ class ServiceManager:
         self._wait_for_ollama_ready()
 
     def _wait_for_ollama_ready(self, timeout: float = 120.0) -> None:
-        """Poll TCP until Ollama's port accepts connections."""
+        """Poll TCP then HTTP /api/tags until Ollama's API is ready."""
         deadline = time.monotonic() + timeout
         while time.monotonic() < deadline:
             with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
                 sock.settimeout(2)
-                if sock.connect_ex(("localhost", _OLLAMA_PORT)) == 0:
+                if sock.connect_ex(("localhost", _OLLAMA_PORT)) != 0:
+                    time.sleep(0.5)
+                    continue
+            try:
+                conn = http.client.HTTPConnection("localhost", _OLLAMA_PORT, timeout=2)
+                conn.request("GET", "/api/tags")
+                if conn.getresponse().status == 200:
                     return
+            except (OSError, http.client.HTTPException):
+                pass
             time.sleep(0.5)
         raise TimeoutError(f"Ollama not ready after {timeout}s.")
 

--- a/tests/test_watcher_services.py
+++ b/tests/test_watcher_services.py
@@ -91,15 +91,21 @@ def test_ensure_ollama_running_starts_process(tmp_path: Path) -> None:
         # First call (already-up check) -> not up; subsequent calls (wait loop) -> up
         return 1 if call_count == 1 else 0
 
+    mock_resp = MagicMock()
+    mock_resp.status = 200
+
     with (
         patch("socket.socket") as mock_sock_cls,
         patch("subprocess.Popen") as mock_popen,
+        patch("http.client.HTTPConnection") as mock_conn_cls,
     ):
         mock_sock = MagicMock()
         mock_sock.__enter__ = lambda s: s
         mock_sock.__exit__ = MagicMock(return_value=False)
         mock_sock.connect_ex.side_effect = _probe_side_effect
         mock_sock_cls.return_value = mock_sock
+
+        mock_conn_cls.return_value.getresponse.return_value = mock_resp
 
         mgr.ensure_ollama_running()
 
@@ -110,3 +116,34 @@ def test_ensure_ollama_running_starts_process(tmp_path: Path) -> None:
     assert cmd[2] == "qwen3-coder:30b"
     assert "--keepalive" in cmd
     assert "120m" in cmd
+
+
+def test_wait_for_ollama_ready_http_retries(tmp_path: Path) -> None:
+    """HTTP /api/tags is retried until it returns 200."""
+    mgr = ServiceManager(tmp_path)
+    http_call_count = 0
+
+    def _conn_side_effect(*args: Any, **kwargs: Any) -> Any:
+        nonlocal http_call_count
+        http_call_count += 1
+        mock_conn = MagicMock()
+        if http_call_count < 3:
+            mock_conn.getresponse.side_effect = OSError("service not ready yet")
+        else:
+            mock_conn.getresponse.return_value = MagicMock(status=200)
+        return mock_conn
+
+    with (
+        patch("socket.socket") as mock_sock_cls,
+        patch("http.client.HTTPConnection", side_effect=_conn_side_effect),
+        patch("time.sleep"),
+    ):
+        mock_sock = MagicMock()
+        mock_sock.__enter__ = lambda s: s
+        mock_sock.__exit__ = MagicMock(return_value=False)
+        mock_sock.connect_ex.return_value = 0  # TCP always accepts
+        mock_sock_cls.return_value = mock_sock
+
+        mgr._wait_for_ollama_ready()
+
+    assert http_call_count == 3


### PR DESCRIPTION
Closes WOR-161

_wait_for_ollama_ready() performs HTTP health check after TCP probe; mock test for N-retry HTTP success passes; ruff, mypy, pytest all pass.