### PR TITLE
Populate bench.toml with full model matrix and fix OllamaDriver num_ctx

### DIFF
--- a/config/bench.toml
+++ b/config/bench.toml
@@ -1,43 +1,148 @@
-# Benchmark configuration.
+# Benchmark configuration for the WOR-180 local LLM testbench.
 # Load with BenchConfig.from_toml("config/bench.toml").
-# expand_matrix() produces the full Cartesian product of models x tiers x contexts x concurrency.
-# Disabled backends are excluded from the matrix.
-# The boundary tier uses boundary_context_sizes; all other tiers use context_sizes.
+# expand_matrix() produces the full Cartesian product of models × tiers × contexts × concurrency.
+# Disabled backends and their models are excluded from the matrix.
+#
+# Quick-start (Ollama already running, all models pre-pulled):
+#   python scripts/bench/run_bench.py --generate-fixtures   # one-time: build 50k-token fixture
+#   python scripts/bench/run_bench.py --tier speed          # fast sanity check (~10 min, 5 models)
+#   python scripts/bench/run_bench.py                       # full matrix — all tiers, all models
+#   python scripts/bench/run_bench.py --browse              # explore results in Datasette
+#
+# To run a single model:
+#   python scripts/bench/run_bench.py --model qwen3-coder:30b --tier speed
+#
+# Enable vLLM: set local_vllm.enabled = true, start server (see backend comment below),
+# then re-run. vLLM model ids must match --model arg used when starting the server.
 
 [matrix]
-# Context sizes (in tokens) for non-boundary tiers.
-context_sizes = [1024, 4096]
-# Context sizes used exclusively by the boundary tier.
-boundary_context_sizes = [8192, 16384]
+# Non-boundary context windows (all tiers except boundary).
+#   4096  = speed/coding warm-up; fits in any KV budget
+#   16384 = realistic coding context
+#   32768 = 32K — common production window
+#   65536 = 64K — confirmed safe on RTX 5090 + qwen3-coder:30b (spike WOR-76)
+context_sizes = [4096, 16384, 32768, 65536]
+# Boundary tier only — OOM cliff probe per WOR-180 (96K / 128K / 160K).
+#   qwen2.5-coder:32b and qwen3-coder:30b will OOM here — that's expected and recorded.
+#   MoE models (35b-a3b, 27b) tolerate larger contexts due to sparse activation.
+boundary_context_sizes = [98304, 131072, 163840]
 # Concurrent requests per probe point.
-concurrency_levels = [1, 4]
-# Number of real (non-warmup) runs per probe point.
-repeats = 1
+# Single Ollama GPU serialises beyond 2; 2 exposes queue-depth effects.
+concurrency_levels = [1, 2]
+# Real (non-warmup) runs per probe point. 3 gives statistical confidence.
+repeats = 3
+
+# ── Backends ──────────────────────────────────────────────────────────────────
+# Driver selection: backend id containing "vllm" → VllmDriver; otherwise → OllamaDriver.
+# OllamaDriver calls {base_url}/api/chat — do NOT include /v1 in the Ollama base_url.
 
 [[backends]]
+# Primary: Ollama. Auto-managed — runner starts, pulls, and flushes models as needed.
 id = "local_qwen"
 enabled = true
-base_url = "http://localhost:11434/v1"
+base_url = "http://localhost:11434"
 
 [[backends]]
-id = "cloud_gpt4o"
+# vLLM — NOT auto-managed. Start manually before enabling, one model at a time:
+#
+#   # Dense models (one at a time — they fill most of the 32 GB):
+#   python -m vllm.entrypoints.openai.api_server \
+#     --model Qwen/Qwen3-14B --port 8000 --max-model-len 65536 \
+#     --gpu-memory-utilization 0.90 --enable-prefix-caching
+#
+#   # MoE models (lower VRAM active; higher max-model-len feasible):
+#   python -m vllm.entrypoints.openai.api_server \
+#     --model Qwen/Qwen3.6-35B-A3B --port 8000 --max-model-len 131072 \
+#     --gpu-memory-utilization 0.90 --enable-prefix-caching
+#
+# The key benefit to measure: vLLM APC on prefill_shared tier vs Ollama.
+# Run with --tier prefill_shared after enabling to isolate that comparison.
+id = "local_vllm"
 enabled = false
-base_url = "https://api.openai.com/v1"
+base_url = "http://localhost:8000"
+
+# ── Ollama models (enabled) ────────────────────────────────────────────────────
+# Model IDs must exactly match Ollama's name format — verify with: ollama list
+# All 5 are confirmed present on this machine (ollama list, 2026-04-26).
 
 [[models]]
