### PR TITLE
WOR-182 WOR-180 Sub-2: Config loader, matrix expansion, and bench.toml

### DIFF
--- a/config/bench.toml
+++ b/config/bench.toml
@@ -1,0 +1,43 @@
+# Benchmark configuration.
+# Load with BenchConfig.from_toml("config/bench.toml").
+# expand_matrix() produces the full Cartesian product of models x tiers x contexts x concurrency.
+# Disabled backends are excluded from the matrix.
+# The boundary tier uses boundary_context_sizes; all other tiers use context_sizes.
+
+[matrix]
+# Context sizes (in tokens) for non-boundary tiers.
+context_sizes = [1024, 4096]
+# Context sizes used exclusively by the boundary tier.
+boundary_context_sizes = [8192, 16384]
+# Concurrent requests per probe point.
+concurrency_levels = [1, 4]
+# Number of real (non-warmup) runs per probe point.
+repeats = 1
+
+[[backends]]
+id = "local_qwen"
+enabled = true
+base_url = "http://localhost:11434/v1"
+
+[[backends]]
+id = "cloud_gpt4o"
+enabled = false
+base_url = "https://api.openai.com/v1"
+
+[[models]]
+id = "qwen3-coder-30b"
+backend_id = "local_qwen"
+
+[[models]]
+id = "qwen3-14b"
+backend_id = "local_qwen"
+
+[[models]]
+id = "gpt-4o"
+backend_id = "cloud_gpt4o"
+
+[[tiers]]
+name = "speed"
+
+[[tiers]]
+name = "boundary"

--- a/scripts/bench/__init__.py
+++ b/scripts/bench/__init__.py
@@ -1,0 +1,1 @@
+"""Benchmark scripts package."""

--- a/scripts/bench/config.py
+++ b/scripts/bench/config.py
@@ -1,0 +1,138 @@
+"""Benchmark config loader and matrix expander."""
+
+from __future__ import annotations
+
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+
+from pydantic import BaseModel, field_validator
+
+
+@dataclass
+class BenchCase:
+    """One probe point in the benchmark matrix."""
+
+    backend_id: str
+    model_id: str
+    tier: str
+    context_size: int
+    concurrency: int
+    repeat_index: int  # 0 = warmup, >=1 = real
+
+
+class MatrixConfig(BaseModel):
+    model_config = {"extra": "forbid"}
+
+    context_sizes: list[int]
+    boundary_context_sizes: list[int]
+    concurrency_levels: list[int]
+    repeats: int = 1
+
+    @field_validator("context_sizes", "boundary_context_sizes", "concurrency_levels")
+    @classmethod
+    def non_empty_list(cls, v: list[int]) -> list[int]:
+        if not v:
+            raise ValueError("must be non-empty")
+        return v
+
+    @field_validator("repeats")
+    @classmethod
+    def positive_repeats(cls, v: int) -> int:
+        if v < 1:
+            raise ValueError("repeats must be >= 1")
+        return v
+
+
+class BackendConfig(BaseModel):
+    model_config = {"extra": "forbid"}
+
+    id: str
+    enabled: bool = True
+    base_url: str
+    api_key: str = ""
+
+
+class ModelConfig(BaseModel):
+    model_config = {"extra": "forbid"}
+
+    id: str
+    backend_id: str
+
+
+class TierConfig(BaseModel):
+    model_config = {"extra": "forbid"}
+
+    name: str
+
+
+class BenchConfig(BaseModel):
+    """Top-level benchmark configuration."""
+
+    model_config = {"extra": "forbid"}
+
+    matrix: MatrixConfig
+    backends: list[BackendConfig]
+    models: list[ModelConfig]
+    tiers: list[TierConfig]
+
+    @classmethod
+    def from_toml(cls, path: Path | str) -> "BenchConfig":
+        """Load and validate config from a TOML file.
+
+        Raises FileNotFoundError if the file is missing.
+        Raises pydantic.ValidationError if the config is structurally invalid.
+        Raises tomllib.TOMLDecodeError if the file is not valid TOML.
+        """
+        resolved = Path(path)
+        raw = resolved.read_bytes()
+        data = tomllib.loads(raw.decode())
+        return cls.model_validate(data)
+
+    def expand_matrix(self) -> list[BenchCase]:
+        """Expand the config into a flat list of BenchCase instances.
+
+        Disabled backends are excluded. Boundary tier uses boundary_context_sizes;
+        all other tiers use context_sizes. Each (model, tier, context_size) produces
+        one warmup case (repeat_index=0) at the first concurrency level, followed by
+        real cases (repeat_index>=1) across all concurrency levels and repeats.
+        """
+        enabled_backends = {b.id for b in self.backends if b.enabled}
+        enabled_models = [m for m in self.models if m.backend_id in enabled_backends]
+
+        cases: list[BenchCase] = []
+
+        for model in enabled_models:
+            for tier in self.tiers:
+                ctx_sizes = (
+                    self.matrix.boundary_context_sizes
+                    if tier.name == "boundary"
+                    else self.matrix.context_sizes
+                )
+
+                for ctx_size in ctx_sizes:
+                    cases.append(
+                        BenchCase(
+                            backend_id=model.backend_id,
+                            model_id=model.id,
+                            tier=tier.name,
+                            context_size=ctx_size,
+                            concurrency=self.matrix.concurrency_levels[0],
+                            repeat_index=0,
+                        )
+                    )
+
+                    for concurrency in self.matrix.concurrency_levels:
+                        for repeat in range(1, self.matrix.repeats + 1):
+                            cases.append(
+                                BenchCase(
+                                    backend_id=model.backend_id,
+                                    model_id=model.id,
+                                    tier=tier.name,
+                                    context_size=ctx_size,
+                                    concurrency=concurrency,
+                                    repeat_index=repeat,
+                                )
+                            )
+
+        return cases

