### PR TITLE
WOR-187 Bench harness API alignment — fix naming drift from WOR-180 review

### DIFF
--- a/app/core/bench_store.py
+++ b/app/core/bench_store.py
@@ -22,7 +22,7 @@ _DB_NAME = "bench.db"
 
 _CREATE_TABLE = """
 CREATE TABLE IF NOT EXISTS bench_run (
-    run_id                  TEXT    NOT NULL PRIMARY KEY,
+    run_id                  TEXT    NOT NULL,
     case_id                 TEXT    NOT NULL,
     repeat_index            INTEGER NOT NULL,
     tier                    TEXT,
@@ -60,7 +60,8 @@ CREATE TABLE IF NOT EXISTS bench_run (
     quality_mypy_passed     INTEGER,
     outcome                 TEXT,
     error_message           TEXT,
-    recorded_at             TEXT NOT NULL DEFAULT (datetime('now'))
+    recorded_at             TEXT NOT NULL DEFAULT (datetime('now')),
+    PRIMARY KEY (run_id, case_id, repeat_index)
 )
 """
 
@@ -235,16 +236,14 @@ class BenchStore:
         with self._connect() as conn:
             conn.execute(_INSERT, d)
 
-    def get_by_run_id(self, run_id: str) -> BenchRun | None:
-        """Return the BenchRun for the given run_id, or None if not found."""
+    def get_by_run_id(self, run_id: str) -> list[BenchRun]:
+        """Return all BenchRun records for the given run_id, oldest first."""
         with self._connect() as conn:
-            row = conn.execute(
-                "SELECT * FROM bench_run WHERE run_id = ?",
+            rows = conn.execute(
+                "SELECT * FROM bench_run WHERE run_id = ? ORDER BY recorded_at",
                 (run_id,),
-            ).fetchone()
-        if row is None:
-            return None
-        return _row_to_bench_run(row)
+            ).fetchall()
+        return [_row_to_bench_run(r) for r in rows]
 
     def get_by_case_id(self, case_id: str) -> list[BenchRun]:
         """Return all BenchRun records for a given case_id, oldest first."""

--- a/scripts/bench/env_snapshot.py
+++ b/scripts/bench/env_snapshot.py
@@ -11,6 +11,8 @@ import sys
 from dataclasses import dataclass
 from typing import Any
 
+from .config import BenchConfig
+
 logger = logging.getLogger(__name__)
 
 
@@ -25,9 +27,7 @@ class EnvSnapshot:
     settings_hash: str
 
     @classmethod
-    def capture(
-        cls, backend: str, model: str, settings: dict[str, Any]
-    ) -> "EnvSnapshot":
+    def capture(cls, backend: str, model: str, config: BenchConfig) -> "EnvSnapshot":
         gpu_driver, cuda_ver = _get_nvidia_info()
         return cls(
             backend=backend,
@@ -36,7 +36,7 @@ class EnvSnapshot:
             cuda_version=cuda_ver,
             python_version=sys.version,
             os_version=platform.platform(),
-            settings_hash=_hash_settings(settings),
+            settings_hash=_hash_settings(config.model_dump()),
         )
 
 

--- a/scripts/bench/lifecycle/ollama_manager.py
+++ b/scripts/bench/lifecycle/ollama_manager.py
@@ -98,18 +98,18 @@ class OllamaManager:
         with urllib.request.urlopen(req, timeout=30) as resp:
             resp.read()
 
-    def get_ps_status(self) -> list[ModelStatus]:
-        """Return currently loaded models from /api/ps."""
+    def get_ps_status(self, model_id: str) -> ModelStatus | None:
+        """Return status of model_id from /api/ps, or None if not loaded."""
         req = urllib.request.Request(f"{self._base_url}/api/ps")
         with urllib.request.urlopen(req, timeout=10) as resp:
             data = json.loads(resp.read())
