### PR TITLE
WOR-207 Capture quantization level and support multi-quantization model testing

### DIFF
--- a/app/core/bench_store.py
+++ b/app/core/bench_store.py
@@ -59,6 +59,8 @@ CREATE TABLE IF NOT EXISTS bench_run (
     cache_state             TEXT,
     ollama_model_loaded     INTEGER,
     ollama_num_ctx          INTEGER,
+    model_quant             TEXT,
+    model_family            TEXT,
     quality_task_success    INTEGER,
     quality_pytest_passed   INTEGER,
     quality_ruff_passed     INTEGER,
@@ -88,7 +90,7 @@ INSERT INTO bench_run (
     avg_gpu_util_pct, avg_gpu_mem_util_pct, avg_power_w,
     peak_temp_c, avg_sm_clock_mhz, avg_mem_clock_mhz,
     peak_ram_gb, cpu_offload_detected,
-    cache_state, ollama_model_loaded, ollama_num_ctx,
+    cache_state, ollama_model_loaded, ollama_num_ctx, model_quant, model_family,
     quality_task_success, quality_pytest_passed,
     quality_ruff_passed, quality_mypy_passed,
     outcome, error_message
@@ -104,7 +106,7 @@ INSERT INTO bench_run (
     :avg_gpu_util_pct, :avg_gpu_mem_util_pct, :avg_power_w,
     :peak_temp_c, :avg_sm_clock_mhz, :avg_mem_clock_mhz,
     :peak_ram_gb, :cpu_offload_detected,
-    :cache_state, :ollama_model_loaded, :ollama_num_ctx,
+    :cache_state, :ollama_model_loaded, :ollama_num_ctx, :model_quant, :model_family,
     :quality_task_success, :quality_pytest_passed,
     :quality_ruff_passed, :quality_mypy_passed,
     :outcome, :error_message
@@ -189,6 +191,10 @@ class BenchRun(BaseModel):
     ollama_model_loaded: bool | None = None
     ollama_num_ctx: int | None = None
 
+    # model metadata (from /api/show)
+    model_quant: str | None = None
+    model_family: str | None = None
+
     # quality
     quality_task_success: bool | None = None
     quality_pytest_passed: bool | None = None
@@ -248,6 +254,10 @@ class BenchStore:
             conn.execute("ALTER TABLE bench_run ADD COLUMN cache_state TEXT")
         if "total_vram_gb" not in existing:
             conn.execute("ALTER TABLE bench_run ADD COLUMN total_vram_gb REAL")
+        if "model_quant" not in existing:
+            conn.execute("ALTER TABLE bench_run ADD COLUMN model_quant TEXT")
+        if "model_family" not in existing:
+            conn.execute("ALTER TABLE bench_run ADD COLUMN model_family TEXT")
 
     @contextmanager
     def _connect(self) -> Generator[sqlite3.Connection, None, None]:

--- a/config/bench.toml
+++ b/config/bench.toml
@@ -68,6 +68,8 @@ base_url = "http://localhost:8000"
 
 [[models]]
 # 9.3 GB | Dense 14B — lightweight baseline and fastest model.
+# quant override: set when Ollama /api/show does not return quantization_level cleanly.
+# Example: quant = "Q4_K_M"
 id = "qwen3:14b"
 backend_id = "local_qwen"
 

--- a/scripts/bench/config.py
+++ b/scripts/bench/config.py
@@ -58,6 +58,7 @@ class ModelConfig(BaseModel):
 
     id: str
     backend_id: str
+    quant: str | None = None
 
 
 class TierConfig(BaseModel):

--- a/scripts/bench/drivers/ollama.py
+++ b/scripts/bench/drivers/ollama.py
@@ -30,6 +30,29 @@ class OllamaDriver:
     def __init__(self, base_url: str = "http://localhost:11434") -> None:
         self._base_url = _validated_base_url(base_url)
 
+    def fetch_model_info(self, model_id: str) -> dict[str, str | None]:
+        """Fetch quantization_level and parameter_size from Ollama /api/show.
+
+        Returns None values for both fields on any error — non-fatal by design.
+        """
+        payload = json.dumps({"name": model_id}).encode()
+        req = urllib.request.Request(
+            f"{self._base_url}/api/show",
+            data=payload,
+            headers={"Content-Type": "application/json"},
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=10) as resp:
+                data: dict[str, Any] = json.loads(resp.read().decode())
+            details: dict[str, Any] = data.get("details") or {}
+            return {
+                "model_quant": details.get("quantization_level") or None,
+                "model_family": details.get("parameter_size") or None,
+            }
+        except Exception as exc:
+            logger.warning("fetch_model_info failed for %s: %s", model_id, exc)
+            return {"model_quant": None, "model_family": None}
+
     def is_available(self) -> bool:
         try:
             req = urllib.request.Request(f"{self._base_url}/api/tags")

--- a/scripts/bench/runner.py
+++ b/scripts/bench/runner.py
@@ -9,7 +9,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from app.core.bench_store import BenchRun, BenchStore
-from scripts.bench.config import BenchCase, BenchConfig
+from scripts.bench.config import BenchCase, BenchConfig, ModelConfig
 from scripts.bench.drivers.ollama import OllamaDriver
 from scripts.bench.drivers.vllm import VllmDriver
 from scripts.bench.env_snapshot import EnvSnapshot
@@ -97,6 +97,9 @@ def run(
     store = BenchStore(db_path)
 
     backends = {b.id: b for b in config.backends if b.enabled}
+    model_cfgs: dict[str, ModelConfig] = {m.id: m for m in config.models}
+    # Cache /api/show result per (backend_id, model_id) — called once per model.
+    model_info_cache: dict[tuple[str, str], dict[str, str | None]] = {}
 
     prev_model_id: str | None = None
     prev_backend_id: str | None = None
@@ -122,6 +125,18 @@ def run(
             continue
 
         driver = _make_driver(case.backend_id, backend_cfg.base_url)
+
+        info_key = (case.backend_id, case.model_id)
+        if info_key not in model_info_cache:
+            if isinstance(driver, OllamaDriver):
+                info = driver.fetch_model_info(case.model_id)
+            else:
+                info = {"model_quant": None, "model_family": None}
+            m_cfg = model_cfgs.get(case.model_id)
+            if m_cfg is not None and m_cfg.quant is not None:
+                info = {**info, "model_quant": m_cfg.quant}
+            model_info_cache[info_key] = info
+        model_info = model_info_cache[info_key]
 
         manager: OllamaManager | None = None
         if "vllm" not in case.backend_id.lower():
@@ -266,6 +281,8 @@ def run(
             cache_state=cache_state,
             ollama_model_loaded=ollama_model_loaded,
             ollama_num_ctx=case.context_size,
+            model_quant=model_info["model_quant"],
+            model_family=model_info["model_family"],
             quality_task_success=quality_task_success,
             quality_pytest_passed=quality_pytest_passed,
             quality_ruff_passed=quality_ruff_passed,

--- a/tests/bench/test_bench_config.py
+++ b/tests/bench/test_bench_config.py
@@ -169,3 +169,61 @@ def test_no_model_on_disabled_backend_in_expanded_cases(tmp_path: Path) -> None:
     cases = cfg.expand_matrix()
     backend_ids = {c.backend_id for c in cases}
     assert "cloud_b" not in backend_ids
+
+
+def test_model_quant_field_defaults_to_none(tmp_path: Path) -> None:
+    cfg = BenchConfig.from_toml(_write_toml(tmp_path, _STANDARD_TOML))
+    for m in cfg.models:
+        assert m.quant is None
+
+
+def test_model_quant_field_parsed_from_toml(tmp_path: Path) -> None:
+    toml = """
+[matrix]
+context_sizes = [1024]
+boundary_context_sizes = [8192]
+concurrency_levels = [1]
+repeats = 1
+
+[[backends]]
+id = "local_a"
+enabled = true
+base_url = "http://localhost:1/"
+api_key = "x"
+
+[[models]]
+id = "some-model:7b"
+backend_id = "local_a"
+quant = "Q4_K_M"
+
+[[tiers]]
+name = "speed"
+"""
+    cfg = BenchConfig.from_toml(_write_toml(tmp_path, toml))
+    assert len(cfg.models) == 1
+    assert cfg.models[0].quant == "Q4_K_M"
+
+
+def test_model_quant_field_is_optional(tmp_path: Path) -> None:
+    toml = """
+[matrix]
+context_sizes = [1024]
+boundary_context_sizes = [8192]
+concurrency_levels = [1]
+repeats = 1
+
+[[backends]]
+id = "local_a"
+enabled = true
+base_url = "http://localhost:1/"
+api_key = "x"
+
+[[models]]
+id = "some-model:7b"
+backend_id = "local_a"
+
+[[tiers]]
+name = "speed"
+"""
+    cfg = BenchConfig.from_toml(_write_toml(tmp_path, toml))
+    assert cfg.models[0].quant is None

--- a/tests/bench/test_bench_drivers.py
+++ b/tests/bench/test_bench_drivers.py
@@ -171,6 +171,61 @@ def test_ollama_generate_payload_omits_seed_when_none():
     assert "seed" not in payload["options"]
 
 
+_OLLAMA_SHOW_BODY = json.dumps(
+    {
+        "modelfile": "FROM ...",
+        "details": {
+            "format": "gguf",
+            "family": "qwen2",
+            "parameter_size": "30.5B",
+            "quantization_level": "Q4_K_M",
+        },
+    }
+).encode()
+
+
+def test_fetch_model_info_returns_quant_and_family():
+    with patch("urllib.request.urlopen", _mock_urlopen(_OLLAMA_SHOW_BODY)):
+        driver = OllamaDriver()
+        info = driver.fetch_model_info("qwen3-coder:30b")
+
+    assert info["model_quant"] == "Q4_K_M"
+    assert info["model_family"] == "30.5B"
+
+
+def test_fetch_model_info_returns_none_on_network_error():
+    with patch(
+        "urllib.request.urlopen",
+        side_effect=urllib.error.URLError("connection refused"),
+    ):
+        driver = OllamaDriver()
+        info = driver.fetch_model_info("some-model:7b")
+
+    assert info["model_quant"] is None
+    assert info["model_family"] is None
+
+
+def test_fetch_model_info_returns_none_when_details_missing():
+    body = json.dumps({"modelfile": "FROM ..."}).encode()
+    with patch("urllib.request.urlopen", _mock_urlopen(body)):
+        driver = OllamaDriver()
+        info = driver.fetch_model_info("some-model:7b")
+
+    assert info["model_quant"] is None
+    assert info["model_family"] is None
+
+
+def test_fetch_model_info_quantization_level_none_when_empty_string():
+    body = json.dumps(
+        {"details": {"quantization_level": "", "parameter_size": "7B"}}
+    ).encode()
+    with patch("urllib.request.urlopen", _mock_urlopen(body)):
+        info = OllamaDriver().fetch_model_info("some-model:7b")
+
+    assert info["model_quant"] is None
+    assert info["model_family"] == "7B"
+
+
 def test_ollama_is_available_returns_false_when_unreachable():
     with patch(
         "urllib.request.urlopen",

--- a/tests/bench/test_bench_store.py
+++ b/tests/bench/test_bench_store.py
@@ -371,6 +371,52 @@ class TestNewColumns:
         assert result.cache_state == "prefix_warm"
 
 
+class TestModelMetadataColumns:
+    """Tests for model_quant and model_family added in WOR-207."""
+
+    def test_model_quant_and_family_default_to_none(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        store.record(_run())
+        result = store.get_by_run_id("run-001")[0]
+        assert result.model_quant is None
+        assert result.model_family is None
+
+    def test_model_quant_and_family_round_trip(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        store.record(_run(model_quant="Q4_K_M", model_family="30.5B"))
+        result = store.get_by_run_id("run-001")[0]
+        assert result.model_quant == "Q4_K_M"
+        assert result.model_family == "30.5B"
+
+    def test_migration_adds_model_quant_and_family_columns(
+        self, tmp_path: Path
+    ) -> None:
+        import sqlite3
+
+        db_path = tmp_path / "old_schema.db"
+        conn = sqlite3.connect(db_path)
+        conn.execute(
+            """
+            CREATE TABLE bench_run (
+                run_id TEXT NOT NULL, case_id TEXT NOT NULL,
+                repeat_index INTEGER NOT NULL,
+                recorded_at TEXT NOT NULL DEFAULT (datetime('now')),
+                PRIMARY KEY (run_id, case_id, repeat_index)
+            )
+            """
+        )
+        conn.execute(
+            "INSERT INTO bench_run(run_id, case_id, repeat_index) VALUES ('r1','c1',0)"
+        )
+        conn.commit()
+        conn.close()
+
+        store = BenchStore(db_path=db_path)
+        result = store.get_by_run_id("r1")[0]
+        assert result.model_quant is None
+        assert result.model_family is None
+
+
 class TestPrintRanking:
     """Tests for per-config grouping in print_ranking()."""
 


### PR DESCRIPTION
Closes WOR-207

model_quant and model_family populated from /api/show in every BenchRun; quant override works in bench.toml; /api/show failure is non-fatal; tests pass.