### PR TITLE
WOR-145 Replace assertion with guard clause in watcher.py process stdout check

### DIFF
--- a/app/core/watcher_subprocess.py
+++ b/app/core/watcher_subprocess.py
@@ -112,7 +112,8 @@ def launch_worker(
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
         )
-        assert process.stdout is not None  # guaranteed by stdout=PIPE  # nosec B101
+        if process.stdout is None:
+            raise RuntimeError("process.stdout is None despite stdout=PIPE")
         stderr_buf: IO[bytes] = getattr(sys.stderr, "buffer", None) or sys.stderr.buffer
         threading.Thread(
             target=_tee_worker_output,


### PR DESCRIPTION
Closes WOR-145

assert replaced with RuntimeError guard; # nosec removed; bandit passes; mypy infers non-None correctly; ruff, mypy, pytest all pass.