### PR TITLE
WOR-194 Wire max_tokens, temperature, and seed into bench driver generate() and runner

### DIFF
--- a/scripts/bench/drivers/base.py
+++ b/scripts/bench/drivers/base.py
@@ -24,5 +24,11 @@ class GenerationResult:
 class BackendDriver(Protocol):
     def is_available(self) -> bool: ...
     def generate(
-        self, model: str, messages: list[dict[str, str]], context_size: int
+        self,
+        model: str,
+        messages: list[dict[str, str]],
+        context_size: int,
+        max_tokens: int,
+        temperature: float,
+        seed: int | None,
     ) -> GenerationResult: ...

--- a/scripts/bench/drivers/ollama.py
+++ b/scripts/bench/drivers/ollama.py
@@ -39,15 +39,23 @@ class OllamaDriver:
             return False
 
     def generate(
-        self, model: str, messages: list[dict[str, str]], context_size: int
+        self,
+        model: str,
+        messages: list[dict[str, str]],
+        context_size: int,
+        max_tokens: int,
+        temperature: float,
+        seed: int | None,
     ) -> GenerationResult:
+        options: dict[str, int | float] = {
+            "num_ctx": context_size,
+            "num_predict": max_tokens,
+            "temperature": temperature,
+        }
+        if seed is not None:
+            options["seed"] = seed
         payload = json.dumps(
-            {
-                "model": model,
-                "messages": messages,
-                "stream": True,
-                "options": {"num_ctx": context_size},
-            }
+            {"model": model, "messages": messages, "stream": True, "options": options}
         ).encode()
         req = urllib.request.Request(
             f"{self._base_url}/api/chat",

--- a/scripts/bench/drivers/vllm.py
+++ b/scripts/bench/drivers/vllm.py
@@ -41,16 +41,25 @@ class VllmDriver:
             return False
 
     def generate(
-        self, model: str, messages: list[dict[str, str]], _context_size: int
+        self,
+        model: str,
+        messages: list[dict[str, str]],
+        _context_size: int,
+        max_tokens: int,
+        temperature: float,
+        seed: int | None,
     ) -> GenerationResult:
-        payload = json.dumps(
-            {
-                "model": model,
-                "messages": messages,
-                "stream": True,
-                "stream_options": {"include_usage": True},
-            }
-        ).encode()
+        body: dict[str, object] = {
+            "model": model,
+            "messages": messages,
+            "stream": True,
+            "stream_options": {"include_usage": True},
+            "max_tokens": max_tokens,
+            "temperature": temperature,
+        }
+        if seed is not None:
+            body["seed"] = seed
+        payload = json.dumps(body).encode()
         req = urllib.request.Request(
             f"{self._base_url}/v1/chat/completions",
             data=payload,

--- a/scripts/bench/run_bench.py
+++ b/scripts/bench/run_bench.py
@@ -17,7 +17,6 @@ import sys
 import time
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
 
 from app.core.bench_store import BenchRun, BenchStore
 from scripts.bench.config import BenchCase, BenchConfig
@@ -28,6 +27,7 @@ from scripts.bench.gpu_monitor import GpuMonitor
 from scripts.bench.lifecycle.ollama_manager import OllamaManager
 from scripts.bench.quality import evaluate_coding_output
 from scripts.bench.sys_monitor import SysMonitor
+from scripts.bench.tasks import BenchPrompt
 from scripts.bench.tasks.boundary import make_boundary_prompt
 from scripts.bench.tasks.coding import make_coding_prompt
 from scripts.bench.tasks.prefill_shared import make_prefill_shared_prompt
@@ -69,7 +69,7 @@ def _is_oom(error: str) -> bool:
 # ── Prompt factory ────────────────────────────────────────────────────────────
 
 
-def _make_prompt(tier: str, repeat_index: int) -> Any:
+def _make_prompt(tier: str, repeat_index: int) -> BenchPrompt:
     if tier == "speed":
         return make_speed_prompt()
     if tier == "coding":
@@ -311,7 +311,14 @@ def _run(args: argparse.Namespace, db_path: Path) -> None:
 
         messages: list[dict[str, str]] = [{"role": "user", "content": prompt.text}]
         t_start = time.monotonic()
-        result = driver.generate(case.model_id, messages, case.context_size)
+        result = driver.generate(
+            case.model_id,
+            messages,
+            case.context_size,
+            prompt.max_tokens,
+            prompt.temperature,
+            prompt.seed,
+        )
         wall_time_s = time.monotonic() - t_start
 
         gpu_sample = gpu_mon.stop()

--- a/scripts/bench/tasks/__init__.py
+++ b/scripts/bench/tasks/__init__.py
@@ -10,4 +10,7 @@ class BenchPrompt:
     text: str
     prompt_hash: str
     task_type: str
+    max_tokens: int
+    temperature: float
+    seed: int | None
     token_count_estimate: int | None = None

--- a/scripts/bench/tasks/boundary.py
+++ b/scripts/bench/tasks/boundary.py
@@ -20,4 +20,11 @@ _TEXT = (
 
 def make_boundary_prompt() -> BenchPrompt:
     prompt_hash = hashlib.sha256(_TEXT.encode()).hexdigest()
-    return BenchPrompt(text=_TEXT, prompt_hash=prompt_hash, task_type="boundary")
+    return BenchPrompt(
+        text=_TEXT,
+        prompt_hash=prompt_hash,
+        task_type="boundary",
+        max_tokens=128,
+        temperature=0.7,
+        seed=None,
+    )

--- a/scripts/bench/tasks/coding.py
+++ b/scripts/bench/tasks/coding.py
@@ -21,4 +21,11 @@ _TEXT = (
 
 def make_coding_prompt() -> BenchPrompt:
     prompt_hash = hashlib.sha256(_TEXT.encode()).hexdigest()
-    return BenchPrompt(text=_TEXT, prompt_hash=prompt_hash, task_type="coding")
+    return BenchPrompt(
+        text=_TEXT,
+        prompt_hash=prompt_hash,
+        task_type="coding",
+        max_tokens=512,
+        temperature=0.0,
+        seed=42,
+    )

--- a/scripts/bench/tasks/prefill_shared.py
+++ b/scripts/bench/tasks/prefill_shared.py
@@ -25,4 +25,11 @@ def make_prefill_shared_prompt(suffix_index: int = 0) -> BenchPrompt:
     suffix = _SUFFIX_TEMPLATE.format(index=suffix_index)
     text = doc + suffix
     prompt_hash = hashlib.sha256(text.encode()).hexdigest()
-    return BenchPrompt(text=text, prompt_hash=prompt_hash, task_type="prefill_shared")
+    return BenchPrompt(
+        text=text,
+        prompt_hash=prompt_hash,
+        task_type="prefill_shared",
+        max_tokens=128,
+        temperature=0.7,
+        seed=None,
+    )

--- a/scripts/bench/tasks/prefill_unshared.py
+++ b/scripts/bench/tasks/prefill_unshared.py
@@ -60,9 +60,14 @@ def make_prefill_unshared_prompt(target: int = 50000, seed: int = 42) -> BenchPr
     text = " ".join(words)
     token_count_estimate = len(text) // _CHARS_PER_TOKEN
     prompt_hash = hashlib.sha256(text.encode()).hexdigest()
+    # seed here is the RNG seed for text generation, not the LLM generation seed.
+    # BenchPrompt.seed (None) controls LLM reproducibility separately.
     return BenchPrompt(
         text=text,
         prompt_hash=prompt_hash,
         task_type="prefill_unshared",
+        max_tokens=128,
+        temperature=0.7,
+        seed=None,
         token_count_estimate=token_count_estimate,
     )

--- a/scripts/bench/tasks/speed.py
+++ b/scripts/bench/tasks/speed.py
@@ -11,4 +11,11 @@ _TEXT = "Count from 1 to 10."
 
 def make_speed_prompt() -> BenchPrompt:
     prompt_hash = hashlib.sha256(_TEXT.encode()).hexdigest()
-    return BenchPrompt(text=_TEXT, prompt_hash=prompt_hash, task_type="speed")
+    return BenchPrompt(
+        text=_TEXT,
+        prompt_hash=prompt_hash,
+        task_type="speed",
+        max_tokens=256,
+        temperature=0.7,
+        seed=None,
+    )

--- a/tests/bench/test_bench_drivers.py
+++ b/tests/bench/test_bench_drivers.py
@@ -33,6 +33,11 @@ def _mock_urlopen(body: bytes) -> MagicMock:
     return mock
 
 
+def _captured_payload(mock_open: MagicMock) -> dict:
+    """Extract and decode the JSON payload sent to urlopen."""
+    return json.loads(mock_open.call_args[0][0].data)
+
+
 # ---------------------------------------------------------------------------
 # OllamaDriver
 # ---------------------------------------------------------------------------
@@ -74,7 +79,9 @@ _OLLAMA_WARM_BODY = _ndjson(
 def test_ollama_generate_cold_start_timings():
     with patch("urllib.request.urlopen", _mock_urlopen(_OLLAMA_COLD_BODY)):
         driver = OllamaDriver()
-        result = driver.generate("q", [{"role": "user", "content": "hi"}], 4096)
+        result = driver.generate(
+            "q", [{"role": "user", "content": "hi"}], 4096, 256, 0.7, None
+        )
 
     assert result.error is None
     assert result.text == "Hello world"
@@ -90,7 +97,9 @@ def test_ollama_generate_cold_start_timings():
 def test_ollama_generate_warm_start_no_load_duration():
     with patch("urllib.request.urlopen", _mock_urlopen(_OLLAMA_WARM_BODY)):
         driver = OllamaDriver()
-        result = driver.generate("q", [{"role": "user", "content": "hi"}], 4096)
+        result = driver.generate(
+            "q", [{"role": "user", "content": "hi"}], 4096, 256, 0.7, None
+        )
 
     assert result.error is None
     assert result.raw_load_duration_ns is None
@@ -106,7 +115,9 @@ def test_ollama_generate_returns_error_on_url_error():
         side_effect=urllib.error.URLError("Connection refused"),
     ):
         driver = OllamaDriver()
-        result = driver.generate("q", [{"role": "user", "content": "hi"}], 4096)
+        result = driver.generate(
+            "q", [{"role": "user", "content": "hi"}], 4096, 256, 0.7, None
+        )
 
     assert result.error is not None
     assert "Connection refused" in result.error
@@ -115,9 +126,49 @@ def test_ollama_generate_returns_error_on_url_error():
 def test_ollama_generate_returns_error_on_generic_exception():
     with patch("urllib.request.urlopen", side_effect=OSError("socket error")):
         driver = OllamaDriver()
-        result = driver.generate("q", [{"role": "user", "content": "hi"}], 4096)
+        result = driver.generate(
+            "q", [{"role": "user", "content": "hi"}], 4096, 256, 0.7, None
+        )
 
     assert result.error is not None
+
+
+def test_ollama_generate_payload_contains_num_predict_and_temperature():
+    with patch("urllib.request.urlopen") as mock_open:
+        mock_open.return_value = io.BytesIO(_OLLAMA_WARM_BODY)
+        OllamaDriver().generate(
+            "q", [{"role": "user", "content": "hi"}], 32768, 256, 0.7, None
+        )
+        payload = _captured_payload(mock_open)
+
+    assert payload["options"]["num_ctx"] == 32768
+    assert payload["options"]["num_predict"] == 256
+    assert payload["options"]["temperature"] == pytest.approx(0.7)
+    assert "seed" not in payload["options"]
+
+
+def test_ollama_generate_payload_includes_seed_when_set():
+    with patch("urllib.request.urlopen") as mock_open:
+        mock_open.return_value = io.BytesIO(_OLLAMA_WARM_BODY)
+        OllamaDriver().generate(
+            "q", [{"role": "user", "content": "hi"}], 4096, 512, 0.0, 42
+        )
+        payload = _captured_payload(mock_open)
+
+    assert payload["options"]["temperature"] == pytest.approx(0.0)
+    assert payload["options"]["num_predict"] == 512
+    assert payload["options"]["seed"] == 42
+
+
+def test_ollama_generate_payload_omits_seed_when_none():
+    with patch("urllib.request.urlopen") as mock_open:
+        mock_open.return_value = io.BytesIO(_OLLAMA_WARM_BODY)
+        OllamaDriver().generate(
+            "q", [{"role": "user", "content": "hi"}], 4096, 128, 0.7, None
+        )
+        payload = _captured_payload(mock_open)
+
+    assert "seed" not in payload["options"]
 
 
 def test_ollama_is_available_returns_false_when_unreachable():
@@ -166,7 +217,9 @@ _VLLM_BODY = _sse(
 def test_vllm_generate_success():
     with patch("urllib.request.urlopen", _mock_urlopen(_VLLM_BODY)):
         driver = VllmDriver()
-        result = driver.generate("mistral", [{"role": "user", "content": "hi"}], 4096)
+        result = driver.generate(
+            "mistral", [{"role": "user", "content": "hi"}], 4096, 256, 0.7, None
+        )
 
     assert result.error is None
     assert result.text == "Hello world"
@@ -181,7 +234,9 @@ def test_vllm_generate_returns_error_on_url_error():
         side_effect=urllib.error.URLError("Connection refused"),
     ):
         driver = VllmDriver()
-        result = driver.generate("mistral", [{"role": "user", "content": "hi"}], 4096)
+        result = driver.generate(
+            "mistral", [{"role": "user", "content": "hi"}], 4096, 256, 0.7, None
+        )
 
     assert result.error is not None
     assert "Connection refused" in result.error
@@ -190,9 +245,37 @@ def test_vllm_generate_returns_error_on_url_error():
 def test_vllm_generate_returns_error_on_generic_exception():
     with patch("urllib.request.urlopen", side_effect=RuntimeError("boom")):
         driver = VllmDriver()
-        result = driver.generate("mistral", [{"role": "user", "content": "hi"}], 4096)
+        result = driver.generate(
+            "mistral", [{"role": "user", "content": "hi"}], 4096, 256, 0.7, None
+        )
 
     assert result.error is not None
+
+
+def test_vllm_generate_payload_contains_max_tokens_and_temperature():
+    with patch("urllib.request.urlopen") as mock_open:
+        mock_open.return_value = io.BytesIO(_VLLM_BODY)
+        VllmDriver().generate(
+            "m", [{"role": "user", "content": "hi"}], 4096, 256, 0.7, None
+        )
+        payload = _captured_payload(mock_open)
+
+    assert payload["max_tokens"] == 256
+    assert payload["temperature"] == pytest.approx(0.7)
+    assert "seed" not in payload
+
+
+def test_vllm_generate_payload_includes_seed_when_set():
+    with patch("urllib.request.urlopen") as mock_open:
+        mock_open.return_value = io.BytesIO(_VLLM_BODY)
+        VllmDriver().generate(
+            "m", [{"role": "user", "content": "hi"}], 4096, 512, 0.0, 42
+        )
+        payload = _captured_payload(mock_open)
+
+    assert payload["max_tokens"] == 512
+    assert payload["temperature"] == pytest.approx(0.0)
+    assert payload["seed"] == 42
 
 
 def test_vllm_is_available_returns_false_when_unreachable():

--- a/tests/bench/test_bench_tasks.py
+++ b/tests/bench/test_bench_tasks.py
@@ -17,6 +17,9 @@ def test_speed_prompt_returns_bench_prompt() -> None:
     assert prompt.task_type == "speed"
     assert len(prompt.text) > 0
     assert len(prompt.prompt_hash) == 64  # SHA-256 hex digest
+    assert prompt.max_tokens == 256
+    assert prompt.temperature == pytest.approx(0.7)
+    assert prompt.seed is None
 
 
 def test_prefill_shared_raises_when_fixture_missing(
@@ -48,6 +51,14 @@ def test_prefill_unshared_token_count_within_5pct() -> None:
     assert abs(prompt.token_count_estimate - target) <= tolerance
 
 
+def test_prefill_unshared_llm_seed_is_none() -> None:
+    prompt = make_prefill_unshared_prompt(target=100, seed=42)
+    # seed=42 above is the RNG seed for text generation
+    # BenchPrompt.seed (None) is the LLM generation seed — a separate concept
+    assert prompt.seed is None
+    assert prompt.max_tokens == 128
+
+
 def test_prefill_unshared_deterministic() -> None:
     p1 = make_prefill_unshared_prompt(target=1000, seed=42)
     p2 = make_prefill_unshared_prompt(target=1000, seed=42)
@@ -66,6 +77,9 @@ def test_coding_prompt_returns_bench_prompt() -> None:
     assert prompt.task_type == "coding"
     assert len(prompt.text) > 0
     assert len(prompt.prompt_hash) == 64
+    assert prompt.max_tokens == 512
+    assert prompt.temperature == pytest.approx(0.0)
+    assert prompt.seed == 42
 
 
 def test_boundary_prompt_returns_bench_prompt() -> None:
@@ -73,3 +87,5 @@ def test_boundary_prompt_returns_bench_prompt() -> None:
     assert prompt.task_type == "boundary"
     assert len(prompt.text) > 0
     assert len(prompt.prompt_hash) == 64
+    assert prompt.max_tokens == 128
+    assert prompt.seed is None


### PR DESCRIPTION
## Summary

- Extended `BenchPrompt` dataclass with three required fields (`max_tokens`, `temperature`, `seed`) set by each task factory with tier-appropriate values
- Updated `BackendDriver` Protocol and both `OllamaDriver` / `VllmDriver` implementations to accept and forward the new parameters (Ollama via `options` dict, vLLM as top-level request fields; seed conditionally omitted when `None`)
- Fixed `_make_prompt()` return type from `Any` → `BenchPrompt` and updated the `driver.generate()` call site in `run_bench.py`; added payload-content assertions to both driver and task test modules

**Milestone:** Bench harness v1

Closes WOR-194