### PR TITLE
WOR-144 Remove unused pyyaml dependency from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 pydantic>=2.0
 jinja2>=3.0
-pyyaml>=6.0
 pyside6>=6.0
 python-dotenv>=1.0


### PR DESCRIPTION
Closes WOR-144

pyyaml line removed from requirements.txt; pytest passes with no import errors; ruff and mypy pass.