-        return [
-            ModelStatus(
-                name=m["name"],
-                size=m.get("size", 0),
-                size_vram=m.get("size_vram", 0),
-                processor_status=m.get("processor", "unknown"),
-                expires_at=m.get("expires_at", ""),
-            )
-            for m in data.get("models", [])
-        ]
+        for m in data.get("models", []):
+            if m["name"] == model_id:
+                return ModelStatus(
+                    name=m["name"],
+                    size=m.get("size", 0),
+                    size_vram=m.get("size_vram", 0),
+                    processor_status=m.get("processor", "unknown"),
+                    expires_at=m.get("expires_at", ""),
+                )
+        return None

--- a/scripts/bench/run_bench.py
+++ b/scripts/bench/run_bench.py
@@ -12,16 +12,14 @@ from __future__ import annotations
 
 import argparse
 import logging
-import platform
-import sqlite3
 import subprocess  # nosec B404
 import sys
 import time
-from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Generator
+from typing import Any
 
+from app.core.bench_store import BenchRun, BenchStore
 from scripts.bench.config import BenchCase, BenchConfig
 from scripts.bench.drivers.ollama import OllamaDriver
 from scripts.bench.drivers.vllm import VllmDriver
@@ -38,135 +36,7 @@ from scripts.bench.tasks.speed import make_speed_prompt
 
 logging.basicConfig(level=logging.WARNING, format="%(levelname)s %(name)s: %(message)s")
 
-# ── DB constants (mirrors app/core/bench_store.py — no app.* imports allowed) ─
-
-_APP_DIR = "repo-scaffold"
-_DB_NAME = "bench.db"
 _FIXTURES_DIR = Path(__file__).parent / "fixtures"
