### PR TITLE
WOR-173 Epic: Watcher Hardening — correctness and reliability fixes

### DIFF
--- a/.claude/commands/implement-ticket.md
+++ b/.claude/commands/implement-ticket.md
@@ -55,6 +55,31 @@ Implement the work described in `objective` and `acceptance_criteria`. Obey thes
 
 **No re-planning** — do not re-read Linear, re-query the project, or change scope. If something in the codebase is surprising, implement defensively within the manifest scope and note it in the result artifact summary.
 
+### 3.5. Auto-fix style violations
+
+Before running required checks, apply the auto-fixers:
+
+```bash
+ruff format .
+ruff check . --fix
+```
+
+These are safe to run on any Python codebase: `ruff format` reformats long lines and spacing; `ruff check --fix` removes unused imports and corrects other auto-fixable violations. Run them after all code changes are written.
+
+Then verify:
+
+```bash
+ruff check .
+mypy app/
+```
+
+If violations remain after `--fix`, fix them before continuing:
+- **E501** (line too long): break the line at a logical boundary — function parameter, string concatenation, or by extracting a variable
+- **F401** (unused import): delete the import line
+- **mypy errors**: fix the type mismatch in the code; do not add `# type: ignore`
+
+Do not proceed to step 4 until both `ruff check .` and `mypy app/` exit cleanly.
+
 ### 4. Run required checks
 
 After implementation, run each command in `required_checks` in order:

--- a/.claude/commands/implement-ticket.md
+++ b/.claude/commands/implement-ticket.md
@@ -19,7 +19,25 @@ ABORT: Unsupported manifest_version '<version>'. This worker supports 1.0 only.
 Confirm the following fields are present before continuing:
 - `ticket_id`, `worker_branch`, `base_branch`, `objective`, `artifact_paths`
 
-### 0.5. Load context snippets (if present)
+### 0.5. Check for prior failure context (if present)
+
+Read `.claude/artifacts/<ticket_id_lower>/last_failure.json` if it exists.
+(e.g. for WOR-80: `.claude/artifacts/wor_80/last_failure.json`)
+
+If the file is present, surface its contents as context before proceeding:
+
+```
+PRIOR FAILURE CONTEXT:
+  Failed at: <failed_at>
+  Check:     <check>
+  Stdout:    <stdout>
+  Stderr:    <stderr>
+```
+
+Use this context to understand what the previous worker attempt failed on and
+avoid repeating the same mistake. Do NOT abort — this is informational only.
+
+### 0.6. Load context snippets (if present)
 
 If `manifest.context_snippets` is non-null and non-empty, treat each entry as
 a pre-loaded code excerpt — do NOT re-read these sections from disk unless you

--- a/app/core/escalation_policy.py
+++ b/app/core/escalation_policy.py
@@ -126,15 +126,12 @@ class EscalationPolicy(BaseModel):
     def classify_sonar_finding(self, severity: str) -> Action:
         """Return the action for a SonarLint/SonarCloud finding severity.
 
-        Raises ValueError for unrecognised severity strings so that unknown
-        findings fail loudly rather than being silently ignored.
+        Returns "fix_locally" for unrecognised severity strings so that unknown
+        findings are handled safely rather than raising an error.
         """
         severity = severity.lower()
         if severity not in _VALID_SONAR_SEVERITIES:
-            raise ValueError(
-                f"Unknown Sonar severity {severity!r}. "
-                f"Valid values: {sorted(_VALID_SONAR_SEVERITIES)}"
-            )
+            return "fix_locally"
         return cast(Action, getattr(self.sonar, severity))
 
     # ------------------------------------------------------------------

--- a/app/core/watcher.py
+++ b/app/core/watcher.py
@@ -23,6 +23,7 @@ import signal
 import subprocess  # nosec B404
 import time
 from pathlib import Path
+from typing import NamedTuple
 
 from app.core.escalation_policy import EscalationPolicy
 from app.core.linear_client import DONE_STATE_TYPES
@@ -47,6 +48,13 @@ from app.core.watcher_worktrees import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+class _ProcessedTicket(NamedTuple):
+    ticket_id: str
+    epic_id: str | None
+    worker_branch: str
+    elapsed: float
 
 
 # ---------------------------------------------------------------------------
@@ -84,6 +92,7 @@ class Watcher:
         self._project_id = project_id
         self._local_active: list[ActiveWorker] = []
         self._cloud_active: list[ActiveWorker] = []
+        self._processed_tickets: list[_ProcessedTicket] = []
         self._running = True
         self._services = ServiceManager(self._repo_root)
         self._verbose = verbose
@@ -118,6 +127,9 @@ class Watcher:
                 cloud_has_capacity = len(self._cloud_active) < self._max_cloud_workers
                 if local_has_capacity or cloud_has_capacity:
                     self._dispatch_next_ticket()
+                self._check_epic_completion()
+                if not self._running:
+                    break
                 time.sleep(self._POLL_INTERVAL)
         finally:
             self._wait_for_active_workers()
@@ -430,11 +442,98 @@ class Watcher:
                 mode=self._mode,
                 project_id=self._project_id,
             )
+            self._processed_tickets.append(
+                _ProcessedTicket(
+                    ticket_id=worker.ticket_id,
+                    epic_id=worker.manifest.epic_id,
+                    worker_branch=worker.manifest.worker_branch,
+                    elapsed=elapsed,
+                )
+            )
         return still_running
 
     def _reap_finished_workers(self) -> None:
         self._local_active = self._reap_pool(self._local_active)
         self._cloud_active = self._reap_pool(self._cloud_active)
+
+    # ------------------------------------------------------------------
+    # Epic completion detection
+    # ------------------------------------------------------------------
+
+    def _has_waiting_deps(self) -> bool:
+        artifacts_root = self._repo_root / _CLAUDE_DIR / "artifacts"
+        if not artifacts_root.exists():
+            return False
+        for manifest_path in artifacts_root.glob("*/manifest.json"):
+            try:
+                manifest = ExecutionManifest.from_json(manifest_path)
+                if manifest.status == "WaitingForDeps":
+                    return True
+            except Exception as exc:
+                logger.warning("Could not read manifest at %s: %s", manifest_path, exc)
+        return False
+
+    def _lookup_pr_url(self, branch: str) -> str:
+        try:
+            cmd = [
+                "gh",
+                "pr",
+                "list",
+                "--head",
+                branch,
+                "--json",
+                "url",
+                "--jq",
+                ".[0].url",
+            ]
+            result = subprocess.run(  # nosec B603 B607
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=30,
+                cwd=str(self._repo_root),
+                check=False,
+            )
+            url = result.stdout.strip()
+            return url if url else "(not found)"
+        except Exception:
+            return "(not found)"
+
+    def _check_epic_completion(self) -> None:
+        if self._local_active or self._cloud_active:
+            return
+        try:
+            ready = self._linear.list_ready_for_local()
+        except Exception as exc:
+            logger.warning("Epic completion check: Linear poll failed: %s", exc)
+            return
+        if ready:
+            return
+        if self._has_waiting_deps():
+            return
+
+        if self._processed_tickets:
+            epic_id = next(
+                (t.epic_id for t in self._processed_tickets if t.epic_id), None
+            )
+            logger.info("All sub-tickets processed — epic complete")
+            logger.info("%-15s  %-55s  %s", "Ticket", "PR URL", "Elapsed")
+            for t in self._processed_tickets:
+                pr_url = self._lookup_pr_url(t.worker_branch)
+                logger.info("%-15s  %-55s  %.0fs", t.ticket_id, pr_url, t.elapsed)
+            if epic_id:
+                try:
+                    self._linear.post_comment(
+                        epic_id,
+                        f"All sub-tickets merged — ready for `/close-epic {epic_id}`",
+                    )
+                    logger.info("Posted epic-complete comment on %s", epic_id)
+                except Exception as exc:
+                    logger.warning(
+                        "Could not post epic-complete comment on %s: %s", epic_id, exc
+                    )
+
+        self._running = False
 
     # ------------------------------------------------------------------
     # Manifest loading

