### PR TITLE
WOR-202 Distinguish TTFT from TTFUT for thinking models in benchmark

### DIFF
--- a/app/core/bench_store.py
+++ b/app/core/bench_store.py
@@ -38,6 +38,7 @@ CREATE TABLE IF NOT EXISTS bench_run (
     python_version          TEXT,
     os_version              TEXT,
     ttft_s                  REAL,
+    ttfut_s                 REAL,
     wall_time_s             REAL,
     throughput_tok_s        REAL,
     prompt_eval_duration_s  REAL,
@@ -83,7 +84,7 @@ INSERT INTO bench_run (
     tier, context_size, concurrency, backend_id, model_id,
     settings_hash, prompt_hash,
     backend_base_url, gpu_driver_version, cuda_version, python_version, os_version,
-    ttft_s, wall_time_s, throughput_tok_s,
+    ttft_s, ttfut_s, wall_time_s, throughput_tok_s,
     prompt_eval_duration_s, load_duration_s, decode_time_s,
     prompt_tokens, completion_tokens, total_tokens,
     peak_vram_gb, total_vram_gb,
@@ -99,7 +100,7 @@ INSERT INTO bench_run (
     :tier, :context_size, :concurrency, :backend_id, :model_id,
     :settings_hash, :prompt_hash,
     :backend_base_url, :gpu_driver_version, :cuda_version, :python_version, :os_version,
-    :ttft_s, :wall_time_s, :throughput_tok_s,
+    :ttft_s, :ttfut_s, :wall_time_s, :throughput_tok_s,
     :prompt_eval_duration_s, :load_duration_s, :decode_time_s,
     :prompt_tokens, :completion_tokens, :total_tokens,
     :peak_vram_gb, :total_vram_gb,
@@ -154,6 +155,10 @@ class BenchRun(BaseModel):
     # timing
     ttft_s: float | None = Field(
         default=None, description="Time to first token in seconds"
+    )
+    ttfut_s: float | None = Field(
+        default=None,
+        description="Time to first user-visible token in seconds (post-</think>)",
     )
     wall_time_s: float | None = Field(
         default=None, description="Total wall time in seconds"
@@ -258,6 +263,8 @@ class BenchStore:
             conn.execute("ALTER TABLE bench_run ADD COLUMN model_quant TEXT")
         if "model_family" not in existing:
             conn.execute("ALTER TABLE bench_run ADD COLUMN model_family TEXT")
+        if "ttfut_s" not in existing:
+            conn.execute("ALTER TABLE bench_run ADD COLUMN ttfut_s REAL")
 
     @contextmanager
     def _connect(self) -> Generator[sqlite3.Connection, None, None]:

--- a/scripts/bench/drivers/base.py
+++ b/scripts/bench/drivers/base.py
@@ -13,6 +13,7 @@ class GenerationResult:
     error: str | None = None
     text: str = ""
     ttft_s: float | None = None
+    ttfut_s: float | None = None
     decode_time_s: float | None = None
     prompt_eval_duration_s: float | None = None
     load_duration_s: float | None = None

--- a/scripts/bench/drivers/ollama.py
+++ b/scripts/bench/drivers/ollama.py
@@ -96,8 +96,14 @@ class OllamaDriver:
 
     def _parse_streaming(self, resp: Any, t_start: float) -> GenerationResult:
         ttft_s: float | None = None
+        ttfut_s: float | None = None
         text_parts: list[str] = []
         final_frame: dict[str, Any] = {}
+
+        _THINK_TAG = "</think>"
+        _TAIL_LEN = len(_THINK_TAG) - 1
+        thinking_phase: bool = True
+        tail_buf: str = ""
 
         while True:
             raw = resp.readline()
@@ -115,6 +121,21 @@ class OllamaDriver:
                 content: str = frame.get("message", {}).get("content", "")
                 if content and ttft_s is None:
                     ttft_s = time.monotonic() - t_start
+                if thinking_phase and content:
+                    check = tail_buf + content
+                    idx = check.find(_THINK_TAG)
+                    if idx >= 0:
+                        thinking_phase = False
+                        after = check[idx + len(_THINK_TAG) :]
+                        if after:
+                            ttfut_s = time.monotonic() - t_start
+                        tail_buf = ""
+                    else:
+                        tail_buf = (
+                            check[-_TAIL_LEN:] if len(check) > _TAIL_LEN else check
+                        )
+                elif not thinking_phase and content and ttfut_s is None:
+                    ttfut_s = time.monotonic() - t_start
                 text_parts.append(content)
             else:
                 final_frame = frame
@@ -149,6 +170,7 @@ class OllamaDriver:
         return GenerationResult(
             text="".join(text_parts),
             ttft_s=ttft_s,
+            ttfut_s=ttfut_s,
             decode_time_s=decode_time_s,
             prompt_eval_duration_s=prompt_eval_duration_s,
             load_duration_s=load_duration_s,

--- a/scripts/bench/reporter.py
+++ b/scripts/bench/reporter.py
@@ -116,8 +116,14 @@ def print_summary_table(rows: list[dict[str, Any]]) -> None:
         print("\n(no results for this sweep)")
         return
 
-    header = "  ".join(name.ljust(w) for name, w in _SUMMARY_COLS)
-    sep = "  ".join("-" * w for _, w in _SUMMARY_COLS)
+    show_ttfut = any(r.get("ttfut_s") is not None for r in rows)
+    cols = list(_SUMMARY_COLS)
+    if show_ttfut:
+        ttft_idx = next(i for i, (name, _) in enumerate(cols) if name == "TTFT(s)")
+        cols.insert(ttft_idx + 1, ("TTFUT(s)", 8))
+
+    header = "  ".join(name.ljust(w) for name, w in cols)
+    sep = "  ".join("-" * w for _, w in cols)
     print(f"\n{'=' * len(sep)}")
     print("SWEEP SUMMARY")
     print(f"{'=' * len(sep)}")
@@ -134,6 +140,10 @@ def print_summary_table(rows: list[dict[str, Any]]) -> None:
             _fmt(r.get("concurrency")),
             _fmt(r.get("repeat_index")),
             _fmt(r.get("ttft_s"), ".2f"),
+        ]
+        if show_ttfut:
+            vals.append(_fmt(r.get("ttfut_s"), ".2f"))
+        vals += [
             _fmt(r.get("wall_time_s"), ".2f"),
             _fmt(r.get("throughput_tok_s"), ".0f"),
             _fmt(r.get("peak_vram_gb"), ".1f"),
@@ -142,7 +152,7 @@ def print_summary_table(rows: list[dict[str, Any]]) -> None:
             "Yes" if offload else "No",
             str(r.get("outcome") or "--")[:7],
         ]
-        line = "  ".join(v.ljust(w) for v, (_, w) in zip(vals, _SUMMARY_COLS))
+        line = "  ".join(v.ljust(w) for v, (_, w) in zip(vals, cols))
         print(line)
 
     print(f"{'=' * len(sep)}\n")

--- a/scripts/bench/runner.py
+++ b/scripts/bench/runner.py
@@ -344,6 +344,7 @@ def run(
             python_version=env.python_version,
             os_version=env.os_version,
             ttft_s=result.ttft_s if not oom else None,
+            ttfut_s=result.ttfut_s if not oom else None,
             wall_time_s=wall_time_s if not oom else None,
             throughput_tok_s=throughput_tok_s,
             prompt_eval_duration_s=result.prompt_eval_duration_s,

--- a/tests/bench/test_bench_drivers.py
+++ b/tests/bench/test_bench_drivers.py
@@ -302,6 +302,162 @@ def test_ollama_generate_cache_state_captured_from_response():
     assert result.cache_state == "loaded"
 
 
+def test_ollama_non_thinking_model_ttfut_is_none():
+    """Non-thinking models never emit </think>, so ttfut_s must remain None."""
+    with patch("urllib.request.urlopen", _mock_urlopen(_OLLAMA_COLD_BODY)):
+        result = OllamaDriver().generate(
+            "q", [{"role": "user", "content": "hi"}], 4096, 256, 0.7, None
+        )
+
+    assert result.ttfut_s is None
+
+
+_OLLAMA_THINKING_SAME_CHUNK = _ndjson(
+    {
+        "model": "q",
+        "message": {"role": "assistant", "content": "</think>Answer"},
+        "done": False,
+    },
+    {
+        "model": "q",
+        "done": True,
+        "done_reason": "stop",
+        "load_duration": 0,
+        "prompt_eval_count": 5,
+        "prompt_eval_duration": 50_000_000,
+        "eval_count": 10,
+        "eval_duration": 200_000_000,
+    },
+)
+
+
+def test_ollama_thinking_model_ttfut_set_when_answer_in_same_chunk():
+    """ttfut_s is set when </think> and the first answer token are in the same chunk."""
+    with patch("urllib.request.urlopen", _mock_urlopen(_OLLAMA_THINKING_SAME_CHUNK)):
+        result = OllamaDriver().generate(
+            "q", [{"role": "user", "content": "hi"}], 4096, 256, 0.7, None
+        )
+
+    assert result.ttfut_s is not None and result.ttfut_s >= 0.0
+    assert result.ttft_s is not None
+
+
+_OLLAMA_THINKING_SEPARATE_CHUNKS = _ndjson(
+    {
+        "model": "q",
+        "message": {"role": "assistant", "content": "<think>reasoning"},
+        "done": False,
+    },
+    {
+        "model": "q",
+        "message": {"role": "assistant", "content": "</think>"},
+        "done": False,
+    },
+    {
+        "model": "q",
+        "message": {"role": "assistant", "content": "The answer"},
+        "done": False,
+    },
+    {
+        "model": "q",
+        "done": True,
+        "done_reason": "stop",
+        "load_duration": 0,
+        "prompt_eval_count": 5,
+        "prompt_eval_duration": 50_000_000,
+        "eval_count": 10,
+        "eval_duration": 200_000_000,
+    },
+)
+
+
+def test_ollama_thinking_model_ttfut_set_after_think_tag_separate_chunk():
+    """ttfut_s is set on the first content chunk that follows </think>."""
+    with patch(
+        "urllib.request.urlopen", _mock_urlopen(_OLLAMA_THINKING_SEPARATE_CHUNKS)
+    ):
+        result = OllamaDriver().generate(
+            "q", [{"role": "user", "content": "hi"}], 4096, 256, 0.7, None
+        )
+
+    assert result.ttfut_s is not None and result.ttfut_s >= 0.0
+
+
+_OLLAMA_THINKING_SPLIT_TAG = _ndjson(
+    {
+        "model": "q",
+        "message": {"role": "assistant", "content": "<think>reasoning</thi"},
+        "done": False,
+    },
+    {
+        "model": "q",
+        "message": {"role": "assistant", "content": "nk>"},
+        "done": False,
+    },
+    {
+        "model": "q",
+        "message": {"role": "assistant", "content": "The answer"},
+        "done": False,
+    },
+    {
+        "model": "q",
+        "done": True,
+        "done_reason": "stop",
+        "load_duration": 0,
+        "prompt_eval_count": 5,
+        "prompt_eval_duration": 50_000_000,
+        "eval_count": 10,
+        "eval_duration": 200_000_000,
+    },
+)
+
+
+def test_ollama_thinking_model_ttfut_detects_split_think_tag():
+    """</think> split across two chunk boundaries is still detected correctly."""
+    with patch("urllib.request.urlopen", _mock_urlopen(_OLLAMA_THINKING_SPLIT_TAG)):
+        result = OllamaDriver().generate(
+            "q", [{"role": "user", "content": "hi"}], 4096, 256, 0.7, None
+        )
+
+    assert result.ttfut_s is not None and result.ttfut_s >= 0.0
+
+
+_OLLAMA_THINKING_EMPTY_CONTENT = _ndjson(
+    {"model": "q", "message": {"role": "assistant", "content": ""}, "done": False},
+    {"model": "q", "message": {"role": "assistant", "content": ""}, "done": False},
+    {
+        "model": "q",
+        "message": {"role": "assistant", "content": "</think>"},
+        "done": False,
+    },
+    {
+        "model": "q",
+        "message": {"role": "assistant", "content": "Hello"},
+        "done": False,
+    },
+    {
+        "model": "q",
+        "done": True,
+        "done_reason": "stop",
+        "load_duration": 0,
+        "prompt_eval_count": 5,
+        "prompt_eval_duration": 50_000_000,
+        "eval_count": 10,
+        "eval_duration": 200_000_000,
+    },
+)
+
+
+def test_ollama_thinking_model_empty_content_during_thinking_then_ttfut():
+    """Empty content chunks during thinking phase; ttfut_s set after </think>."""
+    with patch("urllib.request.urlopen", _mock_urlopen(_OLLAMA_THINKING_EMPTY_CONTENT)):
+        result = OllamaDriver().generate(
+            "q", [{"role": "user", "content": "hi"}], 4096, 256, 0.7, None
+        )
+
+    assert result.ttfut_s is not None and result.ttfut_s >= 0.0
+
+
 # ---------------------------------------------------------------------------
 # VllmDriver
 # ---------------------------------------------------------------------------

--- a/tests/bench/test_bench_store.py
+++ b/tests/bench/test_bench_store.py
@@ -16,7 +16,7 @@ from app.core.bench_store import (
     hash_settings,
     hash_text,
 )
-from scripts.bench.reporter import print_ranking
+from scripts.bench.reporter import print_ranking, print_summary_table
 
 
 def _store(tmp_path: Path) -> BenchStore:
@@ -496,3 +496,58 @@ class TestPrintRanking:
         output = self._capture_ranking(rows)
         assert "RECOMMENDED" in output
         assert "local/qwen3:30b" in output
+
+
+class TestTtfutColumn:
+    """Tests for ttfut_s added in WOR-202."""
+
+    def test_ttfut_s_defaults_to_none(self, tmp_path: Path) -> None:
+        store = BenchStore(db_path=tmp_path / "bench.db")
+        store.record(_run())
+        result = store.get_by_run_id("run-001")[0]
+        assert result.ttfut_s is None
+
+    def test_ttfut_s_round_trips(self, tmp_path: Path) -> None:
+        store = BenchStore(db_path=tmp_path / "bench.db")
+        store.record(_run(ttfut_s=1.234))
+        result = store.get_by_run_id("run-001")[0]
+        assert result.ttfut_s == pytest.approx(1.234)
+
+    def test_migration_adds_ttfut_s_column(self, tmp_path: Path) -> None:
+        import sqlite3
+
+        db_path = tmp_path / "old_schema.db"
+        conn = sqlite3.connect(db_path)
+        conn.execute(
+            """
+            CREATE TABLE bench_run (
+                run_id TEXT NOT NULL, case_id TEXT NOT NULL,
+                repeat_index INTEGER NOT NULL,
+                recorded_at TEXT NOT NULL DEFAULT (datetime('now')),
+                PRIMARY KEY (run_id, case_id, repeat_index)
+            )
+            """
+        )
+        conn.execute(
+            "INSERT INTO bench_run(run_id, case_id, repeat_index) VALUES ('r1','c1',0)"
+        )
+        conn.commit()
+        conn.close()
+
+        store = BenchStore(db_path=db_path)
+        result = store.get_by_run_id("r1")[0]
+        assert result.ttfut_s is None
+
+    def test_summary_table_shows_ttfut_column_when_present(self) -> None:
+        rows = [{"model_id": "qwen3:30b", "ttfut_s": 1.5, "ttft_s": 0.2}]
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            print_summary_table(rows)
+        assert "TTFUT" in buf.getvalue()
+
+    def test_summary_table_hides_ttfut_column_when_all_none(self) -> None:
+        rows = [{"model_id": "mistral", "ttfut_s": None, "ttft_s": 0.2}]
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            print_summary_table(rows)
+        assert "TTFUT" not in buf.getvalue()


### PR DESCRIPTION
Closes WOR-202

ttfut_s populated for thinking models; None for others; stored in DB; shown in summary; </think> boundary detection handles chunk-split tags; tests pass.