### PR TITLE
WOR-189 WOR-187 Sub-2: Fix EnvSnapshot.capture signature to accept BenchConfig

### DIFF
--- a/scripts/bench/env_snapshot.py
+++ b/scripts/bench/env_snapshot.py
@@ -11,6 +11,8 @@ import sys
 from dataclasses import dataclass
 from typing import Any
 
+from .config import BenchConfig
+
 logger = logging.getLogger(__name__)
 
 
@@ -25,9 +27,7 @@ class EnvSnapshot:
     settings_hash: str
 
     @classmethod
-    def capture(
-        cls, backend: str, model: str, settings: dict[str, Any]
-    ) -> "EnvSnapshot":
+    def capture(cls, backend: str, model: str, config: BenchConfig) -> "EnvSnapshot":
         gpu_driver, cuda_ver = _get_nvidia_info()
         return cls(
             backend=backend,
@@ -36,7 +36,7 @@ class EnvSnapshot:
             cuda_version=cuda_ver,
             python_version=sys.version,
             os_version=platform.platform(),
-            settings_hash=_hash_settings(settings),
+            settings_hash=_hash_settings(config.model_dump()),
         )
 
 

--- a/tests/bench/test_env_snapshot.py
+++ b/tests/bench/test_env_snapshot.py
@@ -4,7 +4,30 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+
+from scripts.bench.config import (
+    BackendConfig,
+    BenchConfig,
+    MatrixConfig,
+    ModelConfig,
+    TierConfig,
+)
 from scripts.bench.env_snapshot import EnvSnapshot, _hash_settings
+
+
+@pytest.fixture
+def bench_config() -> BenchConfig:
+    return BenchConfig(
+        matrix=MatrixConfig(
+            context_sizes=[1024],
+            boundary_context_sizes=[4096],
+            concurrency_levels=[1],
+        ),
+        backends=[BackendConfig(id="test-backend", base_url="http://localhost:11434")],
+        models=[ModelConfig(id="test-model", backend_id="test-backend")],
+        tiers=[TierConfig(name="standard")],
+    )
 
 
 class TestSettingsHash:
@@ -32,9 +55,11 @@ class TestSettingsHash:
 
 class TestEnvSnapshotCapture:
     @patch("scripts.bench.env_snapshot.subprocess.run")
-    def test_capture_no_ops_when_nvidia_smi_absent(self, mock_run: MagicMock) -> None:
+    def test_capture_no_ops_when_nvidia_smi_absent(
+        self, mock_run: MagicMock, bench_config: BenchConfig
+    ) -> None:
         mock_run.side_effect = FileNotFoundError("nvidia-smi not found")
-        snap = EnvSnapshot.capture("ollama", "llama3", {"temperature": 0.5})
+        snap = EnvSnapshot.capture("ollama", "llama3", bench_config)
 
         assert snap.gpu_driver_version is None
         assert snap.cuda_version is None
@@ -43,21 +68,25 @@ class TestEnvSnapshotCapture:
         assert len(snap.settings_hash) == 64
 
     @patch("scripts.bench.env_snapshot.subprocess.run")
-    def test_capture_no_ops_when_nonzero_returncode(self, mock_run: MagicMock) -> None:
+    def test_capture_no_ops_when_nonzero_returncode(
+        self, mock_run: MagicMock, bench_config: BenchConfig
+    ) -> None:
         mock_run.return_value = MagicMock(returncode=1, stdout="")
-        snap = EnvSnapshot.capture("litellm", "gemma2", {})
+        snap = EnvSnapshot.capture("litellm", "gemma2", bench_config)
 
         assert snap.gpu_driver_version is None
         assert snap.cuda_version is None
 
     @patch("scripts.bench.env_snapshot.subprocess.run")
-    def test_capture_parses_driver_and_cuda(self, mock_run: MagicMock) -> None:
+    def test_capture_parses_driver_and_cuda(
+        self, mock_run: MagicMock, bench_config: BenchConfig
+    ) -> None:
         # First call: --query-gpu=driver_version; second call: plain nvidia-smi
         mock_run.side_effect = [
             MagicMock(returncode=0, stdout="545.23.08\n"),
             MagicMock(returncode=0, stdout="| CUDA Version: 12.3     |\n"),
         ]
-        snap = EnvSnapshot.capture("litellm", "gemma2", {"max_tokens": 1024})
+        snap = EnvSnapshot.capture("litellm", "gemma2", bench_config)
 
         assert snap.gpu_driver_version == "545.23.08"
         assert snap.cuda_version == "12.3"
@@ -65,21 +94,22 @@ class TestEnvSnapshotCapture:
         assert snap.model == "gemma2"
 
     @patch("scripts.bench.env_snapshot.subprocess.run")
-    def test_settings_hash_stable_in_capture(self, mock_run: MagicMock) -> None:
+    def test_settings_hash_stable_in_capture(
+        self, mock_run: MagicMock, bench_config: BenchConfig
+    ) -> None:
         mock_run.side_effect = FileNotFoundError("nvidia-smi not found")
-        settings = {"temperature": 0.8, "seed": 42}
-        snap1 = EnvSnapshot.capture("ollama", "qwen3", settings)
-        snap2 = EnvSnapshot.capture("ollama", "qwen3", settings)
+        snap1 = EnvSnapshot.capture("ollama", "qwen3", bench_config)
+        snap2 = EnvSnapshot.capture("ollama", "qwen3", bench_config)
 
         assert snap1.settings_hash == snap2.settings_hash
 
-    def test_python_and_os_version_populated(self) -> None:
+    def test_python_and_os_version_populated(self, bench_config: BenchConfig) -> None:
         import platform
         import sys
 
         with patch("scripts.bench.env_snapshot.subprocess.run") as mock_run:
             mock_run.side_effect = FileNotFoundError
-            snap = EnvSnapshot.capture("test", "test", {})
+            snap = EnvSnapshot.capture("test", "test", bench_config)
 
         assert snap.python_version == sys.version
         assert snap.os_version == platform.platform()


### PR DESCRIPTION
Closes WOR-189

EnvSnapshot.capture accepts BenchConfig; test_env_snapshot.py uses BenchConfig fixtures; all required checks green.