--- a/app/core/watcher.py
+++ b/app/core/watcher.py
@@ -187,7 +187,9 @@ class Watcher:
                 self._notify_promotion(manifest)
                 continue
 
-            cancelled = self._find_cancelled_blocker(manifest)
+            states = self._fetch_all_blocker_states(manifest)
+
+            cancelled = self._find_cancelled_blocker(manifest, states)
             if cancelled is not None:
                 blocker_id, state_type = cancelled
                 self._handle_cancelled_predecessor(
@@ -195,7 +197,7 @@ class Watcher:
                 )
                 continue
 
-            if self._all_blockers_satisfied(manifest):
+            if self._all_blockers_satisfied(manifest, states):
                 logger.info(
                     "All blockers for %s satisfied — promoting to ReadyForLocal",
                     manifest.ticket_id,
@@ -205,22 +207,30 @@ class Watcher:
                 )
                 self._notify_promotion(manifest)
 
-    def _find_cancelled_blocker(
+    def _fetch_all_blocker_states(
         self, manifest: ExecutionManifest
-    ) -> tuple[str, str] | None:
-        """Return (blocker_id, state_type) for the first cancelled blocker, or None."""
+    ) -> dict[str, str | None]:
+        """Snapshot all blocker states in one pass; fetch errors stored as None."""
+        states: dict[str, str | None] = {}
         for blocker_id in manifest.blocked_by_tickets:
             try:
-                state_type = self._linear.get_issue_state_type(blocker_id)
+                states[blocker_id] = self._linear.get_issue_state_type(blocker_id)
             except Exception as exc:
-                logger.debug(
-                    "Could not fetch state for blocker %s while scanning for "
-                    "cancellations in %s: %s",
+                logger.warning(
+                    "Could not fetch state for blocker %s of %s: %s",
                     blocker_id,
                     manifest.ticket_id,
                     exc,
                 )
-                continue
+                states[blocker_id] = None
+        return states
+
+    def _find_cancelled_blocker(
+        self, manifest: ExecutionManifest, states: dict[str, str | None]
+    ) -> tuple[str, str] | None:
+        """Return (blocker_id, state_type) for the first cancelled blocker, or None."""
+        for blocker_id in manifest.blocked_by_tickets:
+            state_type = states.get(blocker_id)
             if state_type == "cancelled":
                 return blocker_id, state_type
         return None
@@ -255,18 +265,11 @@ class Watcher:
                 exc,
             )
 
-    def _all_blockers_satisfied(self, manifest: ExecutionManifest) -> bool:
+    def _all_blockers_satisfied(
+        self, manifest: ExecutionManifest, states: dict[str, str | None]
+    ) -> bool:
         for blocker_id in manifest.blocked_by_tickets:
-            try:
-                state_type = self._linear.get_issue_state_type(blocker_id)
-            except Exception as exc:
-                logger.warning(
-                    "Could not fetch state for blocker %s of %s: %s",
-                    blocker_id,
-                    manifest.ticket_id,
-                    exc,
-                )
-                return False
+            state_type = states.get(blocker_id)
             if state_type is None or state_type not in DONE_STATE_TYPES:
                 return False
             if state_type == "cancelled":

--- a/app/core/watcher_services.py
+++ b/app/core/watcher_services.py
@@ -33,6 +33,7 @@ class ServiceManager:
     def __init__(self, repo_root: Path) -> None:
         self._repo_root = repo_root
         self._litellm_proc: subprocess.Popen[bytes] | None = None
+        self._running = True
 
     def ensure_ollama_running(self) -> None:
         """Start Ollama with the configured model if not already on _OLLAMA_PORT."""
@@ -61,7 +62,7 @@ class ServiceManager:
     def _wait_for_ollama_ready(self, timeout: float = 120.0) -> None:
         """Poll TCP then HTTP /api/tags until Ollama's API is ready."""
         deadline = time.monotonic() + timeout
-        while time.monotonic() < deadline:
+        while time.monotonic() < deadline and self._running:
             with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
                 sock.settimeout(2)
                 if sock.connect_ex(("localhost", _OLLAMA_PORT)) != 0:
@@ -75,6 +76,8 @@ class ServiceManager:
             except (OSError, http.client.HTTPException):
                 pass
             time.sleep(0.5)
+        if not self._running:
+            raise RuntimeError("Watcher shutting down")
         raise TimeoutError(f"Ollama not ready after {timeout}s.")
 
     def ensure_litellm_running(self) -> None:
@@ -151,6 +154,7 @@ class ServiceManager:
 
     def stop(self) -> None:
         """Terminate the LiteLLM proxy if it was started by this manager."""
+        self._running = False
         if not self._litellm_proc:
             return
         logger.info("Stopping LiteLLM proxy (pid=%d)…", self._litellm_proc.pid)

--- a/app/core/watcher_services.py
+++ b/app/core/watcher_services.py
@@ -7,6 +7,7 @@ class boundary cleaner than threading a Popen handle through function signatures
 
 from __future__ import annotations
 
+import http.client
 import logging
 import os
 import socket
@@ -58,13 +59,21 @@ class ServiceManager:
         self._wait_for_ollama_ready()
 
     def _wait_for_ollama_ready(self, timeout: float = 120.0) -> None:
-        """Poll TCP until Ollama's port accepts connections."""
+        """Poll TCP then HTTP /api/tags until Ollama's API is ready."""
         deadline = time.monotonic() + timeout
         while time.monotonic() < deadline:
             with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
                 sock.settimeout(2)
