### PR TITLE
WOR-178 Watcher exits immediately when started with empty ReadyForLocal queue

### DIFF
--- a/app/core/watcher.py
+++ b/app/core/watcher.py
@@ -532,8 +532,7 @@ class Watcher:
                     logger.warning(
                         "Could not post epic-complete comment on %s: %s", epic_id, exc
                     )
-
-        self._running = False
+            self._running = False
 
     # ------------------------------------------------------------------
     # Manifest loading

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -371,7 +371,20 @@ def test_check_epic_completion_no_tickets_processed_no_comment_exits(
         w._check_epic_completion()
 
     linear_mock.post_comment.assert_not_called()
-    assert w._running is False
+    assert w._running is True
+
+
+def test_check_epic_completion_empty_startup_keeps_polling(tmp_path: Path) -> None:
+    linear_mock = MagicMock()
+    linear_mock.list_ready_for_local.return_value = []
+    w = Watcher(linear_client=linear_mock, repo_root=tmp_path)
+
+    assert not w._processed_tickets
+
+    with patch.object(w, "_has_waiting_deps", return_value=False):
+        w._check_epic_completion()
+
+    assert w._running is True
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes WOR-178

app/core/watcher.py has self._running = False guarded inside if self._processed_tickets:; existing no-tickets-processed test asserts _running is True; new empty-startup test passes; all required checks green.