### PR TITLE
WOR-203 Add concurrency efficiency metric to benchmark ranking

### DIFF
--- a/scripts/bench/reporter.py
+++ b/scripts/bench/reporter.py
@@ -158,6 +158,60 @@ def print_summary_table(rows: list[dict[str, Any]]) -> None:
     print(f"{'=' * len(sep)}\n")
 
 
+# ── Concurrency efficiency ────────────────────────────────────────────────────
+
+
+def compute_concurrency_efficiency(
+    rows: list[dict[str, Any]],
+) -> dict[tuple[str, str, Any, Any], float | None]:
+    """Compute concurrency efficiency per (backend_id, model_id, ctx, concurrency).
+
+    efficiency = median(toks/s @ N) / (N * median(toks/s @ 1))
+
+    A value near 1.0 means near-linear scaling; >1.0 is super-linear (valid).
+    Only repeat_index >= 1 rows are used. Returns an empty dict when no
+    concurrency>1 data is present. Guards against zero and None baselines.
+    """
+    tok_map: dict[tuple[str, str, Any, Any], list[float]] = {}
+    for row in rows:
+        if row.get("repeat_index", 0) < 1:
+            continue
+        tok = row.get("throughput_tok_s")
+        if tok is None:
+            continue
+        key: tuple[str, str, Any, Any] = (
+            str(row.get("backend_id") or ""),
+            str(row.get("model_id") or ""),
+            row.get("context_size"),
+            row.get("concurrency"),
+        )
+        tok_map.setdefault(key, []).append(float(tok))
+
+    baselines: dict[tuple[str, str, Any], float | None] = {}
+    for (backend, model, ctx, conc), vals in tok_map.items():
+        if conc == 1:
+            baselines[(backend, model, ctx)] = _median(vals)
+
+    result: dict[tuple[str, str, Any, Any], float | None] = {}
+    for (backend, model, ctx, conc), vals in tok_map.items():
+        if conc is None or conc <= 1:
+            continue
+        baseline = baselines.get((backend, model, ctx))
+        if baseline is None:
+            result[(backend, model, ctx, conc)] = None
+            continue
+        if baseline == 0.0:
+            result[(backend, model, ctx, conc)] = None
+            continue
+        median_tok = _median(vals)
+        if median_tok is None:
+            result[(backend, model, ctx, conc)] = None
+        else:
+            result[(backend, model, ctx, conc)] = median_tok / (float(conc) * baseline)
+
+    return result
+
+
 # ── Quality-gated ranking ─────────────────────────────────────────────────────
 
 