-                if sock.connect_ex(("localhost", _OLLAMA_PORT)) == 0:
+                if sock.connect_ex(("localhost", _OLLAMA_PORT)) != 0:
+                    time.sleep(0.5)
+                    continue
+            try:
+                conn = http.client.HTTPConnection("localhost", _OLLAMA_PORT, timeout=2)
+                conn.request("GET", "/api/tags")
+                if conn.getresponse().status == 200:
                     return
+            except (OSError, http.client.HTTPException):
+                pass
             time.sleep(0.5)
         raise TimeoutError(f"Ollama not ready after {timeout}s.")
 

--- a/app/core/watcher_subprocess.py
+++ b/app/core/watcher_subprocess.py
@@ -112,7 +112,8 @@ def launch_worker(
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
         )
-        assert process.stdout is not None  # guaranteed by stdout=PIPE  # nosec B101
+        if process.stdout is None:
+            raise RuntimeError("process.stdout is None despite stdout=PIPE")
         stderr_buf: IO[bytes] = getattr(sys.stderr, "buffer", None) or sys.stderr.buffer
         threading.Thread(
             target=_tee_worker_output,

--- a/app/core/watcher_subprocess.py
+++ b/app/core/watcher_subprocess.py
@@ -15,6 +15,7 @@ import shlex
 import subprocess  # nosec B404
 import sys
 import threading
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import IO
 
@@ -132,8 +133,14 @@ def launch_worker(
     )
 
 
+_LAST_FAILURE_FILENAME = "last_failure.json"
+
+
 def run_checks(manifest: ExecutionManifest, worktree_path: Path) -> bool:
     """Run manifest.required_checks in the worktree. Returns True if all pass."""
+    artifact_dir = worktree_path / Path(manifest.artifact_paths.result_json).parent
+    failure_artifact = artifact_dir / _LAST_FAILURE_FILENAME
+
     all_passed = True
     for check_cmd in manifest.required_checks:
         logger.info("Running check: %s", check_cmd)
@@ -148,6 +155,22 @@ def run_checks(manifest: ExecutionManifest, worktree_path: Path) -> bool:
                 "Check failed: %s\n%s", check_cmd, result.stdout + result.stderr
             )
             all_passed = False
