### PR TITLE
Add --model and --backend filter flags to bench CLI

### DIFF
--- a/config/bench.toml
+++ b/config/bench.toml
@@ -9,8 +9,9 @@
 #   python scripts/bench/run_bench.py                       # full matrix — all tiers, all models
 #   python scripts/bench/run_bench.py --browse              # explore results in Datasette
 #
-# To run a single model:
+# To run a single model or backend:
 #   python scripts/bench/run_bench.py --model qwen3-coder:30b --tier speed
+#   python scripts/bench/run_bench.py --backend local_vllm --tier prefill_shared
 #
 # Enable vLLM: set local_vllm.enabled = true, start server (see backend comment below),
 # then re-run. vLLM model ids must match --model arg used when starting the server.

--- a/scripts/bench/run_bench.py
+++ b/scripts/bench/run_bench.py
@@ -77,6 +77,18 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Filter by tier: speed|coding|prefill_shared|prefill_unshared|boundary",
     )
     parser.add_argument(
+        "--model",
+        default=None,
+        metavar="MODEL_ID",
+        help="Run only cases matching this model id (e.g. qwen3:14b)",
+    )
+    parser.add_argument(
+        "--backend",
+        default=None,
+        metavar="BACKEND_ID",
+        help="Run only cases matching this backend id (e.g. local_qwen)",
+    )
+    parser.add_argument(
         "--resume",
         metavar="SWEEP_ID",
         default=None,
@@ -141,6 +153,8 @@ def main() -> int:
         args.config,
         db_path,
         tier=args.tier,
+        model=args.model,
+        backend=args.backend,
         resume=args.resume,
         output_json=args.output_json,
         output_csv=args.output_csv,

--- a/scripts/bench/runner.py
+++ b/scripts/bench/runner.py
@@ -71,6 +71,8 @@ def run(
     db_path: Path,
     *,
     tier: str | None = None,
+    model: str | None = None,
+    backend: str | None = None,
     resume: str | None = None,
     output_json: str | None = None,
     output_csv: str | None = None,
@@ -80,6 +82,10 @@ def run(
 
     if tier:
         cases = [c for c in cases if c.tier == tier]
+    if model:
+        cases = [c for c in cases if c.model_id == model]
+    if backend:
+        cases = [c for c in cases if c.backend_id == backend]
 
     sweep_id: str = (
         resume


### PR DESCRIPTION
## Summary

- `--model MODEL_ID` — run only cases matching that model id (e.g. `--model qwen3:14b`)
- `--backend BACKEND_ID` — run only cases matching that backend id (e.g. `--backend local_vllm`)
- Both flags compose with `--tier`; same list-filter pattern as the existing `--tier` flag
- `bench.toml` quick-start comment already documented `--model` but the flag didn't exist; now it does, and `--backend` is added alongside it

## Test plan

- [ ] `python scripts/bench/run_bench.py --model qwen3:14b --tier speed` is accepted without error
- [ ] `python scripts/bench/run_bench.py --backend local_vllm --tier prefill_shared` is accepted without error
- [ ] CI lint-and-test passes