-id = "qwen3-coder-30b"
+# 9.3 GB | Dense 14B — lightweight baseline and fastest model.
+id = "qwen3:14b"
 backend_id = "local_qwen"
 
 [[models]]
-id = "qwen3-14b"
+# 23 GB | MoE 35B total / ~3B active — low KV pressure despite large param count.
+# Candidate from WOR-180: expected to match or beat dense 30B on coding quality.
+id = "qwen3.6:35b-a3b"
 backend_id = "local_qwen"
 
 [[models]]
-id = "gpt-4o"
-backend_id = "cloud_gpt4o"
+# 17 GB | Dense 27B — mid-range candidate from WOR-180.
+id = "qwen3.6:27b"
+backend_id = "local_qwen"
+
+[[models]]
+# 18 GB | Dense 30B coder — current production model (spike WOR-76 baseline).
+id = "qwen3-coder:30b"
+backend_id = "local_qwen"
+
+[[models]]
+# 19 GB | Dense 32B coder Q4_K_M — previous spike candidate, ruled "too tight" at 65K
+# but worth re-benchmarking at lower context sizes for coding quality comparison.
+id = "qwen2.5-coder:32b-instruct-q4_K_M"
+backend_id = "local_qwen"
+
+# ── vLLM models (disabled via local_vllm backend) ─────────────────────────────
+# vLLM model ids are HuggingFace repo ids. The model arg must match --model used
+# when starting the server. Enable local_vllm backend and run one model at a time.
+# Verify HuggingFace repo names at https://huggingface.co/Qwen before starting.
+
+[[models]]
+# HF: Qwen/Qwen3-14B
+id = "Qwen/Qwen3-14B"
+backend_id = "local_vllm"
+
+[[models]]
+# HF: verify exact repo name — may be Qwen/Qwen3.6-35B-A3B or similar
+id = "Qwen/Qwen3.6-35B-A3B"
+backend_id = "local_vllm"
+
+[[models]]
+# HF: verify exact repo name — may be Qwen/Qwen3.6-27B or similar
+id = "Qwen/Qwen3.6-27B"
+backend_id = "local_vllm"
+
+[[models]]
+# HF: verify exact repo name — may be Qwen/Qwen3-Coder-30B-Instruct or similar
+id = "Qwen/Qwen3-Coder-30B-Instruct"
+backend_id = "local_vllm"
+
+[[models]]
+# HF: Qwen/Qwen2.5-Coder-32B-Instruct (use unquantized; apply --quantization awq if needed)
+id = "Qwen/Qwen2.5-Coder-32B-Instruct"
+backend_id = "local_vllm"
+
+# ── Tiers ─────────────────────────────────────────────────────────────────────
+# All five tiers. Use --tier <name> for a single-tier run.
+# prefill_shared requires the 50k fixture: run --generate-fixtures once first.
 
 [[tiers]]
+# Raw generation speed: short prompt, ~256 tokens out. No fixture needed.
 name = "speed"
 
 [[tiers]]
+# Real coding task with pytest/ruff/mypy quality evaluation. Temperature=0.
+name = "coding"
+
+[[tiers]]
+# TTFT with shared 50k-token repo prefix. Measures vLLM APC reuse vs Ollama.
+# First request per model = cache warm; subsequent = prefix_warm.
+name = "prefill_shared"
+
+[[tiers]]
+# TTFT with randomized same-length content. APC null baseline (cold prefill every run).
+name = "prefill_unshared"
+
+[[tiers]]
+# Long-context OOM cliff probe at boundary_context_sizes. OOM is recorded, not fatal.
 name = "boundary"

