### PR TITLE
WOR-174 implement-ticket: add ruff/mypy auto-fix pass before result.json

### DIFF
--- a/.claude/commands/implement-ticket.md
+++ b/.claude/commands/implement-ticket.md
@@ -55,6 +55,31 @@ Implement the work described in `objective` and `acceptance_criteria`. Obey thes
 
 **No re-planning** — do not re-read Linear, re-query the project, or change scope. If something in the codebase is surprising, implement defensively within the manifest scope and note it in the result artifact summary.
 
+### 3.5. Auto-fix style violations
+
+Before running required checks, apply the auto-fixers:
+
+```bash
+ruff format .
+ruff check . --fix
+```
+
+These are safe to run on any Python codebase: `ruff format` reformats long lines and spacing; `ruff check --fix` removes unused imports and corrects other auto-fixable violations. Run them after all code changes are written.
+
+Then verify:
+
+```bash
+ruff check .
+mypy app/
+```
+
+If violations remain after `--fix`, fix them before continuing:
+- **E501** (line too long): break the line at a logical boundary — function parameter, string concatenation, or by extracting a variable
+- **F401** (unused import): delete the import line
+- **mypy errors**: fix the type mismatch in the code; do not add `# type: ignore`
+
+Do not proceed to step 4 until both `ruff check .` and `mypy app/` exit cleanly.
+
 ### 4. Run required checks
 
 After implementation, run each command in `required_checks` in order:


### PR DESCRIPTION
## Summary

- Adds **Step 3.5** to `/implement-ticket` between "Implement" and "Run required checks"
- Step runs `ruff format .` + `ruff check . --fix` to auto-correct E501/F401 and other fixable violations
- Then verifies with `ruff check .` and `mypy app/` before proceeding — worker must fix residual errors before writing `result.json`

## Motivation

In the first WOR-173 batch-1 run, all 4 completed tickets failed on `ruff check .` as the watcher's very first post-run check. The workers exited `rc=0` without running ruff. This single addition would have self-corrected 3 of those 4 failures automatically.

## Test plan

- [ ] Skill file only — no Python logic changed, no tests required
- [ ] Pre-commit hooks passed on commit

Closes WOR-174

🤖 Generated with [Claude Code](https://claude.com/claude-code)