### PR TITLE
Split run_bench.py into runner.py, fixtures.py, and thin entry point

### DIFF
--- a/scripts/bench/fixtures.py
+++ b/scripts/bench/fixtures.py
@@ -1,0 +1,97 @@
+"""Fixture generation for the benchmark suite."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+_PROJECT_SUMMARY_TEMPLATE = """\
+# Project Summary: repo-scaffold-desktop
+
+## Overview
+
+repo-scaffold-desktop is a desktop application for generating repository
+scaffolds from configurable presets. It supports Jinja2 templates, optional
+git initialization, pre-commit hook installation, CI workflow generation,
+and CODEOWNERS configuration. The application is built with PySide6 for the
+GUI and exposes a CLI for automation.
+
+## Architecture
+
+The codebase follows a strict layered architecture:
+
+- **app/core/** — all business logic; no UI code allowed here
+- **app/ui/** — PySide6 presentation layer; calls core, contains no logic
+- **templates/** — Jinja2 template files rendered during scaffold generation
+- **tests/** — unit tests for core logic only
+- **schemas/** — exported JSON Schemas for non-Python consumers
+- **scripts/bench/** — standalone benchmark suite; no app.* imports allowed
+
+Data flows one way: UI → config model → generator → disk.
+
+## Module Responsibilities
+
+- **config.py** — Pydantic input models (repo name, output path, preset)
+- **presets.py** — preset definitions (maps preset name → file list)
+- **generator.py** — renders templates and writes files to disk
+- **post_setup.py** — side effects: git init, pre-commit install, etc.
+- **user_prefs.py** — UserPreferences model and PrefsStore (JSON persistence)
+- **manifest.py** — ExecutionManifest Pydantic model: cloud→local contract
+- **escalation_policy.py** — EscalationPolicy: loads escalation_policy.toml
+- **linear_client.py** — thin Linear GraphQL client (stdlib urllib only)
+- **metrics.py** — SQLite-backed store for per-ticket cost and metrics
+- **bench_store.py** — SQLite store for benchmark run records (GPU, timing)
+
+## Engineering Principles
+
+1. UI stays thin. No branching logic, no file I/O in app/ui/.
+2. Prefer config + templates over conditional generation logic.
+3. Generated output must be deterministic and easy to diff.
+4. Avoid over-abstracting v1. Three similar lines beat a premature helper.
+5. Side effects (git, pre-commit) live only in post_setup.py.
+6. Architecture contracts are enforced by Import Linter.
+
+## Benchmark Suite
+
+The benchmark suite (scripts/bench/) evaluates local LLM backends:
+
+- **speed** — minimal prompt measuring raw generation latency
+- **coding** — coding task with automated quality evaluation
+- **prefill_shared** — long shared document prefix to test KV-cache reuse
+- **prefill_unshared** — fresh random document each run (cold prefill)
+- **boundary** — context-window edge probing
+
+The runner collects GPU metrics (VRAM, utilization, power, temperature,
+SM/memory clocks), system metrics (RAM, CPU offload detection), timing
+metrics (TTFT, wall time, throughput), and quality metrics for coding tasks.
+
+## Development Workflow
+
+Each ticket follows grooming → planning → local implementation → PR phases.
+The watcher daemon polls Linear for ReadyForLocal tickets and orchestrates
+local worker sessions in isolated git worktrees.
+
+"""
+
+
+def generate_fixtures() -> None:
+    """Create scripts/bench/fixtures/project_summary_50k.txt (~50k tokens)."""
+    _FIXTURES_DIR.mkdir(parents=True, exist_ok=True)
+    target = _FIXTURES_DIR / "project_summary_50k.txt"
+    # Target: ~50k tokens ≈ 200k chars at 4 chars/token
+    target_chars = 200_000
+    base = _PROJECT_SUMMARY_TEMPLATE
+    parts = [base]
+    section_idx = 0
+    while sum(len(p) for p in parts) < target_chars:
+        section_idx += 1
+        parts.append(
+            f"\n\n## Extended Notes — Section {section_idx}\n\n"
+            + base.replace(
+                "repo-scaffold-desktop", f"repo-scaffold-desktop (ref {section_idx})"
+            )
+        )
+    content = "".join(parts)[:target_chars]
+    target.write_text(content, encoding="utf-8")
+    print(f"Fixture written: {target} ({len(content):,} chars)")

--- a/scripts/bench/run_bench.py
+++ b/scripts/bench/run_bench.py
@@ -14,176 +14,13 @@ import argparse
 import logging
 import subprocess  # nosec B404
 import sys
-import time
-from datetime import datetime, timezone
 from pathlib import Path
 
-from app.core.bench_store import BenchRun, BenchStore
-from scripts.bench.config import BenchCase, BenchConfig
-from scripts.bench.drivers.ollama import OllamaDriver
-from scripts.bench.drivers.vllm import VllmDriver
-from scripts.bench.env_snapshot import EnvSnapshot
-from scripts.bench.gpu_monitor import GpuMonitor
-from scripts.bench.lifecycle.ollama_manager import OllamaManager
-from scripts.bench.quality import evaluate_coding_output
-from scripts.bench.sys_monitor import SysMonitor
-from scripts.bench.tasks import BenchPrompt
-from scripts.bench.tasks.boundary import make_boundary_prompt
-from scripts.bench.tasks.coding import make_coding_prompt
-from scripts.bench.tasks.prefill_shared import make_prefill_shared_prompt
-from scripts.bench.tasks.prefill_unshared import make_prefill_unshared_prompt
-from scripts.bench.tasks.speed import make_speed_prompt
+from app.core.bench_store import BenchStore
+from scripts.bench.fixtures import generate_fixtures
+from scripts.bench.runner import run
 
 logging.basicConfig(level=logging.WARNING, format="%(levelname)s %(name)s: %(message)s")
-
-_FIXTURES_DIR = Path(__file__).parent / "fixtures"
-
-
-# ── ID helpers ────────────────────────────────────────────────────────────────
-
-
-def _case_id(case: BenchCase) -> str:
-    return (
-        f"{case.backend_id}/{case.model_id}"
-        f"/{case.tier}/{case.context_size}/{case.concurrency}"
-    )
-
-
-def _row_run_id(sweep_id: str, case: BenchCase) -> str:
-    return f"{sweep_id}::{_case_id(case)}::{case.repeat_index}"
-
-
-# ── OOM detection ─────────────────────────────────────────────────────────────
-
-
-def _is_oom(error: str) -> bool:
-    low = error.lower()
-    return (
-        "507" in error
-        or "out of memory" in low
-        or "connection reset" in low
-        or "connectionreset" in low
-    )
-
-
-# ── Prompt factory ────────────────────────────────────────────────────────────
-
-
-def _make_prompt(tier: str, repeat_index: int) -> BenchPrompt:
-    if tier == "speed":
-        return make_speed_prompt()
-    if tier == "coding":
-        return make_coding_prompt()
-    if tier == "prefill_shared":
-        return make_prefill_shared_prompt(suffix_index=repeat_index)
-    if tier == "prefill_unshared":
-        return make_prefill_unshared_prompt()
-    if tier == "boundary":
-        return make_boundary_prompt()
-    raise ValueError(f"Unknown tier: {tier!r}")
-
-
-# ── Driver factory ────────────────────────────────────────────────────────────
-
-
-def _make_driver(backend_id: str, base_url: str) -> OllamaDriver | VllmDriver:
-    if "vllm" in backend_id.lower():
-        return VllmDriver(base_url=base_url)
-    return OllamaDriver(base_url=base_url)
-
-
-# ── Fixture generation ────────────────────────────────────────────────────────
-
-_PROJECT_SUMMARY_TEMPLATE = """\
-# Project Summary: repo-scaffold-desktop
-
-## Overview
-
-repo-scaffold-desktop is a desktop application for generating repository
-scaffolds from configurable presets. It supports Jinja2 templates, optional
-git initialization, pre-commit hook installation, CI workflow generation,
-and CODEOWNERS configuration. The application is built with PySide6 for the
-GUI and exposes a CLI for automation.
-
-## Architecture
-
-The codebase follows a strict layered architecture:
-
-- **app/core/** — all business logic; no UI code allowed here
-- **app/ui/** — PySide6 presentation layer; calls core, contains no logic
-- **templates/** — Jinja2 template files rendered during scaffold generation
-- **tests/** — unit tests for core logic only
-- **schemas/** — exported JSON Schemas for non-Python consumers
-- **scripts/bench/** — standalone benchmark suite; no app.* imports allowed
-
-Data flows one way: UI → config model → generator → disk.
-
-## Module Responsibilities
-
-- **config.py** — Pydantic input models (repo name, output path, preset)
-- **presets.py** — preset definitions (maps preset name → file list)
-- **generator.py** — renders templates and writes files to disk
-- **post_setup.py** — side effects: git init, pre-commit install, etc.
-- **user_prefs.py** — UserPreferences model and PrefsStore (JSON persistence)
-- **manifest.py** — ExecutionManifest Pydantic model: cloud→local contract
-- **escalation_policy.py** — EscalationPolicy: loads escalation_policy.toml
-- **linear_client.py** — thin Linear GraphQL client (stdlib urllib only)
-- **metrics.py** — SQLite-backed store for per-ticket cost and metrics
-- **bench_store.py** — SQLite store for benchmark run records (GPU, timing)
-
-## Engineering Principles
-
-1. UI stays thin. No branching logic, no file I/O in app/ui/.
-2. Prefer config + templates over conditional generation logic.
-3. Generated output must be deterministic and easy to diff.
-4. Avoid over-abstracting v1. Three similar lines beat a premature helper.
-5. Side effects (git, pre-commit) live only in post_setup.py.
-6. Architecture contracts are enforced by Import Linter.
-
-## Benchmark Suite
-
-The benchmark suite (scripts/bench/) evaluates local LLM backends:
-
-- **speed** — minimal prompt measuring raw generation latency
-- **coding** — coding task with automated quality evaluation
-- **prefill_shared** — long shared document prefix to test KV-cache reuse
-- **prefill_unshared** — fresh random document each run (cold prefill)
-- **boundary** — context-window edge probing
-
-The runner collects GPU metrics (VRAM, utilization, power, temperature,
-SM/memory clocks), system metrics (RAM, CPU offload detection), timing
-metrics (TTFT, wall time, throughput), and quality metrics for coding tasks.
-
-## Development Workflow
-
-Each ticket follows grooming → planning → local implementation → PR phases.
-The watcher daemon polls Linear for ReadyForLocal tickets and orchestrates
-local worker sessions in isolated git worktrees.
-
-"""
-
-
-def _generate_fixtures() -> None:
-    """Create scripts/bench/fixtures/project_summary_50k.txt (~50k tokens)."""
-    _FIXTURES_DIR.mkdir(parents=True, exist_ok=True)
-    target = _FIXTURES_DIR / "project_summary_50k.txt"
-    # Target: ~50k tokens ≈ 200k chars at 4 chars/token
-    target_chars = 200_000
-    base = _PROJECT_SUMMARY_TEMPLATE
-    # Repeat sections with slight variation to reach target size
-    parts = [base]
-    section_idx = 0
-    while sum(len(p) for p in parts) < target_chars:
-        section_idx += 1
-        parts.append(
-            f"\n\n## Extended Notes — Section {section_idx}\n\n"
-            + base.replace(
-                "repo-scaffold-desktop", f"repo-scaffold-desktop (ref {section_idx})"
-            )
-        )
-    content = "".join(parts)[:target_chars]
-    target.write_text(content, encoding="utf-8")
-    print(f"Fixture written: {target} ({len(content):,} chars)")
 
 
 # ── Browse ────────────────────────────────────────────────────────────────────
@@ -216,228 +53,6 @@ def _compare(id1: str, id2: str, db_path: Path) -> None:
     rows1 = reporter.load_sweep(db_path, id1)
     rows2 = reporter.load_sweep(db_path, id2)
     reporter.print_compare_table(rows1, rows2, id1, id2)
-
-
-# ── Main runner ───────────────────────────────────────────────────────────────
-
-
-def _run(args: argparse.Namespace, db_path: Path) -> None:
-    config = BenchConfig.from_toml(args.config)
-    cases = config.expand_matrix()
-
-    if args.tier:
-        cases = [c for c in cases if c.tier == args.tier]
-
-    sweep_id: str = (
-        args.resume
-        if args.resume
-        else f"run_{datetime.now(tz=timezone.utc).strftime('%Y%m%d_%H%M%S')}"
-    )
-    print(f"Sweep: {sweep_id}  DB: {db_path}")
-
-    store = BenchStore(db_path)
-
-    backends = {b.id: b for b in config.backends if b.enabled}
-
-    prev_model_id: str | None = None
-    prev_backend_id: str | None = None
-    # Tracks which models have had at least one prefill_shared run (for cache_state)
-    prefill_shared_seen: set[str] = set()
-
-    for case in cases:
-        row_run_id = _row_run_id(sweep_id, case)
-
-        if args.resume and store.get_by_run_id(row_run_id):
-            print(
-                f"[SKIP] {case.model_id}/{case.tier}"
-                f"/ctx={case.context_size}/c={case.concurrency}/r={case.repeat_index}"
-            )
-            continue
-
-        backend_cfg = backends.get(case.backend_id)
-        if backend_cfg is None:
-            print(
-                f"[WARN] Unknown backend {case.backend_id!r}, skipping",
-                file=sys.stderr,
-            )
-            continue
-
-        driver = _make_driver(case.backend_id, backend_cfg.base_url)
-
-        manager: OllamaManager | None = None
-        if "vllm" not in case.backend_id.lower():
-            manager = OllamaManager(base_url=backend_cfg.base_url)
-            try:
-                manager.ensure_running()
-                manager.pull_if_needed(case.model_id)
-            except TimeoutError as exc:
-                print(f"[ERROR] Ollama not ready: {exc}", file=sys.stderr)
-                continue
-
-        # Flush previous model when switching models within a backend
-        if (
-            manager is not None
-            and prev_model_id is not None
-            and (prev_model_id != case.model_id or prev_backend_id != case.backend_id)
-        ):
-            try:
-                manager.flush_model(prev_model_id)
-            except Exception as exc:
-                logging.warning("flush_model failed: %s", exc)
-
-        prev_model_id = case.model_id
-        prev_backend_id = case.backend_id
-
-        env = EnvSnapshot.capture(
-            backend=case.backend_id, model=case.model_id, config=config
-        )
-
-        # First prefill_shared per model = warm; subsequent = prefix_warm
-        cache_state: str | None = None
-        if case.tier == "prefill_shared":
-            key = f"{case.backend_id}/{case.model_id}"
-            if key not in prefill_shared_seen:
-                prefill_shared_seen.add(key)
-                cache_state = "warm"
-            else:
-                cache_state = "prefix_warm"
-
-        prompt = _make_prompt(case.tier, case.repeat_index)
-
-        gpu_mon = GpuMonitor()
-        sys_mon = SysMonitor()
-        gpu_mon.start()
-        sys_mon.start()
-
-        messages: list[dict[str, str]] = [{"role": "user", "content": prompt.text}]
-        t_start = time.monotonic()
-        result = driver.generate(
-            case.model_id,
-            messages,
-            case.context_size,
-            prompt.max_tokens,
-            prompt.temperature,
-            prompt.seed,
-        )
-        wall_time_s = time.monotonic() - t_start
-
-        gpu_sample = gpu_mon.stop()
-        sys_result = sys_mon.stop()
-
-        # OOM detection
-        oom = False
-        outcome = "ok"
-        error_message: str | None = None
-        if result.error:
-            error_message = result.error
-            if _is_oom(result.error):
-                oom = True
-                outcome = "oom"
-            else:
-                outcome = "error"
-
-        # Quality evaluation for coding tier only
-        quality_task_success: bool | None = None
-        quality_pytest_passed: bool | None = None
-        quality_ruff_passed: bool | None = None
-        quality_mypy_passed: bool | None = None
-        if case.tier == "coding" and not oom and result.text:
-            repo_path = Path(__file__).parent.parent.parent
-            qr = evaluate_coding_output(result.text, repo_path)
-            quality_task_success = qr.task_success
-            quality_pytest_passed = qr.pytest_passed
-            quality_ruff_passed = qr.ruff_passed
-            quality_mypy_passed = qr.mypy_passed
-            if qr.error_message and error_message is None:
-                error_message = qr.error_message
-
-        total_tokens: int | None = None
-        if result.input_tokens is not None and result.output_tokens is not None:
-            total_tokens = result.input_tokens + result.output_tokens
-
-        throughput_tok_s: float | None = None
-        if (
-            result.output_tokens
-            and result.decode_time_s is not None
-            and result.decode_time_s > 0
-        ):
-            throughput_tok_s = result.output_tokens / result.decode_time_s
-
-        ollama_model_loaded: bool | None = None
-        if manager is not None:
-            try:
-                status = manager.get_ps_status(case.model_id)
-                ollama_model_loaded = status is not None
-            except Exception:
-                pass
-
-        bench_run = BenchRun(
-            run_id=row_run_id,
-            case_id=_case_id(case),
-            repeat_index=case.repeat_index,
-            tier=case.tier,
-            context_size=case.context_size,
-            concurrency=case.concurrency,
-            backend_id=case.backend_id,
-            model_id=case.model_id,
-            settings_hash=env.settings_hash,
-            prompt_hash=prompt.prompt_hash,
-            backend_base_url=backend_cfg.base_url,
-            gpu_driver_version=env.gpu_driver_version,
-            cuda_version=env.cuda_version,
-            python_version=env.python_version,
-            os_version=env.os_version,
-            ttft_s=result.ttft_s if not oom else None,
-            wall_time_s=wall_time_s if not oom else None,
-            throughput_tok_s=throughput_tok_s,
-            prompt_tokens=result.input_tokens,
-            completion_tokens=result.output_tokens,
-            total_tokens=total_tokens,
-            peak_vram_gb=gpu_sample.peak_vram_gb,
-            avg_gpu_util_pct=gpu_sample.avg_gpu_util_pct,
-            avg_gpu_mem_util_pct=gpu_sample.avg_gpu_mem_util_pct,
-            avg_power_w=gpu_sample.avg_power_w,
-            peak_temp_c=gpu_sample.peak_temp_c,
-            avg_sm_clock_mhz=gpu_sample.avg_sm_clock_mhz,
-            avg_mem_clock_mhz=gpu_sample.avg_mem_clock_mhz,
-            peak_ram_gb=sys_result.peak_ram_gb,
-            cpu_offload_detected=sys_result.cpu_offload_detected,
-            ollama_model_loaded=ollama_model_loaded,
-            ollama_num_ctx=case.context_size,
-            quality_task_success=quality_task_success,
-            quality_pytest_passed=quality_pytest_passed,
-            quality_ruff_passed=quality_ruff_passed,
-            quality_mypy_passed=quality_mypy_passed,
-            outcome=outcome,
-            error_message=error_message,
-        )
-
-        # Write before moving to next case (resume safety invariant)
-        store.record(bench_run)
-
-        ttft_str = f" ttft={result.ttft_s:.2f}s" if result.ttft_s else ""
-        tok_str = f" tok/s={throughput_tok_s:.0f}" if throughput_tok_s else ""
-        cache_str = f" [{cache_state}]" if cache_state else ""
-        print(
-            f"[{outcome.upper():5}] {case.model_id} / {case.tier}"
-            f" / ctx={case.context_size} / c={case.concurrency} / r={case.repeat_index}"
-            f"{cache_str}{ttft_str}{tok_str}"
-        )
-
-    print("\nRun complete.")
-
-    from scripts.bench import reporter
-
-    rows = reporter.load_sweep(db_path, sweep_id)
-    reporter.print_summary_table(rows)
-    reporter.print_ranking(rows)
-
-    if args.output_json:
-        reporter.export_json(rows, Path(args.output_json))
-        print(f"JSON exported: {args.output_json}")
-    if args.output_csv:
-        reporter.export_csv(rows, Path(args.output_csv))
-        print(f"CSV exported: {args.output_csv}")
 
 
 # ── CLI ───────────────────────────────────────────────────────────────────────
@@ -508,7 +123,7 @@ def main() -> int:
     db_path = Path(args.db_path) if args.db_path else BenchStore.get_db_path()
 
     if args.generate_fixtures:
-        _generate_fixtures()
+        generate_fixtures()
         return 0
 
     if args.browse:
@@ -519,7 +134,14 @@ def main() -> int:
         _compare(args.compare[0], args.compare[1], db_path)
         return 0
 
-    _run(args, db_path)
+    run(
+        args.config,
+        db_path,
+        tier=args.tier,
+        resume=args.resume,
+        output_json=args.output_json,
+        output_csv=args.output_csv,
+    )
     return 0
 
 

--- a/scripts/bench/runner.py
+++ b/scripts/bench/runner.py
@@ -1,0 +1,291 @@
+"""Benchmark execution engine."""
+
+from __future__ import annotations
+
+import logging
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+from app.core.bench_store import BenchRun, BenchStore
+from scripts.bench.config import BenchCase, BenchConfig
+from scripts.bench.drivers.ollama import OllamaDriver
+from scripts.bench.drivers.vllm import VllmDriver
+from scripts.bench.env_snapshot import EnvSnapshot
+from scripts.bench.gpu_monitor import GpuMonitor
+from scripts.bench.lifecycle.ollama_manager import OllamaManager
+from scripts.bench.quality import evaluate_coding_output
+from scripts.bench.sys_monitor import SysMonitor
+from scripts.bench.tasks import BenchPrompt
+from scripts.bench.tasks.boundary import make_boundary_prompt
+from scripts.bench.tasks.coding import make_coding_prompt
+from scripts.bench.tasks.prefill_shared import make_prefill_shared_prompt
+from scripts.bench.tasks.prefill_unshared import make_prefill_unshared_prompt
+from scripts.bench.tasks.speed import make_speed_prompt
+
+
+def _case_id(case: BenchCase) -> str:
+    return (
+        f"{case.backend_id}/{case.model_id}"
+        f"/{case.tier}/{case.context_size}/{case.concurrency}"
+    )
+
+
+def _row_run_id(sweep_id: str, case: BenchCase) -> str:
+    return f"{sweep_id}::{_case_id(case)}::{case.repeat_index}"
+
+
+def _is_oom(error: str) -> bool:
+    low = error.lower()
+    return (
+        "507" in error
+        or "out of memory" in low
+        or "connection reset" in low
+        or "connectionreset" in low
+    )
+
+
+def _make_prompt(tier: str, repeat_index: int) -> BenchPrompt:
+    if tier == "speed":
+        return make_speed_prompt()
+    if tier == "coding":
+        return make_coding_prompt()
+    if tier == "prefill_shared":
+        return make_prefill_shared_prompt(suffix_index=repeat_index)
+    if tier == "prefill_unshared":
+        return make_prefill_unshared_prompt()
+    if tier == "boundary":
+        return make_boundary_prompt()
+    raise ValueError(f"Unknown tier: {tier!r}")
+
+
+def _make_driver(backend_id: str, base_url: str) -> OllamaDriver | VllmDriver:
+    if "vllm" in backend_id.lower():
+        return VllmDriver(base_url=base_url)
+    return OllamaDriver(base_url=base_url)
+
+
+def run(
+    config_path: str,
+    db_path: Path,
+    *,
+    tier: str | None = None,
+    resume: str | None = None,
+    output_json: str | None = None,
+    output_csv: str | None = None,
+) -> None:
+    config = BenchConfig.from_toml(config_path)
+    cases = config.expand_matrix()
+
+    if tier:
+        cases = [c for c in cases if c.tier == tier]
+
+    sweep_id: str = (
+        resume
+        if resume
+        else f"run_{datetime.now(tz=timezone.utc).strftime('%Y%m%d_%H%M%S')}"
+    )
+    print(f"Sweep: {sweep_id}  DB: {db_path}")
+
+    store = BenchStore(db_path)
+
+    backends = {b.id: b for b in config.backends if b.enabled}
+
+    prev_model_id: str | None = None
+    prev_backend_id: str | None = None
+    # Tracks which models have had at least one prefill_shared run (for cache_state)
+    prefill_shared_seen: set[str] = set()
+
+    for case in cases:
+        row_run_id = _row_run_id(sweep_id, case)
+
+        if resume and store.get_by_run_id(row_run_id):
+            print(
+                f"[SKIP] {case.model_id}/{case.tier}"
+                f"/ctx={case.context_size}/c={case.concurrency}/r={case.repeat_index}"
+            )
+            continue
+
+        backend_cfg = backends.get(case.backend_id)
+        if backend_cfg is None:
+            print(
+                f"[WARN] Unknown backend {case.backend_id!r}, skipping",
+                file=sys.stderr,
+            )
+            continue
+
+        driver = _make_driver(case.backend_id, backend_cfg.base_url)
+
+        manager: OllamaManager | None = None
+        if "vllm" not in case.backend_id.lower():
+            manager = OllamaManager(base_url=backend_cfg.base_url)
+            try:
+                manager.ensure_running()
+                manager.pull_if_needed(case.model_id)
+            except TimeoutError as exc:
+                print(f"[ERROR] Ollama not ready: {exc}", file=sys.stderr)
+                continue
+
+        # Flush previous model when switching models within a backend
+        if (
+            manager is not None
+            and prev_model_id is not None
+            and (prev_model_id != case.model_id or prev_backend_id != case.backend_id)
+        ):
+            try:
+                manager.flush_model(prev_model_id)
+            except Exception as exc:
+                logging.warning("flush_model failed: %s", exc)
+
+        prev_model_id = case.model_id
+        prev_backend_id = case.backend_id
+
+        env = EnvSnapshot.capture(
+            backend=case.backend_id, model=case.model_id, config=config
+        )
+
+        # First prefill_shared per model = warm; subsequent = prefix_warm
+        cache_state: str | None = None
+        if case.tier == "prefill_shared":
+            key = f"{case.backend_id}/{case.model_id}"
+            if key not in prefill_shared_seen:
+                prefill_shared_seen.add(key)
+                cache_state = "warm"
+            else:
+                cache_state = "prefix_warm"
+
+        prompt = _make_prompt(case.tier, case.repeat_index)
+
+        gpu_mon = GpuMonitor()
+        sys_mon = SysMonitor()
+        gpu_mon.start()
+        sys_mon.start()
+
+        messages: list[dict[str, str]] = [{"role": "user", "content": prompt.text}]
+        t_start = time.monotonic()
+        result = driver.generate(
+            case.model_id,
+            messages,
+            case.context_size,
+            prompt.max_tokens,
+            prompt.temperature,
+            prompt.seed,
+        )
+        wall_time_s = time.monotonic() - t_start
+
+        gpu_sample = gpu_mon.stop()
+        sys_result = sys_mon.stop()
+
+        oom = False
+        outcome = "ok"
+        error_message: str | None = None
+        if result.error:
+            error_message = result.error
+            if _is_oom(result.error):
+                oom = True
+                outcome = "oom"
+            else:
+                outcome = "error"
+
+        quality_task_success: bool | None = None
+        quality_pytest_passed: bool | None = None
+        quality_ruff_passed: bool | None = None
+        quality_mypy_passed: bool | None = None
+        if case.tier == "coding" and not oom and result.text:
+            repo_path = Path(__file__).parent.parent.parent
+            qr = evaluate_coding_output(result.text, repo_path)
+            quality_task_success = qr.task_success
+            quality_pytest_passed = qr.pytest_passed
+            quality_ruff_passed = qr.ruff_passed
+            quality_mypy_passed = qr.mypy_passed
+            if qr.error_message and error_message is None:
+                error_message = qr.error_message
+
+        total_tokens: int | None = None
+        if result.input_tokens is not None and result.output_tokens is not None:
+            total_tokens = result.input_tokens + result.output_tokens
+
+        throughput_tok_s: float | None = None
+        if (
+            result.output_tokens
+            and result.decode_time_s is not None
+            and result.decode_time_s > 0
+        ):
+            throughput_tok_s = result.output_tokens / result.decode_time_s
+
+        ollama_model_loaded: bool | None = None
+        if manager is not None:
+            try:
+                status = manager.get_ps_status(case.model_id)
+                ollama_model_loaded = status is not None
+            except Exception:
+                pass
+
+        bench_run = BenchRun(
+            run_id=row_run_id,
+            case_id=_case_id(case),
+            repeat_index=case.repeat_index,
+            tier=case.tier,
+            context_size=case.context_size,
+            concurrency=case.concurrency,
+            backend_id=case.backend_id,
+            model_id=case.model_id,
+            settings_hash=env.settings_hash,
+            prompt_hash=prompt.prompt_hash,
+            backend_base_url=backend_cfg.base_url,
+            gpu_driver_version=env.gpu_driver_version,
+            cuda_version=env.cuda_version,
+            python_version=env.python_version,
+            os_version=env.os_version,
+            ttft_s=result.ttft_s if not oom else None,
+            wall_time_s=wall_time_s if not oom else None,
+            throughput_tok_s=throughput_tok_s,
+            prompt_tokens=result.input_tokens,
+            completion_tokens=result.output_tokens,
+            total_tokens=total_tokens,
+            peak_vram_gb=gpu_sample.peak_vram_gb,
+            avg_gpu_util_pct=gpu_sample.avg_gpu_util_pct,
+            avg_gpu_mem_util_pct=gpu_sample.avg_gpu_mem_util_pct,
+            avg_power_w=gpu_sample.avg_power_w,
+            peak_temp_c=gpu_sample.peak_temp_c,
+            avg_sm_clock_mhz=gpu_sample.avg_sm_clock_mhz,
+            avg_mem_clock_mhz=gpu_sample.avg_mem_clock_mhz,
+            peak_ram_gb=sys_result.peak_ram_gb,
+            cpu_offload_detected=sys_result.cpu_offload_detected,
+            ollama_model_loaded=ollama_model_loaded,
+            ollama_num_ctx=case.context_size,
+            quality_task_success=quality_task_success,
+            quality_pytest_passed=quality_pytest_passed,
+            quality_ruff_passed=quality_ruff_passed,
+            quality_mypy_passed=quality_mypy_passed,
+            outcome=outcome,
+            error_message=error_message,
+        )
+
+        # Write before moving to next case (resume safety invariant)
+        store.record(bench_run)
+
+        ttft_str = f" ttft={result.ttft_s:.2f}s" if result.ttft_s else ""
+        tok_str = f" tok/s={throughput_tok_s:.0f}" if throughput_tok_s else ""
+        cache_str = f" [{cache_state}]" if cache_state else ""
+        print(
+            f"[{outcome.upper():5}] {case.model_id} / {case.tier}"
+            f" / ctx={case.context_size} / c={case.concurrency} / r={case.repeat_index}"
+            f"{cache_str}{ttft_str}{tok_str}"
+        )
+
+    print("\nRun complete.")
+
+    from scripts.bench import reporter
+
+    rows = reporter.load_sweep(db_path, sweep_id)
+    reporter.print_summary_table(rows)
+    reporter.print_ranking(rows)
+
+    if output_json:
+        reporter.export_json(rows, Path(output_json))
+        print(f"JSON exported: {output_json}")
+    if output_csv:
+        reporter.export_csv(rows, Path(output_csv))
+        print(f"CSV exported: {output_csv}")

--- a/tests/bench/test_runner.py
+++ b/tests/bench/test_runner.py
@@ -1,0 +1,108 @@
+"""Tests for benchmark runner helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts.bench.drivers.ollama import OllamaDriver
+from scripts.bench.drivers.vllm import VllmDriver
+from scripts.bench.runner import _case_id, _is_oom, _make_driver, _make_prompt
+from scripts.bench.tasks import BenchPrompt
+
+# ---------------------------------------------------------------------------
+# _is_oom
+# ---------------------------------------------------------------------------
+
+
+def test_is_oom_detects_507() -> None:
+    assert _is_oom("HTTP 507 Insufficient Storage") is True
+
+
+def test_is_oom_detects_out_of_memory() -> None:
+    assert _is_oom("CUDA out of memory") is True
+
+
+def test_is_oom_case_insensitive_oom() -> None:
+    assert _is_oom("OUT OF MEMORY") is True
+
+
+def test_is_oom_detects_connection_reset() -> None:
+    assert _is_oom("connection reset by peer") is True
+
+
+def test_is_oom_detects_connectionreset_camel() -> None:
+    assert _is_oom("ConnectionReset") is True
+
+
+def test_is_oom_returns_false_for_normal_error() -> None:
+    assert _is_oom("timeout waiting for response") is False
+
+
+def test_is_oom_returns_false_for_empty_string() -> None:
+    assert _is_oom("") is False
+
+
+# ---------------------------------------------------------------------------
+# _make_driver
+# ---------------------------------------------------------------------------
+
+
+def test_make_driver_returns_vllm_for_vllm_backend() -> None:
+    assert isinstance(_make_driver("vllm-local", "http://localhost:8000"), VllmDriver)
+
+
+def test_make_driver_vllm_match_is_case_insensitive() -> None:
+    assert isinstance(_make_driver("VLLM", "http://localhost:8000"), VllmDriver)
+
+
+def test_make_driver_returns_ollama_for_ollama_backend() -> None:
+    assert isinstance(_make_driver("ollama", "http://localhost:11434"), OllamaDriver)
+
+
+def test_make_driver_returns_ollama_as_default() -> None:
+    assert isinstance(_make_driver("local", "http://localhost:11434"), OllamaDriver)
+
+
+# ---------------------------------------------------------------------------
+# _make_prompt
+# ---------------------------------------------------------------------------
+
+
+def test_make_prompt_speed() -> None:
+    prompt = _make_prompt("speed", 0)
+    assert isinstance(prompt, BenchPrompt)
+    assert prompt.task_type == "speed"
+
+
+def test_make_prompt_coding() -> None:
+    prompt = _make_prompt("coding", 0)
+    assert isinstance(prompt, BenchPrompt)
+    assert prompt.task_type == "coding"
+
+
+def test_make_prompt_boundary() -> None:
+    prompt = _make_prompt("boundary", 0)
+    assert isinstance(prompt, BenchPrompt)
+    assert prompt.task_type == "boundary"
+
+
+def test_make_prompt_raises_for_unknown_tier() -> None:
+    with pytest.raises(ValueError, match="Unknown tier"):
+        _make_prompt("nonexistent", 0)
+
+
+# ---------------------------------------------------------------------------
+# _case_id
+# ---------------------------------------------------------------------------
+
+
+def test_case_id_format() -> None:
+    from unittest.mock import MagicMock
+
+    case = MagicMock()
+    case.backend_id = "ollama"
+    case.model_id = "qwen3:30b"
+    case.tier = "speed"
+    case.context_size = 4096
+    case.concurrency = 1
+    assert _case_id(case) == "ollama/qwen3:30b/speed/4096/1"


### PR DESCRIPTION
## Summary

- Extract execution engine to `scripts/bench/runner.py` — exposes a clean `run(config_path, db_path, *, tier, resume, ...)` API that no longer takes `argparse.Namespace`, making it independently testable
- Extract the 95-line fixture template + generation logic to `scripts/bench/fixtures.py`
- `run_bench.py` becomes a thin CLI dispatcher (~150 lines): `_browse`, `_compare`, `_build_parser`, `main`
- Add `tests/bench/test_runner.py` with 16 new tests covering `_is_oom`, `_make_driver`, `_make_prompt`, and `_case_id`

## Test plan

- [ ] `pytest tests/bench/test_runner.py` — 16 new tests, all pass
- [ ] `pytest tests/bench/` — full bench suite still passes (115 total)
- [ ] `python scripts/bench/run_bench.py --help` — CLI still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)