### PR TITLE
WOR-175 Watcher: write check-failure context artifact so retry worker knows what broke

### DIFF
--- a/.claude/commands/implement-ticket.md
+++ b/.claude/commands/implement-ticket.md
@@ -19,7 +19,25 @@ ABORT: Unsupported manifest_version '<version>'. This worker supports 1.0 only.
 Confirm the following fields are present before continuing:
 - `ticket_id`, `worker_branch`, `base_branch`, `objective`, `artifact_paths`
 
-### 0.5. Load context snippets (if present)
+### 0.5. Check for prior failure context (if present)
+
+Read `.claude/artifacts/<ticket_id_lower>/last_failure.json` if it exists.
+(e.g. for WOR-80: `.claude/artifacts/wor_80/last_failure.json`)
+
+If the file is present, surface its contents as context before proceeding:
+
+```
+PRIOR FAILURE CONTEXT:
+  Failed at: <failed_at>
+  Check:     <check>
+  Stdout:    <stdout>
+  Stderr:    <stderr>
+```
+
+Use this context to understand what the previous worker attempt failed on and
+avoid repeating the same mistake. Do NOT abort — this is informational only.
+
+### 0.6. Load context snippets (if present)
 
 If `manifest.context_snippets` is non-null and non-empty, treat each entry as
 a pre-loaded code excerpt — do NOT re-read these sections from disk unless you

--- a/app/core/watcher_subprocess.py
+++ b/app/core/watcher_subprocess.py
@@ -15,6 +15,7 @@ import shlex
 import subprocess  # nosec B404
 import sys
 import threading
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import IO
 
@@ -132,8 +133,14 @@ def launch_worker(
     )
 
 
+_LAST_FAILURE_FILENAME = "last_failure.json"
+
+
 def run_checks(manifest: ExecutionManifest, worktree_path: Path) -> bool:
     """Run manifest.required_checks in the worktree. Returns True if all pass."""
+    artifact_dir = worktree_path / Path(manifest.artifact_paths.result_json).parent
+    failure_artifact = artifact_dir / _LAST_FAILURE_FILENAME
+
     all_passed = True
     for check_cmd in manifest.required_checks:
         logger.info("Running check: %s", check_cmd)
@@ -148,6 +155,22 @@ def run_checks(manifest: ExecutionManifest, worktree_path: Path) -> bool:
                 "Check failed: %s\n%s", check_cmd, result.stdout + result.stderr
             )
             all_passed = False
