### PR TITLE
WOR-200 Add repeat variance and stability flag to benchmark ranking

### DIFF
--- a/scripts/bench/reporter.py
+++ b/scripts/bench/reporter.py
@@ -59,6 +59,29 @@ def _median(values: list[float]) -> float | None:
     return statistics.median(clean)
 
 
+def _percentile(values: list[float], pct: int) -> float | None:
+    """Return pct-th percentile via linear interpolation; None if < 2 values."""
+    if len(values) < 2:
+        return None
+    sorted_vals = sorted(values)
+    n = len(sorted_vals)
+    idx = pct / 100 * (n - 1)
+    lo = int(idx)
+    hi = min(lo + 1, n - 1)
+    frac = idx - lo
+    return sorted_vals[lo] + frac * (sorted_vals[hi] - sorted_vals[lo])
+
+
+def _cv(values: list[float]) -> float | None:
+    """Return coefficient of variation (stddev/mean); None if < 2 values or mean==0."""
+    if len(values) < 2:
+        return None
+    m = statistics.mean(values)
+    if m == 0.0:
+        return None
+    return statistics.stdev(values) / m
+
+
 # ── Summary table ─────────────────────────────────────────────────────────────
 
 _SUMMARY_COLS = [
@@ -188,11 +211,14 @@ def print_ranking(
     *,
     min_useful_ctx: int = 4096,
     min_throughput_toks_per_s: float = 5.0,
+    cv_threshold: float = 0.3,
 ) -> None:
     """Print quality-gated ranking with recommendation banner.
 
     Ineligible configs are listed below the ranking table with their rejection reason.
     Threshold parameters keep defaults so existing callers need no changes.
+    When a config has > 1 repeat, ttft_p95 and ttft_cv are computed and the config is
+    flagged unstable when ttft_cv exceeds cv_threshold (default 0.3).
     """
     if not rows:
         return
@@ -236,10 +262,18 @@ def print_ranking(
             successes = sum(1 for r in coding_with_q if r.get("quality_task_success"))
             task_pct = 100.0 * successes / len(coding_with_q)
 
+        ttft_cv = _cv(ttft_values)
+        unstable: bool | None = None
+        if ttft_cv is not None:
+            unstable = ttft_cv > cv_threshold
+
         eligible.append(
             {
                 "config_key": config_key,
                 "ttft_p50": _median(ttft_values),
+                "ttft_p95": _percentile(ttft_values, 95),
+                "ttft_cv": ttft_cv,
+                "unstable": unstable,
                 "tok_p50": _median(tok_values),
                 "task_pct": task_pct,
             }
@@ -262,39 +296,54 @@ def print_ranking(
         )
     )
 
-    print("=" * 80)
+    _W = 108
+    print("=" * _W)
     print("QUALITY-ELIGIBLE RANKING  (oom=No, offload=No, err≤5%, task≥70%)")
-    print("=" * 80)
+    print("=" * _W)
     header = (
         f"{'Rank':>4}  {'Config (backend/model/ctx/c)':<44}  "
-        f"{'TTFT p50(s)':>10}  {'Tok/s p50':>9}  {'Task%':>5}"
+        f"{'TTFT p50(s)':>10}  {'TTFT p95(s)':>10}  {'CV':>6}  "
+        f"{'Tok/s p50':>9}  {'Task%':>5}  {'Stable':>6}"
     )
     print(header)
-    print("-" * 80)
+    print("-" * _W)
 
     for rank, entry in enumerate(eligible, start=1):
-        ttft_str = _fmt(entry["ttft_p50"], ".3f")
+        ttft_p50_str = _fmt(entry["ttft_p50"], ".3f")
+        ttft_p95_str = _fmt(entry["ttft_p95"], ".3f")
+        cv_str = _fmt(entry["ttft_cv"], ".3f")
         tok_str = _fmt(entry["tok_p50"], ".0f")
         task_str = _pct(entry["task_pct"])
+        if entry["unstable"] is None:
+            stable_str = "--"
+        elif entry["unstable"]:
+            stable_str = "[!]"
+        else:
+            stable_str = "OK"
         row_str = (
             f"{rank:>4}  {entry['config_key']:<44}  "
-            f"{ttft_str:>10}  {tok_str:>9}  {task_str:>5}"
+            f"{ttft_p50_str:>10}  {ttft_p95_str:>10}  {cv_str:>6}  "
+            f"{tok_str:>9}  {task_str:>5}  {stable_str:>6}"
         )
         print(row_str)
 
-    print("-" * 80)
+    print("-" * _W)
     best = eligible[0]
     print(f"\n  *** RECOMMENDED: {best['config_key']} ***")
     parts = []
     if best["ttft_p50"] is not None:
         parts.append(f"TTFT p50={best['ttft_p50']:.3f}s")
+    if best["ttft_p95"] is not None:
+        parts.append(f"TTFT p95={best['ttft_p95']:.3f}s")
+    if best["ttft_cv"] is not None:
+        parts.append(f"CV={best['ttft_cv']:.3f}")
     if best["tok_p50"] is not None:
         parts.append(f"tok/s p50={best['tok_p50']:.0f}")
     if best["task_pct"] is not None:
         parts.append(f"task={best['task_pct']:.0f}%")
     if parts:
         print("  " + " | ".join(parts))
-    print("=" * 80 + "\n")
+    print("=" * _W + "\n")
 
     if ineligible:
         print("INELIGIBLE CONFIGS:")

--- a/tests/bench/test_reporter.py
+++ b/tests/bench/test_reporter.py
@@ -6,7 +6,7 @@ import io
 from contextlib import redirect_stdout
 from typing import Any
 
-from scripts.bench.reporter import _is_eligible, print_ranking
+from scripts.bench.reporter import _cv, _is_eligible, _percentile, print_ranking
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -332,3 +332,159 @@ class TestPrintRankingRejectionReasons:
             print_ranking(rows)
         output = buf.getvalue()
         assert "RECOMMENDED" in output
+
+
+# ── _percentile() unit tests ──────────────────────────────────────────────────
+
+
+class TestPercentile:
+    def test_empty_returns_none(self) -> None:
+        assert _percentile([], 95) is None
+
+    def test_single_value_returns_none(self) -> None:
+        assert _percentile([1.0], 95) is None
+
+    def test_two_values_p95_in_range(self) -> None:
+        result = _percentile([0.0, 1.0], 95)
+        assert result is not None
+        assert 0.0 <= result <= 1.0
+
+    def test_p95_higher_than_p50_with_outlier(self) -> None:
+        values = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 5.0]
+        p50 = _percentile(values, 50)
+        p95 = _percentile(values, 95)
+        assert p50 is not None and p95 is not None
+        assert p95 > p50
+
+    def test_uniform_values_returns_that_value(self) -> None:
+        result = _percentile([3.0, 3.0, 3.0], 95)
+        assert result == 3.0
+
+    def test_p100_returns_max(self) -> None:
+        values = [0.1, 0.5, 1.0]
+        assert _percentile(values, 100) == 1.0
+
+
+# ── _cv() unit tests ──────────────────────────────────────────────────────────
+
+
+class TestCV:
+    def test_empty_returns_none(self) -> None:
+        assert _cv([]) is None
+
+    def test_single_value_returns_none(self) -> None:
+        assert _cv([1.0]) is None
+
+    def test_zero_mean_returns_none(self) -> None:
+        assert _cv([0.0, 0.0]) is None
+
+    def test_identical_values_returns_zero(self) -> None:
+        result = _cv([2.0, 2.0, 2.0])
+        assert result == 0.0
+
+    def test_known_cv(self) -> None:
+        # mean=2.0, sample stdev=sqrt(2)≈1.414 → CV≈0.707
+        result = _cv([1.0, 3.0])
+        assert result is not None
+        assert abs(result - (2**0.5 / 2)) < 0.001
+
+    def test_high_variance_exceeds_threshold(self) -> None:
+        result = _cv([0.1, 1.9])
+        assert result is not None
+        assert result > 0.3
+
+    def test_low_variance_below_threshold(self) -> None:
+        result = _cv([0.30, 0.31])
+        assert result is not None
+        assert result < 0.3
+
+
+# ── print_ranking() variance / stability tests ────────────────────────────────
+
+
+class TestPrintRankingVariance:
+    def _make_row(
+        self,
+        *,
+        backend_id: str = "b",
+        model_id: str = "m",
+        context_size: int = 4096,
+        concurrency: int = 1,
+        repeat_index: int = 1,
+        ttft_s: float = 0.3,
+        throughput_tok_s: float = 80.0,
+        outcome: str = "ok",
+        cpu_offload_detected: bool = False,
+    ) -> dict[str, Any]:
+        return {
+            "backend_id": backend_id,
+            "model_id": model_id,
+            "context_size": context_size,
+            "concurrency": concurrency,
+            "repeat_index": repeat_index,
+            "ttft_s": ttft_s,
+            "throughput_tok_s": throughput_tok_s,
+            "outcome": outcome,
+            "cpu_offload_detected": cpu_offload_detected,
+            "tier": "speed",
+            "quality_task_success": None,
+        }
+
+    def test_header_includes_new_columns(self) -> None:
+        rows = [self._make_row()]
+        output = _capture(rows)
+        assert "TTFT p95(s)" in output
+        assert "CV" in output
+        assert "Stable" in output
+
+    def test_single_repeat_shows_dashes_for_p95_cv_stable(self) -> None:
+        rows = [self._make_row(ttft_s=0.3)]
+        output = _capture(rows)
+        # Single-repeat group: no [!] and no OK — stable column is "--"
+        assert "[!]" not in output
+        assert "OK" not in output
+
+    def test_multi_repeat_stable_shows_ok(self) -> None:
+        # ttft values [0.30, 0.31] → very low CV → stable
+        rows = [
+            self._make_row(repeat_index=1, ttft_s=0.30),
+            self._make_row(repeat_index=2, ttft_s=0.31),
+        ]
+        output = _capture(rows)
+        assert "OK" in output
+        assert "[!]" not in output
+
+    def test_multi_repeat_unstable_shows_warning(self) -> None:
+        # ttft values [0.1, 1.9] → CV ≈ 1.27 > 0.3 → unstable
+        rows = [
+            self._make_row(repeat_index=1, ttft_s=0.1),
+            self._make_row(repeat_index=2, ttft_s=1.9),
+        ]
+        output = _capture(rows)
+        assert "[!]" in output
+
+    def test_custom_cv_threshold_changes_stability(self) -> None:
+        # ttft [0.2, 0.4]: mean=0.3, stdev≈0.141, CV≈0.471
+        # default threshold 0.3 → unstable; relaxed threshold 0.5 → stable
+        rows = [
+            self._make_row(repeat_index=1, ttft_s=0.2),
+            self._make_row(repeat_index=2, ttft_s=0.4),
+        ]
+        output_strict = _capture(rows)  # cv_threshold=0.3 (default)
+        assert "[!]" in output_strict
+
+        output_relaxed = _capture(rows, cv_threshold=0.5)
+        assert "OK" in output_relaxed
+
+    def test_p95_appears_in_recommendation_for_multi_repeat(self) -> None:
+        rows = [
+            self._make_row(repeat_index=1, ttft_s=0.3),
+            self._make_row(repeat_index=2, ttft_s=0.32),
+        ]
+        output = _capture(rows)
+        assert "TTFT p95=" in output
+
+    def test_p95_absent_from_recommendation_for_single_repeat(self) -> None:
+        rows = [self._make_row(ttft_s=0.3)]
+        output = _capture(rows)
+        assert "TTFT p95=" not in output


### PR DESCRIPTION
Closes WOR-200

Ranking shows ttft_p50/p95/cv per config; unstable flag applied when cv>threshold; single-repeat groups unchanged; tests pass.