### PR TITLE
WOR-171 Tests: add unit tests for watcher_subprocess.py failure paths

### DIFF
--- a/tests/test_watcher_subprocess.py
+++ b/tests/test_watcher_subprocess.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import io
 import logging
+import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -14,7 +15,10 @@ from app.core.watcher_helpers import _tee_worker_output
 from app.core.watcher_subprocess import (
     build_snippet_tool_restrictions,
     create_pr,
+    expand_skill,
     fetch_sonar_findings,
+    launch_worker,
+    run_checks,
 )
 
 # ---------------------------------------------------------------------------
@@ -307,3 +311,272 @@ def test_fetch_sonar_findings_paginates_multiple_pages(
     assert findings.count("MAJOR") == 500
     assert findings.count("CRITICAL") == 100
     assert mock_urlopen.call_count == 2
+
+
+def test_fetch_sonar_findings_breaks_and_returns_partial_on_mid_pagination_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import json
+
+    monkeypatch.setenv("SONAR_TOKEN", "fake-token")
+    monkeypatch.setenv("SONAR_PROJECT_KEY", "my-project")
+
+    page1_payload = json.dumps(
+        {
+            "issues": [{"key": f"I{i}", "severity": "MAJOR"} for i in range(500)],
+            "total": 1000,
+        }
+    ).encode()
+
+    mock_resp1 = _make_sonar_resp_mock(page1_payload)
+
+    with patch(
+        "urllib.request.urlopen",
+        side_effect=[mock_resp1, Exception("network error on page 2")],
+    ):
+        findings = fetch_sonar_findings("wor-171-branch")
+
+    assert findings is not None
+    assert len(findings) == 500
+    assert all(s == "MAJOR" for s in findings)
+
+
+# ---------------------------------------------------------------------------
+# expand_skill
+# ---------------------------------------------------------------------------
+
+
+def test_expand_skill_returns_substituted_content(tmp_path: Path) -> None:
+    skill_dir = tmp_path / ".claude" / "commands"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "implement-ticket.md").write_text(
+        "Implement $ARGUMENTS and report.", encoding="utf-8"
+    )
+    result = expand_skill(tmp_path, "WOR-171")
+    assert result == "Implement WOR-171 and report."
+
+
+def test_expand_skill_returns_none_on_missing_skill_file(tmp_path: Path) -> None:
+    result = expand_skill(tmp_path, "WOR-171")
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# launch_worker
+# ---------------------------------------------------------------------------
+
+
+def test_launch_worker_quiet_mode_returns_popen(tmp_path: Path) -> None:
+    manifest = _make_manifest()
+    mock_process = MagicMock()
+
+    with (
+        patch("app.core.watcher_subprocess.expand_skill", return_value=None),
+        patch(
+            "app.core.watcher_subprocess.build_worker_cmd",
+            return_value=["claude", "--dangerously-skip-permissions"],
+        ),
+        patch("app.core.watcher_subprocess.build_worker_env", return_value={}),
+        patch(
+            "app.core.watcher_subprocess.subprocess.Popen", return_value=mock_process
+        ) as mock_popen,
+    ):
+        result = launch_worker(tmp_path, manifest, tmp_path, "local", verbose=False)
+
+    assert result is mock_process
+    mock_popen.assert_called_once()
+    assert mock_popen.call_args.kwargs.get("stdout") != subprocess.PIPE
+
+
+def test_launch_worker_verbose_mode_starts_tee_thread(tmp_path: Path) -> None:
+    manifest = _make_manifest()
+    mock_process = MagicMock()
+    mock_process.stdout = io.BytesIO(b"worker output\n")
+
+    with (
+        patch("app.core.watcher_subprocess.expand_skill", return_value=None),
+        patch(
+            "app.core.watcher_subprocess.build_worker_cmd",
+            return_value=["claude"],
+        ),
+        patch("app.core.watcher_subprocess.build_worker_env", return_value={}),
+        patch(
+            "app.core.watcher_subprocess.subprocess.Popen", return_value=mock_process
+        ) as mock_popen,
+        patch("app.core.watcher_subprocess.threading.Thread") as mock_thread,
+    ):
+        result = launch_worker(tmp_path, manifest, tmp_path, "local", verbose=True)
+
+    assert result is mock_process
+    assert mock_popen.call_args.kwargs.get("stdout") == subprocess.PIPE
+    mock_thread.assert_called_once()
+    mock_thread.return_value.start.assert_called_once()
+
+
+def test_launch_worker_cloud_mode_with_snippets_prepends_critical_warning(
+    tmp_path: Path,
+) -> None:
+    snippets = ["# app/core/watcher.py lines 1-10\nsome code here"]
+    manifest = _make_manifest(context_snippets=snippets)
+    mock_process = MagicMock()
+    captured_prompts: list[object] = []
+
+    def capture_cmd(
+        ticket_id: str,
+        mode: str,
+        wt: Path,
+        prompt: object,
+        disallowed: object,
+    ) -> list[str]:
+        captured_prompts.append(prompt)
+        return ["claude"]
+
+    with (
+        patch(
+            "app.core.watcher_subprocess.expand_skill",
+            return_value="Run /implement-ticket WOR-10",
+        ),
+        patch(
+            "app.core.watcher_subprocess.build_worker_cmd",
+            side_effect=capture_cmd,
+        ),
+        patch("app.core.watcher_subprocess.build_worker_env", return_value={}),
+        patch(
+            "app.core.watcher_subprocess.subprocess.Popen", return_value=mock_process
+        ),
+    ):
+        launch_worker(tmp_path, manifest, tmp_path, "cloud", verbose=False)
+
+    assert len(captured_prompts) == 1
+    assert isinstance(captured_prompts[0], str)
+    assert "CRITICAL" in captured_prompts[0]
+    assert "watcher.py" in captured_prompts[0]
+
+
+# ---------------------------------------------------------------------------
+# run_checks
+# ---------------------------------------------------------------------------
+
+
+def test_run_checks_returns_true_when_all_pass(tmp_path: Path) -> None:
+    manifest = _make_manifest(required_checks=["ruff check .", "mypy app/"])
+
+    def fake_run(cmd: list[str], **kwargs: object) -> MagicMock:
+        result = MagicMock()
+        result.returncode = 0
+        result.stdout = ""
+        result.stderr = ""
+        return result
+
+    with patch("app.core.watcher_subprocess.subprocess.run", side_effect=fake_run):
+        assert run_checks(manifest, tmp_path) is True
+
+
+def test_run_checks_returns_false_on_check_failure(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    manifest = _make_manifest(required_checks=["ruff check .", "mypy app/"])
+    call_count = 0
+
+    def fake_run(cmd: list[str], **kwargs: object) -> MagicMock:
+        nonlocal call_count
+        call_count += 1
+        result = MagicMock()
+        result.stdout = "error on line 1" if call_count == 1 else ""
+        result.stderr = ""
+        result.returncode = 1 if call_count == 1 else 0
+        return result
+
+    with (
+        patch("app.core.watcher_subprocess.subprocess.run", side_effect=fake_run),
+        caplog.at_level(logging.ERROR, logger="app.core.watcher_subprocess"),
+    ):
+        passed = run_checks(manifest, tmp_path)
+
+    assert passed is False
+    assert any("Check failed" in msg for msg in caplog.messages)
+    assert call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# create_pr — additional failure paths
+# ---------------------------------------------------------------------------
+
+
+def test_create_pr_raises_when_no_commits_ahead(tmp_path: Path) -> None:
+    manifest = _make_manifest()
+
+    def fake_run(cmd: list[str], **kwargs: object) -> MagicMock:
+        result = MagicMock()
+        result.returncode = 0
+        result.stdout = ""
+        result.stderr = ""
+        return result
+
+    with (
+        patch("app.core.watcher_subprocess.subprocess.run", side_effect=fake_run),
+        pytest.raises(subprocess.CalledProcessError, match="git log"),
+    ):
+        create_pr(manifest, tmp_path)
+
+
+def test_create_pr_falls_back_to_immediate_merge_on_auto_merge_api_error(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    manifest = _make_manifest()
+    pr_url = "https://github.com/example/pr/42"
+
+    def fake_run(cmd: list[str], **kwargs: object) -> MagicMock:
+        result = MagicMock()
+        result.returncode = 0
+        result.stdout = ""
+        result.stderr = ""
+        if cmd[:2] == ["git", "log"]:
+            result.stdout = "abc1234 some commit"
+        elif cmd[:3] == ["gh", "pr", "create"]:
+            result.stdout = pr_url
+        elif cmd[:3] == ["gh", "pr", "merge"] and "--auto" in cmd:
+            result.returncode = 1
+            result.stderr = "GraphQL: Field 'enablePullRequestAutoMerge' doesn't exist"
+        return result
+
+    with (
+        patch("app.core.watcher_subprocess.subprocess.run", side_effect=fake_run),
+        caplog.at_level(logging.INFO, logger="app.core.watcher_subprocess"),
+    ):
+        returned_url = create_pr(manifest, tmp_path)
+
+    assert returned_url == pr_url
+    assert any("No required checks on target branch" in msg for msg in caplog.messages)
+
+
+def test_create_pr_warns_when_immediate_merge_also_fails(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    manifest = _make_manifest()
+    pr_url = "https://github.com/example/pr/42"
+
+    def fake_run(cmd: list[str], **kwargs: object) -> MagicMock:
+        result = MagicMock()
+        result.returncode = 0
+        result.stdout = ""
+        result.stderr = ""
+        if cmd[:2] == ["git", "log"]:
+            result.stdout = "abc1234 some commit"
+        elif cmd[:3] == ["gh", "pr", "create"]:
+            result.stdout = pr_url
+        elif cmd[:3] == ["gh", "pr", "merge"]:
+            result.returncode = 1
+            result.stderr = (
+                "clean status required" if "--auto" in cmd else "conflicts detected"
+            )
+        return result
+
+    with (
+        patch("app.core.watcher_subprocess.subprocess.run", side_effect=fake_run),
+        caplog.at_level(logging.WARNING, logger="app.core.watcher_subprocess"),
+    ):
+        returned_url = create_pr(manifest, tmp_path)
+
+    assert returned_url == pr_url
+    assert any("gh pr merge --squash also failed" in msg for msg in caplog.messages)


### PR DESCRIPTION
Closes WOR-171

watcher_subprocess.py coverage >=80%; failure-path unit tests for launch_worker, run_checks, create_pr pass; ruff, mypy, pytest all pass.