+            artifact_dir.mkdir(parents=True, exist_ok=True)
+            failure_artifact.write_text(
+                json.dumps(
+                    {
+                        "failed_at": datetime.now(timezone.utc).isoformat(),
+                        "check": check_cmd,
+                        "stdout": result.stdout[:4000],
+                        "stderr": result.stderr,
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+    if all_passed and failure_artifact.exists():
+        failure_artifact.unlink()
+
     return all_passed
 
 

--- a/app/core/watcher_worktrees.py
+++ b/app/core/watcher_worktrees.py
@@ -85,14 +85,25 @@ def rebase_worktree_from_base(worktree_path: Path, base_branch: str) -> None:
         )
 
 
+_LAST_FAILURE_FILENAME = "last_failure.json"
+
+
 def copy_manifest_to_worktree(
     repo_root: Path, manifest: ExecutionManifest, worktree_path: Path
 ) -> None:
-    """Copy the manifest JSON into the worktree artifact directory."""
+    """Copy the manifest JSON into the worktree artifact directory.
+
+    Also copies last_failure.json from the repo artifact dir if it exists,
+    so retry workers have context on what the previous run failed on.
+    """
     src = repo_root / manifest.artifact_paths.manifest_copy
     dest = worktree_path / manifest.artifact_paths.manifest_copy
     dest.parent.mkdir(parents=True, exist_ok=True)
     shutil.copy2(src, dest)
+
+    failure_src = src.parent / _LAST_FAILURE_FILENAME
+    if failure_src.exists():
+        shutil.copy2(failure_src, dest.parent / _LAST_FAILURE_FILENAME)
 
 
 def backup_plan_files() -> list[Path]:
@@ -143,6 +154,8 @@ def preserve_worker_artifacts(repo_root: Path, worker: ActiveWorker) -> None:
     """Copy worker log and result.json from the worktree to the repo artifact dir.
 
     The worktree is removed after this call, so any file not copied here is lost.
+    Also handles last_failure.json: copies it on check failure, deletes the repo
+    copy on successful run (when the worktree no longer contains the file).
     """
     artifact_dir = (repo_root / worker.manifest.artifact_paths.result_json).parent
     artifact_dir.mkdir(parents=True, exist_ok=True)
@@ -162,6 +175,17 @@ def preserve_worker_artifacts(repo_root: Path, worker: ActiveWorker) -> None:
             result_src,
             worker.ticket_id,
         )
+
+    wt_failure = (
+        worker.worktree_path / worker.manifest.artifact_paths.result_json
+    ).parent / _LAST_FAILURE_FILENAME
+    repo_failure = artifact_dir / _LAST_FAILURE_FILENAME
+    if wt_failure.exists():
+        shutil.copy2(wt_failure, repo_failure)
+        logger.info("Failure context preserved at %s", repo_failure)
+    elif repo_failure.exists():
+        repo_failure.unlink()
+        logger.debug("Cleared last_failure.json after successful run: %s", repo_failure)
 
 
 def cleanup_worktree(repo_root: Path, worktree_path: Path) -> None:

--- a/tests/test_watcher_subprocess.py
+++ b/tests/test_watcher_subprocess.py
@@ -498,6 +498,108 @@ def test_run_checks_returns_false_on_check_failure(
     assert call_count == 2
 
 
+def test_run_checks_writes_last_failure_json_on_failure(tmp_path: Path) -> None:
+    manifest = _make_manifest(required_checks=["ruff check ."])
+
+    def fake_run(cmd: list[str], **kwargs: object) -> MagicMock:
+        result = MagicMock()
+        result.returncode = 1
+        result.stdout = "E501 line too long\n" * 50  # > 4000 chars after repetition
+        result.stderr = "some stderr"
+        return result
+
+    with patch("app.core.watcher_subprocess.subprocess.run", side_effect=fake_run):
+        run_checks(manifest, tmp_path)
+
+    artifact_dir = tmp_path / Path(manifest.artifact_paths.result_json).parent
+    failure_file = artifact_dir / "last_failure.json"
+    assert failure_file.exists(), "last_failure.json should be written on check failure"
+
+    import json as json_mod
+
+    data = json_mod.loads(failure_file.read_text(encoding="utf-8"))
+    assert data["check"] == "ruff check ."
+    assert "failed_at" in data
+    assert len(data["stdout"]) <= 4000
+    assert data["stderr"] == "some stderr"
+
+
+def test_run_checks_stdout_trimmed_to_4000_chars(tmp_path: Path) -> None:
+    manifest = _make_manifest(required_checks=["ruff check ."])
+    long_stdout = "x" * 8000
+
+    def fake_run(cmd: list[str], **kwargs: object) -> MagicMock:
+        result = MagicMock()
+        result.returncode = 1
+        result.stdout = long_stdout
+        result.stderr = ""
+        return result
+
+    with patch("app.core.watcher_subprocess.subprocess.run", side_effect=fake_run):
+        run_checks(manifest, tmp_path)
+
+    artifact_dir = tmp_path / Path(manifest.artifact_paths.result_json).parent
+    import json as json_mod
+
+    data = json_mod.loads(
+        (artifact_dir / "last_failure.json").read_text(encoding="utf-8")
+    )
+    assert len(data["stdout"]) == 4000
+
+
+def test_run_checks_deletes_last_failure_json_on_success(tmp_path: Path) -> None:
+    manifest = _make_manifest(required_checks=["ruff check ."])
+
+    # Pre-create a stale last_failure.json in the artifact dir
+    artifact_dir = tmp_path / Path(manifest.artifact_paths.result_json).parent
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    stale = artifact_dir / "last_failure.json"
+    stale.write_text('{"check": "old"}', encoding="utf-8")
+
+    def fake_run(cmd: list[str], **kwargs: object) -> MagicMock:
+        result = MagicMock()
+        result.returncode = 0
+        result.stdout = ""
+        result.stderr = ""
+        return result
+
+    with patch("app.core.watcher_subprocess.subprocess.run", side_effect=fake_run):
+        assert run_checks(manifest, tmp_path) is True
+
+    assert not stale.exists(), (
+        "last_failure.json should be deleted after successful run"
+    )
+
+
+def test_run_checks_last_failure_overwritten_by_last_failing_check(
+    tmp_path: Path,
+) -> None:
+    manifest = _make_manifest(required_checks=["ruff check .", "mypy app/"])
+    call_count = 0
+
+    def fake_run(cmd: list[str], **kwargs: object) -> MagicMock:
+        nonlocal call_count
+        call_count += 1
+        result = MagicMock()
+        result.returncode = 1
+        result.stdout = f"output from check {call_count}"
+        result.stderr = ""
+        return result
+
+    with patch("app.core.watcher_subprocess.subprocess.run", side_effect=fake_run):
+        run_checks(manifest, tmp_path)
+
+    artifact_dir = tmp_path / Path(manifest.artifact_paths.result_json).parent
+    import json as json_mod
+
+    data = json_mod.loads(
+        (artifact_dir / "last_failure.json").read_text(encoding="utf-8")
+    )
+    # Last failing check (mypy) should overwrite the first (ruff)
+    assert data["check"] == "mypy app/"
+    assert data["stdout"] == "output from check 2"
+
+
 # ---------------------------------------------------------------------------
 # create_pr — additional failure paths
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes WOR-175

last_failure.json written on check failure and preserved; deleted on success; implement-ticket reads it on startup; test covers write path; ruff, mypy, pytest pass.