### PR TITLE
Fix --config default path: bench.toml → config/bench.toml

### DIFF
--- a/scripts/bench/run_bench.py
+++ b/scripts/bench/run_bench.py
@@ -68,8 +68,8 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--config",
-        default="bench.toml",
-        help="Path to bench.toml (default: bench.toml)",
+        default="config/bench.toml",
+        help="Path to bench.toml (default: config/bench.toml)",
     )
     parser.add_argument(
         "--tier",


### PR DESCRIPTION
## Summary

The `--config` default was `"bench.toml"` (bare filename), but the file lives at `config/bench.toml`. Running from the repo root produced `FileNotFoundError: No such file or directory: 'bench.toml'`.

## Test plan

- [ ] `python scripts/bench/run_bench.py --model qwen3:14b --tier speed` starts without FileNotFoundError
- [x] CI lint-and-test passes