### PR TITLE
Fix fixture filename mismatch: project_summary_50k.txt → prefill_50k.txt

### DIFF
--- a/docs/bench.md
+++ b/docs/bench.md
@@ -33,7 +33,7 @@ Options:
                       | prefill_unshared | boundary
   --resume SWEEP_ID   Resume an interrupted run — skips already-recorded cases
   --compare ID1 ID2   Side-by-side TTFT comparison of two sweep IDs
-  --generate-fixtures Write scripts/bench/fixtures/project_summary_50k.txt
+  --generate-fixtures Write scripts/bench/fixtures/prefill_50k.txt
   --export-json PATH  Export sweep results to JSON
   --export-csv PATH   Export sweep results to CSV
   --browse            Open bench.db in Datasette browser UI

--- a/scripts/bench/fixtures.py
+++ b/scripts/bench/fixtures.py
@@ -76,9 +76,9 @@ local worker sessions in isolated git worktrees.
 
 
 def generate_fixtures() -> None:
-    """Create scripts/bench/fixtures/project_summary_50k.txt (~50k tokens)."""
+    """Create scripts/bench/fixtures/prefill_50k.txt (~50k tokens)."""
     _FIXTURES_DIR.mkdir(parents=True, exist_ok=True)
-    target = _FIXTURES_DIR / "project_summary_50k.txt"
+    target = _FIXTURES_DIR / "prefill_50k.txt"
     # Target: ~50k tokens ≈ 200k chars at 4 chars/token
     target_chars = 200_000
     base = _PROJECT_SUMMARY_TEMPLATE

--- a/scripts/bench/run_bench.py
+++ b/scripts/bench/run_bench.py
@@ -104,7 +104,7 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--generate-fixtures",
         action="store_true",
-        help="Create scripts/bench/fixtures/project_summary_50k.txt",
+        help="Create scripts/bench/fixtures/prefill_50k.txt",
     )
     parser.add_argument(
         "--browse",

--- a/scripts/bench/tasks/prefill_shared.py
+++ b/scripts/bench/tasks/prefill_shared.py
@@ -18,8 +18,7 @@ def make_prefill_shared_prompt(suffix_index: int = 0) -> BenchPrompt:
     if not FIXTURE_PATH.exists():
         raise FileNotFoundError(
             f"Fixture file not found: {FIXTURE_PATH}. "
-            "Generate it first: python scripts/bench/generate_fixtures.py"
-            " --generate-fixtures"
+            "Generate it first: python scripts/bench/run_bench.py --generate-fixtures"
         )
     doc = FIXTURE_PATH.read_text(encoding="utf-8")
     suffix = _SUFFIX_TEMPLATE.format(index=suffix_index)


### PR DESCRIPTION
## Summary

`fixtures.py` wrote `project_summary_50k.txt` but `prefill_shared.py` looked for `prefill_50k.txt`, causing a `FileNotFoundError` as soon as the `prefill_shared` tier started — even after running `--generate-fixtures`.

Also fixes:
- Error message pointed to a non-existent `generate_fixtures.py` script; corrected to `run_bench.py --generate-fixtures`
- Help text in `run_bench.py` and `docs/bench.md` updated to the correct filename

## Test plan

- [x] `python scripts/bench/run_bench.py --generate-fixtures` creates `scripts/bench/fixtures/prefill_50k.txt`
- [x] `python scripts/bench/run_bench.py --model qwen3:14b --tier prefill_shared` runs without FileNotFoundError
- [x] CI lint-and-test passes