### PR TITLE
WOR-208 Adaptive benchmark scheduling: early OOM termination, context-cap discovery, and auto-escalation

### DIFF
--- a/scripts/bench/config.py
+++ b/scripts/bench/config.py
@@ -28,6 +28,8 @@ class MatrixConfig(BaseModel):
     boundary_context_sizes: list[int]
     concurrency_levels: list[int]
     repeats: int = 1
+    skip_oom_larger_ctx: bool = True
+    require_single_concurrency_first: bool = True
 
     @field_validator("context_sizes", "boundary_context_sizes", "concurrency_levels")
     @classmethod

--- a/scripts/bench/runner.py
+++ b/scripts/bench/runner.py
@@ -66,6 +66,59 @@ def _make_driver(backend_id: str, base_url: str) -> OllamaDriver | VllmDriver:
     return OllamaDriver(base_url=base_url)
 
 
+def _should_skip_oom(
+    case: BenchCase,
+    oom_ctx: dict[tuple[str, str], int],
+    skip_oom_larger_ctx: bool,
+) -> bool:
+    if not skip_oom_larger_ctx:
+        return False
+    threshold = oom_ctx.get((case.model_id, case.backend_id))
+    return threshold is not None and case.context_size > threshold
+
+
+def _should_skip_concurrency_gate(
+    case: BenchCase,
+    concurrency_gate: set[tuple[str, str, int]],
+    require_single_concurrency_first: bool,
+) -> bool:
+    if not require_single_concurrency_first or case.concurrency <= 1:
+        return False
+    return (case.model_id, case.backend_id, case.context_size) not in concurrency_gate
+
+
+def _update_adaptive_state(
+    case: BenchCase,
+    outcome: str,
+    oom_ctx: dict[tuple[str, str], int],
+    max_working_ctx: dict[tuple[str, str], int],
+    concurrency_gate: set[tuple[str, str, int]],
+) -> None:
+    key = (case.model_id, case.backend_id)
+    if outcome == "oom":
+        if key not in oom_ctx or case.context_size < oom_ctx[key]:
+            oom_ctx[key] = case.context_size
+    elif outcome == "ok":
+        if key not in max_working_ctx or case.context_size > max_working_ctx[key]:
+            max_working_ctx[key] = case.context_size
+        if case.concurrency == 1:
+            concurrency_gate.add((case.model_id, case.backend_id, case.context_size))
+
+
+def _make_skipped_run(run_id: str, case: BenchCase, outcome: str) -> BenchRun:
+    return BenchRun(
+        run_id=run_id,
+        case_id=_case_id(case),
+        repeat_index=case.repeat_index,
+        tier=case.tier,
+        context_size=case.context_size,
+        concurrency=case.concurrency,
+        backend_id=case.backend_id,
+        model_id=case.model_id,
+        outcome=outcome,
+    )
+
+
 def run(
     config_path: str,
     db_path: Path,
@@ -106,10 +159,19 @@ def run(
     # Tracks which models have had at least one prefill_shared run (for cache_state)
     prefill_shared_seen: set[str] = set()
 
+    # Adaptive scheduling state — per-session in-memory only, not persisted across runs
+    oom_ctx: dict[tuple[str, str], int] = {}
+    max_working_ctx: dict[tuple[str, str], int] = {}
+    concurrency_gate: set[tuple[str, str, int]] = set()
+
     for case in cases:
         row_run_id = _row_run_id(sweep_id, case)
 
-        if resume and store.get_by_run_id(row_run_id):
+        if resume and (existing := store.get_by_run_id(row_run_id)):
+            for row in existing:
+                _update_adaptive_state(
+                    case, row.outcome or "", oom_ctx, max_working_ctx, concurrency_gate
+                )
             print(
                 f"[SKIP] {case.model_id}/{case.tier}"
                 f"/ctx={case.context_size}/c={case.concurrency}/r={case.repeat_index}"
@@ -121,6 +183,28 @@ def run(
             print(
                 f"[WARN] Unknown backend {case.backend_id!r}, skipping",
                 file=sys.stderr,
+            )
+            continue
+
+        if _should_skip_oom(case, oom_ctx, config.matrix.skip_oom_larger_ctx):
+            store.record(_make_skipped_run(row_run_id, case, "skipped_oom"))
+            print(
+                f"[SKIP_OOM  ] {case.model_id} / {case.tier}"
+                f" / ctx={case.context_size} / c={case.concurrency}"
+                f" / r={case.repeat_index}"
+            )
+            continue
+
+        if _should_skip_concurrency_gate(
+            case, concurrency_gate, config.matrix.require_single_concurrency_first
+        ):
+            store.record(
+                _make_skipped_run(row_run_id, case, "skipped_concurrency_gate")
+            )
+            print(
+                f"[SKIP_GATE ] {case.model_id} / {case.tier}"
+                f" / ctx={case.context_size} / c={case.concurrency}"
+                f" / r={case.repeat_index}"
             )
             continue
 
@@ -293,6 +377,9 @@ def run(
 
         # Write before moving to next case (resume safety invariant)
         store.record(bench_run)
+        _update_adaptive_state(
+            case, outcome, oom_ctx, max_working_ctx, concurrency_gate
+        )
 
         ttft_str = f" ttft={result.ttft_s:.2f}s" if result.ttft_s else ""
         tok_str = f" tok/s={throughput_tok_s:.0f}" if throughput_tok_s else ""
@@ -304,6 +391,11 @@ def run(
         )
 
     print("\nRun complete.")
+
+    if max_working_ctx:
+        print("Max working context per (model, backend):")
+        for (model_id, backend_id), ctx in sorted(max_working_ctx.items()):
+            print(f"  {model_id} / {backend_id}: {ctx}")
 
     from scripts.bench import reporter
 

--- a/tests/bench/test_bench_config.py
+++ b/tests/bench/test_bench_config.py
@@ -227,3 +227,69 @@ name = "speed"
 """
     cfg = BenchConfig.from_toml(_write_toml(tmp_path, toml))
     assert cfg.models[0].quant is None
+
+
+def test_matrix_skip_oom_larger_ctx_defaults_to_true(tmp_path: Path) -> None:
+    cfg = BenchConfig.from_toml(_write_toml(tmp_path, _STANDARD_TOML))
+    assert cfg.matrix.skip_oom_larger_ctx is True
+
+
+def test_matrix_require_single_concurrency_first_defaults_to_true(
+    tmp_path: Path,
+) -> None:
+    cfg = BenchConfig.from_toml(_write_toml(tmp_path, _STANDARD_TOML))
+    assert cfg.matrix.require_single_concurrency_first is True
+
+
+def test_matrix_skip_oom_larger_ctx_can_be_disabled(tmp_path: Path) -> None:
+    toml = """
+[matrix]
+context_sizes = [1024]
+boundary_context_sizes = [8192]
+concurrency_levels = [1]
+repeats = 1
+skip_oom_larger_ctx = false
+
+[[backends]]
+id = "local_a"
+enabled = true
+base_url = "http://localhost:1/"
+api_key = "x"
+
+[[models]]
+id = "m"
+backend_id = "local_a"
+
+[[tiers]]
+name = "speed"
+"""
+    cfg = BenchConfig.from_toml(_write_toml(tmp_path, toml))
+    assert cfg.matrix.skip_oom_larger_ctx is False
+
+
+def test_matrix_require_single_concurrency_first_can_be_disabled(
+    tmp_path: Path,
+) -> None:
+    toml = """
+[matrix]
+context_sizes = [1024]
+boundary_context_sizes = [8192]
+concurrency_levels = [1]
+repeats = 1
+require_single_concurrency_first = false
+
+[[backends]]
+id = "local_a"
+enabled = true
+base_url = "http://localhost:1/"
+api_key = "x"
+
+[[models]]
+id = "m"
+backend_id = "local_a"
+
+[[tiers]]
+name = "speed"
+"""
+    cfg = BenchConfig.from_toml(_write_toml(tmp_path, toml))
+    assert cfg.matrix.require_single_concurrency_first is False

--- a/tests/bench/test_runner.py
+++ b/tests/bench/test_runner.py
@@ -4,9 +4,19 @@ from __future__ import annotations
 
 import pytest
 
+from scripts.bench.config import BenchCase
 from scripts.bench.drivers.ollama import OllamaDriver
 from scripts.bench.drivers.vllm import VllmDriver
-from scripts.bench.runner import _case_id, _is_oom, _make_driver, _make_prompt
+from scripts.bench.runner import (
+    _case_id,
+    _is_oom,
+    _make_driver,
+    _make_prompt,
+    _make_skipped_run,
+    _should_skip_concurrency_gate,
+    _should_skip_oom,
+    _update_adaptive_state,
+)
 from scripts.bench.tasks import BenchPrompt
 
 # ---------------------------------------------------------------------------
@@ -106,3 +116,206 @@ def test_case_id_format() -> None:
     case.context_size = 4096
     case.concurrency = 1
     assert _case_id(case) == "ollama/qwen3:30b/speed/4096/1"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _case(
+    context_size: int = 4096,
+    concurrency: int = 1,
+    model_id: str = "model-1",
+    backend_id: str = "ollama",
+) -> BenchCase:
+    return BenchCase(
+        backend_id=backend_id,
+        model_id=model_id,
+        tier="speed",
+        context_size=context_size,
+        concurrency=concurrency,
+        repeat_index=1,
+    )
+
+
+# ---------------------------------------------------------------------------
+# _should_skip_oom
+# ---------------------------------------------------------------------------
+
+
+def test_skip_oom_skips_larger_ctx() -> None:
+    oom: dict[tuple[str, str], int] = {("model-1", "ollama"): 4096}
+    assert _should_skip_oom(_case(context_size=8192), oom, True) is True
+
+
+def test_skip_oom_does_not_skip_same_ctx() -> None:
+    oom: dict[tuple[str, str], int] = {("model-1", "ollama"): 4096}
+    assert _should_skip_oom(_case(context_size=4096), oom, True) is False
+
+
+def test_skip_oom_does_not_skip_smaller_ctx() -> None:
+    oom: dict[tuple[str, str], int] = {("model-1", "ollama"): 4096}
+    assert _should_skip_oom(_case(context_size=2048), oom, True) is False
+
+
+def test_skip_oom_respects_flag_disabled() -> None:
+    oom: dict[tuple[str, str], int] = {("model-1", "ollama"): 4096}
+    assert _should_skip_oom(_case(context_size=8192), oom, False) is False
+
+
+def test_skip_oom_no_oom_recorded() -> None:
+    assert _should_skip_oom(_case(context_size=8192), {}, True) is False
+
+
+def test_skip_oom_different_model_not_affected() -> None:
+    oom: dict[tuple[str, str], int] = {("model-2", "ollama"): 4096}
+    assert (
+        _should_skip_oom(_case(context_size=8192, model_id="model-1"), oom, True)
+        is False
+    )
+
+
+# ---------------------------------------------------------------------------
+# _should_skip_concurrency_gate
+# ---------------------------------------------------------------------------
+
+
+def test_skip_gate_blocks_when_no_c1_success() -> None:
+    gate: set[tuple[str, str, int]] = set()
+    assert _should_skip_concurrency_gate(_case(concurrency=2), gate, True) is True
+
+
+def test_skip_gate_allows_concurrency_1() -> None:
+    gate: set[tuple[str, str, int]] = set()
+    assert _should_skip_concurrency_gate(_case(concurrency=1), gate, True) is False
+
+
+def test_skip_gate_allows_after_c1_success() -> None:
+    gate: set[tuple[str, str, int]] = {("model-1", "ollama", 4096)}
+    assert (
+        _should_skip_concurrency_gate(
+            _case(concurrency=2, context_size=4096), gate, True
+        )
+        is False
+    )
+
+
+def test_skip_gate_respects_flag_disabled() -> None:
+    gate: set[tuple[str, str, int]] = set()
+    assert _should_skip_concurrency_gate(_case(concurrency=2), gate, False) is False
+
+
+def test_skip_gate_different_ctx_not_unlocked() -> None:
+    gate: set[tuple[str, str, int]] = {("model-1", "ollama", 8192)}
+    assert (
+        _should_skip_concurrency_gate(
+            _case(concurrency=2, context_size=4096), gate, True
+        )
+        is True
+    )
+
+
+# ---------------------------------------------------------------------------
+# _update_adaptive_state
+# ---------------------------------------------------------------------------
+
+
+def test_update_state_oom_sets_threshold() -> None:
+    oom_ctx: dict[tuple[str, str], int] = {}
+    max_working: dict[tuple[str, str], int] = {}
+    gate: set[tuple[str, str, int]] = set()
+    _update_adaptive_state(_case(context_size=4096), "oom", oom_ctx, max_working, gate)
+    assert oom_ctx[("model-1", "ollama")] == 4096
+
+
+def test_update_state_oom_keeps_minimum() -> None:
+    oom_ctx: dict[tuple[str, str], int] = {("model-1", "ollama"): 8192}
+    max_working: dict[tuple[str, str], int] = {}
+    gate: set[tuple[str, str, int]] = set()
+    _update_adaptive_state(_case(context_size=4096), "oom", oom_ctx, max_working, gate)
+    assert oom_ctx[("model-1", "ollama")] == 4096
+
+
+def test_update_state_oom_does_not_lower_existing_threshold() -> None:
+    oom_ctx: dict[tuple[str, str], int] = {("model-1", "ollama"): 4096}
+    max_working: dict[tuple[str, str], int] = {}
+    gate: set[tuple[str, str, int]] = set()
+    _update_adaptive_state(_case(context_size=8192), "oom", oom_ctx, max_working, gate)
+    assert oom_ctx[("model-1", "ollama")] == 4096
+
+
+def test_update_state_ok_updates_max_working_ctx() -> None:
+    oom_ctx: dict[tuple[str, str], int] = {}
+    max_working: dict[tuple[str, str], int] = {}
+    gate: set[tuple[str, str, int]] = set()
+    _update_adaptive_state(_case(context_size=4096), "ok", oom_ctx, max_working, gate)
+    assert max_working[("model-1", "ollama")] == 4096
+
+
+def test_update_state_ok_keeps_maximum() -> None:
+    oom_ctx: dict[tuple[str, str], int] = {}
+    max_working: dict[tuple[str, str], int] = {("model-1", "ollama"): 8192}
+    gate: set[tuple[str, str, int]] = set()
+    _update_adaptive_state(_case(context_size=4096), "ok", oom_ctx, max_working, gate)
+    assert max_working[("model-1", "ollama")] == 8192
+
+
+def test_update_state_ok_c1_opens_gate() -> None:
+    oom_ctx: dict[tuple[str, str], int] = {}
+    max_working: dict[tuple[str, str], int] = {}
+    gate: set[tuple[str, str, int]] = set()
+    _update_adaptive_state(
+        _case(context_size=4096, concurrency=1), "ok", oom_ctx, max_working, gate
+    )
+    assert ("model-1", "ollama", 4096) in gate
+
+
+def test_update_state_ok_c2_does_not_open_gate() -> None:
+    oom_ctx: dict[tuple[str, str], int] = {}
+    max_working: dict[tuple[str, str], int] = {}
+    gate: set[tuple[str, str, int]] = set()
+    _update_adaptive_state(
+        _case(context_size=4096, concurrency=2), "ok", oom_ctx, max_working, gate
+    )
+    assert ("model-1", "ollama", 4096) not in gate
+
+
+def test_update_state_error_does_not_open_gate() -> None:
+    oom_ctx: dict[tuple[str, str], int] = {}
+    max_working: dict[tuple[str, str], int] = {}
+    gate: set[tuple[str, str, int]] = set()
+    _update_adaptive_state(
+        _case(context_size=4096, concurrency=1), "error", oom_ctx, max_working, gate
+    )
+    assert ("model-1", "ollama", 4096) not in gate
+
+
+# ---------------------------------------------------------------------------
+# _make_skipped_run
+# ---------------------------------------------------------------------------
+
+
+def test_make_skipped_run_skipped_oom_outcome() -> None:
+    case = _case(context_size=8192, concurrency=1)
+    run = _make_skipped_run("sweep::case::1", case, "skipped_oom")
+    assert run.outcome == "skipped_oom"
+    assert run.context_size == 8192
+    assert run.repeat_index == 1
+
+
+def test_make_skipped_run_skipped_concurrency_gate_outcome() -> None:
+    case = _case(context_size=4096, concurrency=2)
+    run = _make_skipped_run("sweep::case::1", case, "skipped_concurrency_gate")
+    assert run.outcome == "skipped_concurrency_gate"
+    assert run.concurrency == 2
+
+
+def test_make_skipped_run_carries_case_fields() -> None:
+    case = _case(
+        context_size=16384, concurrency=1, model_id="mymodel", backend_id="vllm"
+    )
+    run = _make_skipped_run("sid::cid::0", case, "skipped_oom")
+    assert run.model_id == "mymodel"
+    assert run.backend_id == "vllm"
+    assert run.tier == "speed"


### PR DESCRIPTION
Closes WOR-208

OOM cases skip all larger contexts for that model; concurrency gate prevents higher-concurrency runs until baseline is stable; both behaviors are config-toggleable; skipped cases recorded in DB; tests pass.