@@ -242,6 +296,8 @@ def print_ranking(
     if not rows:
         return
 
+    efficiency_map = compute_concurrency_efficiency(rows)
+
     # Group by (backend_id, model_id, context_size, concurrency) — one row per config
     by_config: dict[str, list[dict[str, Any]]] = {}
     for r in rows:
@@ -286,6 +342,16 @@ def print_ranking(
         if ttft_cv is not None:
             unstable = ttft_cv > cv_threshold
 
+        first = real_runs[0] if real_runs else config_rows[0]
+        conc_eff = efficiency_map.get(
+            (
+                str(first.get("backend_id") or ""),
+                str(first.get("model_id") or ""),
+                first.get("context_size"),
+                first.get("concurrency"),
+            )
+        )
+
         eligible.append(
             {
                 "config_key": config_key,
@@ -295,6 +361,7 @@ def print_ranking(
                 "unstable": unstable,
                 "tok_p50": _median(tok_values),
                 "task_pct": task_pct,
+                "conc_eff": conc_eff,
             }
         )
 
@@ -316,14 +383,14 @@ def print_ranking(
         )
     )
 
-    _W = 108
+    _W = 119
     print("=" * _W)
     print("QUALITY-ELIGIBLE RANKING  (oom=No, offload=No, err≤5%, task≥70%)")
     print("=" * _W)
     header = (
         f"{'Rank':>4}  {'Config (backend/model/ctx/c)':<44}  "
         f"{'TTFT p50(s)':>10}  {'TTFT p95(s)':>10}  {'CV':>6}  "
-        f"{'Tok/s p50':>9}  {'Task%':>5}  {'Stable':>6}"
+        f"{'Tok/s p50':>9}  {'Task%':>5}  {'Stable':>6}  {'Conc.Eff':>9}"
     )
     print(header)
     print("-" * _W)
@@ -340,10 +407,11 @@ def print_ranking(
             stable_str = "[!]"
         else:
             stable_str = "OK"
+        eff_str = f"{entry['conc_eff']:.3f}" if entry["conc_eff"] is not None else "N/A"
         row_str = (
             f"{rank:>4}  {entry['config_key']:<44}  "
             f"{ttft_p50_str:>10}  {ttft_p95_str:>10}  {cv_str:>6}  "
-            f"{tok_str:>9}  {task_str:>5}  {stable_str:>6}"
+            f"{tok_str:>9}  {task_str:>5}  {stable_str:>6}  {eff_str:>9}"
         )
         print(row_str)
 

--- a/tests/bench/test_reporter.py
+++ b/tests/bench/test_reporter.py
@@ -13,6 +13,7 @@ from scripts.bench.reporter import (
     _is_eligible,
     _percentile,
     compute_apc_speedup,
+    compute_concurrency_efficiency,
     print_apc_section,
     print_ranking,
 )
@@ -669,3 +670,181 @@ class TestPrintApcSection:
         ]
         output = _capture(rows)
         assert "APC EFFECTIVENESS" in output
+
+
+# ── compute_concurrency_efficiency() unit tests ───────────────────────────────
+
+
+def _eff_row(
+    *,
+    backend_id: str = "b",
+    model_id: str = "m",
+    context_size: int = 4096,
+    concurrency: int = 1,
+    repeat_index: int = 1,
+    throughput_tok_s: float | None = 100.0,
+) -> dict[str, Any]:
+    return {
+        "backend_id": backend_id,
+        "model_id": model_id,
+        "context_size": context_size,
+        "concurrency": concurrency,
+        "repeat_index": repeat_index,
+        "throughput_tok_s": throughput_tok_s,
+    }
+
+
+class TestComputeConcurrencyEfficiency:
+    def test_near_linear_scaling(self) -> None:
+        rows = [
+            _eff_row(concurrency=1, throughput_tok_s=100.0),
+            _eff_row(concurrency=2, throughput_tok_s=190.0),
+        ]
+        result = compute_concurrency_efficiency(rows)
+        assert result[("b", "m", 4096, 2)] == pytest.approx(0.95)
+
+    def test_no_baseline_returns_none(self) -> None:
+        rows = [_eff_row(concurrency=2, throughput_tok_s=200.0)]
+        result = compute_concurrency_efficiency(rows)
+        assert result[("b", "m", 4096, 2)] is None
+
+    def test_zero_baseline_returns_none(self) -> None:
+        rows = [
+            _eff_row(concurrency=1, throughput_tok_s=0.0),
+            _eff_row(concurrency=2, throughput_tok_s=100.0),
+        ]
+        result = compute_concurrency_efficiency(rows)
+        assert result[("b", "m", 4096, 2)] is None
+
+    def test_none_throughput_baseline_returns_none(self) -> None:
+        # concurrency=1 row has None throughput → no baseline built
+        rows = [
+            _eff_row(concurrency=1, throughput_tok_s=None),
+            _eff_row(concurrency=2, throughput_tok_s=100.0),
+        ]
+        result = compute_concurrency_efficiency(rows)
+        assert result[("b", "m", 4096, 2)] is None
+
+    def test_concurrency_1_not_in_result(self) -> None:
+        rows = [_eff_row(concurrency=1, throughput_tok_s=100.0)]
+        result = compute_concurrency_efficiency(rows)
+        assert ("b", "m", 4096, 1) not in result
+
+    def test_super_linear_not_clamped(self) -> None:
+        rows = [
+            _eff_row(concurrency=1, throughput_tok_s=50.0),
+            _eff_row(concurrency=2, throughput_tok_s=150.0),
+        ]
+        result = compute_concurrency_efficiency(rows)
+        eff = result[("b", "m", 4096, 2)]
+        assert eff is not None
+        assert eff == pytest.approx(1.5)
+
+    def test_warmup_runs_excluded(self) -> None:
+        # Only warmup (repeat_index=0) run for c=1 → no baseline
+        rows = [
+            _eff_row(concurrency=1, repeat_index=0, throughput_tok_s=100.0),
+            _eff_row(concurrency=2, repeat_index=1, throughput_tok_s=200.0),
+        ]
+        result = compute_concurrency_efficiency(rows)
+        assert result[("b", "m", 4096, 2)] is None
+
+    def test_median_used_for_multiple_repeats(self) -> None:
+        rows = [
+            _eff_row(concurrency=1, repeat_index=1, throughput_tok_s=80.0),
+            _eff_row(concurrency=1, repeat_index=2, throughput_tok_s=120.0),
+            _eff_row(concurrency=2, repeat_index=1, throughput_tok_s=180.0),
+        ]
+        result = compute_concurrency_efficiency(rows)
+        # median c=1 = 100.0; eff = 180.0 / (2 * 100.0) = 0.90
+        assert result[("b", "m", 4096, 2)] == pytest.approx(0.90)
+
+    def test_empty_rows_returns_empty_dict(self) -> None:
+        assert compute_concurrency_efficiency([]) == {}
+
+    def test_multiple_models_grouped_separately(self) -> None:
+        rows = [
+            _eff_row(model_id="A", concurrency=1, throughput_tok_s=100.0),
+            _eff_row(model_id="A", concurrency=2, throughput_tok_s=160.0),
+            _eff_row(model_id="B", concurrency=1, throughput_tok_s=200.0),
+            _eff_row(model_id="B", concurrency=2, throughput_tok_s=300.0),
+        ]
+        result = compute_concurrency_efficiency(rows)
+        assert result[("b", "A", 4096, 2)] == pytest.approx(0.80)
+        assert result[("b", "B", 4096, 2)] == pytest.approx(0.75)
+
+    def test_different_backends_use_own_baseline(self) -> None:
+        rows = [
+            _eff_row(backend_id="x", concurrency=1, throughput_tok_s=100.0),
+            _eff_row(backend_id="x", concurrency=2, throughput_tok_s=160.0),
+            _eff_row(backend_id="y", concurrency=1, throughput_tok_s=50.0),
+            _eff_row(backend_id="y", concurrency=2, throughput_tok_s=60.0),
+        ]
+        result = compute_concurrency_efficiency(rows)
+        assert result[("x", "m", 4096, 2)] == pytest.approx(0.80)
+        assert result[("y", "m", 4096, 2)] == pytest.approx(0.60)
+
+
+# ── print_ranking() concurrency efficiency column tests ───────────────────────
+
+
+class TestPrintRankingConcurrencyEfficiency:
+    def _make_row(
+        self,
+        *,
+        model_id: str = "m",
+        backend_id: str = "b",
+        context_size: int = 4096,
+        concurrency: int = 1,
+        repeat_index: int = 1,
+        ttft_s: float = 0.3,
+        throughput_tok_s: float = 100.0,
+        outcome: str = "ok",
+        cpu_offload_detected: bool = False,
+    ) -> dict[str, Any]:
+        return {
+            "model_id": model_id,
+            "backend_id": backend_id,
+            "context_size": context_size,
+            "concurrency": concurrency,
+            "repeat_index": repeat_index,
+            "ttft_s": ttft_s,
+            "throughput_tok_s": throughput_tok_s,
+            "outcome": outcome,
+            "cpu_offload_detected": cpu_offload_detected,
+            "tier": "speed",
+            "quality_task_success": None,
+        }
+
+    def test_header_contains_conc_eff(self) -> None:
+        rows = [self._make_row()]
+        output = _capture(rows)
+        assert "Conc.Eff" in output
+
+    def test_concurrency_1_shows_na(self) -> None:
+        rows = [self._make_row(concurrency=1)]
+        output = _capture(rows)
+        assert "N/A" in output
+
+    def test_concurrency_gt1_with_baseline_shows_ratio(self) -> None:
+        rows = [
+            self._make_row(concurrency=1, throughput_tok_s=100.0, ttft_s=0.3),
+            self._make_row(concurrency=2, throughput_tok_s=150.0, ttft_s=0.4),
+        ]
+        output = _capture(rows)
+        # efficiency = 150 / (2 * 100) = 0.750
+        assert "0.750" in output
+
+    def test_concurrency_gt1_without_baseline_shows_na(self) -> None:
+        rows = [self._make_row(concurrency=2, throughput_tok_s=150.0)]
+        output = _capture(rows)
+        assert "N/A" in output
+
+    def test_super_linear_efficiency_displayed(self) -> None:
+        rows = [
+            self._make_row(concurrency=1, throughput_tok_s=50.0, ttft_s=0.3),
+            self._make_row(concurrency=2, throughput_tok_s=150.0, ttft_s=0.4),
+        ]
+        output = _capture(rows)
+        # efficiency = 150 / (2 * 50) = 1.500
+        assert "1.500" in output


### PR DESCRIPTION
Closes WOR-203

Concurrency efficiency ratio shown in ranking when baseline exists; N/A otherwise; division-by-zero safe; tests pass.