-
-_CREATE_TABLE = """
-CREATE TABLE IF NOT EXISTS bench_run (
-    run_id                  TEXT    NOT NULL PRIMARY KEY,
-    case_id                 TEXT    NOT NULL,
-    repeat_index            INTEGER NOT NULL,
-    tier                    TEXT,
-    context_size            INTEGER,
-    concurrency             INTEGER,
-    backend_id              TEXT,
-    model_id                TEXT,
-    settings_hash           TEXT,
-    prompt_hash             TEXT,
-    backend_base_url        TEXT,
-    gpu_driver_version      TEXT,
-    cuda_version            TEXT,
-    python_version          TEXT,
-    os_version              TEXT,
-    ttft_s                  REAL,
-    wall_time_s             REAL,
-    throughput_tok_s        REAL,
-    prompt_tokens           INTEGER,
-    completion_tokens       INTEGER,
-    total_tokens            INTEGER,
-    peak_vram_gb            REAL,
-    avg_gpu_util_pct        REAL,
-    avg_gpu_mem_util_pct    REAL,
-    avg_power_w             REAL,
-    peak_temp_c             REAL,
-    avg_sm_clock_mhz        REAL,
-    avg_mem_clock_mhz       REAL,
-    peak_ram_gb             REAL,
-    cpu_offload_detected    INTEGER,
-    ollama_model_loaded     INTEGER,
-    ollama_num_ctx          INTEGER,
-    quality_task_success    INTEGER,
-    quality_pytest_passed   INTEGER,
-    quality_ruff_passed     INTEGER,
-    quality_mypy_passed     INTEGER,
-    outcome                 TEXT,
-    error_message           TEXT,
-    recorded_at             TEXT NOT NULL DEFAULT (datetime('now'))
-)
-"""
-
-_CREATE_INDEX = """
-CREATE INDEX IF NOT EXISTS idx_bench_run_case_id
-    ON bench_run (case_id)
-"""
-
-_INSERT = """
-INSERT INTO bench_run (
-    run_id, case_id, repeat_index,
-    tier, context_size, concurrency, backend_id, model_id,
-    settings_hash, prompt_hash,
-    backend_base_url, gpu_driver_version, cuda_version, python_version, os_version,
-    ttft_s, wall_time_s, throughput_tok_s,
-    prompt_tokens, completion_tokens, total_tokens,
-    peak_vram_gb, avg_gpu_util_pct, avg_gpu_mem_util_pct, avg_power_w,
-    peak_temp_c, avg_sm_clock_mhz, avg_mem_clock_mhz,
-    peak_ram_gb, cpu_offload_detected,
-    ollama_model_loaded, ollama_num_ctx,
-    quality_task_success, quality_pytest_passed,
-    quality_ruff_passed, quality_mypy_passed,
-    outcome, error_message
-) VALUES (
-    :run_id, :case_id, :repeat_index,
-    :tier, :context_size, :concurrency, :backend_id, :model_id,
-    :settings_hash, :prompt_hash,
-    :backend_base_url, :gpu_driver_version, :cuda_version, :python_version, :os_version,
-    :ttft_s, :wall_time_s, :throughput_tok_s,
-    :prompt_tokens, :completion_tokens, :total_tokens,
-    :peak_vram_gb, :avg_gpu_util_pct, :avg_gpu_mem_util_pct, :avg_power_w,
-    :peak_temp_c, :avg_sm_clock_mhz, :avg_mem_clock_mhz,
-    :peak_ram_gb, :cpu_offload_detected,
-    :ollama_model_loaded, :ollama_num_ctx,
-    :quality_task_success, :quality_pytest_passed,
-    :quality_ruff_passed, :quality_mypy_passed,
-    :outcome, :error_message
-)
-"""
-
-# ── DB helpers ────────────────────────────────────────────────────────────────
-
-
-def _get_db_path() -> Path:
-    if platform.system() == "Windows":
-        base = Path.home() / "AppData" / "Roaming"
-    else:
-        base = Path.home() / ".config"
-    return base / _APP_DIR / _DB_NAME
-
-
-@contextmanager
-def _connect(db_path: Path) -> Generator[sqlite3.Connection, None, None]:
-    conn = sqlite3.connect(db_path)
-    conn.row_factory = sqlite3.Row
-    try:
-        yield conn
-        conn.commit()
-    finally:
-        conn.close()
-
-
-def _ensure_schema(db_path: Path) -> None:
-    db_path.parent.mkdir(parents=True, exist_ok=True)
-    with _connect(db_path) as conn:
-        conn.execute(_CREATE_TABLE)
-        conn.execute(_CREATE_INDEX)
-
-
-def _run_id_exists(db_path: Path, run_id: str) -> bool:
-    with _connect(db_path) as conn:
-        return (
-            conn.execute(
-                "SELECT 1 FROM bench_run WHERE run_id = ?", (run_id,)
-            ).fetchone()
-            is not None
-        )
-
-
-def _insert_row(db_path: Path, row: dict[str, Any]) -> None:
-    with _connect(db_path) as conn:
-        conn.execute(_INSERT, row)
 
 
 # ── ID helpers ────────────────────────────────────────────────────────────────
@@ -365,7 +235,7 @@ def _run(args: argparse.Namespace, db_path: Path) -> None:
     )
     print(f"Sweep: {sweep_id}  DB: {db_path}")
 
-    _ensure_schema(db_path)
+    store = BenchStore(db_path)
 
     backends = {b.id: b for b in config.backends if b.enabled}
 
@@ -377,7 +247,7 @@ def _run(args: argparse.Namespace, db_path: Path) -> None:
     for case in cases:
         row_run_id = _row_run_id(sweep_id, case)
 
