### PR TITLE
Fix ModuleNotFoundError when running run_bench.py as a script

### DIFF
--- a/scripts/bench/run_bench.py
+++ b/scripts/bench/run_bench.py
@@ -16,6 +16,9 @@ import subprocess  # nosec B404
 import sys
 from pathlib import Path
 
+# Ensure repo root is on sys.path when run as `python scripts/bench/run_bench.py`
+sys.path.insert(0, str(Path(__file__).parents[2]))
+
 from app.core.bench_store import BenchStore
 from scripts.bench.fixtures import generate_fixtures
 from scripts.bench.runner import run


### PR DESCRIPTION
## Summary

- `python scripts/bench/run_bench.py` puts the *script directory* (`scripts/bench/`) on `sys.path`, not the repo root — so `from app.core.bench_store import ...` fails with `ModuleNotFoundError: No module named 'app'`
- Inserts the repo root into `sys.path` before the `app` imports, matching the documented usage in `bench.toml` and `docs/bench.md`

## Test plan

- [x] `python scripts/bench/run_bench.py --generate-fixtures` runs without error from repo root
- [x] CI lint-and-test passes