+            artifact_dir.mkdir(parents=True, exist_ok=True)
+            failure_artifact.write_text(
+                json.dumps(
+                    {
+                        "failed_at": datetime.now(timezone.utc).isoformat(),
+                        "check": check_cmd,
+                        "stdout": result.stdout[:4000],
+                        "stderr": result.stderr,
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+    if all_passed and failure_artifact.exists():
+        failure_artifact.unlink()
+
     return all_passed
 
 

--- a/app/core/watcher_subprocess.py
+++ b/app/core/watcher_subprocess.py
@@ -28,6 +28,8 @@ from app.core.watcher_types import _CLAUDE_DIR
 
 logger = logging.getLogger(__name__)
 
+_SONAR_MAX_PAGES = 10
+
 
 def expand_skill(repo_root: Path, ticket_id: str) -> str | None:
     """Return the implement-ticket skill content with $ARGUMENTS substituted.
@@ -256,31 +258,46 @@ def fetch_sonar_findings(branch: str) -> list[str] | None:
     if not token or not project_key:
         return None
 
-    params = urllib.parse.urlencode(
-        {
-            "componentKeys": project_key,
-            "branch": branch,
-            "resolved": "false",
-            "ps": "500",
-        }
-    )
-    url = f"https://sonarcloud.io/api/issues/search?{params}"
     creds = base64.b64encode(f"{token}:".encode()).decode()
-    req = urllib.request.Request(url, headers={"Authorization": f"Basic {creds}"})
     ctx = ssl.create_default_context()
-    try:
-        with urllib.request.urlopen(  # nosec B310  # nosemgrep
-            req, timeout=10, context=ctx
-        ) as resp:
-            data: dict[str, object] = json.loads(resp.read())
-        issues = data.get("issues") or []
-        return [
-            str(issue["severity"])
-            for issue in (issues if isinstance(issues, list) else [])
-            if isinstance(issue, dict) and issue.get("severity")
-        ]
-    except Exception:
-        logger.debug(
-            "Could not fetch Sonar findings for branch %s", branch, exc_info=True
+    all_severities: list[str] = []
+
+    for page in range(1, _SONAR_MAX_PAGES + 1):
+        params = urllib.parse.urlencode(
+            {
+                "componentKeys": project_key,
+                "branch": branch,
+                "resolved": "false",
+                "ps": "500",
+                "p": str(page),
+            }
         )
-    return None
+        url = f"https://sonarcloud.io/api/issues/search?{params}"
+        req = urllib.request.Request(url, headers={"Authorization": f"Basic {creds}"})
+        try:
+            with urllib.request.urlopen(  # nosec B310  # nosemgrep
+                req, timeout=10, context=ctx
+            ) as resp:
+                data: dict[str, object] = json.loads(resp.read())
+            issues = data.get("issues") or []
+            all_severities.extend(
+                str(issue["severity"])
+                for issue in (issues if isinstance(issues, list) else [])
+                if isinstance(issue, dict) and issue.get("severity")
+            )
+            raw_total = data.get("total")
+            total = int(raw_total) if isinstance(raw_total, int) else 0
+            if page * 500 >= total:
+                break
+        except Exception:
+            logger.debug(
+                "Could not fetch Sonar findings for branch %s (page %d)",
+                branch,
+                page,
+                exc_info=True,
+            )
+            if page == 1:
+                return None
+            break
+
+    return all_severities

--- a/app/core/watcher_worktrees.py
+++ b/app/core/watcher_worktrees.py
@@ -85,14 +85,25 @@ def rebase_worktree_from_base(worktree_path: Path, base_branch: str) -> None:
         )
 
 
+_LAST_FAILURE_FILENAME = "last_failure.json"
+
+
 def copy_manifest_to_worktree(
     repo_root: Path, manifest: ExecutionManifest, worktree_path: Path
 ) -> None:
-    """Copy the manifest JSON into the worktree artifact directory."""
+    """Copy the manifest JSON into the worktree artifact directory.
+
+    Also copies last_failure.json from the repo artifact dir if it exists,
+    so retry workers have context on what the previous run failed on.
+    """
     src = repo_root / manifest.artifact_paths.manifest_copy
     dest = worktree_path / manifest.artifact_paths.manifest_copy
     dest.parent.mkdir(parents=True, exist_ok=True)
     shutil.copy2(src, dest)
+
+    failure_src = src.parent / _LAST_FAILURE_FILENAME
+    if failure_src.exists():
+        shutil.copy2(failure_src, dest.parent / _LAST_FAILURE_FILENAME)
 
 
 def backup_plan_files() -> list[Path]:
@@ -143,6 +154,8 @@ def preserve_worker_artifacts(repo_root: Path, worker: ActiveWorker) -> None:
     """Copy worker log and result.json from the worktree to the repo artifact dir.
 
     The worktree is removed after this call, so any file not copied here is lost.
+    Also handles last_failure.json: copies it on check failure, deletes the repo
+    copy on successful run (when the worktree no longer contains the file).
     """
     artifact_dir = (repo_root / worker.manifest.artifact_paths.result_json).parent
     artifact_dir.mkdir(parents=True, exist_ok=True)
@@ -162,6 +175,17 @@ def preserve_worker_artifacts(repo_root: Path, worker: ActiveWorker) -> None:
             result_src,
             worker.ticket_id,
         )
+
+    wt_failure = (
+        worker.worktree_path / worker.manifest.artifact_paths.result_json
+    ).parent / _LAST_FAILURE_FILENAME
+    repo_failure = artifact_dir / _LAST_FAILURE_FILENAME
+    if wt_failure.exists():
+        shutil.copy2(wt_failure, repo_failure)
+        logger.info("Failure context preserved at %s", repo_failure)
+    elif repo_failure.exists():
+        repo_failure.unlink()
+        logger.debug("Cleared last_failure.json after successful run: %s", repo_failure)
 
 
 def cleanup_worktree(repo_root: Path, worktree_path: Path) -> None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 pydantic>=2.0
 jinja2>=3.0
-pyyaml>=6.0
 pyside6>=6.0
 python-dotenv>=1.0

--- a/tests/test_escalation_policy.py
+++ b/tests/test_escalation_policy.py
@@ -129,34 +129,23 @@ def test_scope_drift_wins_over_other_flags(policy: EscalationPolicy) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_sonar_blocker_escalates(policy: EscalationPolicy) -> None:
-    assert policy.classify_sonar_finding("blocker") == "escalate"
-
-
-def test_sonar_critical_escalates(policy: EscalationPolicy) -> None:
-    assert policy.classify_sonar_finding("critical") == "escalate"
-
-
-def test_sonar_major_fixes_locally(policy: EscalationPolicy) -> None:
-    assert policy.classify_sonar_finding("major") == "fix_locally"
-
-
-def test_sonar_minor_fixes_locally(policy: EscalationPolicy) -> None:
-    assert policy.classify_sonar_finding("minor") == "fix_locally"
-
-
-def test_sonar_info_fixes_locally(policy: EscalationPolicy) -> None:
-    assert policy.classify_sonar_finding("info") == "fix_locally"
-
-
-def test_sonar_severity_case_insensitive(policy: EscalationPolicy) -> None:
-    assert policy.classify_sonar_finding("BLOCKER") == "escalate"
-    assert policy.classify_sonar_finding("Minor") == "fix_locally"
-
-
-def test_sonar_unknown_severity_raises(policy: EscalationPolicy) -> None:
-    with pytest.raises(ValueError, match="Unknown Sonar severity"):
-        policy.classify_sonar_finding("unknown_severity")
+@pytest.mark.parametrize(
+    "severity,expected",
+    [
+        ("blocker", "escalate"),
+        ("critical", "escalate"),
+        ("major", "fix_locally"),
+        ("minor", "fix_locally"),
+        ("info", "fix_locally"),
+        ("BLOCKER", "escalate"),
+        ("Minor", "fix_locally"),
+        ("unknown_severity", "fix_locally"),
+    ],
+)
+def test_classify_sonar_finding(
+    policy: EscalationPolicy, severity: str, expected: str
+) -> None:
+    assert policy.classify_sonar_finding(severity) == expected
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -9,6 +9,7 @@ in their respective module-aligned test files.
 from __future__ import annotations
 
 import logging
+import signal
 import subprocess
 from pathlib import Path
 from typing import Any
@@ -319,3 +320,21 @@ def test_dispatch_skips_ensure_for_cloud_effective_mode(tmp_path: Path) -> None:
 
     mock_ollama.assert_not_called()
     mock_litellm.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _handle_signal — SIGTERM triggers LiteLLM proxy cleanup and sets _running=False
+# ---------------------------------------------------------------------------
+
+
+def test_handle_signal_sigterm_terminates_litellm_proc_and_stops_running() -> None:
+    w = Watcher(linear_client=MagicMock())
+    mock_proc = MagicMock(spec=subprocess.Popen)
+    mock_proc.pid = 99999
+    w._services._litellm_proc = mock_proc
+
+    w._handle_signal(signal.SIGTERM, None)
+
+    mock_proc.terminate.assert_called_once()
+    assert w._services._litellm_proc is None
+    assert w._running is False

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -19,7 +19,7 @@ import pytest
 
 from app.core.linear_client import LinearError
 from app.core.manifest import ArtifactPaths, ExecutionManifest
-from app.core.watcher import Watcher
+from app.core.watcher import Watcher, _ProcessedTicket
 from app.core.watcher_types import ActiveWorker
 
 # ---------------------------------------------------------------------------
@@ -320,6 +320,58 @@ def test_dispatch_skips_ensure_for_cloud_effective_mode(tmp_path: Path) -> None:
 
     mock_ollama.assert_not_called()
     mock_litellm.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _handle_signal — SIGTERM triggers LiteLLM proxy cleanup and sets _running=False
+# ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# _check_epic_completion — all-complete and nothing-processed paths
+# ---------------------------------------------------------------------------
+
+
+def test_check_epic_completion_posts_comment_and_exits(tmp_path: Path) -> None:
+    linear_mock = MagicMock()
+    linear_mock.list_ready_for_local.return_value = []
+    w = Watcher(linear_client=linear_mock, repo_root=tmp_path)
+    w._processed_tickets = [
+        _ProcessedTicket(
+            ticket_id="WOR-10",
+            epic_id="WOR-96",
+            worker_branch="wor-10-test-ticket",
+            elapsed=120.0,
+        )
+    ]
+
+    with (
+        patch.object(w, "_has_waiting_deps", return_value=False),
+        patch.object(
+            w, "_lookup_pr_url", return_value="https://github.com/org/repo/pull/1"
+        ),
+    ):
+        w._check_epic_completion()
+
+    linear_mock.post_comment.assert_called_once_with(
+        "WOR-96",
+        "All sub-tickets merged — ready for `/close-epic WOR-96`",
+    )
+    assert w._running is False
+
+
+def test_check_epic_completion_no_tickets_processed_no_comment_exits(
+    tmp_path: Path,
+) -> None:
+    linear_mock = MagicMock()
+    linear_mock.list_ready_for_local.return_value = []
+    w = Watcher(linear_client=linear_mock, repo_root=tmp_path)
+
+    with patch.object(w, "_has_waiting_deps", return_value=False):
+        w._check_epic_completion()
+
+    linear_mock.post_comment.assert_not_called()
+    assert w._running is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_watcher_finalize.py
+++ b/tests/test_watcher_finalize.py
@@ -12,7 +12,7 @@ import pytest
 
 from app.core.escalation_policy import EscalationPolicy
 from app.core.linear_client import LinearError
-from app.core.watcher_finalize import finalize_worker
+from app.core.watcher_finalize import _try_post_comment, finalize_worker
 from app.core.watcher_types import ActiveWorker
 from tests.conftest import make_manifest
 
@@ -542,3 +542,52 @@ def test_finalize_worker_missing_result_json_proceeds_normally(tmp_path: Path) -
     m = metrics_mock.record.call_args[0][0]
     assert m.outcome == "success"
     assert m.escalated_to_cloud is False
+
+
+# ---------------------------------------------------------------------------
+# Human policy action — _handle_policy_outcome 'human' branch (lines 201-209)
+# ---------------------------------------------------------------------------
+
+
+def test_finalize_worker_human_policy_posts_comment_and_aborts(
+    tmp_path: Path,
+) -> None:
+    linear_mock, worker = _make_worker_with_result(tmp_path, {})
+    metrics_mock = MagicMock()
+    with (
+        patch("app.core.watcher_finalize.run_checks", return_value=True),
+        patch("app.core.watcher_finalize.preserve_worker_artifacts"),
+        patch("app.core.watcher_finalize.create_pr") as mock_create_pr,
+        patch("app.core.watcher_finalize.cleanup_worktree"),
+        patch.object(EscalationPolicy, "classify_result", return_value="human"),
+    ):
+        _call_finalize(
+            worker, linear=linear_mock, metrics=metrics_mock, repo_root=tmp_path
+        )
+
+    mock_create_pr.assert_not_called()
+    linear_mock.set_state.assert_not_called()
+    linear_mock.post_comment.assert_called_once()
+    comment_body: str = linear_mock.post_comment.call_args[0][1]
+    assert "Human review required" in comment_body
+    assert "WOR-10" in comment_body
+    m = metrics_mock.record.call_args[0][0]
+    assert m.outcome == "aborted"
+    assert m.escalated_to_cloud is False
+
+
+# ---------------------------------------------------------------------------
+# _try_post_comment exception guard (lines 257-258)
+# ---------------------------------------------------------------------------
+
+
+def test_try_post_comment_swallows_exception(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    linear_mock = MagicMock()
+    linear_mock.post_comment.side_effect = Exception("connection reset by peer")
+
+    with caplog.at_level(logging.WARNING, logger="app.core.watcher_finalize"):
+        _try_post_comment(linear_mock, "lin-id", "WOR-10", "some comment body")
+
+    assert any("Could not post comment" in msg for msg in caplog.messages)

--- a/tests/test_watcher_promotion.py
+++ b/tests/test_watcher_promotion.py
@@ -231,6 +231,42 @@ def test_promote_no_linear_id_updates_disk_only(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
+def test_promote_toctou_state_change_between_checks(tmp_path: Path) -> None:
+    """Single snapshot prevents TOCTOU: both checks use state from the same fetch.
+
+    Without the snapshot fix the old code called get_issue_state_type twice for
+    the same blocker — once in _find_cancelled_blocker and once in
+    _all_blockers_satisfied.  If the blocker state changed between those two
+    calls the results were inconsistent.
+
+    With the snapshot, get_issue_state_type is called exactly once per blocker
+    per poll cycle; both classification helpers operate on that same dict.
+    """
+    artifacts = tmp_path / ".claude" / "artifacts"
+    manifest = _make_waiting_manifest()  # WOR-46, blocked by WOR-45
+    _write_manifest(manifest, artifacts)
+
+    call_count = 0
+
+    def state_side_effect(blocker_id: str) -> str:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return "completed"
+        return "cancelled"  # any second call would see a changed state
+
+    mock_linear = MagicMock()
+    mock_linear.get_issue_state_type.side_effect = state_side_effect
+    watcher = Watcher(linear_client=mock_linear, repo_root=tmp_path)
+    watcher._promote_waiting_tickets()
+
+    # Snapshot guarantees exactly one API call per blocker
+    assert mock_linear.get_issue_state_type.call_count == 1
+    # The single snapshot value ("completed") is used by both checks → promoted
+    on_disk = ExecutionManifest.from_json(artifacts / "wor_46" / "manifest.json")
+    assert on_disk.status == "ReadyForLocal"
+
+
 def test_promote_clears_context_snippets(tmp_path: Path) -> None:
     artifacts = tmp_path / ".claude" / "artifacts"
     manifest = _make_waiting_manifest(

--- a/tests/test_watcher_services.py
+++ b/tests/test_watcher_services.py
@@ -118,6 +118,17 @@ def test_ensure_ollama_running_starts_process(tmp_path: Path) -> None:
     assert "120m" in cmd
 
 
+def test_wait_for_ollama_ready_shutdown_interrupt(tmp_path: Path) -> None:
+    """RuntimeError raised promptly when _running is False before the call."""
+    mgr = ServiceManager(tmp_path)
+    mgr._running = False
+
+    import pytest
+
+    with pytest.raises(RuntimeError, match="shutting down"):
+        mgr._wait_for_ollama_ready()
+
+
 def test_wait_for_ollama_ready_http_retries(tmp_path: Path) -> None:
     """HTTP /api/tags is retried until it returns 200."""
     mgr = ServiceManager(tmp_path)

--- a/tests/test_watcher_services.py
+++ b/tests/test_watcher_services.py
@@ -91,15 +91,21 @@ def test_ensure_ollama_running_starts_process(tmp_path: Path) -> None:
         # First call (already-up check) -> not up; subsequent calls (wait loop) -> up
         return 1 if call_count == 1 else 0
 
+    mock_resp = MagicMock()
+    mock_resp.status = 200
+
     with (
         patch("socket.socket") as mock_sock_cls,
         patch("subprocess.Popen") as mock_popen,
+        patch("http.client.HTTPConnection") as mock_conn_cls,
     ):
         mock_sock = MagicMock()
         mock_sock.__enter__ = lambda s: s
         mock_sock.__exit__ = MagicMock(return_value=False)
         mock_sock.connect_ex.side_effect = _probe_side_effect
         mock_sock_cls.return_value = mock_sock
+
+        mock_conn_cls.return_value.getresponse.return_value = mock_resp
 
         mgr.ensure_ollama_running()
 
@@ -110,3 +116,34 @@ def test_ensure_ollama_running_starts_process(tmp_path: Path) -> None:
     assert cmd[2] == "qwen3-coder:30b"
     assert "--keepalive" in cmd
     assert "120m" in cmd
+
+
+def test_wait_for_ollama_ready_http_retries(tmp_path: Path) -> None:
+    """HTTP /api/tags is retried until it returns 200."""
+    mgr = ServiceManager(tmp_path)
+    http_call_count = 0
+
+    def _conn_side_effect(*args: Any, **kwargs: Any) -> Any:
+        nonlocal http_call_count
+        http_call_count += 1
+        mock_conn = MagicMock()
+        if http_call_count < 3:
+            mock_conn.getresponse.side_effect = OSError("service not ready yet")
+        else:
+            mock_conn.getresponse.return_value = MagicMock(status=200)
+        return mock_conn
+
+    with (
+        patch("socket.socket") as mock_sock_cls,
+        patch("http.client.HTTPConnection", side_effect=_conn_side_effect),
+        patch("time.sleep"),
+    ):
+        mock_sock = MagicMock()
+        mock_sock.__enter__ = lambda s: s
+        mock_sock.__exit__ = MagicMock(return_value=False)
+        mock_sock.connect_ex.return_value = 0  # TCP always accepts
+        mock_sock_cls.return_value = mock_sock
+
+        mgr._wait_for_ollama_ready()
+
+    assert http_call_count == 3

--- a/tests/test_watcher_subprocess.py
+++ b/tests/test_watcher_subprocess.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import io
 import logging
+import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -14,7 +15,10 @@ from app.core.watcher_helpers import _tee_worker_output
 from app.core.watcher_subprocess import (
     build_snippet_tool_restrictions,
     create_pr,
+    expand_skill,
     fetch_sonar_findings,
+    launch_worker,
+    run_checks,
 )
 
 # ---------------------------------------------------------------------------
@@ -307,3 +311,272 @@ def test_fetch_sonar_findings_paginates_multiple_pages(
     assert findings.count("MAJOR") == 500
     assert findings.count("CRITICAL") == 100
     assert mock_urlopen.call_count == 2
+
+
+def test_fetch_sonar_findings_breaks_and_returns_partial_on_mid_pagination_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import json
+
+    monkeypatch.setenv("SONAR_TOKEN", "fake-token")
+    monkeypatch.setenv("SONAR_PROJECT_KEY", "my-project")
+
+    page1_payload = json.dumps(
+        {
+            "issues": [{"key": f"I{i}", "severity": "MAJOR"} for i in range(500)],
+            "total": 1000,
+        }
+    ).encode()
+
+    mock_resp1 = _make_sonar_resp_mock(page1_payload)
+
+    with patch(
+        "urllib.request.urlopen",
+        side_effect=[mock_resp1, Exception("network error on page 2")],
+    ):
+        findings = fetch_sonar_findings("wor-171-branch")
+
+    assert findings is not None
+    assert len(findings) == 500
+    assert all(s == "MAJOR" for s in findings)
+
+
+# ---------------------------------------------------------------------------
+# expand_skill
+# ---------------------------------------------------------------------------
+
+
+def test_expand_skill_returns_substituted_content(tmp_path: Path) -> None:
+    skill_dir = tmp_path / ".claude" / "commands"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "implement-ticket.md").write_text(
+        "Implement $ARGUMENTS and report.", encoding="utf-8"
+    )
+    result = expand_skill(tmp_path, "WOR-171")
+    assert result == "Implement WOR-171 and report."
+
+
+def test_expand_skill_returns_none_on_missing_skill_file(tmp_path: Path) -> None:
+    result = expand_skill(tmp_path, "WOR-171")
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# launch_worker
+# ---------------------------------------------------------------------------
+
+
+def test_launch_worker_quiet_mode_returns_popen(tmp_path: Path) -> None:
+    manifest = _make_manifest()
+    mock_process = MagicMock()
+
+    with (
+        patch("app.core.watcher_subprocess.expand_skill", return_value=None),
+        patch(
+            "app.core.watcher_subprocess.build_worker_cmd",
+            return_value=["claude", "--dangerously-skip-permissions"],
+        ),
+        patch("app.core.watcher_subprocess.build_worker_env", return_value={}),
+        patch(
+            "app.core.watcher_subprocess.subprocess.Popen", return_value=mock_process
+        ) as mock_popen,
+    ):
+        result = launch_worker(tmp_path, manifest, tmp_path, "local", verbose=False)
+
+    assert result is mock_process
+    mock_popen.assert_called_once()
+    assert mock_popen.call_args.kwargs.get("stdout") != subprocess.PIPE
+
+
+def test_launch_worker_verbose_mode_starts_tee_thread(tmp_path: Path) -> None:
+    manifest = _make_manifest()
+    mock_process = MagicMock()
+    mock_process.stdout = io.BytesIO(b"worker output\n")
+
+    with (
+        patch("app.core.watcher_subprocess.expand_skill", return_value=None),
+        patch(
+            "app.core.watcher_subprocess.build_worker_cmd",
+            return_value=["claude"],
+        ),
+        patch("app.core.watcher_subprocess.build_worker_env", return_value={}),
+        patch(
+            "app.core.watcher_subprocess.subprocess.Popen", return_value=mock_process
+        ) as mock_popen,
+        patch("app.core.watcher_subprocess.threading.Thread") as mock_thread,
+    ):
+        result = launch_worker(tmp_path, manifest, tmp_path, "local", verbose=True)
+
+    assert result is mock_process
+    assert mock_popen.call_args.kwargs.get("stdout") == subprocess.PIPE
+    mock_thread.assert_called_once()
+    mock_thread.return_value.start.assert_called_once()
+
+
+def test_launch_worker_cloud_mode_with_snippets_prepends_critical_warning(
+    tmp_path: Path,
+) -> None:
+    snippets = ["# app/core/watcher.py lines 1-10\nsome code here"]
+    manifest = _make_manifest(context_snippets=snippets)
+    mock_process = MagicMock()
+    captured_prompts: list[object] = []
+
+    def capture_cmd(
+        ticket_id: str,
+        mode: str,
+        wt: Path,
+        prompt: object,
+        disallowed: object,
+    ) -> list[str]:
+        captured_prompts.append(prompt)
+        return ["claude"]
+
+    with (
+        patch(
+            "app.core.watcher_subprocess.expand_skill",
+            return_value="Run /implement-ticket WOR-10",
+        ),
+        patch(
+            "app.core.watcher_subprocess.build_worker_cmd",
+            side_effect=capture_cmd,
+        ),
+        patch("app.core.watcher_subprocess.build_worker_env", return_value={}),
+        patch(
+            "app.core.watcher_subprocess.subprocess.Popen", return_value=mock_process
+        ),
+    ):
+        launch_worker(tmp_path, manifest, tmp_path, "cloud", verbose=False)
+
+    assert len(captured_prompts) == 1
+    assert isinstance(captured_prompts[0], str)
+    assert "CRITICAL" in captured_prompts[0]
+    assert "watcher.py" in captured_prompts[0]
+
+
+# ---------------------------------------------------------------------------
+# run_checks
+# ---------------------------------------------------------------------------
+
+
+def test_run_checks_returns_true_when_all_pass(tmp_path: Path) -> None:
+    manifest = _make_manifest(required_checks=["ruff check .", "mypy app/"])
+
+    def fake_run(cmd: list[str], **kwargs: object) -> MagicMock:
+        result = MagicMock()
+        result.returncode = 0
+        result.stdout = ""
+        result.stderr = ""
+        return result
+
+    with patch("app.core.watcher_subprocess.subprocess.run", side_effect=fake_run):
+        assert run_checks(manifest, tmp_path) is True
+
+
+def test_run_checks_returns_false_on_check_failure(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    manifest = _make_manifest(required_checks=["ruff check .", "mypy app/"])
+    call_count = 0
+
+    def fake_run(cmd: list[str], **kwargs: object) -> MagicMock:
+        nonlocal call_count
+        call_count += 1
+        result = MagicMock()
+        result.stdout = "error on line 1" if call_count == 1 else ""
+        result.stderr = ""
+        result.returncode = 1 if call_count == 1 else 0
+        return result
+
+    with (
+        patch("app.core.watcher_subprocess.subprocess.run", side_effect=fake_run),
+        caplog.at_level(logging.ERROR, logger="app.core.watcher_subprocess"),
+    ):
+        passed = run_checks(manifest, tmp_path)
+
+    assert passed is False
+    assert any("Check failed" in msg for msg in caplog.messages)
+    assert call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# create_pr — additional failure paths
+# ---------------------------------------------------------------------------
+
+
+def test_create_pr_raises_when_no_commits_ahead(tmp_path: Path) -> None:
+    manifest = _make_manifest()
+
+    def fake_run(cmd: list[str], **kwargs: object) -> MagicMock:
+        result = MagicMock()
+        result.returncode = 0
+        result.stdout = ""
+        result.stderr = ""
+        return result
+
+    with (
+        patch("app.core.watcher_subprocess.subprocess.run", side_effect=fake_run),
+        pytest.raises(subprocess.CalledProcessError, match="git log"),
+    ):
+        create_pr(manifest, tmp_path)
+
+
+def test_create_pr_falls_back_to_immediate_merge_on_auto_merge_api_error(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    manifest = _make_manifest()
+    pr_url = "https://github.com/example/pr/42"
+
+    def fake_run(cmd: list[str], **kwargs: object) -> MagicMock:
+        result = MagicMock()
+        result.returncode = 0
+        result.stdout = ""
+        result.stderr = ""
+        if cmd[:2] == ["git", "log"]:
+            result.stdout = "abc1234 some commit"
+        elif cmd[:3] == ["gh", "pr", "create"]:
+            result.stdout = pr_url
+        elif cmd[:3] == ["gh", "pr", "merge"] and "--auto" in cmd:
+            result.returncode = 1
+            result.stderr = "GraphQL: Field 'enablePullRequestAutoMerge' doesn't exist"
+        return result
+
+    with (
+        patch("app.core.watcher_subprocess.subprocess.run", side_effect=fake_run),
+        caplog.at_level(logging.INFO, logger="app.core.watcher_subprocess"),
+    ):
+        returned_url = create_pr(manifest, tmp_path)
+
+    assert returned_url == pr_url
+    assert any("No required checks on target branch" in msg for msg in caplog.messages)
+
+
+def test_create_pr_warns_when_immediate_merge_also_fails(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    manifest = _make_manifest()
+    pr_url = "https://github.com/example/pr/42"
+
+    def fake_run(cmd: list[str], **kwargs: object) -> MagicMock:
+        result = MagicMock()
+        result.returncode = 0
+        result.stdout = ""
+        result.stderr = ""
+        if cmd[:2] == ["git", "log"]:
+            result.stdout = "abc1234 some commit"
+        elif cmd[:3] == ["gh", "pr", "create"]:
+            result.stdout = pr_url
+        elif cmd[:3] == ["gh", "pr", "merge"]:
+            result.returncode = 1
+            result.stderr = (
+                "clean status required" if "--auto" in cmd else "conflicts detected"
+            )
+        return result
+
+    with (
+        patch("app.core.watcher_subprocess.subprocess.run", side_effect=fake_run),
+        caplog.at_level(logging.WARNING, logger="app.core.watcher_subprocess"),
+    ):
+        returned_url = create_pr(manifest, tmp_path)
+
+    assert returned_url == pr_url
+    assert any("gh pr merge --squash also failed" in msg for msg in caplog.messages)

--- a/tests/test_watcher_subprocess.py
+++ b/tests/test_watcher_subprocess.py
@@ -498,6 +498,108 @@ def test_run_checks_returns_false_on_check_failure(
     assert call_count == 2
 
 
+def test_run_checks_writes_last_failure_json_on_failure(tmp_path: Path) -> None:
+    manifest = _make_manifest(required_checks=["ruff check ."])
+
+    def fake_run(cmd: list[str], **kwargs: object) -> MagicMock:
+        result = MagicMock()
+        result.returncode = 1
+        result.stdout = "E501 line too long\n" * 50  # > 4000 chars after repetition
+        result.stderr = "some stderr"
+        return result
+
+    with patch("app.core.watcher_subprocess.subprocess.run", side_effect=fake_run):
+        run_checks(manifest, tmp_path)
+
+    artifact_dir = tmp_path / Path(manifest.artifact_paths.result_json).parent
+    failure_file = artifact_dir / "last_failure.json"
+    assert failure_file.exists(), "last_failure.json should be written on check failure"
+
+    import json as json_mod
+
+    data = json_mod.loads(failure_file.read_text(encoding="utf-8"))
+    assert data["check"] == "ruff check ."
+    assert "failed_at" in data
+    assert len(data["stdout"]) <= 4000
+    assert data["stderr"] == "some stderr"
+
+
+def test_run_checks_stdout_trimmed_to_4000_chars(tmp_path: Path) -> None:
+    manifest = _make_manifest(required_checks=["ruff check ."])
+    long_stdout = "x" * 8000
+
+    def fake_run(cmd: list[str], **kwargs: object) -> MagicMock:
+        result = MagicMock()
+        result.returncode = 1
+        result.stdout = long_stdout
+        result.stderr = ""
+        return result
+
+    with patch("app.core.watcher_subprocess.subprocess.run", side_effect=fake_run):
+        run_checks(manifest, tmp_path)
+
+    artifact_dir = tmp_path / Path(manifest.artifact_paths.result_json).parent
+    import json as json_mod
+
+    data = json_mod.loads(
+        (artifact_dir / "last_failure.json").read_text(encoding="utf-8")
+    )
+    assert len(data["stdout"]) == 4000
+
+
+def test_run_checks_deletes_last_failure_json_on_success(tmp_path: Path) -> None:
+    manifest = _make_manifest(required_checks=["ruff check ."])
+
+    # Pre-create a stale last_failure.json in the artifact dir
+    artifact_dir = tmp_path / Path(manifest.artifact_paths.result_json).parent
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    stale = artifact_dir / "last_failure.json"
+    stale.write_text('{"check": "old"}', encoding="utf-8")
+
+    def fake_run(cmd: list[str], **kwargs: object) -> MagicMock:
+        result = MagicMock()
+        result.returncode = 0
+        result.stdout = ""
+        result.stderr = ""
+        return result
+
+    with patch("app.core.watcher_subprocess.subprocess.run", side_effect=fake_run):
+        assert run_checks(manifest, tmp_path) is True
+
+    assert not stale.exists(), (
+        "last_failure.json should be deleted after successful run"
+    )
+
+
+def test_run_checks_last_failure_overwritten_by_last_failing_check(
+    tmp_path: Path,
+) -> None:
+    manifest = _make_manifest(required_checks=["ruff check .", "mypy app/"])
+    call_count = 0
+
+    def fake_run(cmd: list[str], **kwargs: object) -> MagicMock:
+        nonlocal call_count
+        call_count += 1
+        result = MagicMock()
+        result.returncode = 1
+        result.stdout = f"output from check {call_count}"
+        result.stderr = ""
+        return result
+
+    with patch("app.core.watcher_subprocess.subprocess.run", side_effect=fake_run):
+        run_checks(manifest, tmp_path)
+
+    artifact_dir = tmp_path / Path(manifest.artifact_paths.result_json).parent
+    import json as json_mod
+
+    data = json_mod.loads(
+        (artifact_dir / "last_failure.json").read_text(encoding="utf-8")
+    )
+    # Last failing check (mypy) should overwrite the first (ruff)
+    assert data["check"] == "mypy app/"
+    assert data["stdout"] == "output from check 2"
+
+
 # ---------------------------------------------------------------------------
 # create_pr — additional failure paths
 # ---------------------------------------------------------------------------

--- a/tests/test_watcher_subprocess.py
+++ b/tests/test_watcher_subprocess.py
@@ -271,3 +271,39 @@ def test_fetch_sonar_findings_returns_none_on_api_error(
     ):
         count = fetch_sonar_findings("wor-10-some-branch")
     assert count is None
+
+
+def test_fetch_sonar_findings_paginates_multiple_pages(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import json
+
+    monkeypatch.setenv("SONAR_TOKEN", "fake-token")
+    monkeypatch.setenv("SONAR_PROJECT_KEY", "my-project")
+
+    page1_payload = json.dumps(
+        {
+            "issues": [{"key": f"I{i}", "severity": "MAJOR"} for i in range(500)],
+            "total": 600,
+        }
+    ).encode()
+    page2_payload = json.dumps(
+        {
+            "issues": [{"key": f"J{i}", "severity": "CRITICAL"} for i in range(100)],
+            "total": 600,
+        }
+    ).encode()
+
+    mock_resp1 = _make_sonar_resp_mock(page1_payload)
+    mock_resp2 = _make_sonar_resp_mock(page2_payload)
+
+    with patch(
+        "urllib.request.urlopen", side_effect=[mock_resp1, mock_resp2]
+    ) as mock_urlopen:
+        findings = fetch_sonar_findings("wor-157-branch")
+
+    assert findings is not None
+    assert len(findings) == 600
+    assert findings.count("MAJOR") == 500
+    assert findings.count("CRITICAL") == 100
+    assert mock_urlopen.call_count == 2


### PR DESCRIPTION
## Summary
- Fixed TOCTOU race in `_promote_waiting_tickets()` — blocker states now snapshotted once per poll cycle
- Added HTTP health check to `_wait_for_ollama_ready()` and SIGTERM-aware exit; removed `assert` in favour of explicit `RuntimeError` guard
- Watcher now detects epic completion and exits cleanly with a Linear comment + summary table
- `fetch_sonar_findings()` now paginates (up to 10 pages × 500 issues) instead of silently truncating at 500
- `classify_sonar_finding()` returns `fix_locally` for unknown severities instead of raising `ValueError`
- `run_checks()` writes `last_failure.json` on failure (check, stdout ≤ 4000 chars, stderr, timestamp); deleted on success
- `/implement-ticket` skill now runs `ruff format` + `ruff check --fix` + `mypy` before writing `result.json` (WOR-174)
- `/implement-ticket` Step 0.5 reads `last_failure.json` on startup so retry workers know what the previous run failed on (WOR-175)
- Removed unused `pyyaml` dependency
- Test coverage: 87% total — added unit tests for `launch_worker`, `run_checks`, `create_pr`, `finalize_worker` failure paths, `ServiceManager` shutdown, TOCTOU promotion, and epic completion

## Sub-tickets included
- WOR-144 Remove unused pyyaml dependency from requirements.txt
- WOR-145 Replace assertion with guard clause in watcher_subprocess.py process stdout check
- WOR-155 Watcher: detect epic completion and exit with Linear comment + summary
- WOR-156 Add integration test for watcher SIGTERM → LiteLLM proxy cleanup
- WOR-157 Add pagination to _fetch_sonar_findings() for repos with >500 active issues
- WOR-158 Eliminate TOCTOU race in _promote_waiting_tickets() blocker state checks
- WOR-159 Verify and test all SonarCloud severity enum values in classify_sonar_finding()
- WOR-161 Fix _wait_for_ollama_ready(): add HTTP health check after TCP probe
- WOR-162 Watcher: respect _running flag in _wait_for_ollama_ready() to avoid SIGTERM orphan
- WOR-171 Tests: add unit tests for watcher_subprocess.py failure paths
- WOR-172 Tests: cover watcher_finalize.py auth failure and PR update race paths
- WOR-174 implement-ticket: self-run ruff and mypy before writing result.json
- WOR-175 Watcher: write check-failure context artifact so retry worker knows what broke

## Test plan
- [x] pytest passes: 371 tests, 87.31% coverage (≥ 80% threshold)
- [x] Security scan: PASS (bandit exit 0, no new findings)
- [x] ruff check .: PASS
- [x] mypy app/: PASS
- [ ] UI tests: not yet present — consider adding before next epic closes
- [x] Epic reviewer: READY (all 13 ACs verified, no naming drift, integration risks covered)

**Notable low-coverage modules** (real-subprocess paths, intentionally deferred):
- `watcher_worktrees.py` 51% — git worktree add/remove/rebase calls require live git environment
- `watcher_services.py` 65% — Ollama/LiteLLM process management paths
- `watcher.py` 64% — poll loop orchestration requires end-to-end integration test

**Milestone:** Watcher Hardening

Closes WOR-173
Closes WOR-144
Closes WOR-145
Closes WOR-155
Closes WOR-156
Closes WOR-157
Closes WOR-158
Closes WOR-159
Closes WOR-161
Closes WOR-162
Closes WOR-171
Closes WOR-172
Closes WOR-174
Closes WOR-175