-        if args.resume and _run_id_exists(db_path, row_run_id):
+        if args.resume and store.get_by_run_id(row_run_id):
             print(
                 f"[SKIP] {case.model_id}/{case.tier}"
                 f"/ctx={case.context_size}/c={case.concurrency}/r={case.repeat_index}"
@@ -418,13 +288,8 @@ def _run(args: argparse.Namespace, db_path: Path) -> None:
         prev_model_id = case.model_id
         prev_backend_id = case.backend_id
 
-        settings: dict[str, Any] = {
-            "tier": case.tier,
-            "context_size": case.context_size,
-            "concurrency": case.concurrency,
-        }
         env = EnvSnapshot.capture(
-            backend=case.backend_id, model=case.model_id, settings=settings
+            backend=case.backend_id, model=case.model_id, config=config
         )
 
         # First prefill_shared per model = warm; subsequent = prefix_warm
@@ -494,66 +359,54 @@ def _run(args: argparse.Namespace, db_path: Path) -> None:
         ollama_model_loaded: bool | None = None
         if manager is not None:
             try:
-                statuses = manager.get_ps_status()
-                ollama_model_loaded = any(s.name == case.model_id for s in statuses)
+                status = manager.get_ps_status(case.model_id)
+                ollama_model_loaded = status is not None
             except Exception:
                 pass
 
-        row: dict[str, Any] = {
-            "run_id": row_run_id,
-            "case_id": _case_id(case),
-            "repeat_index": case.repeat_index,
-            "tier": case.tier,
-            "context_size": case.context_size,
-            "concurrency": case.concurrency,
-            "backend_id": case.backend_id,
-            "model_id": case.model_id,
-            "settings_hash": env.settings_hash,
-            "prompt_hash": prompt.prompt_hash,
-            "backend_base_url": backend_cfg.base_url,
-            "gpu_driver_version": env.gpu_driver_version,
-            "cuda_version": env.cuda_version,
-            "python_version": env.python_version,
-            "os_version": env.os_version,
-            "ttft_s": result.ttft_s if not oom else None,
-            "wall_time_s": wall_time_s if not oom else None,
-            "throughput_tok_s": throughput_tok_s,
-            "prompt_tokens": result.input_tokens,
-            "completion_tokens": result.output_tokens,
-            "total_tokens": total_tokens,
-            "peak_vram_gb": gpu_sample.peak_vram_gb,
-            "avg_gpu_util_pct": gpu_sample.avg_gpu_util_pct,
-            "avg_gpu_mem_util_pct": gpu_sample.avg_gpu_mem_util_pct,
-            "avg_power_w": gpu_sample.avg_power_w,
-            "peak_temp_c": gpu_sample.peak_temp_c,
-            "avg_sm_clock_mhz": gpu_sample.avg_sm_clock_mhz,
-            "avg_mem_clock_mhz": gpu_sample.avg_mem_clock_mhz,
-            "peak_ram_gb": sys_result.peak_ram_gb,
-            "cpu_offload_detected": int(sys_result.cpu_offload_detected),
-            "ollama_model_loaded": (
-                int(ollama_model_loaded) if ollama_model_loaded is not None else None
-            ),
-            "ollama_num_ctx": case.context_size,
-            "quality_task_success": (
-                int(quality_task_success) if quality_task_success is not None else None
-            ),
-            "quality_pytest_passed": (
-                int(quality_pytest_passed)
-                if quality_pytest_passed is not None
-                else None
-            ),
-            "quality_ruff_passed": (
-                int(quality_ruff_passed) if quality_ruff_passed is not None else None
-            ),
-            "quality_mypy_passed": (
-                int(quality_mypy_passed) if quality_mypy_passed is not None else None
-            ),
-            "outcome": outcome,
-            "error_message": error_message,
-        }
+        bench_run = BenchRun(
+            run_id=row_run_id,
+            case_id=_case_id(case),
+            repeat_index=case.repeat_index,
+            tier=case.tier,
+            context_size=case.context_size,
+            concurrency=case.concurrency,
+            backend_id=case.backend_id,
+            model_id=case.model_id,
+            settings_hash=env.settings_hash,
+            prompt_hash=prompt.prompt_hash,
+            backend_base_url=backend_cfg.base_url,
+            gpu_driver_version=env.gpu_driver_version,
+            cuda_version=env.cuda_version,
+            python_version=env.python_version,
+            os_version=env.os_version,
+            ttft_s=result.ttft_s if not oom else None,
+            wall_time_s=wall_time_s if not oom else None,
+            throughput_tok_s=throughput_tok_s,
+            prompt_tokens=result.input_tokens,
+            completion_tokens=result.output_tokens,
+            total_tokens=total_tokens,
+            peak_vram_gb=gpu_sample.peak_vram_gb,
+            avg_gpu_util_pct=gpu_sample.avg_gpu_util_pct,
+            avg_gpu_mem_util_pct=gpu_sample.avg_gpu_mem_util_pct,
+            avg_power_w=gpu_sample.avg_power_w,
+            peak_temp_c=gpu_sample.peak_temp_c,
+            avg_sm_clock_mhz=gpu_sample.avg_sm_clock_mhz,
+            avg_mem_clock_mhz=gpu_sample.avg_mem_clock_mhz,
+            peak_ram_gb=sys_result.peak_ram_gb,
+            cpu_offload_detected=sys_result.cpu_offload_detected,
+            ollama_model_loaded=ollama_model_loaded,
+            ollama_num_ctx=case.context_size,
+            quality_task_success=quality_task_success,
+            quality_pytest_passed=quality_pytest_passed,
+            quality_ruff_passed=quality_ruff_passed,
+            quality_mypy_passed=quality_mypy_passed,
+            outcome=outcome,
+            error_message=error_message,
+        )
 
         # Write before moving to next case (resume safety invariant)
-        _insert_row(db_path, row)
+        store.record(bench_run)
 
         ttft_str = f" ttft={result.ttft_s:.2f}s" if result.ttft_s else ""
         tok_str = f" tok/s={throughput_tok_s:.0f}" if throughput_tok_s else ""
@@ -645,7 +498,7 @@ def main() -> int:
     parser = _build_parser()
     args = parser.parse_args()
 
-    db_path = Path(args.db_path) if args.db_path else _get_db_path()
+    db_path = Path(args.db_path) if args.db_path else BenchStore.get_db_path()
 
     if args.generate_fixtures:
         _generate_fixtures()

--- a/tests/bench/test_bench_store.py
+++ b/tests/bench/test_bench_store.py
@@ -76,8 +76,9 @@ class TestRoundTrip:
         store = _store(tmp_path)
         run = _run()
         store.record(run)
-        result = store.get_by_run_id("run-001")
-        assert result is not None
+        results = store.get_by_run_id("run-001")
+        assert len(results) == 1
+        result = results[0]
         assert result.run_id == "run-001"
         assert result.case_id == "case-a"
         assert result.repeat_index == 1
@@ -86,8 +87,9 @@ class TestRoundTrip:
         store = _store(tmp_path)
         run = _run()
         store.record(run)
-        result = store.get_by_run_id("run-001")
-        assert result is not None
+        results = store.get_by_run_id("run-001")
+        assert len(results) == 1
+        result = results[0]
         assert result.tier is None
         assert result.context_size is None
         assert result.concurrency is None
@@ -164,9 +166,9 @@ class TestRoundTrip:
             error_message=None,
         )
         store.record(run)
