### PR TITLE
Fix silent exception swallow and overly broad catch in bench harness

### DIFF
--- a/scripts/bench/quality.py
+++ b/scripts/bench/quality.py
@@ -79,7 +79,12 @@ def evaluate_coding_output(model_output: str, repo_path: Path) -> QualityResult:
             ruff_passed=ruff_passed,
             mypy_passed=mypy_passed,
         )
-    except Exception as exc:
+    except (
+        json.JSONDecodeError,
+        ValueError,
+        OSError,
+        subprocess.SubprocessError,
+    ) as exc:
         return QualityResult(
             task_success=False,
             pytest_passed=False,

--- a/scripts/bench/runner.py
+++ b/scripts/bench/runner.py
@@ -219,8 +219,8 @@ def run(
             try:
                 status = manager.get_ps_status(case.model_id)
                 ollama_model_loaded = status is not None
-            except Exception:
-                pass
+            except Exception as exc:
+                logging.debug("Could not check model status: %s", exc)
 
         bench_run = BenchRun(
             run_id=row_run_id,

--- a/tests/bench/test_quality.py
+++ b/tests/bench/test_quality.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 import tempfile
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -112,7 +113,7 @@ def test_temp_dir_cleaned_up_on_exception(tmp_path: Path) -> None:
     with patch.object(quality_mod.tempfile, "mkdtemp", side_effect=capturing_mkdtemp):
         with patch(
             "scripts.bench.quality.subprocess.run",
-            side_effect=RuntimeError("simulated failure"),
+            side_effect=subprocess.SubprocessError("simulated failure"),
         ):
             result = evaluate_coding_output(_make_patch_output(), tmp_path)
 


### PR DESCRIPTION
## Summary

- **`runner.py:222`** — bare `except: pass` on optional Ollama model-status telemetry replaced with `logging.debug(...)` so failures surface in debug output during long benchmark runs
- **`quality.py:82`** — bare `except Exception` narrowed to the specific exceptions that can actually be raised (`JSONDecodeError`, `ValueError`, `OSError`, `SubprocessError`) so unexpected errors are not silently swallowed

## Test plan

- [ ] Existing 115-test benchmark suite passes (`pytest tests/bench/`)
- [ ] `ruff check` and `mypy` clean (enforced by pre-commit hooks — passed on commit)
- [ ] No behaviour change for normal runs; `logging.debug` output visible only when `--log-level debug` is set