### PR TITLE
Fix missing TTFT for qwen3 thinking-model runs in OllamaDriver

### DIFF
--- a/scripts/bench/drivers/ollama.py
+++ b/scripts/bench/drivers/ollama.py
@@ -104,6 +104,11 @@ class OllamaDriver:
             raw_eval_duration_ns / 1e9 if raw_eval_duration_ns is not None else None
         )
 
+        # Fall back to Ollama-reported prompt_eval_duration when client-side TTFT
+        # was not captured (e.g. thinking models stream empty content chunks first).
+        if ttft_s is None and final_frame.get("prompt_eval_duration"):
+            ttft_s = final_frame["prompt_eval_duration"] / 1e9
+
         return GenerationResult(
             text="".join(text_parts),
             ttft_s=ttft_s,


### PR DESCRIPTION
## Summary

qwen3 is a thinking model. Ollama strips `<think>...</think>` tokens from the `content` field in `/api/chat` streaming responses. The client-side TTFT measurement fires on the first non-empty `content` chunk — but during the thinking phase all chunks arrive with `content = ""`, so for short generations the visible response arrives before we ever see a non-empty chunk, and `ttft_s` stays `None` (shown as `--` in the results table).

Fix: fall back to Ollama's own `prompt_eval_duration` from the final frame when client-side TTFT wasn't captured. `prompt_eval_duration` is Ollama's server-side measure of time to process the prompt and emit the first token — semantically equivalent to TTFT.

## Test plan

- [ ] Run `python scripts/bench/run_bench.py --model qwen3:14b --tier speed` — TTFT column should be populated for all repeats, not just r=0
- [ ] CI lint-and-test passes