-        result = store.get_by_run_id("run-001")
-        assert result is not None
-        assert result == run
+        results = store.get_by_run_id("run-001")
+        assert len(results) == 1
+        assert results[0] == run
 
     def test_bool_fields_round_trip_true(self, tmp_path: Path) -> None:
         store = _store(tmp_path)
@@ -179,8 +181,9 @@ class TestRoundTrip:
             quality_mypy_passed=True,
         )
         store.record(run)
-        result = store.get_by_run_id("run-001")
-        assert result is not None
+        results = store.get_by_run_id("run-001")
+        assert len(results) == 1
+        result = results[0]
         assert result.cpu_offload_detected is True
         assert result.ollama_model_loaded is True
         assert result.quality_task_success is True
@@ -199,19 +202,20 @@ class TestRoundTrip:
             quality_mypy_passed=False,
         )
         store.record(run)
-        result = store.get_by_run_id("run-001")
-        assert result is not None
+        results = store.get_by_run_id("run-001")
+        assert len(results) == 1
+        result = results[0]
         assert result.cpu_offload_detected is False
         assert result.ollama_model_loaded is False
         assert result.quality_task_success is False
 
-    def test_missing_run_returns_none(self, tmp_path: Path) -> None:
+    def test_missing_run_returns_empty_list(self, tmp_path: Path) -> None:
         store = _store(tmp_path)