--- a/docs/bench.md
+++ b/docs/bench.md
@@ -1,0 +1,155 @@
+# Local LLM Benchmark Harness
+
+Standalone benchmark suite for evaluating local LLM models and backends before
+production use in the watcher. Lives entirely in `scripts/bench/` — no app.*
+imports allowed.
+
+## Quick start
+
+```bash
+# 1. Generate the 50k-token context fixture (needed for prefill tiers)
+python scripts/bench/run_bench.py --generate-fixtures
+
+# 2. Edit config/bench.toml to match your models and backend URLs
+
+# 3. Run a quick speed-only sweep
+python scripts/bench/run_bench.py --tier speed
+
+# 4. Run the full matrix (all tiers, all models in config)
+python scripts/bench/run_bench.py
+
+# 5. View results in Datasette browser
+python scripts/bench/run_bench.py --browse
+```
+
+## CLI reference
+
+```
+python scripts/bench/run_bench.py [OPTIONS]
+
+Options:
+  --config PATH       Path to bench.toml (default: config/bench.toml)
+  --tier TIER         Filter to a single tier: speed | coding | prefill_shared
+                      | prefill_unshared | boundary
+  --resume SWEEP_ID   Resume an interrupted run — skips already-recorded cases
+  --compare ID1 ID2   Side-by-side TTFT comparison of two sweep IDs
+  --generate-fixtures Write scripts/bench/fixtures/project_summary_50k.txt
+  --export-json PATH  Export sweep results to JSON
+  --export-csv PATH   Export sweep results to CSV
+  --browse            Open bench.db in Datasette browser UI
+```
+
+## Benchmark tiers
+
+| Tier | What it measures |
+|------|-----------------|
+| `speed` | Raw generation speed — short prompt, ~256 tokens out |
+| `prefill_shared` | TTFT with shared 50k repo prefix — tests KV-cache reuse (vLLM APC benefit) |
+| `prefill_unshared` | TTFT with randomized same-length content — APC null baseline |
+| `coding` | Real coding task with pytest/ruff/mypy quality evaluation |
+| `boundary` | Long-context OOM probe at configured context sizes |
+
+## Config (config/bench.toml)
+
+```toml
+[matrix]
+context_sizes = [1024, 4096]          # token context sizes for non-boundary tiers
+boundary_context_sizes = [8192, 16384] # boundary-only context sizes
+concurrency_levels = [1, 4]            # concurrent requests per probe
+repeats = 1                            # real runs per probe point (warmup is always 1)
+
+[[backends]]
+id = "local_qwen"
+enabled = true
+base_url = "http://localhost:11434/v1"
+
+[[models]]
+id = "qwen3-coder-30b"
+backend_id = "local_qwen"
+
+[[tiers]]
+name = "speed"
+
+[[tiers]]
+name = "coding"
+```
+
+## Prerequisites
+
+**Ollama backend:**
+```bash
+# Start Ollama (auto-managed by the runner if on localhost:11434)
+ollama serve
+```
+
+**vLLM backend:**
+```bash
+# vLLM is NOT auto-managed — start it manually before running
+# WSL2 example:
+python -m vllm.entrypoints.openai.api_server \
+  --model Qwen/Qwen2.5-Coder-32B-Instruct \
+  --port 8000 --gpu-memory-utilization 0.90
+```
+
+Set `enabled = true` and `base_url = "http://localhost:8000"` in bench.toml for
+the vllm backend entry, and include `"vllm"` in the backend `id` so the runner
+selects `VllmDriver`.
+
+## Resume interrupted runs
+
+```bash
+# A sweep ID is printed at start: e.g. "Sweep: run_20260425_192600"
+python scripts/bench/run_bench.py --tier coding --resume run_20260425_192600
+```
+
+Each case is written to `bench.db` before the next one starts — the runner
+never loses completed results on interruption.
+
+## Ranking and recommendations
+
+The reporter prints a quality-gated ranking after each sweep. A config is
+**eligible** for recommendation only if it passes all gates:
+
+- No OOM during the run
+- No CPU offload detected (RAM spike > 2 GB above baseline)
+- Error rate ≤ 5% across repeats
+- Task success ≥ 70% on coding tier (if coding data is present)
+
+Ineligible configs are listed with the reason they were excluded.
+
+## Data store
+
+Results are written to `bench.db` (platform config dir, same parent as
+`metrics.db`). Use Datasette to explore:
+
+```bash
+python scripts/bench/run_bench.py --browse
+# or directly:
+datasette ~/AppData/Roaming/repo-scaffold/bench.db   # Windows
+datasette ~/.config/repo-scaffold/bench.db            # Linux/macOS
+```
+
+## Adding a new backend
+
+1. Add a backend entry in `config/bench.toml` with a unique `id`.
+2. If `"vllm"` appears in the `id`, `VllmDriver` is used; otherwise `OllamaDriver`.
+3. For a fully custom backend, implement `BackendDriver` Protocol from
+   `scripts/bench/drivers/base.py` and register it in `_make_driver()` in
+   `run_bench.py`.
+
+## Schema
+
+`BenchRun` fields written per case (see `app/core/bench_store.py`):
+
+| Group | Fields |
+|-------|--------|
+| Identity | run_id, case_id, repeat_index |
+| Config | tier, context_size, concurrency, backend_id, model_id, settings_hash, prompt_hash |
+| Environment | backend_base_url, gpu_driver_version, cuda_version, python_version, os_version |
+| Timing | ttft_s, wall_time_s, throughput_tok_s |
+| Tokens | prompt_tokens, completion_tokens, total_tokens |
+| GPU | peak_vram_gb, avg_gpu_util_pct, avg_gpu_mem_util_pct, avg_power_w, peak_temp_c, avg_sm_clock_mhz, avg_mem_clock_mhz |
+| CPU/RAM | peak_ram_gb, cpu_offload_detected |
+| Ollama | ollama_model_loaded, ollama_num_ctx |
+| Quality | quality_task_success, quality_pytest_passed, quality_ruff_passed, quality_mypy_passed |
+| Outcome | outcome, error_message, recorded_at |

