### PR TITLE
WOR-180 Local LLM Testbench — benchmark model/backend/settings matrix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ litellm-local.yaml
 # Claude Code watcher logs
 .claude/*.log
 .claude/*.pid
+
+# Benchmark fixtures (generated locally, not committed)
+scripts/bench/fixtures/

--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,2 +1,8 @@
 # URL is a hardcoded constant (https://api.linear.app/graphql) — not user-controlled.
 app/core/linear_client.py
+
+# URLs are operator-provided config values validated to http/https scheme at construction
+# time (ValueError on any other scheme). Not user-controlled input from an untrusted source.
+scripts/bench/drivers/ollama.py
+scripts/bench/drivers/vllm.py
+scripts/bench/lifecycle/ollama_manager.py

--- a/app/core/bench_store.py
+++ b/app/core/bench_store.py
@@ -1,0 +1,265 @@
+"""Benchmark run data model and SQLite store.
+
+SQLite-backed append-only store for benchmark run records.
+Mirrors app/core/metrics.py: same _connect(), get_db_path(), DDL style,
+and _APP_DIR='repo-scaffold', but uses _DB_NAME='bench.db'.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import platform
+import sqlite3
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Generator
+
+from pydantic import BaseModel, Field
+
+_APP_DIR = "repo-scaffold"
+_DB_NAME = "bench.db"
+
+_CREATE_TABLE = """
+CREATE TABLE IF NOT EXISTS bench_run (
+    run_id                  TEXT    NOT NULL PRIMARY KEY,
+    case_id                 TEXT    NOT NULL,
+    repeat_index            INTEGER NOT NULL,
+    tier                    TEXT,
+    context_size            INTEGER,
+    concurrency             INTEGER,
+    backend_id              TEXT,
+    model_id                TEXT,
+    settings_hash           TEXT,
+    prompt_hash             TEXT,
+    backend_base_url        TEXT,
+    gpu_driver_version      TEXT,
+    cuda_version            TEXT,
+    python_version          TEXT,
+    os_version              TEXT,
+    ttft_s                  REAL,
+    wall_time_s             REAL,
+    throughput_tok_s        REAL,
+    prompt_tokens           INTEGER,
+    completion_tokens       INTEGER,
+    total_tokens            INTEGER,
+    peak_vram_gb            REAL,
+    avg_gpu_util_pct        REAL,
+    avg_gpu_mem_util_pct    REAL,
+    avg_power_w             REAL,
+    peak_temp_c             REAL,
+    avg_sm_clock_mhz        REAL,
+    avg_mem_clock_mhz       REAL,
+    peak_ram_gb             REAL,
+    cpu_offload_detected    INTEGER,
+    ollama_model_loaded     INTEGER,
+    ollama_num_ctx          INTEGER,
+    quality_task_success    INTEGER,
+    quality_pytest_passed   INTEGER,
+    quality_ruff_passed     INTEGER,
+    quality_mypy_passed     INTEGER,
+    outcome                 TEXT,
+    error_message           TEXT,
+    recorded_at             TEXT NOT NULL DEFAULT (datetime('now'))
+)
+"""
+
+_CREATE_INDEX = """
+CREATE INDEX IF NOT EXISTS idx_bench_run_case_id
+    ON bench_run (case_id)
+"""
+
+_INSERT = """
+INSERT INTO bench_run (
+    run_id, case_id, repeat_index,
+    tier, context_size, concurrency, backend_id, model_id,
+    settings_hash, prompt_hash,
+    backend_base_url, gpu_driver_version, cuda_version, python_version, os_version,
+    ttft_s, wall_time_s, throughput_tok_s,
+    prompt_tokens, completion_tokens, total_tokens,
+    peak_vram_gb, avg_gpu_util_pct, avg_gpu_mem_util_pct, avg_power_w,
+    peak_temp_c, avg_sm_clock_mhz, avg_mem_clock_mhz,
+    peak_ram_gb, cpu_offload_detected,
+    ollama_model_loaded, ollama_num_ctx,
+    quality_task_success, quality_pytest_passed,
+    quality_ruff_passed, quality_mypy_passed,
+    outcome, error_message
+) VALUES (
+    :run_id, :case_id, :repeat_index,
+    :tier, :context_size, :concurrency, :backend_id, :model_id,
+    :settings_hash, :prompt_hash,
+    :backend_base_url, :gpu_driver_version, :cuda_version, :python_version, :os_version,
+    :ttft_s, :wall_time_s, :throughput_tok_s,
+    :prompt_tokens, :completion_tokens, :total_tokens,
+    :peak_vram_gb, :avg_gpu_util_pct, :avg_gpu_mem_util_pct, :avg_power_w,
+    :peak_temp_c, :avg_sm_clock_mhz, :avg_mem_clock_mhz,
+    :peak_ram_gb, :cpu_offload_detected,
+    :ollama_model_loaded, :ollama_num_ctx,
+    :quality_task_success, :quality_pytest_passed,
+    :quality_ruff_passed, :quality_mypy_passed,
+    :outcome, :error_message
+)
+"""
+
+_BOOL_COLUMNS = frozenset(
+    {
+        "cpu_offload_detected",
+        "ollama_model_loaded",
+        "quality_task_success",
+        "quality_pytest_passed",
+        "quality_ruff_passed",
+        "quality_mypy_passed",
+    }
+)
+
+
+class BenchRun(BaseModel):
+    """Single benchmark run record."""
+
+    model_config = {"extra": "forbid"}
+
+    # identity — required
+    run_id: str
+    case_id: str
+    repeat_index: int
+
+    # config
+    tier: str | None = None
+    context_size: int | None = None
+    concurrency: int | None = None
+    backend_id: str | None = None
+    model_id: str | None = None
+    settings_hash: str | None = None
+    prompt_hash: str | None = None
+
+    # backend metadata
+    backend_base_url: str | None = None
+    gpu_driver_version: str | None = None
+    cuda_version: str | None = None
+    python_version: str | None = None
+    os_version: str | None = None
+
+    # timing
+    ttft_s: float | None = Field(
+        default=None, description="Time to first token in seconds"
+    )
+    wall_time_s: float | None = Field(
+        default=None, description="Total wall time in seconds"
+    )
+    throughput_tok_s: float | None = Field(
+        default=None, description="Tokens per second"
+    )
+
+    # tokens
+    prompt_tokens: int | None = None
+    completion_tokens: int | None = None
+    total_tokens: int | None = None
+
+    # GPU
+    peak_vram_gb: float | None = None
+    avg_gpu_util_pct: float | None = None
+    avg_gpu_mem_util_pct: float | None = None
+    avg_power_w: float | None = None
+    peak_temp_c: float | None = None
+    avg_sm_clock_mhz: float | None = None
+    avg_mem_clock_mhz: float | None = None
+
+    # CPU/RAM
+    peak_ram_gb: float | None = None
+    cpu_offload_detected: bool | None = None
+
+    # Ollama status
+    ollama_model_loaded: bool | None = None
+    ollama_num_ctx: int | None = None
+
+    # quality
+    quality_task_success: bool | None = None
+    quality_pytest_passed: bool | None = None
+    quality_ruff_passed: bool | None = None
+    quality_mypy_passed: bool | None = None
+
+    # outcome
+    outcome: str | None = None
+    error_message: str | None = None
+
+
+def hash_settings(settings: dict[str, Any]) -> str:
+    """Return stable SHA256 hex digest of JSON-serialized settings (key-sorted)."""
+    return hashlib.sha256(json.dumps(settings, sort_keys=True).encode()).hexdigest()
+
+
+def hash_text(text: str) -> str:
+    """Return stable SHA256 hex digest of UTF-8 encoded text."""
+    return hashlib.sha256(text.encode()).hexdigest()
+
+
+class BenchStore:
+    """SQLite-backed append-only store for benchmark run records."""
+
+    _APP_DIR = _APP_DIR
+
+    @classmethod
+    def get_db_path(cls) -> Path:
+        if platform.system() == "Windows":
+            base = Path.home() / "AppData" / "Roaming"
+        else:
+            base = Path.home() / ".config"
+        return base / cls._APP_DIR / _DB_NAME
+
+    def __init__(self, db_path: Path | None = None) -> None:
+        self._path = db_path if db_path is not None else self.get_db_path()
+        self._ensure_schema()
+
+    def _ensure_schema(self) -> None:
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        with self._connect() as conn:
+            conn.execute(_CREATE_TABLE)
+            conn.execute(_CREATE_INDEX)
+
+    @contextmanager
+    def _connect(self) -> Generator[sqlite3.Connection, None, None]:
+        conn = sqlite3.connect(self._path)
+        conn.row_factory = sqlite3.Row
+        try:
+            yield conn
+            conn.commit()
+        finally:
+            conn.close()
+
+    def record(self, run: BenchRun) -> None:
+        """Append a benchmark run record. Raises IntegrityError on duplicate run_id."""
+        d = run.model_dump()
+        for col in _BOOL_COLUMNS:
+            if d[col] is not None:
+                d[col] = int(d[col])
+        with self._connect() as conn:
+            conn.execute(_INSERT, d)
+
+    def get_by_run_id(self, run_id: str) -> BenchRun | None:
+        """Return the BenchRun for the given run_id, or None if not found."""
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT * FROM bench_run WHERE run_id = ?",
+                (run_id,),
+            ).fetchone()
+        if row is None:
+            return None
+        return _row_to_bench_run(row)
+
+    def get_by_case_id(self, case_id: str) -> list[BenchRun]:
+        """Return all BenchRun records for a given case_id, oldest first."""
+        with self._connect() as conn:
+            rows = conn.execute(
+                "SELECT * FROM bench_run WHERE case_id = ? ORDER BY recorded_at",
+                (case_id,),
+            ).fetchall()
+        return [_row_to_bench_run(r) for r in rows]
+
+
+def _row_to_bench_run(row: sqlite3.Row) -> BenchRun:
+    d = dict(row)
+    d.pop("recorded_at", None)
+    for col in _BOOL_COLUMNS:
+        if d[col] is not None:
+            d[col] = bool(d[col])
+    return BenchRun.model_validate(d)

--- a/config/bench.toml
+++ b/config/bench.toml
@@ -1,0 +1,43 @@
+# Benchmark configuration.
+# Load with BenchConfig.from_toml("config/bench.toml").
+# expand_matrix() produces the full Cartesian product of models x tiers x contexts x concurrency.
+# Disabled backends are excluded from the matrix.
+# The boundary tier uses boundary_context_sizes; all other tiers use context_sizes.
+
+[matrix]
+# Context sizes (in tokens) for non-boundary tiers.
+context_sizes = [1024, 4096]
+# Context sizes used exclusively by the boundary tier.
+boundary_context_sizes = [8192, 16384]
+# Concurrent requests per probe point.
+concurrency_levels = [1, 4]
+# Number of real (non-warmup) runs per probe point.
+repeats = 1
+
+[[backends]]
+id = "local_qwen"
+enabled = true
+base_url = "http://localhost:11434/v1"
+
+[[backends]]
+id = "cloud_gpt4o"
+enabled = false
+base_url = "https://api.openai.com/v1"
+
+[[models]]
+id = "qwen3-coder-30b"
+backend_id = "local_qwen"
+
+[[models]]
+id = "qwen3-14b"
+backend_id = "local_qwen"
+
+[[models]]
+id = "gpt-4o"
+backend_id = "cloud_gpt4o"
+
+[[tiers]]
+name = "speed"
+
+[[tiers]]
+name = "boundary"

--- a/scripts/bench/__init__.py
+++ b/scripts/bench/__init__.py
@@ -1,0 +1,1 @@
+"""Benchmark scripts package."""

--- a/scripts/bench/config.py
+++ b/scripts/bench/config.py
@@ -1,0 +1,138 @@
+"""Benchmark config loader and matrix expander."""
+
+from __future__ import annotations
+
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+
+from pydantic import BaseModel, field_validator
+
+
+@dataclass
+class BenchCase:
+    """One probe point in the benchmark matrix."""
+
+    backend_id: str
+    model_id: str
+    tier: str
+    context_size: int
+    concurrency: int
+    repeat_index: int  # 0 = warmup, >=1 = real
+
+
+class MatrixConfig(BaseModel):
+    model_config = {"extra": "forbid"}
+
+    context_sizes: list[int]
+    boundary_context_sizes: list[int]
+    concurrency_levels: list[int]
+    repeats: int = 1
+
+    @field_validator("context_sizes", "boundary_context_sizes", "concurrency_levels")
+    @classmethod
+    def non_empty_list(cls, v: list[int]) -> list[int]:
+        if not v:
+            raise ValueError("must be non-empty")
+        return v
+
+    @field_validator("repeats")
+    @classmethod
+    def positive_repeats(cls, v: int) -> int:
+        if v < 1:
+            raise ValueError("repeats must be >= 1")
+        return v
+
+
+class BackendConfig(BaseModel):
+    model_config = {"extra": "forbid"}
+
+    id: str
+    enabled: bool = True
+    base_url: str
+    api_key: str = ""
+
+
+class ModelConfig(BaseModel):
+    model_config = {"extra": "forbid"}
+
+    id: str
+    backend_id: str
+
+
+class TierConfig(BaseModel):
+    model_config = {"extra": "forbid"}
+
+    name: str
+
+
+class BenchConfig(BaseModel):
+    """Top-level benchmark configuration."""
+
+    model_config = {"extra": "forbid"}
+
+    matrix: MatrixConfig
+    backends: list[BackendConfig]
+    models: list[ModelConfig]
+    tiers: list[TierConfig]
+
+    @classmethod
+    def from_toml(cls, path: Path | str) -> "BenchConfig":
+        """Load and validate config from a TOML file.
+
+        Raises FileNotFoundError if the file is missing.
+        Raises pydantic.ValidationError if the config is structurally invalid.
+        Raises tomllib.TOMLDecodeError if the file is not valid TOML.
+        """
+        resolved = Path(path)
+        raw = resolved.read_bytes()
+        data = tomllib.loads(raw.decode())
+        return cls.model_validate(data)
+
+    def expand_matrix(self) -> list[BenchCase]:
+        """Expand the config into a flat list of BenchCase instances.
+
+        Disabled backends are excluded. Boundary tier uses boundary_context_sizes;
+        all other tiers use context_sizes. Each (model, tier, context_size) produces
+        one warmup case (repeat_index=0) at the first concurrency level, followed by
+        real cases (repeat_index>=1) across all concurrency levels and repeats.
+        """
+        enabled_backends = {b.id for b in self.backends if b.enabled}
+        enabled_models = [m for m in self.models if m.backend_id in enabled_backends]
+
+        cases: list[BenchCase] = []
+
+        for model in enabled_models:
+            for tier in self.tiers:
+                ctx_sizes = (
+                    self.matrix.boundary_context_sizes
+                    if tier.name == "boundary"
+                    else self.matrix.context_sizes
+                )
+
+                for ctx_size in ctx_sizes:
+                    cases.append(
+                        BenchCase(
+                            backend_id=model.backend_id,
+                            model_id=model.id,
+                            tier=tier.name,
+                            context_size=ctx_size,
+                            concurrency=self.matrix.concurrency_levels[0],
+                            repeat_index=0,
+                        )
+                    )
+
+                    for concurrency in self.matrix.concurrency_levels:
+                        for repeat in range(1, self.matrix.repeats + 1):
+                            cases.append(
+                                BenchCase(
+                                    backend_id=model.backend_id,
+                                    model_id=model.id,
+                                    tier=tier.name,
+                                    context_size=ctx_size,
+                                    concurrency=concurrency,
+                                    repeat_index=repeat,
+                                )
+                            )
+
+        return cases

--- a/scripts/bench/drivers/__init__.py
+++ b/scripts/bench/drivers/__init__.py
@@ -1,0 +1,1 @@
+"""Backend driver package for benchmark backends."""

--- a/scripts/bench/drivers/base.py
+++ b/scripts/bench/drivers/base.py
@@ -1,0 +1,28 @@
+"""BackendDriver Protocol and GenerationResult shared by all backend drivers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+
+@dataclass
+class GenerationResult:
+    """Result of a single generation call to a backend."""
+
+    error: str | None = None
+    text: str = ""
+    ttft_s: float | None = None
+    decode_time_s: float | None = None
+    raw_prompt_eval_duration_ns: int | None = None
+    raw_eval_duration_ns: int | None = None
+    raw_load_duration_ns: int | None = None
+    input_tokens: int | None = None
+    output_tokens: int | None = None
+
+
+class BackendDriver(Protocol):
+    def is_available(self) -> bool: ...
+    def generate(
+        self, model: str, messages: list[dict[str, str]]
+    ) -> GenerationResult: ...

--- a/scripts/bench/drivers/ollama.py
+++ b/scripts/bench/drivers/ollama.py
@@ -1,0 +1,101 @@
+"""Ollama backend driver: streaming NDJSON via urllib POST /api/chat."""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+import urllib.error
+import urllib.request
+from typing import Any
+from urllib.parse import urlparse
+
+from scripts.bench.drivers.base import GenerationResult
+
+logger = logging.getLogger(__name__)
+
+_ALLOWED_SCHEMES = frozenset({"http", "https"})
+
+
+def _validated_base_url(url: str) -> str:
+    scheme = urlparse(url).scheme
+    if scheme not in _ALLOWED_SCHEMES:
+        raise ValueError(f"base_url must use http or https scheme, got: {scheme!r}")
+    return url.rstrip("/")
+
+
+class OllamaDriver:
+    """Implements BackendDriver for Ollama's /api/chat streaming endpoint."""
+
+    def __init__(self, base_url: str = "http://localhost:11434") -> None:
+        self._base_url = _validated_base_url(base_url)
+
+    def is_available(self) -> bool:
+        try:
+            req = urllib.request.Request(f"{self._base_url}/api/tags")
+            with urllib.request.urlopen(req, timeout=2):
+                return True
+        except Exception:
+            return False
+
+    def generate(self, model: str, messages: list[dict[str, str]]) -> GenerationResult:
+        payload = json.dumps(
+            {"model": model, "messages": messages, "stream": True}
+        ).encode()
+        req = urllib.request.Request(
+            f"{self._base_url}/api/chat",
+            data=payload,
+            headers={"Content-Type": "application/json"},
+        )
+        try:
+            t_start = time.monotonic()
+            with urllib.request.urlopen(req, timeout=300) as resp:
+                return self._parse_streaming(resp, t_start)
+        except urllib.error.URLError as exc:
+            return GenerationResult(error=str(exc))
+        except Exception as exc:
+            return GenerationResult(error=str(exc))
+
+    def _parse_streaming(self, resp: Any, t_start: float) -> GenerationResult:
+        ttft_s: float | None = None
+        text_parts: list[str] = []
+        final_frame: dict[str, Any] = {}
+
+        while True:
+            raw = resp.readline()
+            if not raw:
+                break
+            line = raw.decode("utf-8").strip()
+            if not line:
+                continue
+            try:
+                frame: dict[str, Any] = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+
+            if not frame.get("done", False):
+                content: str = frame.get("message", {}).get("content", "")
+                if content and ttft_s is None:
+                    ttft_s = time.monotonic() - t_start
+                text_parts.append(content)
+            else:
+                final_frame = frame
+
+        load_ns: int = final_frame.get("load_duration") or 0
+        raw_load_duration_ns: int | None = load_ns if load_ns > 0 else None
+
+        raw_eval_duration_ns: int | None = final_frame.get("eval_duration")
+        decode_time_s: float | None = (
+            raw_eval_duration_ns / 1e9 if raw_eval_duration_ns is not None else None
+        )
+
+        return GenerationResult(
+            text="".join(text_parts),
+            ttft_s=ttft_s,
+            decode_time_s=decode_time_s,
+            raw_prompt_eval_duration_ns=final_frame.get("prompt_eval_duration"),
+            raw_eval_duration_ns=raw_eval_duration_ns,
+            raw_load_duration_ns=raw_load_duration_ns,
+            input_tokens=final_frame.get("prompt_eval_count"),
+            output_tokens=final_frame.get("eval_count"),
+        )

--- a/scripts/bench/drivers/vllm.py
+++ b/scripts/bench/drivers/vllm.py
@@ -1,0 +1,104 @@
+"""vLLM backend driver: SSE streaming via urllib POST /v1/chat/completions."""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+import urllib.error
+import urllib.request
+from typing import Any
+from urllib.parse import urlparse
+
+from scripts.bench.drivers.base import GenerationResult
+
+logger = logging.getLogger(__name__)
+
+_SSE_PREFIX = "data: "
+_SSE_DONE = "[DONE]"
+_ALLOWED_SCHEMES = frozenset({"http", "https"})
+
+
+def _validated_base_url(url: str) -> str:
+    scheme = urlparse(url).scheme
+    if scheme not in _ALLOWED_SCHEMES:
+        raise ValueError(f"base_url must use http or https scheme, got: {scheme!r}")
+    return url.rstrip("/")
+
+
+class VllmDriver:
+    """Implements BackendDriver for vLLM's /v1/chat/completions SSE endpoint."""
+
+    def __init__(self, base_url: str = "http://localhost:8000") -> None:
+        self._base_url = _validated_base_url(base_url)
+
+    def is_available(self) -> bool:
+        try:
+            req = urllib.request.Request(f"{self._base_url}/health")
+            with urllib.request.urlopen(req, timeout=2):
+                return True
+        except Exception:
+            return False
+
+    def generate(self, model: str, messages: list[dict[str, str]]) -> GenerationResult:
+        payload = json.dumps(
+            {
+                "model": model,
+                "messages": messages,
+                "stream": True,
+                "stream_options": {"include_usage": True},
+            }
+        ).encode()
+        req = urllib.request.Request(
+            f"{self._base_url}/v1/chat/completions",
+            data=payload,
+            headers={"Content-Type": "application/json"},
+        )
+        try:
+            t_start = time.monotonic()
+            with urllib.request.urlopen(req, timeout=300) as resp:
+                return self._parse_streaming(resp, t_start)
+        except urllib.error.URLError as exc:
+            return GenerationResult(error=str(exc))
+        except Exception as exc:
+            return GenerationResult(error=str(exc))
+
+    def _parse_streaming(self, resp: Any, t_start: float) -> GenerationResult:
+        ttft_s: float | None = None
+        text_parts: list[str] = []
+        input_tokens: int | None = None
+        output_tokens: int | None = None
+
+        while True:
+            raw = resp.readline()
+            if not raw:
+                break
+            line = raw.decode("utf-8").rstrip("\r\n")
+            if not line.startswith(_SSE_PREFIX):
+                continue
+            data = line[len(_SSE_PREFIX) :]
+            if data == _SSE_DONE:
+                break
+            try:
+                frame: dict[str, Any] = json.loads(data)
+            except json.JSONDecodeError:
+                continue
+
+            usage = frame.get("usage")
+            if usage:
+                input_tokens = usage.get("prompt_tokens")
+                output_tokens = usage.get("completion_tokens")
+
+            for choice in frame.get("choices", []):
+                content: str = choice.get("delta", {}).get("content") or ""
+                if content:
+                    if ttft_s is None:
+                        ttft_s = time.monotonic() - t_start
+                    text_parts.append(content)
+
+        return GenerationResult(
+            text="".join(text_parts),
+            ttft_s=ttft_s,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+        )

--- a/scripts/bench/env_snapshot.py
+++ b/scripts/bench/env_snapshot.py
@@ -1,0 +1,88 @@
+"""One-shot environment snapshot per benchmark sweep."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import platform
+import subprocess  # nosec B404
+import sys
+from dataclasses import dataclass
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class EnvSnapshot:
+    backend: str
+    model: str
+    gpu_driver_version: str | None
+    cuda_version: str | None
+    python_version: str
+    os_version: str
+    settings_hash: str
+
+    @classmethod
+    def capture(
+        cls, backend: str, model: str, settings: dict[str, Any]
+    ) -> "EnvSnapshot":
+        gpu_driver, cuda_ver = _get_nvidia_info()
+        return cls(
+            backend=backend,
+            model=model,
+            gpu_driver_version=gpu_driver,
+            cuda_version=cuda_ver,
+            python_version=sys.version,
+            os_version=platform.platform(),
+            settings_hash=_hash_settings(settings),
+        )
+
+
+def _hash_settings(settings: dict[str, Any]) -> str:
+    return hashlib.sha256(json.dumps(settings, sort_keys=True).encode()).hexdigest()
+
+
+def _get_nvidia_info() -> tuple[str | None, str | None]:
+    """Return (driver_version, cuda_version) or (None, None) if nvidia-smi absent."""
+    try:
+        driver_result = subprocess.run(  # nosec B603, B607
+            [
+                "nvidia-smi",
+                "--query-gpu=driver_version",
+                "--format=csv,noheader,nounits",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
+        logger.warning("nvidia-smi unavailable: %s", exc)
+        return None, None
+
+    if driver_result.returncode != 0:
+        return None, None
+
+    lines = driver_result.stdout.strip().splitlines()
+    driver_version: str | None = lines[0].strip() if lines else None
+
+    cuda_version: str | None = None
+    try:
+        smi_result = subprocess.run(  # nosec B603, B607
+            ["nvidia-smi"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if smi_result.returncode == 0:
+            for line in smi_result.stdout.splitlines():
+                if "CUDA Version:" in line:
+                    parts = line.split("CUDA Version:")
+                    if len(parts) > 1:
+                        cuda_version = parts[1].split("|")[0].strip()
+                    break
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        pass
+
+    return driver_version or None, cuda_version

--- a/scripts/bench/gpu_monitor.py
+++ b/scripts/bench/gpu_monitor.py
@@ -1,0 +1,126 @@
+"""Background GPU monitor: polls nvidia-smi every 0.5 s."""
+
+from __future__ import annotations
+
+import logging
+import subprocess  # nosec B404
+import threading
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+_QUERY = (
+    "memory.used,utilization.gpu,utilization.memory,power.draw,"
+    "temperature.gpu,clocks.sm,clocks.mem"
+)
+_NVIDIA_SMI_CMD: list[str] = [
+    "nvidia-smi",
+    f"--query-gpu={_QUERY}",
+    "--format=csv,noheader,nounits",
+]
+
+
+@dataclass
+class GpuSample:
+    peak_vram_gb: float | None
+    avg_gpu_util_pct: float | None
+    avg_gpu_mem_util_pct: float | None
+    avg_power_w: float | None
+    peak_temp_c: float | None
+    avg_sm_clock_mhz: float | None
+    avg_mem_clock_mhz: float | None
+
+
+def _all_none() -> GpuSample:
+    return GpuSample(
+        peak_vram_gb=None,
+        avg_gpu_util_pct=None,
+        avg_gpu_mem_util_pct=None,
+        avg_power_w=None,
+        peak_temp_c=None,
+        avg_sm_clock_mhz=None,
+        avg_mem_clock_mhz=None,
+    )
+
+
+def _parse_nvidia_smi(
+    stdout: str,
+) -> tuple[float, float, float, float, float, float, float] | None:
+    """Parse first line of nvidia-smi csv output; return None on any error."""
+    lines = stdout.strip().splitlines()
+    if not lines:
+        return None
+    parts = [p.strip() for p in lines[0].split(",")]
+    if len(parts) != 7:
+        return None
+    try:
+        vram_mib, gpu_util, mem_util, power, temp, sm_clk, mem_clk = (
+            float(p) for p in parts
+        )
+    except ValueError:
+        return None
+    return vram_mib / 1024.0, gpu_util, mem_util, power, temp, sm_clk, mem_clk
+
+
+class GpuMonitor:
+    """Daemon thread that polls nvidia-smi every *interval* seconds."""
+
+    def __init__(self, interval: float = 0.5) -> None:
+        self._interval = interval
+        self._thread: threading.Thread | None = None
+        self._stop_event = threading.Event()
+        self._samples: list[tuple[float, float, float, float, float, float, float]] = []
+
+    def _poll_once(
+        self,
+    ) -> tuple[float, float, float, float, float, float, float] | None:
+        try:
+            result = subprocess.run(  # nosec B603, B607
+                _NVIDIA_SMI_CMD,
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+        except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
+            logger.warning("nvidia-smi unavailable: %s", exc)
+            return None
+        if result.returncode != 0:
+            return None
+        return _parse_nvidia_smi(result.stdout)
+
+    def _run(self) -> None:
+        while not self._stop_event.is_set():
+            sample = self._poll_once()
+            if sample is not None:
+                self._samples.append(sample)
+            self._stop_event.wait(self._interval)
+
+    def start(self) -> None:
+        self._stop_event.clear()
+        self._samples.clear()
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._thread.start()
+
+    def stop(self) -> GpuSample:
+        self._stop_event.set()
+        if self._thread is not None:
+            self._thread.join(timeout=10)
+        if not self._samples:
+            return _all_none()
+        vram = [s[0] for s in self._samples]
+        gpu_util = [s[1] for s in self._samples]
+        mem_util = [s[2] for s in self._samples]
+        power = [s[3] for s in self._samples]
+        temp = [s[4] for s in self._samples]
+        sm_clk = [s[5] for s in self._samples]
+        mem_clk = [s[6] for s in self._samples]
+        n = len(self._samples)
+        return GpuSample(
+            peak_vram_gb=max(vram),
+            avg_gpu_util_pct=sum(gpu_util) / n,
+            avg_gpu_mem_util_pct=sum(mem_util) / n,
+            avg_power_w=sum(power) / n,
+            peak_temp_c=max(temp),
+            avg_sm_clock_mhz=sum(sm_clk) / n,
+            avg_mem_clock_mhz=sum(mem_clk) / n,
+        )

--- a/scripts/bench/lifecycle/__init__.py
+++ b/scripts/bench/lifecycle/__init__.py
@@ -1,0 +1,1 @@
+"""Lifecycle management package for benchmark backends."""

--- a/scripts/bench/lifecycle/ollama_manager.py
+++ b/scripts/bench/lifecycle/ollama_manager.py
@@ -1,0 +1,115 @@
+"""Ollama lifecycle manager: ensure_running, pull_if_needed, flush_model, get_ps_status.
+
+Uses stdlib urllib only — no third-party HTTP dependencies.
+"""
+
+from __future__ import annotations
+
+import http.client
+import json
+import logging
+import socket
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from urllib.parse import urlparse
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_PORT = 11434
+_ALLOWED_SCHEMES = frozenset({"http", "https"})
+
+
+@dataclass
+class ModelStatus:
+    """Status of a loaded model from /api/ps."""
+
+    name: str
+    size: int
+    size_vram: int
+    processor_status: str
+    expires_at: str
+
+
+class OllamaManager:
+    """Manages Ollama process lifecycle and model state."""
+
+    def __init__(self, base_url: str = "http://localhost:11434") -> None:
+        parsed = urlparse(base_url)
+        if parsed.scheme not in _ALLOWED_SCHEMES:
+            raise ValueError(
+                f"base_url must use http or https scheme, got: {parsed.scheme!r}"
+            )
+        self._base_url = base_url.rstrip("/")
+        self._host = parsed.hostname or "localhost"
+        self._port = parsed.port or _DEFAULT_PORT
+
+    def ensure_running(self, timeout: float = 120.0) -> None:
+        """Wait until Ollama is reachable via TCP probe then HTTP /api/tags."""
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+                sock.settimeout(2)
+                if sock.connect_ex((self._host, self._port)) != 0:
+                    time.sleep(0.5)
+                    continue
+            try:
+                conn = http.client.HTTPConnection(self._host, self._port, timeout=2)
+                conn.request("GET", "/api/tags")
+                if conn.getresponse().status == 200:
+                    return
+            except (OSError, http.client.HTTPException):
+                pass
+            time.sleep(0.5)
+        raise TimeoutError(f"Ollama not ready after {timeout}s")
+
+    def pull_if_needed(self, model: str) -> None:
+        """Pull model only if it is not already listed in /api/tags."""
+        try:
+            req = urllib.request.Request(f"{self._base_url}/api/tags")
+            with urllib.request.urlopen(req, timeout=10) as resp:
+                data = json.loads(resp.read())
+            existing = {m["name"] for m in data.get("models", [])}
+            if model in existing:
+                logger.info("Model %r already present, skipping pull", model)
+                return
+        except urllib.error.URLError as exc:
+            logger.warning("Could not check /api/tags: %s", exc)
+
+        logger.info("Pulling model %r", model)
+        payload = json.dumps({"model": model, "stream": False}).encode()
+        req = urllib.request.Request(
+            f"{self._base_url}/api/pull",
+            data=payload,
+            headers={"Content-Type": "application/json"},
+        )
+        with urllib.request.urlopen(req, timeout=600) as resp:
+            resp.read()
+
+    def flush_model(self, model: str) -> None:
+        """Unload model from memory via POST /api/generate with keep_alive=0."""
+        payload = json.dumps({"model": model, "keep_alive": 0}).encode()
+        req = urllib.request.Request(
+            f"{self._base_url}/api/generate",
+            data=payload,
+            headers={"Content-Type": "application/json"},
+        )
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            resp.read()
+
+    def get_ps_status(self) -> list[ModelStatus]:
+        """Return currently loaded models from /api/ps."""
+        req = urllib.request.Request(f"{self._base_url}/api/ps")
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            data = json.loads(resp.read())
+        return [
+            ModelStatus(
+                name=m["name"],
+                size=m.get("size", 0),
+                size_vram=m.get("size_vram", 0),
+                processor_status=m.get("processor", "unknown"),
+                expires_at=m.get("expires_at", ""),
+            )
+            for m in data.get("models", [])
+        ]

--- a/scripts/bench/quality.py
+++ b/scripts/bench/quality.py
@@ -1,0 +1,91 @@
+"""Coding quality evaluator: applies a patch and runs pytest/ruff/mypy."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess  # nosec B404
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass
+class QualityResult:
+    task_success: bool
+    pytest_passed: bool
+    ruff_passed: bool
+    mypy_passed: bool
+    error_message: str | None = None
+
+
+def _apply_patch(patch: dict[str, str], dest: Path) -> None:
+    file_path = Path(patch["path"])
+    if file_path.is_absolute() or ".." in file_path.parts:
+        raise ValueError(f"Unsafe patch path: {patch['path']!r}")
+    target = dest / file_path
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(patch["content"], encoding="utf-8")
+
+
+def evaluate_coding_output(model_output: str, repo_path: Path) -> QualityResult:
+    """Parse model_output as tool-call JSON, apply to a temp repo copy, run checks."""
+    temp_dir = tempfile.mkdtemp()
+    try:
+        patch = json.loads(model_output)
+        if not isinstance(patch, dict) or "path" not in patch or "content" not in patch:
+            return QualityResult(
+                task_success=False,
+                pytest_passed=False,
+                ruff_passed=False,
+                mypy_passed=False,
+                error_message=(
+                    "model output must be a JSON object with 'path' and 'content' keys"
+                ),
+            )
+
+        dest = Path(temp_dir)
+        shutil.copytree(str(repo_path), str(dest), dirs_exist_ok=True)
+        _apply_patch(patch, dest)
+
+        python = sys.executable
+        pytest_rc = subprocess.run(  # nosec B603
+            [python, "-m", "pytest", "--tb=short", "-q"],
+            cwd=dest,
+            capture_output=True,
+            text=True,
+        ).returncode
+        ruff_rc = subprocess.run(  # nosec B603
+            [python, "-m", "ruff", "check", "."],
+            cwd=dest,
+            capture_output=True,
+            text=True,
+        ).returncode
+        mypy_rc = subprocess.run(  # nosec B603
+            [python, "-m", "mypy", "app/"],
+            cwd=dest,
+            capture_output=True,
+            text=True,
+        ).returncode
+
+        pytest_passed = pytest_rc == 0
+        ruff_passed = ruff_rc == 0
+        mypy_passed = mypy_rc == 0
+
+        return QualityResult(
+            task_success=pytest_passed and ruff_passed and mypy_passed,
+            pytest_passed=pytest_passed,
+            ruff_passed=ruff_passed,
+            mypy_passed=mypy_passed,
+        )
+    except Exception as exc:
+        return QualityResult(
+            task_success=False,
+            pytest_passed=False,
+            ruff_passed=False,
+            mypy_passed=False,
+            error_message=str(exc),
+        )
+    finally:
+        shutil.rmtree(temp_dir, ignore_errors=True)

--- a/scripts/bench/reporter.py
+++ b/scripts/bench/reporter.py
@@ -1,0 +1,348 @@
+"""Benchmark reporter: console tables, quality-gated ranking, and data export."""
+
+from __future__ import annotations
+
+import csv
+import json
+import sqlite3
+import statistics
+from pathlib import Path
+from typing import Any
+
+# ── DB loader ─────────────────────────────────────────────────────────────────
+
+
+def load_sweep(db_path: Path, sweep_id: str) -> list[dict[str, Any]]:
+    """Load all rows recorded under *sweep_id* from bench.db."""
+    if not db_path.exists():
+        return []
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        rows = conn.execute(
+            "SELECT * FROM bench_run WHERE run_id LIKE ?",
+            (f"{sweep_id}::%",),
+        ).fetchall()
+    finally:
+        conn.close()
+    return [dict(r) for r in rows]
+
+
+# ── Formatting helpers ────────────────────────────────────────────────────────
+
+
+def _fmt(value: Any, fmt: str = "", na: str = "--") -> str:
+    if value is None:
+        return na
+    try:
+        return format(value, fmt)
+    except (TypeError, ValueError):
+        return str(value)
+
+
+def _bool_col(value: Any) -> str:
+    if value is None:
+        return "--"
+    return "Yes" if value else "No"
+
+
+def _pct(value: float | None) -> str:
+    if value is None:
+        return "--"
+    return f"{value:.0f}%"
+
+
+def _median(values: list[float]) -> float | None:
+    clean = [v for v in values if v is not None]
+    if not clean:
+        return None
+    return statistics.median(clean)
+
+
+# ── Summary table ─────────────────────────────────────────────────────────────
+
+_SUMMARY_COLS = [
+    ("Model", 20),
+    ("Tier", 14),
+    ("Ctx", 6),
+    ("C", 3),
+    ("R", 3),
+    ("TTFT(s)", 8),
+    ("Wall(s)", 8),
+    ("Tok/s", 7),
+    ("VRAM(GB)", 9),
+    ("GPU%", 5),
+    ("OOM", 5),
+    ("Offload", 7),
+    ("Outcome", 7),
+]
+
+
+def print_summary_table(rows: list[dict[str, Any]]) -> None:
+    """Print a per-case summary table to stdout."""
+    if not rows:
+        print("\n(no results for this sweep)")
+        return
+
+    header = "  ".join(name.ljust(w) for name, w in _SUMMARY_COLS)
+    sep = "  ".join("-" * w for _, w in _SUMMARY_COLS)
+    print(f"\n{'=' * len(sep)}")
+    print("SWEEP SUMMARY")
+    print(f"{'=' * len(sep)}")
+    print(header)
+    print(sep)
+
+    for r in rows:
+        oom = r.get("outcome") == "oom"
+        offload = bool(r.get("cpu_offload_detected"))
+        vals = [
+            str(r.get("model_id") or "--")[:20],
+            str(r.get("tier") or "--")[:14],
+            _fmt(r.get("context_size")),
+            _fmt(r.get("concurrency")),
+            _fmt(r.get("repeat_index")),
+            _fmt(r.get("ttft_s"), ".2f"),
+            _fmt(r.get("wall_time_s"), ".2f"),
+            _fmt(r.get("throughput_tok_s"), ".0f"),
+            _fmt(r.get("peak_vram_gb"), ".1f"),
+            _pct(r.get("avg_gpu_util_pct")),
+            "Yes" if oom else "No",
+            "Yes" if offload else "No",
+            str(r.get("outcome") or "--")[:7],
+        ]
+        line = "  ".join(v.ljust(w) for v, (_, w) in zip(vals, _SUMMARY_COLS))
+        print(line)
+
+    print(f"{'=' * len(sep)}\n")
+
+
+# ── Quality-gated ranking ─────────────────────────────────────────────────────
+
+
+def _is_eligible(rows_for_model: list[dict[str, Any]]) -> bool:
+    """Return True if the model meets all quality-gate criteria."""
+    if not rows_for_model:
+        return False
+
+    real_runs = [r for r in rows_for_model if r.get("repeat_index", 0) >= 1]
+    if not real_runs:
+        return False
+
+    # Must have no OOM
+    if any(r.get("outcome") == "oom" for r in real_runs):
+        return False
+
+    # Must have no CPU offload
+    if any(r.get("cpu_offload_detected") for r in real_runs):
+        return False
+
+    # error_rate <= 5%
+    errors = sum(1 for r in real_runs if r.get("outcome") not in ("ok", None))
+    if errors / len(real_runs) > 0.05:
+        return False
+
+    # task_success >= 70% for coding rows that have quality data
+    coding_with_quality = [
+        r
+        for r in real_runs
+        if r.get("tier") == "coding" and r.get("quality_task_success") is not None
+    ]
+    if coding_with_quality:
+        successes = sum(1 for r in coding_with_quality if r.get("quality_task_success"))
+        if successes / len(coding_with_quality) < 0.70:
+            return False
+
+    return True
+
+
+def print_ranking(rows: list[dict[str, Any]]) -> None:
+    """Print quality-gated ranking with recommendation banner."""
+    if not rows:
+        return
+
+    # Group by (backend_id, model_id)
+    by_model: dict[str, list[dict[str, Any]]] = {}
+    for r in rows:
+        key = f"{r.get('backend_id', '')} / {r.get('model_id', '')}"
+        by_model.setdefault(key, []).append(r)
+
+    eligible: list[dict[str, Any]] = []
+    for model_key, model_rows in by_model.items():
+        if not _is_eligible(model_rows):
+            continue
+        real_runs = [r for r in model_rows if r.get("repeat_index", 0) >= 1]
+        ttft_values: list[float] = [
+            r["ttft_s"] for r in real_runs if r.get("ttft_s") is not None
+        ]
+        tok_values: list[float] = [
+            r["throughput_tok_s"]
+            for r in real_runs
+            if r.get("throughput_tok_s") is not None
+        ]
+        coding_with_q = [
+            r
+            for r in real_runs
+            if r.get("tier") == "coding" and r.get("quality_task_success") is not None
+        ]
+        task_pct: float | None = None
+        if coding_with_q:
+            successes = sum(1 for r in coding_with_q if r.get("quality_task_success"))
+            task_pct = 100.0 * successes / len(coding_with_q)
+
+        eligible.append(
+            {
+                "model_key": model_key,
+                "ttft_p50": _median(ttft_values),
+                "tok_p50": _median(tok_values),
+                "task_pct": task_pct,
+            }
+        )
+
+    if not eligible:
+        print("No quality-eligible configurations found for this sweep.\n")
+        return
+
+    # Sort by TTFT p50 ascending (lower is better); fall back to tok/s descending
+    eligible.sort(
+        key=lambda e: (
+            e["ttft_p50"] if e["ttft_p50"] is not None else float("inf"),
+            -(e["tok_p50"] if e["tok_p50"] is not None else 0.0),
+        )
+    )
+
+    print("=" * 72)
+    print("QUALITY-ELIGIBLE RANKING  (oom=No, offload=No, err≤5%, task≥70%)")
+    print("=" * 72)
+    header = (
+        f"{'Rank':>4}  {'Model / Backend':<36}  "
+        f"{'TTFT p50(s)':>10}  {'Tok/s p50':>9}  {'Task%':>5}"
+    )
+    print(header)
+    print("-" * 72)
+
+    for rank, entry in enumerate(eligible, start=1):
+        ttft_str = _fmt(entry["ttft_p50"], ".3f")
+        tok_str = _fmt(entry["tok_p50"], ".0f")
+        task_str = _pct(entry["task_pct"])
+        row_str = (
+            f"{rank:>4}  {entry['model_key']:<36}  "
+            f"{ttft_str:>10}  {tok_str:>9}  {task_str:>5}"
+        )
+        print(row_str)
+
+    print("-" * 72)
+    best = eligible[0]
+    print(f"\n  *** RECOMMENDED: {best['model_key']} ***")
+    parts = []
+    if best["ttft_p50"] is not None:
+        parts.append(f"TTFT p50={best['ttft_p50']:.3f}s")
+    if best["tok_p50"] is not None:
+        parts.append(f"tok/s p50={best['tok_p50']:.0f}")
+    if best["task_pct"] is not None:
+        parts.append(f"task={best['task_pct']:.0f}%")
+    if parts:
+        print("  " + " | ".join(parts))
+    print("=" * 72 + "\n")
+
+
+# ── Compare table ─────────────────────────────────────────────────────────────
+
+
+def _fingerprint(run_id: str, sweep_id: str) -> str:
+    """Extract case fingerprint from run_id by stripping the sweep prefix."""
+    prefix = f"{sweep_id}::"
+    if run_id.startswith(prefix):
+        return run_id[len(prefix) :]
+    return run_id
+
+
+def print_compare_table(
+    rows1: list[dict[str, Any]],
+    rows2: list[dict[str, Any]],
+    id1: str,
+    id2: str,
+) -> None:
+    """Print side-by-side comparison for two sweep IDs with OOM/offload annotations."""
+    by_fp1 = {_fingerprint(r["run_id"], id1): r for r in rows1}
+    by_fp2 = {_fingerprint(r["run_id"], id2): r for r in rows2}
+    all_fps = sorted(set(by_fp1) | set(by_fp2))
+
+    if not all_fps:
+        print("No rows found for either sweep ID.")
+        return
+
+    id1_short = id1[:20]
+    id2_short = id2[:20]
+    sep = "=" * 100
+    print(f"\n{sep}")
+    print(f"COMPARISON: {id1_short}  vs  {id2_short}")
+    print(sep)
+
+    hdr = (
+        f"{'Model':<20}  {'Tier':<14}  {'Ctx':>6}  {'C':>3}  {'R':>3}  "
+        f"{'TTFT-1(s)':>10}  {'TTFT-2(s)':>10}  {'Δ%':>8}  "
+        f"{'OOM1':>6}  {'OOM2':>6}  {'Off1':>5}  {'Off2':>5}"
+    )
+    print(hdr)
+    print("-" * 100)
+
+    for fp in all_fps:
+        r1 = by_fp1.get(fp)
+        r2 = by_fp2.get(fp)
+
+        if r1 is not None:
+            model = str(r1.get("model_id") or "--")[:20]
+            tier = str(r1.get("tier") or "--")[:14]
+            ctx = _fmt(r1.get("context_size"))
+            concurrency = _fmt(r1.get("concurrency"))
+            repeat = _fmt(r1.get("repeat_index"))
+        elif r2 is not None:
+            model = str(r2.get("model_id") or "--")[:20]
+            tier = str(r2.get("tier") or "--")[:14]
+            ctx = _fmt(r2.get("context_size"))
+            concurrency = _fmt(r2.get("concurrency"))
+            repeat = _fmt(r2.get("repeat_index"))
+        else:
+            continue
+
+        ttft1 = r1.get("ttft_s") if r1 else None
+        ttft2 = r2.get("ttft_s") if r2 else None
+        oom1 = "Yes" if (r1 and r1.get("outcome") == "oom") else "No"
+        oom2 = "Yes" if (r2 and r2.get("outcome") == "oom") else "No"
+        off1 = "Yes" if (r1 and r1.get("cpu_offload_detected")) else "No"
+        off2 = "Yes" if (r2 and r2.get("cpu_offload_detected")) else "No"
+
+        if ttft1 is not None and ttft2 is not None and ttft1 > 0:
+            delta_pct = (ttft2 - ttft1) / ttft1 * 100.0
+            delta_str = f"{delta_pct:+.1f}%"
+        else:
+            delta_str = "--"
+
+        line = (
+            f"{model:<20}  {tier:<14}  {ctx:>6}  {concurrency:>3}  {repeat:>3}  "
+            f"{_fmt(ttft1, '.3f'):>10}  {_fmt(ttft2, '.3f'):>10}  {delta_str:>8}  "
+            f"{oom1:>6}  {oom2:>6}  {off1:>5}  {off2:>5}"
+        )
+        print(line)
+
+    print(sep + "\n")
+
+
+# ── Export ────────────────────────────────────────────────────────────────────
+
+
+def export_json(rows: list[dict[str, Any]], path: Path) -> None:
+    """Export sweep rows to JSON (list of objects)."""
+    path.write_text(json.dumps(rows, indent=2, default=str), encoding="utf-8")
+
+
+def export_csv(rows: list[dict[str, Any]], path: Path) -> None:
+    """Export sweep rows to CSV."""
+    if not rows:
+        path.write_text("", encoding="utf-8")
+        return
+    fieldnames = list(rows[0].keys())
+    with path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)

--- a/scripts/bench/run_bench.py
+++ b/scripts/bench/run_bench.py
@@ -1,0 +1,667 @@
+"""Benchmark runner CLI entry point.
+
+Usage:
+    python scripts/bench/run_bench.py --tier speed
+    python scripts/bench/run_bench.py --resume run_20240101_120000
+    python scripts/bench/run_bench.py --compare run_20240101 run_20240102
+    python scripts/bench/run_bench.py --generate-fixtures
+    python scripts/bench/run_bench.py --browse
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import platform
+import sqlite3
+import subprocess  # nosec B404
+import sys
+import time
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Generator
+
+from scripts.bench.config import BenchCase, BenchConfig
+from scripts.bench.drivers.ollama import OllamaDriver
+from scripts.bench.drivers.vllm import VllmDriver
+from scripts.bench.env_snapshot import EnvSnapshot
+from scripts.bench.gpu_monitor import GpuMonitor
+from scripts.bench.lifecycle.ollama_manager import OllamaManager
+from scripts.bench.quality import evaluate_coding_output
+from scripts.bench.sys_monitor import SysMonitor
+from scripts.bench.tasks.boundary import make_boundary_prompt
+from scripts.bench.tasks.coding import make_coding_prompt
+from scripts.bench.tasks.prefill_shared import make_prefill_shared_prompt
+from scripts.bench.tasks.prefill_unshared import make_prefill_unshared_prompt
+from scripts.bench.tasks.speed import make_speed_prompt
+
+logging.basicConfig(level=logging.WARNING, format="%(levelname)s %(name)s: %(message)s")
+
+# ── DB constants (mirrors app/core/bench_store.py — no app.* imports allowed) ─
+
+_APP_DIR = "repo-scaffold"
+_DB_NAME = "bench.db"
+_FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+_CREATE_TABLE = """
+CREATE TABLE IF NOT EXISTS bench_run (
+    run_id                  TEXT    NOT NULL PRIMARY KEY,
+    case_id                 TEXT    NOT NULL,
+    repeat_index            INTEGER NOT NULL,
+    tier                    TEXT,
+    context_size            INTEGER,
+    concurrency             INTEGER,
+    backend_id              TEXT,
+    model_id                TEXT,
+    settings_hash           TEXT,
+    prompt_hash             TEXT,
+    backend_base_url        TEXT,
+    gpu_driver_version      TEXT,
+    cuda_version            TEXT,
+    python_version          TEXT,
+    os_version              TEXT,
+    ttft_s                  REAL,
+    wall_time_s             REAL,
+    throughput_tok_s        REAL,
+    prompt_tokens           INTEGER,
+    completion_tokens       INTEGER,
+    total_tokens            INTEGER,
+    peak_vram_gb            REAL,
+    avg_gpu_util_pct        REAL,
+    avg_gpu_mem_util_pct    REAL,
+    avg_power_w             REAL,
+    peak_temp_c             REAL,
+    avg_sm_clock_mhz        REAL,
+    avg_mem_clock_mhz       REAL,
+    peak_ram_gb             REAL,
+    cpu_offload_detected    INTEGER,
+    ollama_model_loaded     INTEGER,
+    ollama_num_ctx          INTEGER,
+    quality_task_success    INTEGER,
+    quality_pytest_passed   INTEGER,
+    quality_ruff_passed     INTEGER,
+    quality_mypy_passed     INTEGER,
+    outcome                 TEXT,
+    error_message           TEXT,
+    recorded_at             TEXT NOT NULL DEFAULT (datetime('now'))
+)
+"""
+
+_CREATE_INDEX = """
+CREATE INDEX IF NOT EXISTS idx_bench_run_case_id
+    ON bench_run (case_id)
+"""
+
+_INSERT = """
+INSERT INTO bench_run (
+    run_id, case_id, repeat_index,
+    tier, context_size, concurrency, backend_id, model_id,
+    settings_hash, prompt_hash,
+    backend_base_url, gpu_driver_version, cuda_version, python_version, os_version,
+    ttft_s, wall_time_s, throughput_tok_s,
+    prompt_tokens, completion_tokens, total_tokens,
+    peak_vram_gb, avg_gpu_util_pct, avg_gpu_mem_util_pct, avg_power_w,
+    peak_temp_c, avg_sm_clock_mhz, avg_mem_clock_mhz,
+    peak_ram_gb, cpu_offload_detected,
+    ollama_model_loaded, ollama_num_ctx,
+    quality_task_success, quality_pytest_passed,
+    quality_ruff_passed, quality_mypy_passed,
+    outcome, error_message
+) VALUES (
+    :run_id, :case_id, :repeat_index,
+    :tier, :context_size, :concurrency, :backend_id, :model_id,
+    :settings_hash, :prompt_hash,
+    :backend_base_url, :gpu_driver_version, :cuda_version, :python_version, :os_version,
+    :ttft_s, :wall_time_s, :throughput_tok_s,
+    :prompt_tokens, :completion_tokens, :total_tokens,
+    :peak_vram_gb, :avg_gpu_util_pct, :avg_gpu_mem_util_pct, :avg_power_w,
+    :peak_temp_c, :avg_sm_clock_mhz, :avg_mem_clock_mhz,
+    :peak_ram_gb, :cpu_offload_detected,
+    :ollama_model_loaded, :ollama_num_ctx,
+    :quality_task_success, :quality_pytest_passed,
+    :quality_ruff_passed, :quality_mypy_passed,
+    :outcome, :error_message
+)
+"""
+
+# ── DB helpers ────────────────────────────────────────────────────────────────
+
+
+def _get_db_path() -> Path:
+    if platform.system() == "Windows":
+        base = Path.home() / "AppData" / "Roaming"
+    else:
+        base = Path.home() / ".config"
+    return base / _APP_DIR / _DB_NAME
+
+
+@contextmanager
+def _connect(db_path: Path) -> Generator[sqlite3.Connection, None, None]:
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        yield conn
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _ensure_schema(db_path: Path) -> None:
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    with _connect(db_path) as conn:
+        conn.execute(_CREATE_TABLE)
+        conn.execute(_CREATE_INDEX)
+
+
+def _run_id_exists(db_path: Path, run_id: str) -> bool:
+    with _connect(db_path) as conn:
+        return (
+            conn.execute(
+                "SELECT 1 FROM bench_run WHERE run_id = ?", (run_id,)
+            ).fetchone()
+            is not None
+        )
+
+
+def _insert_row(db_path: Path, row: dict[str, Any]) -> None:
+    with _connect(db_path) as conn:
+        conn.execute(_INSERT, row)
+
+
+# ── ID helpers ────────────────────────────────────────────────────────────────
+
+
+def _case_id(case: BenchCase) -> str:
+    return (
+        f"{case.backend_id}/{case.model_id}"
+        f"/{case.tier}/{case.context_size}/{case.concurrency}"
+    )
+
+
+def _row_run_id(sweep_id: str, case: BenchCase) -> str:
+    return f"{sweep_id}::{_case_id(case)}::{case.repeat_index}"
+
+
+# ── OOM detection ─────────────────────────────────────────────────────────────
+
+
+def _is_oom(error: str) -> bool:
+    low = error.lower()
+    return (
+        "507" in error
+        or "out of memory" in low
+        or "connection reset" in low
+        or "connectionreset" in low
+    )
+
+
+# ── Prompt factory ────────────────────────────────────────────────────────────
+
+
+def _make_prompt(tier: str, repeat_index: int) -> Any:
+    if tier == "speed":
+        return make_speed_prompt()
+    if tier == "coding":
+        return make_coding_prompt()
+    if tier == "prefill_shared":
+        return make_prefill_shared_prompt(suffix_index=repeat_index)
+    if tier == "prefill_unshared":
+        return make_prefill_unshared_prompt()
+    if tier == "boundary":
+        return make_boundary_prompt()
+    raise ValueError(f"Unknown tier: {tier!r}")
+
+
+# ── Driver factory ────────────────────────────────────────────────────────────
+
+
+def _make_driver(backend_id: str, base_url: str) -> OllamaDriver | VllmDriver:
+    if "vllm" in backend_id.lower():
+        return VllmDriver(base_url=base_url)
+    return OllamaDriver(base_url=base_url)
+
+
+# ── Fixture generation ────────────────────────────────────────────────────────
+
+_PROJECT_SUMMARY_TEMPLATE = """\
+# Project Summary: repo-scaffold-desktop
+
+## Overview
+
+repo-scaffold-desktop is a desktop application for generating repository
+scaffolds from configurable presets. It supports Jinja2 templates, optional
+git initialization, pre-commit hook installation, CI workflow generation,
+and CODEOWNERS configuration. The application is built with PySide6 for the
+GUI and exposes a CLI for automation.
+
+## Architecture
+
+The codebase follows a strict layered architecture:
+
+- **app/core/** — all business logic; no UI code allowed here
+- **app/ui/** — PySide6 presentation layer; calls core, contains no logic
+- **templates/** — Jinja2 template files rendered during scaffold generation
+- **tests/** — unit tests for core logic only
+- **schemas/** — exported JSON Schemas for non-Python consumers
+- **scripts/bench/** — standalone benchmark suite; no app.* imports allowed
+
+Data flows one way: UI → config model → generator → disk.
+
+## Module Responsibilities
+
+- **config.py** — Pydantic input models (repo name, output path, preset)
+- **presets.py** — preset definitions (maps preset name → file list)
+- **generator.py** — renders templates and writes files to disk
+- **post_setup.py** — side effects: git init, pre-commit install, etc.
+- **user_prefs.py** — UserPreferences model and PrefsStore (JSON persistence)
+- **manifest.py** — ExecutionManifest Pydantic model: cloud→local contract
+- **escalation_policy.py** — EscalationPolicy: loads escalation_policy.toml
+- **linear_client.py** — thin Linear GraphQL client (stdlib urllib only)
+- **metrics.py** — SQLite-backed store for per-ticket cost and metrics
+- **bench_store.py** — SQLite store for benchmark run records (GPU, timing)
+
+## Engineering Principles
+
+1. UI stays thin. No branching logic, no file I/O in app/ui/.
+2. Prefer config + templates over conditional generation logic.
+3. Generated output must be deterministic and easy to diff.
+4. Avoid over-abstracting v1. Three similar lines beat a premature helper.
+5. Side effects (git, pre-commit) live only in post_setup.py.
+6. Architecture contracts are enforced by Import Linter.
+
+## Benchmark Suite
+
+The benchmark suite (scripts/bench/) evaluates local LLM backends:
+
+- **speed** — minimal prompt measuring raw generation latency
+- **coding** — coding task with automated quality evaluation
+- **prefill_shared** — long shared document prefix to test KV-cache reuse
+- **prefill_unshared** — fresh random document each run (cold prefill)
+- **boundary** — context-window edge probing
+
+The runner collects GPU metrics (VRAM, utilization, power, temperature,
+SM/memory clocks), system metrics (RAM, CPU offload detection), timing
+metrics (TTFT, wall time, throughput), and quality metrics for coding tasks.
+
+## Development Workflow
+
+Each ticket follows grooming → planning → local implementation → PR phases.
+The watcher daemon polls Linear for ReadyForLocal tickets and orchestrates
+local worker sessions in isolated git worktrees.
+
+"""
+
+
+def _generate_fixtures() -> None:
+    """Create scripts/bench/fixtures/project_summary_50k.txt (~50k tokens)."""
+    _FIXTURES_DIR.mkdir(parents=True, exist_ok=True)
+    target = _FIXTURES_DIR / "project_summary_50k.txt"
+    # Target: ~50k tokens ≈ 200k chars at 4 chars/token
+    target_chars = 200_000
+    base = _PROJECT_SUMMARY_TEMPLATE
+    # Repeat sections with slight variation to reach target size
+    parts = [base]
+    section_idx = 0
+    while sum(len(p) for p in parts) < target_chars:
+        section_idx += 1
+        parts.append(
+            f"\n\n## Extended Notes — Section {section_idx}\n\n"
+            + base.replace(
+                "repo-scaffold-desktop", f"repo-scaffold-desktop (ref {section_idx})"
+            )
+        )
+    content = "".join(parts)[:target_chars]
+    target.write_text(content, encoding="utf-8")
+    print(f"Fixture written: {target} ({len(content):,} chars)")
+
+
+# ── Browse ────────────────────────────────────────────────────────────────────
+
+
+def _browse(db_path: Path) -> None:
+    """Open bench.db in datasette."""
+    if not db_path.exists():
+        print(f"Database not found: {db_path}", file=sys.stderr)
+        sys.exit(1)
+    try:
+        subprocess.run(  # nosec B603
+            [sys.executable, "-m", "datasette", str(db_path)],
+            check=True,
+        )
+    except FileNotFoundError:
+        print(
+            "datasette is not installed. Install with: pip install datasette",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+
+# ── Compare ───────────────────────────────────────────────────────────────────
+
+
+def _compare(id1: str, id2: str, db_path: Path) -> None:
+    from scripts.bench import reporter
+
+    rows1 = reporter.load_sweep(db_path, id1)
+    rows2 = reporter.load_sweep(db_path, id2)
+    reporter.print_compare_table(rows1, rows2, id1, id2)
+
+
+# ── Main runner ───────────────────────────────────────────────────────────────
+
+
+def _run(args: argparse.Namespace, db_path: Path) -> None:
+    config = BenchConfig.from_toml(args.config)
+    cases = config.expand_matrix()
+
+    if args.tier:
+        cases = [c for c in cases if c.tier == args.tier]
+
+    sweep_id: str = (
+        args.resume
+        if args.resume
+        else f"run_{datetime.now(tz=timezone.utc).strftime('%Y%m%d_%H%M%S')}"
+    )
+    print(f"Sweep: {sweep_id}  DB: {db_path}")
+
+    _ensure_schema(db_path)
+
+    backends = {b.id: b for b in config.backends if b.enabled}
+
+    prev_model_id: str | None = None
+    prev_backend_id: str | None = None
+    # Tracks which models have had at least one prefill_shared run (for cache_state)
+    prefill_shared_seen: set[str] = set()
+
+    for case in cases:
+        row_run_id = _row_run_id(sweep_id, case)
+
+        if args.resume and _run_id_exists(db_path, row_run_id):
+            print(
+                f"[SKIP] {case.model_id}/{case.tier}"
+                f"/ctx={case.context_size}/c={case.concurrency}/r={case.repeat_index}"
+            )
+            continue
+
+        backend_cfg = backends.get(case.backend_id)
+        if backend_cfg is None:
+            print(
+                f"[WARN] Unknown backend {case.backend_id!r}, skipping",
+                file=sys.stderr,
+            )
+            continue
+
+        driver = _make_driver(case.backend_id, backend_cfg.base_url)
+
+        manager: OllamaManager | None = None
+        if "vllm" not in case.backend_id.lower():
+            manager = OllamaManager(base_url=backend_cfg.base_url)
+            try:
+                manager.ensure_running()
+                manager.pull_if_needed(case.model_id)
+            except TimeoutError as exc:
+                print(f"[ERROR] Ollama not ready: {exc}", file=sys.stderr)
+                continue
+
+        # Flush previous model when switching models within a backend
+        if (
+            manager is not None
+            and prev_model_id is not None
+            and (prev_model_id != case.model_id or prev_backend_id != case.backend_id)
+        ):
+            try:
+                manager.flush_model(prev_model_id)
+            except Exception as exc:
+                logging.warning("flush_model failed: %s", exc)
+
+        prev_model_id = case.model_id
+        prev_backend_id = case.backend_id
+
+        settings: dict[str, Any] = {
+            "tier": case.tier,
+            "context_size": case.context_size,
+            "concurrency": case.concurrency,
+        }
+        env = EnvSnapshot.capture(
+            backend=case.backend_id, model=case.model_id, settings=settings
+        )
+
+        # First prefill_shared per model = warm; subsequent = prefix_warm
+        cache_state: str | None = None
+        if case.tier == "prefill_shared":
+            key = f"{case.backend_id}/{case.model_id}"
+            if key not in prefill_shared_seen:
+                prefill_shared_seen.add(key)
+                cache_state = "warm"
+            else:
+                cache_state = "prefix_warm"
+
+        prompt = _make_prompt(case.tier, case.repeat_index)
+
+        gpu_mon = GpuMonitor()
+        sys_mon = SysMonitor()
+        gpu_mon.start()
+        sys_mon.start()
+
+        messages: list[dict[str, str]] = [{"role": "user", "content": prompt.text}]
+        t_start = time.monotonic()
+        result = driver.generate(case.model_id, messages)
+        wall_time_s = time.monotonic() - t_start
+
+        gpu_sample = gpu_mon.stop()
+        sys_result = sys_mon.stop()
+
+        # OOM detection
+        oom = False
+        outcome = "ok"
+        error_message: str | None = None
+        if result.error:
+            error_message = result.error
+            if _is_oom(result.error):
+                oom = True
+                outcome = "oom"
+            else:
+                outcome = "error"
+
+        # Quality evaluation for coding tier only
+        quality_task_success: bool | None = None
+        quality_pytest_passed: bool | None = None
+        quality_ruff_passed: bool | None = None
+        quality_mypy_passed: bool | None = None
+        if case.tier == "coding" and not oom and result.text:
+            repo_path = Path(__file__).parent.parent.parent
+            qr = evaluate_coding_output(result.text, repo_path)
+            quality_task_success = qr.task_success
+            quality_pytest_passed = qr.pytest_passed
+            quality_ruff_passed = qr.ruff_passed
+            quality_mypy_passed = qr.mypy_passed
+            if qr.error_message and error_message is None:
+                error_message = qr.error_message
+
+        total_tokens: int | None = None
+        if result.input_tokens is not None and result.output_tokens is not None:
+            total_tokens = result.input_tokens + result.output_tokens
+
+        throughput_tok_s: float | None = None
+        if (
+            result.output_tokens
+            and result.decode_time_s is not None
+            and result.decode_time_s > 0
+        ):
+            throughput_tok_s = result.output_tokens / result.decode_time_s
+
+        ollama_model_loaded: bool | None = None
+        if manager is not None:
+            try:
+                statuses = manager.get_ps_status()
+                ollama_model_loaded = any(s.name == case.model_id for s in statuses)
+            except Exception:
+                pass
+
+        row: dict[str, Any] = {
+            "run_id": row_run_id,
+            "case_id": _case_id(case),
+            "repeat_index": case.repeat_index,
+            "tier": case.tier,
+            "context_size": case.context_size,
+            "concurrency": case.concurrency,
+            "backend_id": case.backend_id,
+            "model_id": case.model_id,
+            "settings_hash": env.settings_hash,
+            "prompt_hash": prompt.prompt_hash,
+            "backend_base_url": backend_cfg.base_url,
+            "gpu_driver_version": env.gpu_driver_version,
+            "cuda_version": env.cuda_version,
+            "python_version": env.python_version,
+            "os_version": env.os_version,
+            "ttft_s": result.ttft_s if not oom else None,
+            "wall_time_s": wall_time_s if not oom else None,
+            "throughput_tok_s": throughput_tok_s,
+            "prompt_tokens": result.input_tokens,
+            "completion_tokens": result.output_tokens,
+            "total_tokens": total_tokens,
+            "peak_vram_gb": gpu_sample.peak_vram_gb,
+            "avg_gpu_util_pct": gpu_sample.avg_gpu_util_pct,
+            "avg_gpu_mem_util_pct": gpu_sample.avg_gpu_mem_util_pct,
+            "avg_power_w": gpu_sample.avg_power_w,
+            "peak_temp_c": gpu_sample.peak_temp_c,
+            "avg_sm_clock_mhz": gpu_sample.avg_sm_clock_mhz,
+            "avg_mem_clock_mhz": gpu_sample.avg_mem_clock_mhz,
+            "peak_ram_gb": sys_result.peak_ram_gb,
+            "cpu_offload_detected": int(sys_result.cpu_offload_detected),
+            "ollama_model_loaded": (
+                int(ollama_model_loaded) if ollama_model_loaded is not None else None
+            ),
+            "ollama_num_ctx": case.context_size,
+            "quality_task_success": (
+                int(quality_task_success) if quality_task_success is not None else None
+            ),
+            "quality_pytest_passed": (
+                int(quality_pytest_passed)
+                if quality_pytest_passed is not None
+                else None
+            ),
+            "quality_ruff_passed": (
+                int(quality_ruff_passed) if quality_ruff_passed is not None else None
+            ),
+            "quality_mypy_passed": (
+                int(quality_mypy_passed) if quality_mypy_passed is not None else None
+            ),
+            "outcome": outcome,
+            "error_message": error_message,
+        }
+
+        # Write before moving to next case (resume safety invariant)
+        _insert_row(db_path, row)
+
+        ttft_str = f" ttft={result.ttft_s:.2f}s" if result.ttft_s else ""
+        tok_str = f" tok/s={throughput_tok_s:.0f}" if throughput_tok_s else ""
+        cache_str = f" [{cache_state}]" if cache_state else ""
+        print(
+            f"[{outcome.upper():5}] {case.model_id} / {case.tier}"
+            f" / ctx={case.context_size} / c={case.concurrency} / r={case.repeat_index}"
+            f"{cache_str}{ttft_str}{tok_str}"
+        )
+
+    print("\nRun complete.")
+
+    from scripts.bench import reporter
+
+    rows = reporter.load_sweep(db_path, sweep_id)
+    reporter.print_summary_table(rows)
+    reporter.print_ranking(rows)
+
+    if args.output_json:
+        reporter.export_json(rows, Path(args.output_json))
+        print(f"JSON exported: {args.output_json}")
+    if args.output_csv:
+        reporter.export_csv(rows, Path(args.output_csv))
+        print(f"CSV exported: {args.output_csv}")
+
+
+# ── CLI ───────────────────────────────────────────────────────────────────────
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Local LLM benchmark runner",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--config",
+        default="bench.toml",
+        help="Path to bench.toml (default: bench.toml)",
+    )
+    parser.add_argument(
+        "--tier",
+        default=None,
+        help="Filter by tier: speed|coding|prefill_shared|prefill_unshared|boundary",
+    )
+    parser.add_argument(
+        "--resume",
+        metavar="SWEEP_ID",
+        default=None,
+        help="Continue a previous sweep, skipping already-recorded cases",
+    )
+    parser.add_argument(
+        "--compare",
+        nargs=2,
+        metavar=("ID1", "ID2"),
+        default=None,
+        help="Print side-by-side comparison table for two sweep IDs",
+    )
+    parser.add_argument(
+        "--generate-fixtures",
+        action="store_true",
+        help="Create scripts/bench/fixtures/project_summary_50k.txt",
+    )
+    parser.add_argument(
+        "--browse",
+        action="store_true",
+        help="Open bench.db in datasette browser",
+    )
+    parser.add_argument(
+        "--db-path",
+        default=None,
+        help="Override default bench.db path",
+    )
+    parser.add_argument(
+        "--output-json",
+        default=None,
+        metavar="PATH",
+        help="Export sweep results to JSON",
+    )
+    parser.add_argument(
+        "--output-csv",
+        default=None,
+        metavar="PATH",
+        help="Export sweep results to CSV",
+    )
+    return parser
+
+
+def main() -> int:
+    parser = _build_parser()
+    args = parser.parse_args()
+
+    db_path = Path(args.db_path) if args.db_path else _get_db_path()
+
+    if args.generate_fixtures:
+        _generate_fixtures()
+        return 0
+
+    if args.browse:
+        _browse(db_path)
+        return 0
+
+    if args.compare:
+        _compare(args.compare[0], args.compare[1], db_path)
+        return 0
+
+    _run(args, db_path)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/bench/sys_monitor.py
+++ b/scripts/bench/sys_monitor.py
@@ -1,0 +1,133 @@
+"""Background system monitor: polls RAM via wmic (Windows) or /proc/meminfo (Linux)."""
+
+from __future__ import annotations
+
+import logging
+import platform
+import subprocess  # nosec B404
+import threading
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+_OFFLOAD_THRESHOLD_GB = 2.0
+
+
+@dataclass
+class SysResult:
+    cpu_offload_detected: bool
+    peak_ram_gb: float | None = None
+
+
+def _read_ram_gb_windows() -> float | None:
+    """Return current RAM usage in GB via wmic, or None if unavailable."""
+    try:
+        result = subprocess.run(  # nosec B603, B607
+            [
+                "wmic",
+                "OS",
+                "get",
+                "TotalVisibleMemorySize,FreePhysicalMemory",
+                "/format:value",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
+        logger.warning("wmic unavailable: %s", exc)
+        return None
+    if result.returncode != 0:
+        return None
+    total_kb: float | None = None
+    free_kb: float | None = None
+    for raw_line in result.stdout.splitlines():
+        line = raw_line.strip()
+        if line.startswith("FreePhysicalMemory="):
+            try:
+                free_kb = float(line.split("=", 1)[1])
+            except ValueError:
+                pass
+        elif line.startswith("TotalVisibleMemorySize="):
+            try:
+                total_kb = float(line.split("=", 1)[1])
+            except ValueError:
+                pass
+    if total_kb is None or free_kb is None:
+        return None
+    return (total_kb - free_kb) / (1024.0 * 1024.0)
+
+
+def _read_ram_gb_linux() -> float | None:
+    """Return current RAM usage in GB via /proc/meminfo, or None if unavailable."""
+    try:
+        with open("/proc/meminfo", encoding="ascii") as f:
+            info: dict[str, float] = {}
+            for raw_line in f:
+                parts = raw_line.split()
+                if len(parts) >= 2:
+                    key = parts[0].rstrip(":")
+                    try:
+                        info[key] = float(parts[1])
+                    except ValueError:
+                        pass
+    except OSError:
+        return None
+    total = info.get("MemTotal")
+    available = info.get("MemAvailable")
+    if total is None or available is None:
+        return None
+    return (total - available) / (1024.0 * 1024.0)
+
+
+def _read_ram_gb() -> float | None:
+    """Platform-dispatched RAM usage in GB."""
+    if platform.system() == "Windows":
+        return _read_ram_gb_windows()
+    return _read_ram_gb_linux()
+
+
+class SysMonitor:
+    """Daemon thread that polls RAM every *interval* seconds and detects CPU offload."""
+
+    def __init__(self, interval: float = 1.0) -> None:
+        self._interval = interval
+        self._thread: threading.Thread | None = None
+        self._stop_event = threading.Event()
+        self._baseline_ram_gb: float | None = None
+        self._peak_ram_gb: float | None = None
+        self._cpu_offload_detected = False
+
+    def _poll_ram_gb(self) -> float | None:
+        return _read_ram_gb()
+
+    def _run(self) -> None:
+        self._baseline_ram_gb = self._poll_ram_gb()
+        while not self._stop_event.is_set():
+            ram = self._poll_ram_gb()
+            if ram is not None:
+                if self._peak_ram_gb is None or ram > self._peak_ram_gb:
+                    self._peak_ram_gb = ram
+                if (
+                    self._baseline_ram_gb is not None
+                    and ram - self._baseline_ram_gb > _OFFLOAD_THRESHOLD_GB
+                ):
+                    self._cpu_offload_detected = True
+            self._stop_event.wait(self._interval)
+
+    def start(self) -> None:
+        self._stop_event.clear()
+        self._baseline_ram_gb = None
+        self._peak_ram_gb = None
+        self._cpu_offload_detected = False
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._thread.start()
+
+    def stop(self) -> SysResult:
+        self._stop_event.set()
+        if self._thread is not None:
+            self._thread.join(timeout=10)
+        return SysResult(
+            cpu_offload_detected=self._cpu_offload_detected,
+            peak_ram_gb=self._peak_ram_gb,
+        )

--- a/scripts/bench/tasks/__init__.py
+++ b/scripts/bench/tasks/__init__.py
@@ -1,0 +1,13 @@
+"""Benchmark task prompt factories — shared types."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class BenchPrompt:
+    text: str
+    prompt_hash: str
+    task_type: str
+    token_count_estimate: int | None = None

--- a/scripts/bench/tasks/boundary.py
+++ b/scripts/bench/tasks/boundary.py
@@ -1,0 +1,23 @@
+"""Boundary benchmark: probes the model at context-window and instruction edges."""
+
+from __future__ import annotations
+
+import hashlib
+
+from . import BenchPrompt
+
+_PASSAGE = "The quick brown fox. " * 500
+
+_TEXT = (
+    "You are given a long passage followed by a specific question."
+    " Your answer must be derived only from the passage."
+    " Do not use outside knowledge.\n\n"
+    f"Passage: {_PASSAGE}\n\n"
+    "Question: What animal is described as quick and brown?\n"
+    "Answer in one sentence."
+)
+
+
+def make_boundary_prompt() -> BenchPrompt:
+    prompt_hash = hashlib.sha256(_TEXT.encode()).hexdigest()
+    return BenchPrompt(text=_TEXT, prompt_hash=prompt_hash, task_type="boundary")

--- a/scripts/bench/tasks/coding.py
+++ b/scripts/bench/tasks/coding.py
@@ -1,0 +1,24 @@
+"""Coding benchmark: asks the model to implement a small utility function."""
+
+from __future__ import annotations
+
+import hashlib
+
+from . import BenchPrompt
+
+_TEXT = (
+    "Implement a Python function `flatten(nested)` that recursively flattens"
+    " a nested list of arbitrary depth into a single flat list.\n\n"
+    "Requirements:\n"
+    "- Handle lists nested to any depth.\n"
+    "- Leave non-list values (int, str, float, etc.) as-is.\n"
+    "- Return a new flat list; do not mutate the input.\n\n"
+    "Provide only the function definition — no example usage or imports.\n"
+    'Return your answer as a JSON object: {"path": "solution.py",'
+    ' "content": "<code>"}'
+)
+
+
+def make_coding_prompt() -> BenchPrompt:
+    prompt_hash = hashlib.sha256(_TEXT.encode()).hexdigest()
+    return BenchPrompt(text=_TEXT, prompt_hash=prompt_hash, task_type="coding")

--- a/scripts/bench/tasks/prefill_shared.py
+++ b/scripts/bench/tasks/prefill_shared.py
@@ -1,0 +1,28 @@
+"""Prefill-shared benchmark: loads a shared fixture document."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+from . import BenchPrompt
+
+FIXTURE_PATH = Path(__file__).parent.parent / "fixtures" / "prefill_50k.txt"
+
+_SUFFIX_TEMPLATE = (
+    "\n\n[Query {index}] Summarise the document above in three bullet points."
+)
+
+
+def make_prefill_shared_prompt(suffix_index: int = 0) -> BenchPrompt:
+    if not FIXTURE_PATH.exists():
+        raise FileNotFoundError(
+            f"Fixture file not found: {FIXTURE_PATH}. "
+            "Generate it first: python scripts/bench/generate_fixtures.py"
+            " --generate-fixtures"
+        )
+    doc = FIXTURE_PATH.read_text(encoding="utf-8")
+    suffix = _SUFFIX_TEMPLATE.format(index=suffix_index)
+    text = doc + suffix
+    prompt_hash = hashlib.sha256(text.encode()).hexdigest()
+    return BenchPrompt(text=text, prompt_hash=prompt_hash, task_type="prefill_shared")

--- a/scripts/bench/tasks/prefill_unshared.py
+++ b/scripts/bench/tasks/prefill_unshared.py
@@ -1,0 +1,68 @@
+"""Prefill-unshared benchmark: generates a fresh random document each run."""
+
+from __future__ import annotations
+
+import hashlib
+import random
+
+from . import BenchPrompt
+
+_WORDS = [
+    "the",
+    "quick",
+    "brown",
+    "fox",
+    "jumps",
+    "over",
+    "lazy",
+    "dog",
+    "data",
+    "model",
+    "system",
+    "function",
+    "result",
+    "value",
+    "code",
+    "test",
+    "output",
+    "input",
+    "process",
+    "task",
+    "metric",
+    "bench",
+    "run",
+    "step",
+    "call",
+    "return",
+    "error",
+    "success",
+    "failure",
+    "target",
+    "token",
+    "prompt",
+    "response",
+    "context",
+    "window",
+]
+
+_CHARS_PER_TOKEN = 4
+
+
+def make_prefill_unshared_prompt(target: int = 50000, seed: int = 42) -> BenchPrompt:
+    rng = random.Random(seed)
+    target_chars = target * _CHARS_PER_TOKEN
+    words: list[str] = []
+    total = 0
+    while total < target_chars:
+        word = rng.choice(_WORDS)
+        words.append(word)
+        total += len(word) + 1  # +1 for the separating space
+    text = " ".join(words)
+    token_count_estimate = len(text) // _CHARS_PER_TOKEN
+    prompt_hash = hashlib.sha256(text.encode()).hexdigest()
+    return BenchPrompt(
+        text=text,
+        prompt_hash=prompt_hash,
+        task_type="prefill_unshared",
+        token_count_estimate=token_count_estimate,
+    )

--- a/scripts/bench/tasks/speed.py
+++ b/scripts/bench/tasks/speed.py
@@ -1,0 +1,14 @@
+"""Speed benchmark: minimal prompt measuring raw generation latency."""
+
+from __future__ import annotations
+
+import hashlib
+
+from . import BenchPrompt
+
+_TEXT = "Count from 1 to 10."
+
+
+def make_speed_prompt() -> BenchPrompt:
+    prompt_hash = hashlib.sha256(_TEXT.encode()).hexdigest()
+    return BenchPrompt(text=_TEXT, prompt_hash=prompt_hash, task_type="speed")

--- a/tests/bench/__init__.py
+++ b/tests/bench/__init__.py
@@ -1,0 +1,1 @@
+"""Benchmark test package."""

--- a/tests/bench/test_bench_config.py
+++ b/tests/bench/test_bench_config.py
@@ -1,0 +1,170 @@
+"""Tests for BenchConfig.from_toml and BenchConfig.expand_matrix."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from scripts.bench.config import BenchCase, BenchConfig
+
+_BENCH_TOML = Path(__file__).parent.parent.parent / "config" / "bench.toml"
+
+_STANDARD_TOML = """
+[matrix]
+context_sizes = [1024, 4096]
+boundary_context_sizes = [8192, 16384]
+concurrency_levels = [1, 4]
+repeats = 1
+
+[[backends]]
+id = "local_a"
+enabled = true
+base_url = "http://localhost:1/"
+api_key = "x"
+
+[[backends]]
+id = "cloud_b"
+enabled = false
+base_url = "http://localhost:2/"
+api_key = "y"
+
+[[models]]
+id = "model-1"
+backend_id = "local_a"
+
+[[models]]
+id = "model-2"
+backend_id = "local_a"
+
+[[models]]
+id = "model-3"
+backend_id = "cloud_b"
+
+[[tiers]]
+name = "speed"
+
+[[tiers]]
+name = "boundary"
+"""
+
+
+def _write_toml(tmp_path: Path, content: str) -> Path:
+    p = tmp_path / "bench.toml"
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+def test_from_toml_loads_real_config() -> None:
+    cfg = BenchConfig.from_toml(_BENCH_TOML)
+    assert cfg.matrix.context_sizes == [1024, 4096]
+    assert len(cfg.backends) >= 1
+    assert len(cfg.models) >= 1
+    assert len(cfg.tiers) >= 1
+
+
+def test_bench_case_importable() -> None:
+    assert hasattr(BenchCase, "__dataclass_fields__")
+
+
+def test_expand_matrix_real_and_warmup_counts(tmp_path: Path) -> None:
+    cfg = BenchConfig.from_toml(_write_toml(tmp_path, _STANDARD_TOML))
+    cases = cfg.expand_matrix()
+
+    real = [c for c in cases if c.repeat_index >= 1]
+    warmup = [c for c in cases if c.repeat_index == 0]
+
+    assert len(real) == 16, f"Expected 16 real cases, got {len(real)}"
+    assert len(warmup) == 8, f"Expected 8 warmup cases, got {len(warmup)}"
+
+
+def test_disabled_backend_excluded(tmp_path: Path) -> None:
+    toml = """
+[matrix]
+context_sizes = [1024]
+boundary_context_sizes = [8192]
+concurrency_levels = [1]
+repeats = 1
+
+[[backends]]
+id = "off"
+enabled = false
+base_url = "http://localhost:1/"
+api_key = "x"
+
+[[models]]
+id = "model-1"
+backend_id = "off"
+
+[[tiers]]
+name = "speed"
+"""
+    cfg = BenchConfig.from_toml(_write_toml(tmp_path, toml))
+    assert cfg.expand_matrix() == []
+
+
+def test_invalid_toml_syntax_raises(tmp_path: Path) -> None:
+    p = tmp_path / "bench.toml"
+    p.write_bytes(b"[matrix\n")  # malformed TOML
+    with pytest.raises(Exception):
+        BenchConfig.from_toml(p)
+
+
+def test_invalid_config_structure_raises_validation_error(tmp_path: Path) -> None:
+    toml = """
+[matrix]
+context_sizes = []
+boundary_context_sizes = [8192]
+concurrency_levels = [1]
+"""
+    with pytest.raises(ValidationError):
+        BenchConfig.from_toml(_write_toml(tmp_path, toml))
+
+
+def test_boundary_tier_uses_boundary_context_sizes(tmp_path: Path) -> None:
+    toml = """
+[matrix]
+context_sizes = [1024, 4096]
+boundary_context_sizes = [8192, 16384]
+concurrency_levels = [1]
+repeats = 1
+
+[[backends]]
+id = "local_a"
+enabled = true
+base_url = "http://localhost:1/"
+api_key = "x"
+
+[[models]]
+id = "model-1"
+backend_id = "local_a"
+
+[[tiers]]
+name = "speed"
+
+[[tiers]]
+name = "boundary"
+"""
+    cfg = BenchConfig.from_toml(_write_toml(tmp_path, toml))
+    cases = cfg.expand_matrix()
+
+    boundary_ctx = {c.context_size for c in cases if c.tier == "boundary"}
+    speed_ctx = {c.context_size for c in cases if c.tier == "speed"}
+
+    assert boundary_ctx == {8192, 16384}
+    assert speed_ctx == {1024, 4096}
+
+
+def test_warmup_uses_first_concurrency_level(tmp_path: Path) -> None:
+    cfg = BenchConfig.from_toml(_write_toml(tmp_path, _STANDARD_TOML))
+    warmup = [c for c in cfg.expand_matrix() if c.repeat_index == 0]
+    first_concurrency = cfg.matrix.concurrency_levels[0]
+    assert all(c.concurrency == first_concurrency for c in warmup)
+
+
+def test_no_model_on_disabled_backend_in_expanded_cases(tmp_path: Path) -> None:
+    cfg = BenchConfig.from_toml(_write_toml(tmp_path, _STANDARD_TOML))
+    cases = cfg.expand_matrix()
+    backend_ids = {c.backend_id for c in cases}
+    assert "cloud_b" not in backend_ids

--- a/tests/bench/test_bench_drivers.py
+++ b/tests/bench/test_bench_drivers.py
@@ -1,0 +1,210 @@
+"""Tests for OllamaDriver and VllmDriver — all network calls mocked."""
+
+from __future__ import annotations
+
+import io
+import json
+import urllib.error
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from scripts.bench.drivers.ollama import OllamaDriver
+from scripts.bench.drivers.vllm import VllmDriver
+
+
+def _ndjson(*frames: dict) -> bytes:
+    return b"\n".join(json.dumps(f).encode() for f in frames) + b"\n"
+
+
+def _sse(*frames: dict | str) -> bytes:
+    lines: list[bytes] = []
+    for frame in frames:
+        if isinstance(frame, str):
+            lines.append(f"data: {frame}\n\n".encode())
+        else:
+            lines.append(f"data: {json.dumps(frame)}\n\n".encode())
+    return b"".join(lines)
+
+
+def _mock_urlopen(body: bytes) -> MagicMock:
+    """Return a mock for urllib.request.urlopen that yields body as a BytesIO."""
+    mock = MagicMock(return_value=io.BytesIO(body))
+    return mock
+
+
+# ---------------------------------------------------------------------------
+# OllamaDriver
+# ---------------------------------------------------------------------------
+
+_OLLAMA_COLD_BODY = _ndjson(
+    {"model": "q", "message": {"role": "assistant", "content": "Hello"}, "done": False},
+    {
+        "model": "q",
+        "message": {"role": "assistant", "content": " world"},
+        "done": False,
+    },
+    {
+        "model": "q",
+        "done": True,
+        "done_reason": "stop",
+        "load_duration": 2_000_000,
+        "prompt_eval_count": 10,
+        "prompt_eval_duration": 100_000_000,
+        "eval_count": 20,
+        "eval_duration": 500_000_000,
+    },
+)
+
+_OLLAMA_WARM_BODY = _ndjson(
+    {"model": "q", "message": {"role": "assistant", "content": "Hi"}, "done": False},
+    {
+        "model": "q",
+        "done": True,
+        "done_reason": "stop",
+        "load_duration": 0,
+        "prompt_eval_count": 5,
+        "prompt_eval_duration": 50_000_000,
+        "eval_count": 10,
+        "eval_duration": 200_000_000,
+    },
+)
+
+
+def test_ollama_generate_cold_start_timings():
+    with patch("urllib.request.urlopen", _mock_urlopen(_OLLAMA_COLD_BODY)):
+        driver = OllamaDriver()
+        result = driver.generate("q", [{"role": "user", "content": "hi"}])
+
+    assert result.error is None
+    assert result.text == "Hello world"
+    assert result.ttft_s is not None and result.ttft_s >= 0.0
+    assert result.raw_prompt_eval_duration_ns == 100_000_000
+    assert result.raw_eval_duration_ns == 500_000_000
+    assert result.decode_time_s == pytest.approx(0.5)
+    assert result.raw_load_duration_ns == 2_000_000
+    assert result.input_tokens == 10
+    assert result.output_tokens == 20
+
+
+def test_ollama_generate_warm_start_no_load_duration():
+    with patch("urllib.request.urlopen", _mock_urlopen(_OLLAMA_WARM_BODY)):
+        driver = OllamaDriver()
+        result = driver.generate("q", [{"role": "user", "content": "hi"}])
+
+    assert result.error is None
+    assert result.raw_load_duration_ns is None
+    assert result.raw_eval_duration_ns == 200_000_000
+    assert result.decode_time_s == pytest.approx(0.2)
+    assert result.input_tokens == 5
+    assert result.output_tokens == 10
+
+
+def test_ollama_generate_returns_error_on_url_error():
+    with patch(
+        "urllib.request.urlopen",
+        side_effect=urllib.error.URLError("Connection refused"),
+    ):
+        driver = OllamaDriver()
+        result = driver.generate("q", [{"role": "user", "content": "hi"}])
+
+    assert result.error is not None
+    assert "Connection refused" in result.error
+
+
+def test_ollama_generate_returns_error_on_generic_exception():
+    with patch("urllib.request.urlopen", side_effect=OSError("socket error")):
+        driver = OllamaDriver()
+        result = driver.generate("q", [{"role": "user", "content": "hi"}])
+
+    assert result.error is not None
+
+
+def test_ollama_is_available_returns_false_when_unreachable():
+    with patch(
+        "urllib.request.urlopen",
+        side_effect=urllib.error.URLError("Connection refused"),
+    ):
+        driver = OllamaDriver()
+        assert driver.is_available() is False
+
+
+def test_ollama_is_available_returns_true_when_reachable():
+    with patch("urllib.request.urlopen", _mock_urlopen(b"{}")):
+        driver = OllamaDriver()
+        assert driver.is_available() is True
+
+
+# ---------------------------------------------------------------------------
+# VllmDriver
+# ---------------------------------------------------------------------------
+
+_VLLM_BODY = _sse(
+    {
+        "id": "c1",
+        "choices": [
+            {"delta": {"role": "assistant", "content": ""}, "finish_reason": None}
+        ],
+    },
+    {
+        "id": "c1",
+        "choices": [{"delta": {"content": "Hello"}, "finish_reason": None}],
+    },
+    {
+        "id": "c1",
+        "choices": [{"delta": {"content": " world"}, "finish_reason": None}],
+    },
+    {
+        "id": "c1",
+        "choices": [{"delta": {}, "finish_reason": "stop"}],
+        "usage": {"prompt_tokens": 10, "completion_tokens": 20, "total_tokens": 30},
+    },
+    "[DONE]",
+)
+
+
+def test_vllm_generate_success():
+    with patch("urllib.request.urlopen", _mock_urlopen(_VLLM_BODY)):
+        driver = VllmDriver()
+        result = driver.generate("mistral", [{"role": "user", "content": "hi"}])
+
+    assert result.error is None
+    assert result.text == "Hello world"
+    assert result.ttft_s is not None and result.ttft_s >= 0.0
+    assert result.input_tokens == 10
+    assert result.output_tokens == 20
+
+
+def test_vllm_generate_returns_error_on_url_error():
+    with patch(
+        "urllib.request.urlopen",
+        side_effect=urllib.error.URLError("Connection refused"),
+    ):
+        driver = VllmDriver()
+        result = driver.generate("mistral", [{"role": "user", "content": "hi"}])
+
+    assert result.error is not None
+    assert "Connection refused" in result.error
+
+
+def test_vllm_generate_returns_error_on_generic_exception():
+    with patch("urllib.request.urlopen", side_effect=RuntimeError("boom")):
+        driver = VllmDriver()
+        result = driver.generate("mistral", [{"role": "user", "content": "hi"}])
+
+    assert result.error is not None
+
+
+def test_vllm_is_available_returns_false_when_unreachable():
+    with patch(
+        "urllib.request.urlopen",
+        side_effect=urllib.error.URLError("Connection refused"),
+    ):
+        driver = VllmDriver()
+        assert driver.is_available() is False
+
+
+def test_vllm_is_available_returns_true_when_reachable():
+    with patch("urllib.request.urlopen", _mock_urlopen(b"ok")):
+        driver = VllmDriver()
+        assert driver.is_available() is True

--- a/tests/bench/test_bench_store.py
+++ b/tests/bench/test_bench_store.py
@@ -1,0 +1,276 @@
+"""Tests for app.core.bench_store — BenchRun model and BenchStore SQLite store."""
+
+from __future__ import annotations
+
+import platform
+from pathlib import Path
+
+import pytest
+
+from app.core.bench_store import (
+    BenchRun,
+    BenchStore,
+    hash_settings,
+    hash_text,
+)
+
+
+def _store(tmp_path: Path) -> BenchStore:
+    return BenchStore(db_path=tmp_path / "bench.db")
+
+
+def _run(**kwargs: object) -> BenchRun:
+    defaults: dict[str, object] = {
+        "run_id": "run-001",
+        "case_id": "case-a",
+        "repeat_index": 1,
+    }
+    defaults.update(kwargs)
+    return BenchRun(**defaults)  # type: ignore[arg-type]
+
+
+class TestSchemaCreation:
+    def test_db_file_created_on_init(self, tmp_path: Path) -> None:
+        db = tmp_path / "bench.db"
+        assert not db.exists()
+        BenchStore(db_path=db)
+        assert db.exists()
+
+    def test_second_init_is_idempotent(self, tmp_path: Path) -> None:
+        BenchStore(db_path=tmp_path / "bench.db")
+        BenchStore(db_path=tmp_path / "bench.db")
+
+    def test_index_exists_after_init(self, tmp_path: Path) -> None:
+        import sqlite3
+
+        db = tmp_path / "bench.db"
+        BenchStore(db_path=db)
+        conn = sqlite3.connect(db)
+        rows = conn.execute(
+            "SELECT name FROM sqlite_master"
+            " WHERE type='index' AND name='idx_bench_run_case_id'"
+        ).fetchall()
+        conn.close()
+        assert len(rows) == 1
+
+
+class TestGetDbPath:
+    def test_path_ends_with_bench_db(self) -> None:
+        path = BenchStore.get_db_path()
+        assert path.name == "bench.db"
+
+    def test_path_is_in_platform_config_dir(self) -> None:
+        path = BenchStore.get_db_path()
+        if platform.system() == "Windows":
+            assert "AppData" in str(path) or "Roaming" in str(path)
+        else:
+            assert ".config" in str(path)
+
+    def test_path_contains_app_dir(self) -> None:
+        path = BenchStore.get_db_path()
+        assert "repo-scaffold" in str(path)
+
+
+class TestRoundTrip:
+    def test_minimal_run_round_trips(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        run = _run()
+        store.record(run)
+        result = store.get_by_run_id("run-001")
+        assert result is not None
+        assert result.run_id == "run-001"
+        assert result.case_id == "case-a"
+        assert result.repeat_index == 1
+
+    def test_all_none_optional_fields_round_trip(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        run = _run()
+        store.record(run)
+        result = store.get_by_run_id("run-001")
+        assert result is not None
+        assert result.tier is None
+        assert result.context_size is None
+        assert result.concurrency is None
+        assert result.backend_id is None
+        assert result.model_id is None
+        assert result.settings_hash is None
+        assert result.prompt_hash is None
+        assert result.backend_base_url is None
+        assert result.gpu_driver_version is None
+        assert result.cuda_version is None
+        assert result.python_version is None
+        assert result.os_version is None
+        assert result.ttft_s is None
+        assert result.wall_time_s is None
+        assert result.throughput_tok_s is None
+        assert result.prompt_tokens is None
+        assert result.completion_tokens is None
+        assert result.total_tokens is None
+        assert result.peak_vram_gb is None
+        assert result.avg_gpu_util_pct is None
+        assert result.avg_gpu_mem_util_pct is None
+        assert result.avg_power_w is None
+        assert result.peak_temp_c is None
+        assert result.avg_sm_clock_mhz is None
+        assert result.avg_mem_clock_mhz is None
+        assert result.peak_ram_gb is None
+        assert result.cpu_offload_detected is None
+        assert result.ollama_model_loaded is None
+        assert result.ollama_num_ctx is None
+        assert result.quality_task_success is None
+        assert result.quality_pytest_passed is None
+        assert result.quality_ruff_passed is None
+        assert result.quality_mypy_passed is None
+        assert result.outcome is None
+        assert result.error_message is None
+
+    def test_full_run_round_trips(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        run = _run(
+            tier="speed",
+            context_size=4096,
+            concurrency=4,
+            backend_id="local_a",
+            model_id="qwen3-coder:30b",
+            settings_hash="a" * 64,
+            prompt_hash="b" * 64,
+            backend_base_url="http://localhost:8082",
+            gpu_driver_version="545.23",
+            cuda_version="12.3",
+            python_version="3.12.0",
+            os_version="Windows-11",
+            ttft_s=0.42,
+            wall_time_s=12.5,
+            throughput_tok_s=88.3,
+            prompt_tokens=1024,
+            completion_tokens=512,
+            total_tokens=1536,
+            peak_vram_gb=18.5,
+            avg_gpu_util_pct=92.0,
+            avg_gpu_mem_util_pct=85.0,
+            avg_power_w=350.0,
+            peak_temp_c=78.0,
+            avg_sm_clock_mhz=2400.0,
+            avg_mem_clock_mhz=10000.0,
+            peak_ram_gb=32.1,
+            cpu_offload_detected=False,
+            ollama_model_loaded=True,
+            ollama_num_ctx=4096,
+            quality_task_success=True,
+            quality_pytest_passed=True,
+            quality_ruff_passed=True,
+            quality_mypy_passed=False,
+            outcome="success",
+            error_message=None,
+        )
+        store.record(run)
+        result = store.get_by_run_id("run-001")
+        assert result is not None
+        assert result == run
+
+    def test_bool_fields_round_trip_true(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        run = _run(
+            cpu_offload_detected=True,
+            ollama_model_loaded=True,
+            quality_task_success=True,
+            quality_pytest_passed=True,
+            quality_ruff_passed=True,
+            quality_mypy_passed=True,
+        )
+        store.record(run)
+        result = store.get_by_run_id("run-001")
+        assert result is not None
+        assert result.cpu_offload_detected is True
+        assert result.ollama_model_loaded is True
+        assert result.quality_task_success is True
+        assert result.quality_pytest_passed is True
+        assert result.quality_ruff_passed is True
+        assert result.quality_mypy_passed is True
+
+    def test_bool_fields_round_trip_false(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        run = _run(
+            cpu_offload_detected=False,
+            ollama_model_loaded=False,
+            quality_task_success=False,
+            quality_pytest_passed=False,
+            quality_ruff_passed=False,
+            quality_mypy_passed=False,
+        )
+        store.record(run)
+        result = store.get_by_run_id("run-001")
+        assert result is not None
+        assert result.cpu_offload_detected is False
+        assert result.ollama_model_loaded is False
+        assert result.quality_task_success is False
+
+    def test_missing_run_returns_none(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        assert store.get_by_run_id("nonexistent") is None
+
+
+class TestAppendOnly:
+    def test_duplicate_run_id_raises(self, tmp_path: Path) -> None:
+        import sqlite3 as _sqlite3
+
+        store = _store(tmp_path)
+        store.record(_run())
+        with pytest.raises(_sqlite3.IntegrityError):
+            store.record(_run())
+
+    def test_multiple_runs_accumulate(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        store.record(_run(run_id="run-1"))
+        store.record(_run(run_id="run-2"))
+        store.record(_run(run_id="run-3"))
+        assert store.get_by_run_id("run-1") is not None
+        assert store.get_by_run_id("run-2") is not None
+        assert store.get_by_run_id("run-3") is not None
+
+
+class TestGetByCaseId:
+    def test_returns_all_runs_for_case(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        store.record(_run(run_id="r1", case_id="case-x", repeat_index=0))
+        store.record(_run(run_id="r2", case_id="case-x", repeat_index=1))
+        store.record(_run(run_id="r3", case_id="case-y", repeat_index=1))
+        results = store.get_by_case_id("case-x")
+        assert len(results) == 2
+        assert {r.run_id for r in results} == {"r1", "r2"}
+
+    def test_unknown_case_returns_empty_list(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        assert store.get_by_case_id("no-such-case") == []
+
+
+class TestHashFunctions:
+    def test_hash_settings_is_64_chars(self) -> None:
+        h = hash_settings({"temperature": 0.7, "max_tokens": 2048})
+        assert len(h) == 64
+
+    def test_hash_settings_stable(self) -> None:
+        settings = {"temperature": 0.7, "seed": 42}
+        assert hash_settings(settings) == hash_settings(settings)
+
+    def test_hash_settings_key_order_independent(self) -> None:
+        assert hash_settings({"a": 1, "b": 2}) == hash_settings({"b": 2, "a": 1})
+
+    def test_hash_settings_different_values_differ(self) -> None:
+        assert hash_settings({"a": 1}) != hash_settings({"a": 2})
+
+    def test_hash_settings_empty_dict_stable(self) -> None:
+        h1 = hash_settings({})
+        h2 = hash_settings({})
+        assert h1 == h2
+        assert len(h1) == 64
+
+    def test_hash_text_is_64_chars(self) -> None:
+        h = hash_text("hello world")
+        assert len(h) == 64
+
+    def test_hash_text_stable(self) -> None:
+        assert hash_text("same") == hash_text("same")
+
+    def test_hash_text_different_inputs_differ(self) -> None:
+        assert hash_text("foo") != hash_text("bar")

--- a/tests/bench/test_bench_tasks.py
+++ b/tests/bench/test_bench_tasks.py
@@ -1,0 +1,75 @@
+"""Tests for benchmark task prompt factories."""
+
+from __future__ import annotations
+
+import pytest
+
+import scripts.bench.tasks.prefill_shared as prefill_shared_mod
+from scripts.bench.tasks.boundary import make_boundary_prompt
+from scripts.bench.tasks.coding import make_coding_prompt
+from scripts.bench.tasks.prefill_shared import make_prefill_shared_prompt
+from scripts.bench.tasks.prefill_unshared import make_prefill_unshared_prompt
+from scripts.bench.tasks.speed import make_speed_prompt
+
+
+def test_speed_prompt_returns_bench_prompt() -> None:
+    prompt = make_speed_prompt()
+    assert prompt.task_type == "speed"
+    assert len(prompt.text) > 0
+    assert len(prompt.prompt_hash) == 64  # SHA-256 hex digest
+
+
+def test_prefill_shared_raises_when_fixture_missing(
+    tmp_path: pytest.TempPathFactory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(prefill_shared_mod, "FIXTURE_PATH", tmp_path / "missing.txt")  # type: ignore[arg-type]
+    with pytest.raises(FileNotFoundError):
+        make_prefill_shared_prompt()
+
+
+def test_prefill_shared_different_suffix_produces_different_hash(
+    tmp_path: pytest.TempPathFactory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixture = tmp_path / "prefill_50k.txt"  # type: ignore[operator]
+    fixture.write_text("Sample document content for testing.", encoding="utf-8")  # type: ignore[union-attr]
+    monkeypatch.setattr(prefill_shared_mod, "FIXTURE_PATH", fixture)
+    p0 = make_prefill_shared_prompt(suffix_index=0)
+    p1 = make_prefill_shared_prompt(suffix_index=1)
+    assert p0.prompt_hash != p1.prompt_hash
+
+
+def test_prefill_unshared_token_count_within_5pct() -> None:
+    target = 50000
+    prompt = make_prefill_unshared_prompt(target=target, seed=42)
+    assert prompt.token_count_estimate is not None
+    tolerance = target * 0.05
+    assert abs(prompt.token_count_estimate - target) <= tolerance
+
+
+def test_prefill_unshared_deterministic() -> None:
+    p1 = make_prefill_unshared_prompt(target=1000, seed=42)
+    p2 = make_prefill_unshared_prompt(target=1000, seed=42)
+    assert p1.text == p2.text
+    assert p1.prompt_hash == p2.prompt_hash
+
+
+def test_prefill_unshared_different_seeds_differ() -> None:
+    p1 = make_prefill_unshared_prompt(target=1000, seed=42)
+    p2 = make_prefill_unshared_prompt(target=1000, seed=99)
+    assert p1.text != p2.text
+
+
+def test_coding_prompt_returns_bench_prompt() -> None:
+    prompt = make_coding_prompt()
+    assert prompt.task_type == "coding"
+    assert len(prompt.text) > 0
+    assert len(prompt.prompt_hash) == 64
+
+
+def test_boundary_prompt_returns_bench_prompt() -> None:
+    prompt = make_boundary_prompt()
+    assert prompt.task_type == "boundary"
+    assert len(prompt.text) > 0
+    assert len(prompt.prompt_hash) == 64

--- a/tests/bench/test_env_snapshot.py
+++ b/tests/bench/test_env_snapshot.py
@@ -1,0 +1,85 @@
+"""Tests for EnvSnapshot."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from scripts.bench.env_snapshot import EnvSnapshot, _hash_settings
+
+
+class TestSettingsHash:
+    def test_stable_on_repeated_calls(self) -> None:
+        settings = {"temperature": 0.7, "max_tokens": 2048, "model": "test"}
+        h1 = _hash_settings(settings)
+        h2 = _hash_settings(settings)
+        assert h1 == h2
+        assert len(h1) == 64  # SHA-256 hex digest
+
+    def test_key_order_independent(self) -> None:
+        s1 = {"a": 1, "b": 2}
+        s2 = {"b": 2, "a": 1}
+        assert _hash_settings(s1) == _hash_settings(s2)
+
+    def test_different_inputs_produce_different_hashes(self) -> None:
+        assert _hash_settings({"a": 1}) != _hash_settings({"a": 2})
+
+    def test_empty_dict_produces_stable_hash(self) -> None:
+        h1 = _hash_settings({})
+        h2 = _hash_settings({})
+        assert h1 == h2
+        assert len(h1) == 64
+
+
+class TestEnvSnapshotCapture:
+    @patch("scripts.bench.env_snapshot.subprocess.run")
+    def test_capture_no_ops_when_nvidia_smi_absent(self, mock_run: MagicMock) -> None:
+        mock_run.side_effect = FileNotFoundError("nvidia-smi not found")
+        snap = EnvSnapshot.capture("ollama", "llama3", {"temperature": 0.5})
+
+        assert snap.gpu_driver_version is None
+        assert snap.cuda_version is None
+        assert snap.backend == "ollama"
+        assert snap.model == "llama3"
+        assert len(snap.settings_hash) == 64
+
+    @patch("scripts.bench.env_snapshot.subprocess.run")
+    def test_capture_no_ops_when_nonzero_returncode(self, mock_run: MagicMock) -> None:
+        mock_run.return_value = MagicMock(returncode=1, stdout="")
+        snap = EnvSnapshot.capture("litellm", "gemma2", {})
+
+        assert snap.gpu_driver_version is None
+        assert snap.cuda_version is None
+
+    @patch("scripts.bench.env_snapshot.subprocess.run")
+    def test_capture_parses_driver_and_cuda(self, mock_run: MagicMock) -> None:
+        # First call: --query-gpu=driver_version; second call: plain nvidia-smi
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout="545.23.08\n"),
+            MagicMock(returncode=0, stdout="| CUDA Version: 12.3     |\n"),
+        ]
+        snap = EnvSnapshot.capture("litellm", "gemma2", {"max_tokens": 1024})
+
+        assert snap.gpu_driver_version == "545.23.08"
+        assert snap.cuda_version == "12.3"
+        assert snap.backend == "litellm"
+        assert snap.model == "gemma2"
+
+    @patch("scripts.bench.env_snapshot.subprocess.run")
+    def test_settings_hash_stable_in_capture(self, mock_run: MagicMock) -> None:
+        mock_run.side_effect = FileNotFoundError("nvidia-smi not found")
+        settings = {"temperature": 0.8, "seed": 42}
+        snap1 = EnvSnapshot.capture("ollama", "qwen3", settings)
+        snap2 = EnvSnapshot.capture("ollama", "qwen3", settings)
+
+        assert snap1.settings_hash == snap2.settings_hash
+
+    def test_python_and_os_version_populated(self) -> None:
+        import platform
+        import sys
+
+        with patch("scripts.bench.env_snapshot.subprocess.run") as mock_run:
+            mock_run.side_effect = FileNotFoundError
+            snap = EnvSnapshot.capture("test", "test", {})
+
+        assert snap.python_version == sys.version
+        assert snap.os_version == platform.platform()

--- a/tests/bench/test_gpu_monitor.py
+++ b/tests/bench/test_gpu_monitor.py
@@ -1,0 +1,169 @@
+"""Tests for GpuMonitor and SysMonitor."""
+
+from __future__ import annotations
+
+import time
+from itertools import chain, repeat
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from scripts.bench.gpu_monitor import (
+    GpuMonitor,
+    GpuSample,
+    _all_none,
+    _parse_nvidia_smi,
+)
+from scripts.bench.sys_monitor import SysMonitor
+
+
+class TestParseNvidiaSmi:
+    def test_valid_line(self) -> None:
+        stdout = "2048, 80, 50, 200.5, 75, 1530, 7000\n"
+        result = _parse_nvidia_smi(stdout)
+        assert result is not None
+        vram, gpu_util, mem_util, power, temp, sm_clk, mem_clk = result
+        assert vram == pytest.approx(2048 / 1024)
+        assert gpu_util == pytest.approx(80.0)
+        assert mem_util == pytest.approx(50.0)
+        assert power == pytest.approx(200.5)
+        assert temp == pytest.approx(75.0)
+        assert sm_clk == pytest.approx(1530.0)
+        assert mem_clk == pytest.approx(7000.0)
+
+    def test_empty_returns_none(self) -> None:
+        assert _parse_nvidia_smi("") is None
+
+    def test_wrong_field_count_returns_none(self) -> None:
+        assert _parse_nvidia_smi("100, 50, 30\n") is None
+
+    def test_non_numeric_returns_none(self) -> None:
+        assert _parse_nvidia_smi("[N/A], 80, 50, 200, 75, 1530, 7000\n") is None
+
+
+class TestAllNone:
+    def test_all_fields_are_none(self) -> None:
+        sample = _all_none()
+        assert sample.peak_vram_gb is None
+        assert sample.avg_gpu_util_pct is None
+        assert sample.avg_gpu_mem_util_pct is None
+        assert sample.avg_power_w is None
+        assert sample.peak_temp_c is None
+        assert sample.avg_sm_clock_mhz is None
+        assert sample.avg_mem_clock_mhz is None
+
+
+class TestGpuMonitorPopulated:
+    @patch("scripts.bench.gpu_monitor.subprocess.run")
+    def test_stop_returns_all_seven_fields(self, mock_run: MagicMock) -> None:
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout="2048, 80, 50, 200.5, 75, 1530, 7000\n",
+        )
+        monitor = GpuMonitor(interval=0.001)
+        monitor.start()
+        time.sleep(0.05)
+        sample = monitor.stop()
+
+        assert isinstance(sample, GpuSample)
+        assert sample.peak_vram_gb == pytest.approx(2048 / 1024)
+        assert sample.avg_gpu_util_pct == pytest.approx(80.0)
+        assert sample.avg_gpu_mem_util_pct == pytest.approx(50.0)
+        assert sample.avg_power_w == pytest.approx(200.5)
+        assert sample.peak_temp_c == pytest.approx(75.0)
+        assert sample.avg_sm_clock_mhz == pytest.approx(1530.0)
+        assert sample.avg_mem_clock_mhz == pytest.approx(7000.0)
+
+    def test_peak_fields_track_maximum(self) -> None:
+        monitor = GpuMonitor()
+        # Inject samples directly to test aggregation without threading
+        monitor._samples = [
+            (1024 / 1024, 60.0, 40.0, 150.0, 70.0, 1400.0, 6000.0),
+            (3072 / 1024, 90.0, 60.0, 250.0, 85.0, 1600.0, 8000.0),
+            (2048 / 1024, 75.0, 50.0, 200.0, 78.0, 1500.0, 7000.0),
+        ]
+        sample = monitor.stop()
+
+        assert sample.peak_vram_gb == pytest.approx(3072 / 1024)
+        assert sample.peak_temp_c == pytest.approx(85.0)
+        assert sample.avg_gpu_util_pct == pytest.approx((60.0 + 90.0 + 75.0) / 3)
+
+
+class TestGpuMonitorAbsent:
+    @patch("scripts.bench.gpu_monitor.subprocess.run")
+    def test_no_exception_when_nvidia_smi_absent(self, mock_run: MagicMock) -> None:
+        mock_run.side_effect = FileNotFoundError("nvidia-smi not found")
+        monitor = GpuMonitor(interval=0.001)
+        monitor.start()
+        time.sleep(0.05)
+        sample = monitor.stop()
+
+        assert isinstance(sample, GpuSample)
+        assert sample.peak_vram_gb is None
+        assert sample.avg_gpu_util_pct is None
+        assert sample.avg_gpu_mem_util_pct is None
+        assert sample.avg_power_w is None
+        assert sample.peak_temp_c is None
+        assert sample.avg_sm_clock_mhz is None
+        assert sample.avg_mem_clock_mhz is None
+
+    @patch("scripts.bench.gpu_monitor.subprocess.run")
+    def test_no_exception_when_nonzero_returncode(self, mock_run: MagicMock) -> None:
+        mock_run.return_value = MagicMock(returncode=1, stdout="")
+        monitor = GpuMonitor(interval=0.001)
+        monitor.start()
+        time.sleep(0.05)
+        sample = monitor.stop()
+
+        assert sample.peak_vram_gb is None
+
+    def test_stop_before_start_returns_all_none(self) -> None:
+        monitor = GpuMonitor()
+        sample = monitor.stop()
+        assert sample.peak_vram_gb is None
+
+
+class TestSysMonitorOffload:
+    @patch("scripts.bench.sys_monitor._read_ram_gb")
+    def test_cpu_offload_detected_on_spike(self, mock_read: MagicMock) -> None:
+        # baseline=8.0, then spike to 11.5 (delta 3.5 GB > threshold 2.0 GB)
+        mock_read.side_effect = chain([8.0], repeat(11.5))
+        monitor = SysMonitor(interval=0.001)
+        monitor.start()
+        time.sleep(0.05)
+        result = monitor.stop()
+
+        assert result.cpu_offload_detected is True
+
+    @patch("scripts.bench.sys_monitor._read_ram_gb")
+    def test_no_offload_when_spike_below_threshold(self, mock_read: MagicMock) -> None:
+        # baseline=8.0, small increase of 1.5 GB (below 2.0 threshold)
+        mock_read.side_effect = chain([8.0], repeat(9.5))
+        monitor = SysMonitor(interval=0.001)
+        monitor.start()
+        time.sleep(0.05)
+        result = monitor.stop()
+
+        assert result.cpu_offload_detected is False
+
+    @patch("scripts.bench.sys_monitor._read_ram_gb")
+    def test_no_offload_at_exact_threshold(self, mock_read: MagicMock) -> None:
+        # baseline=8.0, spike of exactly 2.0 GB (not strictly greater)
+        mock_read.side_effect = chain([8.0], repeat(10.0))
+        monitor = SysMonitor(interval=0.001)
+        monitor.start()
+        time.sleep(0.05)
+        result = monitor.stop()
+
+        assert result.cpu_offload_detected is False
+
+    @patch("scripts.bench.sys_monitor._read_ram_gb")
+    def test_peak_ram_tracked(self, mock_read: MagicMock) -> None:
+        mock_read.side_effect = chain([8.0], repeat(9.0))
+        monitor = SysMonitor(interval=0.001)
+        monitor.start()
+        time.sleep(0.05)
+        result = monitor.stop()
+
+        assert result.peak_ram_gb is not None
+        assert result.peak_ram_gb >= 9.0

--- a/tests/bench/test_ollama_manager.py
+++ b/tests/bench/test_ollama_manager.py
@@ -1,0 +1,178 @@
+"""Tests for OllamaManager lifecycle methods — all network calls mocked."""
+
+from __future__ import annotations
+
+import io
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from scripts.bench.lifecycle.ollama_manager import ModelStatus, OllamaManager
+
+
+def _mock_urlopen(body: bytes) -> MagicMock:
+    return MagicMock(return_value=io.BytesIO(body))
+
+
+_PS_RESPONSE = json.dumps(
+    {
+        "models": [
+            {
+                "name": "llama3:latest",
+                "model": "llama3:latest",
+                "size": 4_000_000_000,
+                "digest": "abc123",
+                "details": {},
+                "expires_at": "2024-12-31T23:59:59Z",
+                "size_vram": 4_000_000_000,
+                "processor": "100% GPU",
+            }
+        ]
+    }
+).encode()
+
+_TAGS_EMPTY = json.dumps({"models": []}).encode()
+_TAGS_WITH_MODEL = json.dumps({"models": [{"name": "llama3:latest"}]}).encode()
+_PULL_RESPONSE = json.dumps({"status": "success"}).encode()
+_FLUSH_RESPONSE = json.dumps({}).encode()
+
+
+# ---------------------------------------------------------------------------
+# get_ps_status
+# ---------------------------------------------------------------------------
+
+
+def test_get_ps_status_returns_model_status():
+    with patch("urllib.request.urlopen", _mock_urlopen(_PS_RESPONSE)):
+        manager = OllamaManager()
+        statuses = manager.get_ps_status()
+
+    assert len(statuses) == 1
+    s = statuses[0]
+    assert isinstance(s, ModelStatus)
+    assert s.name == "llama3:latest"
+    assert s.size == 4_000_000_000
+    assert s.size_vram == 4_000_000_000
+    assert s.processor_status == "100% GPU"
+    assert s.expires_at == "2024-12-31T23:59:59Z"
+
+
+def test_get_ps_status_returns_empty_list_when_no_models():
+    with patch(
+        "urllib.request.urlopen", _mock_urlopen(json.dumps({"models": []}).encode())
+    ):
+        manager = OllamaManager()
+        assert manager.get_ps_status() == []
+
+
+def test_get_ps_status_processor_status_defaults_to_unknown():
+    body = json.dumps(
+        {
+            "models": [
+                {
+                    "name": "phi3:latest",
+                    "size": 1_000_000,
+                    "size_vram": 0,
+                    # no 'processor' key
+                }
+            ]
+        }
+    ).encode()
+    with patch("urllib.request.urlopen", _mock_urlopen(body)):
+        manager = OllamaManager()
+        statuses = manager.get_ps_status()
+
+    assert statuses[0].processor_status == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# flush_model
+# ---------------------------------------------------------------------------
+
+
+def test_flush_model_sends_post_with_keep_alive_zero():
+    mock_urlopen = _mock_urlopen(_FLUSH_RESPONSE)
+    with patch("urllib.request.urlopen", mock_urlopen):
+        manager = OllamaManager()
+        manager.flush_model("llama3:latest")
+
+    mock_urlopen.assert_called_once()
+    req = mock_urlopen.call_args[0][0]
+    assert req.full_url == "http://localhost:11434/api/generate"
+    body = json.loads(req.data)
+    assert body["model"] == "llama3:latest"
+    assert body["keep_alive"] == 0
+
+
+# ---------------------------------------------------------------------------
+# pull_if_needed
+# ---------------------------------------------------------------------------
+
+
+def test_pull_if_needed_skips_when_model_already_present():
+    mock_urlopen = _mock_urlopen(_TAGS_WITH_MODEL)
+    with patch("urllib.request.urlopen", mock_urlopen):
+        manager = OllamaManager()
+        manager.pull_if_needed("llama3:latest")
+
+    # Only the /api/tags GET should be called; no /api/pull
+    mock_urlopen.assert_called_once()
+    req = mock_urlopen.call_args[0][0]
+    assert "/api/tags" in req.full_url
+
+
+def test_pull_if_needed_pulls_when_model_missing():
+    call_count = 0
+    responses = [_TAGS_EMPTY, _PULL_RESPONSE]
+
+    def side_effect(req, timeout=None):  # type: ignore[no-untyped-def]
+        nonlocal call_count
+        body = responses[call_count]
+        call_count += 1
+        return io.BytesIO(body)
+
+    with patch("urllib.request.urlopen", side_effect=side_effect):
+        manager = OllamaManager()
+        manager.pull_if_needed("llama3:latest")
+
+    assert call_count == 2  # tags check + pull
+
+
+# ---------------------------------------------------------------------------
+# ensure_running
+# ---------------------------------------------------------------------------
+
+
+def test_ensure_running_returns_immediately_when_port_open():
+    mock_sock = MagicMock()
+    mock_sock.__enter__ = MagicMock(return_value=mock_sock)
+    mock_sock.__exit__ = MagicMock(return_value=False)
+    mock_sock.connect_ex.return_value = 0
+
+    mock_resp = MagicMock()
+    mock_resp.status = 200
+    mock_conn = MagicMock()
+    mock_conn.getresponse.return_value = mock_resp
+
+    with (
+        patch("socket.socket", return_value=mock_sock),
+        patch("http.client.HTTPConnection", return_value=mock_conn),
+    ):
+        manager = OllamaManager()
+        manager.ensure_running(timeout=5.0)
+
+    mock_sock.connect_ex.assert_called_once()
+    mock_conn.request.assert_called_once_with("GET", "/api/tags")
+
+
+def test_ensure_running_raises_timeout_when_port_never_opens():
+    mock_sock = MagicMock()
+    mock_sock.__enter__ = MagicMock(return_value=mock_sock)
+    mock_sock.__exit__ = MagicMock(return_value=False)
+    mock_sock.connect_ex.return_value = 1  # always closed
+
+    with patch("socket.socket", return_value=mock_sock), patch("time.sleep"):
+        manager = OllamaManager()
+        with pytest.raises(TimeoutError):
+            manager.ensure_running(timeout=0.01)

--- a/tests/bench/test_quality.py
+++ b/tests/bench/test_quality.py
@@ -1,0 +1,122 @@
+"""Tests for the coding quality evaluator."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import scripts.bench.quality as quality_mod
+from scripts.bench.quality import evaluate_coding_output
+
+
+def _make_patch_output(path: str = "solution.py", content: str = "x = 1") -> str:
+    return json.dumps({"path": path, "content": content})
+
+
+def test_returns_false_when_json_parse_fails(tmp_path: Path) -> None:
+    result = evaluate_coding_output("not valid json", tmp_path)
+    assert result.task_success is False
+    assert result.error_message is not None
+
+
+def test_returns_false_when_patch_missing_keys(tmp_path: Path) -> None:
+    result = evaluate_coding_output(json.dumps({"foo": "bar"}), tmp_path)
+    assert result.task_success is False
+    assert result.error_message is not None
+
+
+def test_returns_false_when_pytest_fails(tmp_path: Path) -> None:
+    failing = MagicMock()
+    failing.returncode = 1
+    passing = MagicMock()
+    passing.returncode = 0
+    with patch(
+        "scripts.bench.quality.subprocess.run", side_effect=[failing, passing, passing]
+    ):
+        result = evaluate_coding_output(_make_patch_output(), tmp_path)
+    assert result.task_success is False
+    assert result.pytest_passed is False
+    assert result.ruff_passed is True
+    assert result.mypy_passed is True
+
+
+def test_returns_false_when_ruff_fails(tmp_path: Path) -> None:
+    passing = MagicMock()
+    passing.returncode = 0
+    failing = MagicMock()
+    failing.returncode = 1
+    with patch(
+        "scripts.bench.quality.subprocess.run", side_effect=[passing, failing, passing]
+    ):
+        result = evaluate_coding_output(_make_patch_output(), tmp_path)
+    assert result.task_success is False
+    assert result.ruff_passed is False
+
+
+def test_returns_false_when_mypy_fails(tmp_path: Path) -> None:
+    passing = MagicMock()
+    passing.returncode = 0
+    failing = MagicMock()
+    failing.returncode = 1
+    with patch(
+        "scripts.bench.quality.subprocess.run", side_effect=[passing, passing, failing]
+    ):
+        result = evaluate_coding_output(_make_patch_output(), tmp_path)
+    assert result.task_success is False
+    assert result.mypy_passed is False
+
+
+def test_returns_success_when_all_checks_pass(tmp_path: Path) -> None:
+    passing = MagicMock()
+    passing.returncode = 0
+    with patch("scripts.bench.quality.subprocess.run", return_value=passing):
+        result = evaluate_coding_output(_make_patch_output(), tmp_path)
+    assert result.task_success is True
+    assert result.pytest_passed is True
+    assert result.ruff_passed is True
+    assert result.mypy_passed is True
+    assert result.error_message is None
+
+
+def test_temp_dir_cleaned_up_after_success(tmp_path: Path) -> None:
+    captured: list[str] = []
+    orig_mkdtemp = tempfile.mkdtemp
+
+    def capturing_mkdtemp() -> str:
+        d = orig_mkdtemp()
+        captured.append(d)
+        return d
+
+    passing = MagicMock()
+    passing.returncode = 0
+    with patch.object(quality_mod.tempfile, "mkdtemp", side_effect=capturing_mkdtemp):
+        with patch("scripts.bench.quality.subprocess.run", return_value=passing):
+            evaluate_coding_output(_make_patch_output(), tmp_path)
+
+    assert captured, "mkdtemp was never called"
+    for d in captured:
+        assert not Path(d).exists(), f"Temp dir {d} was not cleaned up"
+
+
+def test_temp_dir_cleaned_up_on_exception(tmp_path: Path) -> None:
+    captured: list[str] = []
+    orig_mkdtemp = tempfile.mkdtemp
+
+    def capturing_mkdtemp() -> str:
+        d = orig_mkdtemp()
+        captured.append(d)
+        return d
+
+    with patch.object(quality_mod.tempfile, "mkdtemp", side_effect=capturing_mkdtemp):
+        with patch(
+            "scripts.bench.quality.subprocess.run",
+            side_effect=RuntimeError("simulated failure"),
+        ):
+            result = evaluate_coding_output(_make_patch_output(), tmp_path)
+
+    assert captured, "mkdtemp was never called"
+    for d in captured:
+        assert not Path(d).exists(), f"Temp dir {d} was not cleaned up"
+    assert result.task_success is False


### PR DESCRIPTION
## Summary
- Adds a standalone benchmark harness (`scripts/bench/`) for evaluating local LLM models and backends before production use in the watcher — no `app.*` imports anywhere in the harness
- Implements five benchmark tiers (speed, prefill_shared, prefill_unshared, coding, boundary), Ollama/vLLM streaming drivers, GPU/RAM/environment monitoring, a quality evaluator that runs pytest/ruff/mypy on model-generated patches, and a full CLI entry point with resume, compare, JSON/CSV export, and Datasette browse support
- Adds `app/core/bench_store.py` (mirrors `metrics.py` pattern) to persist `BenchRun` records in `bench.db`; writes `docs/bench.md` as user-facing quick-start and reference guide

## Sub-tickets included
- WOR-181: BenchStore — BenchRun data model and SQLite persistence layer
- WOR-182: Config loader, matrix expansion, and bench.toml
- WOR-183: GPU monitor, system monitor, and environment snapshot
- WOR-184: Task prompt factories and coding quality evaluator
- WOR-185: Backend drivers (Ollama + vLLM) and Ollama lifecycle manager
- WOR-186: Runner, reporter, CLI entry point, and resume support

## Reviewer notes (NEEDS_ATTENTION — non-blocking)
- `BenchStore.get_by_run_id` returns `BenchRun | None` rather than `list[BenchRun]` as AC specified
- `EnvSnapshot.capture` accepts `settings: dict` rather than `config: BenchConfig`
- `OllamaManager.get_ps_status` returns `list[ModelStatus]` (no model_id filter) rather than `ModelStatus`
- `run_bench.py` duplicates BenchStore DDL/INSERT SQL directly instead of calling `BenchStore.record()` — schema drift risk

These are tracked as follow-up items; none block correctness of the current implementation.

## File-size advisory
- `scripts/bench/run_bench.py` is 667 LOC (≥ 500 advisory threshold). Consider splitting the runner core from the CLI argument handling before this file grows further.

## Test plan
- [x] pytest passes — 466 passed, 88.15% coverage (≥ 80% threshold)
- [x] ruff check . — clean
- [x] mypy app/ — clean
- [x] bandit security scan — PASS
- [x] Import Linter — 4 contracts kept, 0 violations; `scripts/bench/` correctly outside app boundary
- [ ] UI tests — not present (bench harness is CLI-only; no UI surface)

**Milestone:** V1 MVP

Closes WOR-180
Closes WOR-181
Closes WOR-182
Closes WOR-183
Closes WOR-184
Closes WOR-185
Closes WOR-186