-        assert store.get_by_run_id("nonexistent") is None
+        assert store.get_by_run_id("nonexistent") == []
 
 
 class TestAppendOnly:
-    def test_duplicate_run_id_raises(self, tmp_path: Path) -> None:
+    def test_duplicate_run_case_repeat_raises(self, tmp_path: Path) -> None:
         import sqlite3 as _sqlite3
 
         store = _store(tmp_path)
@@ -224,9 +228,30 @@ class TestAppendOnly:
         store.record(_run(run_id="run-1"))
         store.record(_run(run_id="run-2"))
         store.record(_run(run_id="run-3"))
-        assert store.get_by_run_id("run-1") is not None
-        assert store.get_by_run_id("run-2") is not None
-        assert store.get_by_run_id("run-3") is not None
+        assert len(store.get_by_run_id("run-1")) == 1
+        assert len(store.get_by_run_id("run-2")) == 1
+        assert len(store.get_by_run_id("run-3")) == 1
+
+
+class TestGetByRunId:
+    def test_returns_all_cases_for_run(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        store.record(_run(run_id="batch-1", case_id="case-a", repeat_index=0))
+        store.record(_run(run_id="batch-1", case_id="case-a", repeat_index=1))
+        store.record(_run(run_id="batch-1", case_id="case-b", repeat_index=0))
+        store.record(_run(run_id="batch-2", case_id="case-a", repeat_index=0))
+        results = store.get_by_run_id("batch-1")
+        assert len(results) == 3
+        assert all(r.run_id == "batch-1" for r in results)
+        assert {(r.case_id, r.repeat_index) for r in results} == {
+            ("case-a", 0),
+            ("case-a", 1),
+            ("case-b", 0),
+        }
+
+    def test_unknown_run_returns_empty_list(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        assert store.get_by_run_id("no-such-run") == []
 
 
 class TestGetByCaseId:

--- a/tests/bench/test_env_snapshot.py
+++ b/tests/bench/test_env_snapshot.py
@@ -4,7 +4,30 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+
+from scripts.bench.config import (
+    BackendConfig,
+    BenchConfig,
+    MatrixConfig,
+    ModelConfig,
+    TierConfig,
+)
 from scripts.bench.env_snapshot import EnvSnapshot, _hash_settings
+
+
+@pytest.fixture
+def bench_config() -> BenchConfig:
+    return BenchConfig(
+        matrix=MatrixConfig(
+            context_sizes=[1024],
+            boundary_context_sizes=[4096],
+            concurrency_levels=[1],
+        ),
+        backends=[BackendConfig(id="test-backend", base_url="http://localhost:11434")],
+        models=[ModelConfig(id="test-model", backend_id="test-backend")],
+        tiers=[TierConfig(name="standard")],
+    )
 
 
 class TestSettingsHash:
@@ -32,9 +55,11 @@ class TestSettingsHash:
 
 class TestEnvSnapshotCapture:
     @patch("scripts.bench.env_snapshot.subprocess.run")
-    def test_capture_no_ops_when_nvidia_smi_absent(self, mock_run: MagicMock) -> None:
+    def test_capture_no_ops_when_nvidia_smi_absent(
+        self, mock_run: MagicMock, bench_config: BenchConfig
+    ) -> None:
         mock_run.side_effect = FileNotFoundError("nvidia-smi not found")
-        snap = EnvSnapshot.capture("ollama", "llama3", {"temperature": 0.5})
+        snap = EnvSnapshot.capture("ollama", "llama3", bench_config)
 
         assert snap.gpu_driver_version is None
         assert snap.cuda_version is None
@@ -43,21 +68,25 @@ class TestEnvSnapshotCapture:
         assert len(snap.settings_hash) == 64
 
     @patch("scripts.bench.env_snapshot.subprocess.run")
-    def test_capture_no_ops_when_nonzero_returncode(self, mock_run: MagicMock) -> None:
+    def test_capture_no_ops_when_nonzero_returncode(
+        self, mock_run: MagicMock, bench_config: BenchConfig
+    ) -> None:
         mock_run.return_value = MagicMock(returncode=1, stdout="")
-        snap = EnvSnapshot.capture("litellm", "gemma2", {})
+        snap = EnvSnapshot.capture("litellm", "gemma2", bench_config)
 
         assert snap.gpu_driver_version is None
         assert snap.cuda_version is None
 
     @patch("scripts.bench.env_snapshot.subprocess.run")
-    def test_capture_parses_driver_and_cuda(self, mock_run: MagicMock) -> None:
+    def test_capture_parses_driver_and_cuda(
+        self, mock_run: MagicMock, bench_config: BenchConfig
+    ) -> None:
         # First call: --query-gpu=driver_version; second call: plain nvidia-smi
         mock_run.side_effect = [
             MagicMock(returncode=0, stdout="545.23.08\n"),
             MagicMock(returncode=0, stdout="| CUDA Version: 12.3     |\n"),
         ]
-        snap = EnvSnapshot.capture("litellm", "gemma2", {"max_tokens": 1024})
+        snap = EnvSnapshot.capture("litellm", "gemma2", bench_config)
 
         assert snap.gpu_driver_version == "545.23.08"
         assert snap.cuda_version == "12.3"
@@ -65,21 +94,22 @@ class TestEnvSnapshotCapture:
         assert snap.model == "gemma2"
 
     @patch("scripts.bench.env_snapshot.subprocess.run")
-    def test_settings_hash_stable_in_capture(self, mock_run: MagicMock) -> None:
+    def test_settings_hash_stable_in_capture(
+        self, mock_run: MagicMock, bench_config: BenchConfig
+    ) -> None:
         mock_run.side_effect = FileNotFoundError("nvidia-smi not found")
-        settings = {"temperature": 0.8, "seed": 42}
-        snap1 = EnvSnapshot.capture("ollama", "qwen3", settings)
-        snap2 = EnvSnapshot.capture("ollama", "qwen3", settings)
+        snap1 = EnvSnapshot.capture("ollama", "qwen3", bench_config)
+        snap2 = EnvSnapshot.capture("ollama", "qwen3", bench_config)
 
         assert snap1.settings_hash == snap2.settings_hash
 
-    def test_python_and_os_version_populated(self) -> None:
+    def test_python_and_os_version_populated(self, bench_config: BenchConfig) -> None:
         import platform
         import sys
 
         with patch("scripts.bench.env_snapshot.subprocess.run") as mock_run:
             mock_run.side_effect = FileNotFoundError
-            snap = EnvSnapshot.capture("test", "test", {})
+            snap = EnvSnapshot.capture("test", "test", bench_config)
 
         assert snap.python_version == sys.version
         assert snap.os_version == platform.platform()

--- a/tests/bench/test_ollama_manager.py
+++ b/tests/bench/test_ollama_manager.py
@@ -46,24 +46,22 @@ _FLUSH_RESPONSE = json.dumps({}).encode()
 def test_get_ps_status_returns_model_status():
     with patch("urllib.request.urlopen", _mock_urlopen(_PS_RESPONSE)):
         manager = OllamaManager()
-        statuses = manager.get_ps_status()
+        status = manager.get_ps_status("llama3:latest")
 
-    assert len(statuses) == 1
-    s = statuses[0]
-    assert isinstance(s, ModelStatus)
-    assert s.name == "llama3:latest"
-    assert s.size == 4_000_000_000
-    assert s.size_vram == 4_000_000_000
-    assert s.processor_status == "100% GPU"
-    assert s.expires_at == "2024-12-31T23:59:59Z"
+    assert isinstance(status, ModelStatus)
+    assert status.name == "llama3:latest"
+    assert status.size == 4_000_000_000
+    assert status.size_vram == 4_000_000_000
+    assert status.processor_status == "100% GPU"
+    assert status.expires_at == "2024-12-31T23:59:59Z"
 
 
-def test_get_ps_status_returns_empty_list_when_no_models():
+def test_get_ps_status_returns_none_when_not_loaded():
     with patch(
         "urllib.request.urlopen", _mock_urlopen(json.dumps({"models": []}).encode())
     ):
         manager = OllamaManager()
-        assert manager.get_ps_status() == []
+        assert manager.get_ps_status("llama3:latest") is None
 
 
 def test_get_ps_status_processor_status_defaults_to_unknown():
@@ -81,9 +79,10 @@ def test_get_ps_status_processor_status_defaults_to_unknown():
     ).encode()
     with patch("urllib.request.urlopen", _mock_urlopen(body)):
         manager = OllamaManager()
-        statuses = manager.get_ps_status()
+        status = manager.get_ps_status("phi3:latest")
 
-    assert statuses[0].processor_status == "unknown"
+    assert status is not None
+    assert status.processor_status == "unknown"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Fixed `BenchStore.get_by_run_id` to return `list[BenchRun]` instead of `BenchRun | None`; PRIMARY KEY updated to composite `(run_id, case_id, repeat_index)` to allow multiple cases per run
- Fixed `EnvSnapshot.capture` to accept `config: BenchConfig` instead of untyped `settings: dict`; fixed `OllamaManager.get_ps_status` to accept `model_id: str` and return `ModelStatus | None`
- Removed ~245 lines of duplicated DDL/SQL from `run_bench.py`; all DB writes now route through `BenchStore.record()`; `--resume` uses `BenchStore.get_by_run_id()`

## Sub-tickets included
- WOR-188 Fix BenchStore.get_by_run_id return type to list[BenchRun]
- WOR-189 Fix EnvSnapshot.capture signature to accept BenchConfig
- WOR-190 Fix OllamaManager.get_ps_status to filter by model_id
- WOR-191 Refactor run_bench.py to use BenchStore.record() — remove inline DDL/SQL

## Reviewer notes (NEEDS_ATTENTION)
- **Schema migration:** `bench_run` PRIMARY KEY changed from `(run_id)` to `(run_id, case_id, repeat_index)`. Existing `bench.db` instances need to be recreated — the table will be recreated on first run if it does not exist. If you have benchmark data to preserve, back it up first.
- **run_bench.py integration coverage:** `scripts/bench/` is excluded from pytest coverage scope. The `--resume` path and `BenchStore.record()` wiring should be verified with a short manual smoke-test (`python scripts/bench/run_bench.py --tier speed --resume`) before relying on benchmark data in production.

## Test plan
- [x] pytest passes: 468 passed, 88.13% coverage (≥ 80%)
- [x] Security scan: PASS (no new findings; pre-existing `nosec` markers in app/cli.py and watcher modules unchanged)
- [x] UI tests: not yet present — bench harness has no UI surface
- [ ] Manual smoke-test: `python scripts/bench/run_bench.py --tier speed` + `--resume` to verify end-to-end DB write and skip logic

**Milestone:** Post-MVP Explorations

Closes WOR-187
Closes WOR-188
Closes WOR-189
Closes WOR-190
Closes WOR-191