--- a/tests/bench/test_bench_config.py
+++ b/tests/bench/test_bench_config.py
@@ -1,0 +1,170 @@
+"""Tests for BenchConfig.from_toml and BenchConfig.expand_matrix."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from scripts.bench.config import BenchCase, BenchConfig
+
+_BENCH_TOML = Path(__file__).parent.parent.parent / "config" / "bench.toml"
+
+_STANDARD_TOML = """
+[matrix]
+context_sizes = [1024, 4096]
+boundary_context_sizes = [8192, 16384]
+concurrency_levels = [1, 4]
+repeats = 1
+
+[[backends]]
+id = "local_a"
+enabled = true
+base_url = "http://localhost:1/"
+api_key = "x"
+
+[[backends]]
+id = "cloud_b"
+enabled = false
+base_url = "http://localhost:2/"
+api_key = "y"
+
+[[models]]
+id = "model-1"
+backend_id = "local_a"
+
+[[models]]
+id = "model-2"
+backend_id = "local_a"
+
+[[models]]
+id = "model-3"
+backend_id = "cloud_b"
+
+[[tiers]]
+name = "speed"
+
+[[tiers]]
+name = "boundary"
+"""
+
+
+def _write_toml(tmp_path: Path, content: str) -> Path:
+    p = tmp_path / "bench.toml"
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+def test_from_toml_loads_real_config() -> None:
+    cfg = BenchConfig.from_toml(_BENCH_TOML)
+    assert cfg.matrix.context_sizes == [1024, 4096]
+    assert len(cfg.backends) >= 1
+    assert len(cfg.models) >= 1
+    assert len(cfg.tiers) >= 1
+
+
+def test_bench_case_importable() -> None:
+    assert hasattr(BenchCase, "__dataclass_fields__")
+
+
+def test_expand_matrix_real_and_warmup_counts(tmp_path: Path) -> None:
+    cfg = BenchConfig.from_toml(_write_toml(tmp_path, _STANDARD_TOML))
+    cases = cfg.expand_matrix()
+
+    real = [c for c in cases if c.repeat_index >= 1]
+    warmup = [c for c in cases if c.repeat_index == 0]
+
+    assert len(real) == 16, f"Expected 16 real cases, got {len(real)}"
+    assert len(warmup) == 8, f"Expected 8 warmup cases, got {len(warmup)}"
+
+
+def test_disabled_backend_excluded(tmp_path: Path) -> None:
+    toml = """
+[matrix]
+context_sizes = [1024]
+boundary_context_sizes = [8192]
+concurrency_levels = [1]
+repeats = 1
+
+[[backends]]
+id = "off"
+enabled = false
+base_url = "http://localhost:1/"
+api_key = "x"
+
+[[models]]
+id = "model-1"
+backend_id = "off"
+
+[[tiers]]
+name = "speed"
+"""
+    cfg = BenchConfig.from_toml(_write_toml(tmp_path, toml))
+    assert cfg.expand_matrix() == []
+
+
+def test_invalid_toml_syntax_raises(tmp_path: Path) -> None:
+    p = tmp_path / "bench.toml"
+    p.write_bytes(b"[matrix\n")  # malformed TOML
+    with pytest.raises(Exception):
+        BenchConfig.from_toml(p)
+
+
+def test_invalid_config_structure_raises_validation_error(tmp_path: Path) -> None:
+    toml = """
+[matrix]
+context_sizes = []
+boundary_context_sizes = [8192]
+concurrency_levels = [1]
+"""
+    with pytest.raises(ValidationError):
+        BenchConfig.from_toml(_write_toml(tmp_path, toml))
+
+
+def test_boundary_tier_uses_boundary_context_sizes(tmp_path: Path) -> None:
+    toml = """
+[matrix]
+context_sizes = [1024, 4096]
+boundary_context_sizes = [8192, 16384]
+concurrency_levels = [1]
+repeats = 1
+
+[[backends]]
+id = "local_a"
+enabled = true
+base_url = "http://localhost:1/"
+api_key = "x"
+
+[[models]]
+id = "model-1"
+backend_id = "local_a"
+
+[[tiers]]
+name = "speed"
+
+[[tiers]]
+name = "boundary"
+"""
+    cfg = BenchConfig.from_toml(_write_toml(tmp_path, toml))
+    cases = cfg.expand_matrix()
+
+    boundary_ctx = {c.context_size for c in cases if c.tier == "boundary"}
+    speed_ctx = {c.context_size for c in cases if c.tier == "speed"}
+
+    assert boundary_ctx == {8192, 16384}
+    assert speed_ctx == {1024, 4096}
+
+
+def test_warmup_uses_first_concurrency_level(tmp_path: Path) -> None:
+    cfg = BenchConfig.from_toml(_write_toml(tmp_path, _STANDARD_TOML))
+    warmup = [c for c in cfg.expand_matrix() if c.repeat_index == 0]
+    first_concurrency = cfg.matrix.concurrency_levels[0]
+    assert all(c.concurrency == first_concurrency for c in warmup)
+
+
+def test_no_model_on_disabled_backend_in_expanded_cases(tmp_path: Path) -> None:
+    cfg = BenchConfig.from_toml(_write_toml(tmp_path, _STANDARD_TOML))
+    cases = cfg.expand_matrix()
+    backend_ids = {c.backend_id for c in cases}
+    assert "cloud_b" not in backend_ids


### PR DESCRIPTION
Closes WOR-182

scripts/bench/config.py loads bench.toml and expands the matrix correctly; BenchCase importable; disabled backends excluded from matrix; all required checks green.