### PR TITLE
Fix sys_monitor wmic spam on Windows 11: fall back to PowerShell

### DIFF
--- a/scripts/bench/sys_monitor.py
+++ b/scripts/bench/sys_monitor.py
@@ -1,4 +1,4 @@
-"""Background system monitor: polls RAM via wmic (Windows) or /proc/meminfo (Linux)."""
+"""Background RAM monitor: wmic/PowerShell on Windows, /proc/meminfo on Linux."""
 
 from __future__ import annotations
 
@@ -6,6 +6,7 @@ import logging
 import platform
 import subprocess  # nosec B404
 import threading
+from collections.abc import Callable
 from dataclasses import dataclass
 
 logger = logging.getLogger(__name__)
@@ -19,8 +20,8 @@ class SysResult:
     peak_ram_gb: float | None = None
 
 
-def _read_ram_gb_windows() -> float | None:
-    """Return current RAM usage in GB via wmic, or None if unavailable."""
+def _read_ram_gb_windows_wmic() -> float | None:
+    """Return RAM usage in GB via wmic, or None on any failure (silent)."""
     try:
         result = subprocess.run(  # nosec B603, B607
             [
@@ -34,8 +35,7 @@ def _read_ram_gb_windows() -> float | None:
             text=True,
             timeout=5,
         )
-    except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
-        logger.warning("wmic unavailable: %s", exc)
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
         return None
     if result.returncode != 0:
         return None
@@ -56,6 +56,63 @@ def _read_ram_gb_windows() -> float | None:
     if total_kb is None or free_kb is None:
         return None
     return (total_kb - free_kb) / (1024.0 * 1024.0)
+
+
+def _read_ram_gb_windows_powershell() -> float | None:
+    """Return RAM usage in GB via Get-CimInstance (Windows 11+), or None on failure."""
+    try:
+        result = subprocess.run(  # nosec B603, B607
+            [
+                "powershell",
+                "-NonInteractive",
+                "-NoProfile",
+                "-Command",
+                "$o=Get-CimInstance Win32_OperatingSystem;"
+                '"$($o.FreePhysicalMemory) $($o.TotalVisibleMemorySize)"',
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return None
+    if result.returncode != 0:
+        return None
+    parts = result.stdout.strip().split()
+    if len(parts) != 2:
+        return None
+    try:
+        free_kb, total_kb = float(parts[0]), float(parts[1])
+        return (total_kb - free_kb) / (1024.0 * 1024.0)
+    except ValueError:
+        return None
+
+
+# Cached reader selected on first call: avoids re-probing every poll cycle.
+_windows_ram_fn: Callable[[], float | None] | None = None
+
+
+def _read_ram_gb_windows() -> float | None:
+    """Auto-detect the fastest available RAM reader on Windows and cache it."""
+    global _windows_ram_fn
+    if _windows_ram_fn is not None:
+        return _windows_ram_fn()
+
+    val = _read_ram_gb_windows_wmic()
+    if val is not None:
+        _windows_ram_fn = _read_ram_gb_windows_wmic
+        return val
+
+    val = _read_ram_gb_windows_powershell()
+    if val is not None:
+        _windows_ram_fn = _read_ram_gb_windows_powershell
+        return val
+
+    logger.warning(
+        "RAM monitoring unavailable on this system (wmic and PowerShell both failed)"
+    )
+    _windows_ram_fn = lambda: None  # noqa: E731
+    return None
 
 
 def _read_ram_gb_linux() -> float | None:


### PR DESCRIPTION
## Summary

`wmic` was deprecated and removed from many Windows 11 builds. The old code called it on every 1-second poll cycle and logged a `WARNING` each time, flooding benchmark output with noise.

**Fix:**
- `_read_ram_gb_windows_wmic()` — silent on failure (no warning), returns `None`
- `_read_ram_gb_windows_powershell()` — calls `Get-CimInstance Win32_OperatingSystem`, the official `wmic` replacement
- `_read_ram_gb_windows()` — probes both on first call, caches the working one; warns once (not per-poll) if both fail

On this machine: PowerShell path returns ~23 GB used, verified working.

## Test plan

- [ ] `python scripts/bench/run_bench.py --model qwen3:14b --tier speed` produces no wmic warnings
- [x] 115 bench tests pass
- [x] CI lint-and-test passes