### PR TITLE
WOR-201 Compute and display APC effectiveness ratio from prefill tier results

### DIFF
--- a/scripts/bench/reporter.py
+++ b/scripts/bench/reporter.py
@@ -82,6 +82,15 @@ def _cv(values: list[float]) -> float | None:
     return statistics.stdev(values) / m
 
 
+def _get_ttft(row: dict[str, Any]) -> float | None:
+    """Prefer prompt_eval_duration_s; fall back to ttft_s."""
+    for key in ("prompt_eval_duration_s", "ttft_s"):
+        v = row.get(key)
+        if v is not None:
+            return float(v)
+    return None
+
+
 # ── Summary table ─────────────────────────────────────────────────────────────
 
 _SUMMARY_COLS = [
@@ -286,6 +295,7 @@ def print_ranking(
             for config_key, reason in ineligible:
                 print(f"  {config_key}  [{reason}]")
             print()
+        print_apc_section(rows)
         return
 
     # Sort by TTFT p50 ascending (lower is better); fall back to tok/s descending
@@ -350,6 +360,99 @@ def print_ranking(
         for config_key, reason in ineligible:
             print(f"  {config_key}  [{reason}]")
         print()
+
+    print_apc_section(rows)
+
+
+# ── APC effectiveness ─────────────────────────────────────────────────────────
+
+
+def compute_apc_speedup(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Compute KV-cache speedup ratio per (model_id, context_size, concurrency).
+
+    Only prefill_shared / prefill_unshared tier rows (repeat_index >= 1) are used.
+    Returns a list of dicts; apc_speedup_ratio is None when either tier is absent
+    or shared TTFT is zero (division-by-zero guard).
+    """
+    shared_ttfts: dict[tuple[str, Any, Any], list[float]] = {}
+    unshared_ttfts: dict[tuple[str, Any, Any], list[float]] = {}
+
+    for row in rows:
+        tier = row.get("tier")
+        if tier not in ("prefill_shared", "prefill_unshared"):
+            continue
+        if row.get("repeat_index", 0) < 1:
+            continue
+        ttft = _get_ttft(row)
+        if ttft is None:
+            continue
+        key: tuple[str, Any, Any] = (
+            str(row.get("model_id") or ""),
+            row.get("context_size"),
+            row.get("concurrency"),
+        )
+        target = shared_ttfts if tier == "prefill_shared" else unshared_ttfts
+        target.setdefault(key, []).append(ttft)
+
+    all_keys = sorted(
+        set(shared_ttfts) | set(unshared_ttfts),
+        key=lambda k: (k[0], k[1] or 0, k[2] or 0),
+    )
+    results: list[dict[str, Any]] = []
+    for key in all_keys:
+        model, context_size, concurrency = key
+        shared_p50 = _median(shared_ttfts.get(key, []))
+        unshared_p50 = _median(unshared_ttfts.get(key, []))
+        ratio: float | None = None
+        if shared_p50 is not None and shared_p50 > 0 and unshared_p50 is not None:
+            ratio = unshared_p50 / shared_p50
+        results.append(
+            {
+                "model": model,
+                "context_size": context_size,
+                "concurrency": concurrency,
+                "shared_ttft_p50": shared_p50,
+                "unshared_ttft_p50": unshared_p50,
+                "apc_speedup_ratio": ratio,
+            }
+        )
+    return results
+
+
+_APC_W = 79
+
+
+def print_apc_section(rows: list[dict[str, Any]]) -> None:
+    """Print APC effectiveness table if prefill-tier rows are present."""
+    entries = compute_apc_speedup(rows)
+    if not entries:
+        return
+
+    print("=" * _APC_W)
+    print("APC EFFECTIVENESS  (speedup = prefill_unshared_ttft / prefill_shared_ttft)")
+    print("=" * _APC_W)
+    header = (
+        f"{'Model':<25}  {'Ctx':>6}  {'C':>3}  "
+        f"{'Shared p50(s)':>13}  {'Unshared p50(s)':>15}  {'Speedup':>7}"
+    )
+    print(header)
+    print("-" * _APC_W)
+
+    for entry in entries:
+        model_str = str(entry["model"] or "--")[:25]
+        ctx_str = _fmt(entry["context_size"])
+        c_str = _fmt(entry["concurrency"])
+        shared_str = _fmt(entry["shared_ttft_p50"], ".3f")
+        unshared_str = _fmt(entry["unshared_ttft_p50"], ".3f")
+        ratio = entry["apc_speedup_ratio"]
+        ratio_str = f"{ratio:.2f}x" if ratio is not None else "N/A"
+        line = (
+            f"{model_str:<25}  {ctx_str:>6}  {c_str:>3}  "
+            f"{shared_str:>13}  {unshared_str:>15}  {ratio_str:>7}"
+        )
+        print(line)
+
+    print("=" * _APC_W + "\n")
 
 
 # ── Compare table ─────────────────────────────────────────────────────────────

--- a/tests/bench/test_reporter.py
+++ b/tests/bench/test_reporter.py
@@ -6,7 +6,16 @@ import io
 from contextlib import redirect_stdout
 from typing import Any
 
-from scripts.bench.reporter import _cv, _is_eligible, _percentile, print_ranking
+import pytest
+
+from scripts.bench.reporter import (
+    _cv,
+    _is_eligible,
+    _percentile,
+    compute_apc_speedup,
+    print_apc_section,
+    print_ranking,
+)
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -488,3 +497,175 @@ class TestPrintRankingVariance:
         rows = [self._make_row(ttft_s=0.3)]
         output = _capture(rows)
         assert "TTFT p95=" not in output
+
+
+# ── APC speedup tests ─────────────────────────────────────────────────────────
+
+
+def _prefill_row(
+    tier: str,
+    *,
+    model_id: str = "m",
+    context_size: int = 4096,
+    concurrency: int = 1,
+    repeat_index: int = 1,
+    ttft_s: float | None = 1.0,
+    prompt_eval_duration_s: float | None = None,
+    backend_id: str = "b",
+) -> dict[str, Any]:
+    return {
+        "tier": tier,
+        "model_id": model_id,
+        "context_size": context_size,
+        "concurrency": concurrency,
+        "repeat_index": repeat_index,
+        "ttft_s": ttft_s,
+        "prompt_eval_duration_s": prompt_eval_duration_s,
+        "backend_id": backend_id,
+    }
+
+
+class TestComputeApcSpeedup:
+    def test_both_tiers_computes_ratio(self) -> None:
+        rows = [
+            _prefill_row("prefill_shared", ttft_s=1.0),
+            _prefill_row("prefill_unshared", ttft_s=2.0),
+        ]
+        results = compute_apc_speedup(rows)
+        assert len(results) == 1
+        r = results[0]
+        assert r["shared_ttft_p50"] == pytest.approx(1.0)
+        assert r["unshared_ttft_p50"] == pytest.approx(2.0)
+        assert r["apc_speedup_ratio"] == pytest.approx(2.0)
+
+    def test_only_shared_ratio_is_none(self) -> None:
+        rows = [_prefill_row("prefill_shared", ttft_s=0.5)]
+        results = compute_apc_speedup(rows)
+        assert len(results) == 1
+        assert results[0]["apc_speedup_ratio"] is None
+        assert results[0]["unshared_ttft_p50"] is None
+
+    def test_only_unshared_ratio_is_none(self) -> None:
+        rows = [_prefill_row("prefill_unshared", ttft_s=2.0)]
+        results = compute_apc_speedup(rows)
+        assert len(results) == 1
+        assert results[0]["apc_speedup_ratio"] is None
+        assert results[0]["shared_ttft_p50"] is None
+
+    def test_zero_shared_ttft_ratio_is_none(self) -> None:
+        rows = [
+            _prefill_row("prefill_shared", ttft_s=0.0),
+            _prefill_row("prefill_unshared", ttft_s=2.0),
+        ]
+        results = compute_apc_speedup(rows)
+        assert results[0]["apc_speedup_ratio"] is None
+
+    def test_uses_prompt_eval_duration_s_over_ttft_s(self) -> None:
+        rows = [
+            _prefill_row("prefill_shared", ttft_s=1.0, prompt_eval_duration_s=0.5),
+            _prefill_row("prefill_unshared", ttft_s=2.0, prompt_eval_duration_s=1.5),
+        ]
+        results = compute_apc_speedup(rows)
+        r = results[0]
+        assert r["shared_ttft_p50"] == pytest.approx(0.5)
+        assert r["unshared_ttft_p50"] == pytest.approx(1.5)
+        assert r["apc_speedup_ratio"] == pytest.approx(3.0)
+
+    def test_falls_back_to_ttft_s_when_no_prompt_eval(self) -> None:
+        rows = [
+            _prefill_row("prefill_shared", ttft_s=0.8, prompt_eval_duration_s=None),
+            _prefill_row("prefill_unshared", ttft_s=1.6, prompt_eval_duration_s=None),
+        ]
+        results = compute_apc_speedup(rows)
+        assert results[0]["shared_ttft_p50"] == pytest.approx(0.8)
+        assert results[0]["apc_speedup_ratio"] == pytest.approx(2.0)
+
+    def test_warmup_runs_excluded(self) -> None:
+        rows = [
+            _prefill_row("prefill_shared", ttft_s=0.5, repeat_index=0),
+            _prefill_row("prefill_unshared", ttft_s=2.0, repeat_index=0),
+        ]
+        assert compute_apc_speedup(rows) == []
+
+    def test_non_prefill_tiers_ignored(self) -> None:
+        rows = [
+            _prefill_row("speed", ttft_s=0.5),
+            _prefill_row("coding", ttft_s=1.0),
+            _prefill_row("prefill_shared", ttft_s=0.5),
+        ]
+        results = compute_apc_speedup(rows)
+        assert len(results) == 1
+
+    def test_multiple_configs_grouped_separately(self) -> None:
+        rows = [
+            _prefill_row("prefill_shared", model_id="A", context_size=4096, ttft_s=1.0),
+            _prefill_row(
+                "prefill_unshared", model_id="A", context_size=4096, ttft_s=3.0
+            ),
+            _prefill_row("prefill_shared", model_id="B", context_size=8192, ttft_s=2.0),
+            _prefill_row(
+                "prefill_unshared", model_id="B", context_size=8192, ttft_s=4.0
+            ),
+        ]
+        results = compute_apc_speedup(rows)
+        assert len(results) == 2
+        a = next(r for r in results if r["model"] == "A")
+        b = next(r for r in results if r["model"] == "B")
+        assert a["apc_speedup_ratio"] == pytest.approx(3.0)
+        assert b["apc_speedup_ratio"] == pytest.approx(2.0)
+
+    def test_median_used_for_multiple_runs(self) -> None:
+        rows = [
+            _prefill_row("prefill_shared", ttft_s=1.0, repeat_index=1),
+            _prefill_row("prefill_shared", ttft_s=3.0, repeat_index=2),
+            _prefill_row("prefill_unshared", ttft_s=4.0, repeat_index=1),
+        ]
+        results = compute_apc_speedup(rows)
+        # median of [1.0, 3.0] = 2.0; ratio = 4.0 / 2.0 = 2.0
+        assert results[0]["shared_ttft_p50"] == pytest.approx(2.0)
+        assert results[0]["apc_speedup_ratio"] == pytest.approx(2.0)
+
+    def test_empty_rows_returns_empty(self) -> None:
+        assert compute_apc_speedup([]) == []
+
+
+class TestPrintApcSection:
+    def _capture_apc(self, rows: list[dict[str, Any]]) -> str:
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            print_apc_section(rows)
+        return buf.getvalue()
+
+    def test_no_prefill_rows_no_output(self) -> None:
+        rows = [_row(tier="speed")]
+        assert self._capture_apc(rows) == ""
+
+    def test_shows_apc_header(self) -> None:
+        rows = [
+            _prefill_row("prefill_shared", ttft_s=0.5),
+            _prefill_row("prefill_unshared", ttft_s=1.5),
+        ]
+        output = self._capture_apc(rows)
+        assert "APC EFFECTIVENESS" in output
+        assert "Speedup" in output
+
+    def test_shows_na_for_missing_tier(self) -> None:
+        rows = [_prefill_row("prefill_shared", ttft_s=0.5)]
+        output = self._capture_apc(rows)
+        assert "N/A" in output
+
+    def test_shows_speedup_ratio(self) -> None:
+        rows = [
+            _prefill_row("prefill_shared", ttft_s=1.0),
+            _prefill_row("prefill_unshared", ttft_s=3.0),
+        ]
+        output = self._capture_apc(rows)
+        assert "3.00x" in output
+
+    def test_ranking_includes_apc_section_when_prefill_rows_present(self) -> None:
+        rows = [
+            _prefill_row("prefill_shared", ttft_s=0.5),
+            _prefill_row("prefill_unshared", ttft_s=1.5),
+        ]
+        output = _capture(rows)
+        assert "APC EFFECTIVENESS" in output


### PR DESCRIPTION
Closes WOR-201

APC speedup ratio computed and shown in ranking when both prefill tiers present; division-by-zero safe; uses prompt_eval_duration_s; tests pass.