### PR TITLE
WOR-158 Eliminate TOCTOU race in _promote_waiting_tickets() blocker state checks

### DIFF
--- a/app/core/watcher.py
+++ b/app/core/watcher.py
@@ -187,7 +187,9 @@ class Watcher:
                 self._notify_promotion(manifest)
                 continue
 
-            cancelled = self._find_cancelled_blocker(manifest)
+            states = self._fetch_all_blocker_states(manifest)
+
+            cancelled = self._find_cancelled_blocker(manifest, states)
             if cancelled is not None:
                 blocker_id, state_type = cancelled
                 self._handle_cancelled_predecessor(
@@ -195,7 +197,7 @@ class Watcher:
                 )
                 continue
 
-            if self._all_blockers_satisfied(manifest):
+            if self._all_blockers_satisfied(manifest, states):
                 logger.info(
                     "All blockers for %s satisfied — promoting to ReadyForLocal",
                     manifest.ticket_id,
@@ -205,22 +207,30 @@ class Watcher:
                 )
                 self._notify_promotion(manifest)
 
-    def _find_cancelled_blocker(
+    def _fetch_all_blocker_states(
         self, manifest: ExecutionManifest
-    ) -> tuple[str, str] | None:
-        """Return (blocker_id, state_type) for the first cancelled blocker, or None."""
+    ) -> dict[str, str | None]:
+        """Snapshot all blocker states in one pass; fetch errors stored as None."""
+        states: dict[str, str | None] = {}
         for blocker_id in manifest.blocked_by_tickets:
             try:
-                state_type = self._linear.get_issue_state_type(blocker_id)
+                states[blocker_id] = self._linear.get_issue_state_type(blocker_id)
             except Exception as exc:
-                logger.debug(
-                    "Could not fetch state for blocker %s while scanning for "
-                    "cancellations in %s: %s",
+                logger.warning(
+                    "Could not fetch state for blocker %s of %s: %s",
                     blocker_id,
                     manifest.ticket_id,
                     exc,
                 )
-                continue
+                states[blocker_id] = None
+        return states
+
+    def _find_cancelled_blocker(
+        self, manifest: ExecutionManifest, states: dict[str, str | None]
+    ) -> tuple[str, str] | None:
+        """Return (blocker_id, state_type) for the first cancelled blocker, or None."""
+        for blocker_id in manifest.blocked_by_tickets:
+            state_type = states.get(blocker_id)
             if state_type == "cancelled":
                 return blocker_id, state_type
         return None
@@ -255,18 +265,11 @@ class Watcher:
                 exc,
             )
 
-    def _all_blockers_satisfied(self, manifest: ExecutionManifest) -> bool:
+    def _all_blockers_satisfied(
+        self, manifest: ExecutionManifest, states: dict[str, str | None]
+    ) -> bool:
         for blocker_id in manifest.blocked_by_tickets:
-            try:
-                state_type = self._linear.get_issue_state_type(blocker_id)
-            except Exception as exc:
-                logger.warning(
-                    "Could not fetch state for blocker %s of %s: %s",
-                    blocker_id,
-                    manifest.ticket_id,
-                    exc,
-                )
-                return False
+            state_type = states.get(blocker_id)
             if state_type is None or state_type not in DONE_STATE_TYPES:
                 return False
             if state_type == "cancelled":

--- a/tests/test_watcher_promotion.py
+++ b/tests/test_watcher_promotion.py
@@ -231,6 +231,42 @@ def test_promote_no_linear_id_updates_disk_only(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
+def test_promote_toctou_state_change_between_checks(tmp_path: Path) -> None:
+    """Single snapshot prevents TOCTOU: both checks use state from the same fetch.
+
+    Without the snapshot fix the old code called get_issue_state_type twice for
+    the same blocker — once in _find_cancelled_blocker and once in
+    _all_blockers_satisfied.  If the blocker state changed between those two
+    calls the results were inconsistent.
+
+    With the snapshot, get_issue_state_type is called exactly once per blocker
+    per poll cycle; both classification helpers operate on that same dict.
+    """
+    artifacts = tmp_path / ".claude" / "artifacts"
+    manifest = _make_waiting_manifest()  # WOR-46, blocked by WOR-45
+    _write_manifest(manifest, artifacts)
+
+    call_count = 0
+
+    def state_side_effect(blocker_id: str) -> str:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return "completed"
+        return "cancelled"  # any second call would see a changed state
+
+    mock_linear = MagicMock()
+    mock_linear.get_issue_state_type.side_effect = state_side_effect
+    watcher = Watcher(linear_client=mock_linear, repo_root=tmp_path)
+    watcher._promote_waiting_tickets()
+
+    # Snapshot guarantees exactly one API call per blocker
+    assert mock_linear.get_issue_state_type.call_count == 1
+    # The single snapshot value ("completed") is used by both checks → promoted
+    on_disk = ExecutionManifest.from_json(artifacts / "wor_46" / "manifest.json")
+    assert on_disk.status == "ReadyForLocal"
+
+
 def test_promote_clears_context_snippets(tmp_path: Path) -> None:
     artifacts = tmp_path / ".claude" / "artifacts"
     manifest = _make_waiting_manifest(


### PR DESCRIPTION
Closes WOR-158

_promote_waiting_tickets() issues one Linear API call per blocker per poll cycle; TOCTOU test passes; all existing promotion tests pass; ruff, mypy, pytest all pass.