--- a/scripts/bench/drivers/base.py
+++ b/scripts/bench/drivers/base.py
@@ -24,5 +24,5 @@ class GenerationResult:
 class BackendDriver(Protocol):
     def is_available(self) -> bool: ...
     def generate(
-        self, model: str, messages: list[dict[str, str]]
+        self, model: str, messages: list[dict[str, str]], context_size: int
     ) -> GenerationResult: ...

--- a/scripts/bench/drivers/ollama.py
+++ b/scripts/bench/drivers/ollama.py
@@ -38,9 +38,16 @@ class OllamaDriver:
         except Exception:
             return False
 
-    def generate(self, model: str, messages: list[dict[str, str]]) -> GenerationResult:
+    def generate(
+        self, model: str, messages: list[dict[str, str]], context_size: int
+    ) -> GenerationResult:
         payload = json.dumps(
-            {"model": model, "messages": messages, "stream": True}
+            {
+                "model": model,
+                "messages": messages,
+                "stream": True,
+                "options": {"num_ctx": context_size},
+            }
         ).encode()
         req = urllib.request.Request(
             f"{self._base_url}/api/chat",

--- a/scripts/bench/drivers/vllm.py
+++ b/scripts/bench/drivers/vllm.py
@@ -40,7 +40,9 @@ class VllmDriver:
         except Exception:
             return False
 
-    def generate(self, model: str, messages: list[dict[str, str]]) -> GenerationResult:
+    def generate(
+        self, model: str, messages: list[dict[str, str]], _context_size: int
+    ) -> GenerationResult:
         payload = json.dumps(
             {
                 "model": model,

--- a/scripts/bench/run_bench.py
+++ b/scripts/bench/run_bench.py
@@ -311,7 +311,7 @@ def _run(args: argparse.Namespace, db_path: Path) -> None:
 
         messages: list[dict[str, str]] = [{"role": "user", "content": prompt.text}]
         t_start = time.monotonic()
-        result = driver.generate(case.model_id, messages)
+        result = driver.generate(case.model_id, messages, case.context_size)
         wall_time_s = time.monotonic() - t_start
 
         gpu_sample = gpu_mon.stop()

--- a/tests/bench/test_bench_config.py
+++ b/tests/bench/test_bench_config.py
@@ -58,7 +58,8 @@ def _write_toml(tmp_path: Path, content: str) -> Path:
 
 def test_from_toml_loads_real_config() -> None:
     cfg = BenchConfig.from_toml(_BENCH_TOML)
-    assert cfg.matrix.context_sizes == [1024, 4096]
+    assert len(cfg.matrix.context_sizes) >= 1
+    assert len(cfg.matrix.boundary_context_sizes) >= 1
     assert len(cfg.backends) >= 1
     assert len(cfg.models) >= 1
     assert len(cfg.tiers) >= 1

--- a/tests/bench/test_bench_drivers.py
+++ b/tests/bench/test_bench_drivers.py
@@ -74,7 +74,7 @@ _OLLAMA_WARM_BODY = _ndjson(
 def test_ollama_generate_cold_start_timings():
     with patch("urllib.request.urlopen", _mock_urlopen(_OLLAMA_COLD_BODY)):
         driver = OllamaDriver()
-        result = driver.generate("q", [{"role": "user", "content": "hi"}])
+        result = driver.generate("q", [{"role": "user", "content": "hi"}], 4096)
 
     assert result.error is None
     assert result.text == "Hello world"
@@ -90,7 +90,7 @@ def test_ollama_generate_cold_start_timings():
 def test_ollama_generate_warm_start_no_load_duration():
     with patch("urllib.request.urlopen", _mock_urlopen(_OLLAMA_WARM_BODY)):
         driver = OllamaDriver()
-        result = driver.generate("q", [{"role": "user", "content": "hi"}])
+        result = driver.generate("q", [{"role": "user", "content": "hi"}], 4096)
 
     assert result.error is None
     assert result.raw_load_duration_ns is None
@@ -106,7 +106,7 @@ def test_ollama_generate_returns_error_on_url_error():
         side_effect=urllib.error.URLError("Connection refused"),
     ):
         driver = OllamaDriver()
-        result = driver.generate("q", [{"role": "user", "content": "hi"}])
+        result = driver.generate("q", [{"role": "user", "content": "hi"}], 4096)
 
     assert result.error is not None
     assert "Connection refused" in result.error
@@ -115,7 +115,7 @@ def test_ollama_generate_returns_error_on_url_error():
 def test_ollama_generate_returns_error_on_generic_exception():
     with patch("urllib.request.urlopen", side_effect=OSError("socket error")):
         driver = OllamaDriver()
-        result = driver.generate("q", [{"role": "user", "content": "hi"}])
+        result = driver.generate("q", [{"role": "user", "content": "hi"}], 4096)
 
     assert result.error is not None
 
@@ -166,7 +166,7 @@ _VLLM_BODY = _sse(
 def test_vllm_generate_success():
     with patch("urllib.request.urlopen", _mock_urlopen(_VLLM_BODY)):
         driver = VllmDriver()
-        result = driver.generate("mistral", [{"role": "user", "content": "hi"}])
+        result = driver.generate("mistral", [{"role": "user", "content": "hi"}], 4096)
 
     assert result.error is None
     assert result.text == "Hello world"
@@ -181,7 +181,7 @@ def test_vllm_generate_returns_error_on_url_error():
         side_effect=urllib.error.URLError("Connection refused"),
     ):
         driver = VllmDriver()
-        result = driver.generate("mistral", [{"role": "user", "content": "hi"}])
+        result = driver.generate("mistral", [{"role": "user", "content": "hi"}], 4096)
 
     assert result.error is not None
     assert "Connection refused" in result.error
@@ -190,7 +190,7 @@ def test_vllm_generate_returns_error_on_url_error():
 def test_vllm_generate_returns_error_on_generic_exception():
     with patch("urllib.request.urlopen", side_effect=RuntimeError("boom")):
         driver = VllmDriver()
-        result = driver.generate("mistral", [{"role": "user", "content": "hi"}])
+        result = driver.generate("mistral", [{"role": "user", "content": "hi"}], 4096)
 
     assert result.error is not None
 


### PR DESCRIPTION
## Summary

- **bench.toml**: Replaced placeholder values with the full confirmed model matrix — all 5 models from `ollama list` (qwen3:14b, qwen3.6:35b-a3b, qwen3.6:27b, qwen3-coder:30b, qwen2.5-coder:32b-instruct-q4_K_M) — along with correct context sizes, boundary sizes per WOR-180 spec (96K/128K/160K), and disabled vLLM backend with HuggingFace model IDs and startup commands
- **OllamaDriver.generate()**: Added `context_size` parameter to the `BackendDriver` Protocol and both drivers; Ollama now sends `options.num_ctx` per request so each matrix case actually runs at its configured context window (previously all runs used Ollama's loaded default regardless of the config)
- **docs/bench.md**: Add to repo (was untracked)

## Bug fixed

`OllamaDriver.generate()` never passed `options.num_ctx` to Ollama, so every run used whatever context window the model happened to be loaded with — making `context_sizes` in the matrix effectively inert. Now the driver enforces the exact context size per case.

## Known follow-on gaps (not blocking)

- `max_tokens`, `temperature`, `seed` are specced in WOR-185 but not yet wired into the driver or runner — the coding tier runs at model-default temperature instead of 0
- `VllmDriver.is_available()` checks `/health` which returns 200 even with no model loaded; `/v1/models` would be more reliable
- `qwen2.5-coder:32b-instruct-q4_K_M` will OOM at 65K context (spike WOR-76: ~28 GB VRAM loaded); runner records OOM and continues — no crash

## Test plan

- [x] `python scripts/bench/run_bench.py --generate-fixtures` — builds 50k fixture
- [x] `python scripts/bench/run_bench.py --tier speed --model qwen3:14b` — fastest sanity check
- [x] `python scripts/bench/run_bench.py --tier speed` — all 5 models, speed tier only
- [x] Confirm `ollama ps` shows the correct `num_ctx` after a run starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)