### PR TITLE
WOR-195 Fix VllmDriver.is_available() to check /v1/models instead of /health

### DIFF
--- a/scripts/bench/drivers/vllm.py
+++ b/scripts/bench/drivers/vllm.py
@@ -34,7 +34,7 @@ class VllmDriver:
 
     def is_available(self) -> bool:
         try:
-            req = urllib.request.Request(f"{self._base_url}/health")
+            req = urllib.request.Request(f"{self._base_url}/v1/models")
             with urllib.request.urlopen(req, timeout=2):
                 return True
         except Exception:

--- a/tests/bench/test_bench_drivers.py
+++ b/tests/bench/test_bench_drivers.py
@@ -288,6 +288,8 @@ def test_vllm_is_available_returns_false_when_unreachable():
 
 
 def test_vllm_is_available_returns_true_when_reachable():
-    with patch("urllib.request.urlopen", _mock_urlopen(b"ok")):
+    with patch("urllib.request.urlopen") as mock_open:
+        mock_open.return_value = io.BytesIO(b"ok")
         driver = VllmDriver()
         assert driver.is_available() is True
+        assert mock_open.call_args[0][0].full_url.endswith("/v1/models")


### PR DESCRIPTION
- `VllmDriver.is_available()` was calling `GET /health`, which returns 200 before model weights are loaded
- Changed to `GET /v1/models`, which only returns 200 once the model is ready to serve
- Updated `test_vllm_is_available_returns_true_when_reachable` to assert the correct URL is called

## Test plan
- [x] `test_vllm_is_available_returns_true_when_reachable` — asserts `full_url.endswith("/v1/models")`
- [x] `test_vllm_is_available_returns_false_when_unreachable` — passes (behavior unchanged)
- [x] 474 tests pass, 88% coverage
- [x] `ruff check .` and `mypy app/` clean

Closes WOR-195