### PR TITLE
WOR-204 Show VRAM headroom column in benchmark ranking table

### DIFF
--- a/scripts/bench/reporter.py
+++ b/scripts/bench/reporter.py
@@ -9,6 +9,8 @@ import statistics
 from pathlib import Path
 from typing import Any
 
+VRAM_HEADROOM_WARN_GB: float = 2.0
+
 # ── DB loader ─────────────────────────────────────────────────────────────────
 
 
@@ -352,6 +354,24 @@ def print_ranking(
             )
         )
 
+        peak_vram_values: list[float] = [
+            float(r["peak_vram_gb"])
+            for r in real_runs
+            if r.get("peak_vram_gb") is not None
+        ]
+        peak_vram_p50 = _median(peak_vram_values)
+        total_vram: float | None = next(
+            (
+                float(r["total_vram_gb"])
+                for r in real_runs
+                if r.get("total_vram_gb") is not None
+            ),
+            None,
+        )
+        vram_headroom_gb: float | None = None
+        if peak_vram_p50 is not None and total_vram is not None:
+            vram_headroom_gb = total_vram - peak_vram_p50
+
         eligible.append(
             {
                 "config_key": config_key,
@@ -362,6 +382,7 @@ def print_ranking(
                 "tok_p50": _median(tok_values),
                 "task_pct": task_pct,
                 "conc_eff": conc_eff,
+                "vram_headroom_gb": vram_headroom_gb,
             }
         )
 
@@ -383,14 +404,15 @@ def print_ranking(
         )
     )
 
-    _W = 119
+    _W = 130
     print("=" * _W)
     print("QUALITY-ELIGIBLE RANKING  (oom=No, offload=No, err≤5%, task≥70%)")
     print("=" * _W)
     header = (
         f"{'Rank':>4}  {'Config (backend/model/ctx/c)':<44}  "
         f"{'TTFT p50(s)':>10}  {'TTFT p95(s)':>10}  {'CV':>6}  "
-        f"{'Tok/s p50':>9}  {'Task%':>5}  {'Stable':>6}  {'Conc.Eff':>9}"
+        f"{'Tok/s p50':>9}  {'Task%':>5}  {'Stable':>6}  "
+        f"{'VRAM Hdrm':>9}  {'Conc.Eff':>9}"
     )
     print(header)
     print("-" * _W)
@@ -407,11 +429,19 @@ def print_ranking(
             stable_str = "[!]"
         else:
             stable_str = "OK"
+        headroom = entry["vram_headroom_gb"]
+        if headroom is None:
+            headroom_str = "N/A"
+        elif headroom < VRAM_HEADROOM_WARN_GB:
+            headroom_str = f"{headroom:.1f}[!]"
+        else:
+            headroom_str = f"{headroom:.1f}"
         eff_str = f"{entry['conc_eff']:.3f}" if entry["conc_eff"] is not None else "N/A"
         row_str = (
             f"{rank:>4}  {entry['config_key']:<44}  "
             f"{ttft_p50_str:>10}  {ttft_p95_str:>10}  {cv_str:>6}  "
-            f"{tok_str:>9}  {task_str:>5}  {stable_str:>6}  {eff_str:>9}"
+            f"{tok_str:>9}  {task_str:>5}  {stable_str:>6}  "
+            f"{headroom_str:>9}  {eff_str:>9}"
         )
         print(row_str)
 

--- a/tests/bench/test_reporter.py
+++ b/tests/bench/test_reporter.py
@@ -9,6 +9,7 @@ from typing import Any
 import pytest
 
 from scripts.bench.reporter import (
+    VRAM_HEADROOM_WARN_GB,
     _cv,
     _is_eligible,
     _percentile,
@@ -783,6 +784,90 @@ class TestComputeConcurrencyEfficiency:
         result = compute_concurrency_efficiency(rows)
         assert result[("x", "m", 4096, 2)] == pytest.approx(0.80)
         assert result[("y", "m", 4096, 2)] == pytest.approx(0.60)
+
+
+# ── print_ranking() VRAM headroom column tests ────────────────────────────────
+
+
+class TestPrintRankingVramHeadroom:
+    def _make_row(
+        self,
+        *,
+        model_id: str = "m",
+        backend_id: str = "b",
+        context_size: int = 4096,
+        concurrency: int = 1,
+        repeat_index: int = 1,
+        ttft_s: float = 0.3,
+        throughput_tok_s: float = 80.0,
+        outcome: str = "ok",
+        cpu_offload_detected: bool = False,
+        peak_vram_gb: float | None = 20.0,
+        total_vram_gb: float | None = 24.0,
+    ) -> dict[str, Any]:
+        return {
+            "model_id": model_id,
+            "backend_id": backend_id,
+            "context_size": context_size,
+            "concurrency": concurrency,
+            "repeat_index": repeat_index,
+            "ttft_s": ttft_s,
+            "throughput_tok_s": throughput_tok_s,
+            "outcome": outcome,
+            "cpu_offload_detected": cpu_offload_detected,
+            "tier": "speed",
+            "quality_task_success": None,
+            "peak_vram_gb": peak_vram_gb,
+            "total_vram_gb": total_vram_gb,
+        }
+
+    def test_header_includes_vram_headroom_column(self) -> None:
+        rows = [self._make_row()]
+        output = _capture(rows)
+        assert "VRAM Hdrm" in output
+
+    def test_headroom_value_computed_and_shown(self) -> None:
+        # total=24.0, peak=20.0 → headroom=4.0
+        rows = [self._make_row(total_vram_gb=24.0, peak_vram_gb=20.0)]
+        output = _capture(rows)
+        assert "4.0" in output
+
+    def test_low_headroom_shows_warning_indicator(self) -> None:
+        # headroom = 24.0 - 22.5 = 1.5 < VRAM_HEADROOM_WARN_GB
+        rows = [self._make_row(total_vram_gb=24.0, peak_vram_gb=22.5)]
+        output = _capture(rows)
+        assert "1.5[!]" in output
+
+    def test_headroom_at_warn_threshold_no_warning(self) -> None:
+        # headroom exactly at threshold — no warning
+        rows = [
+            self._make_row(
+                total_vram_gb=24.0,
+                peak_vram_gb=24.0 - VRAM_HEADROOM_WARN_GB,
+            )
+        ]
+        output = _capture(rows)
+        assert f"{VRAM_HEADROOM_WARN_GB:.1f}" in output
+        assert "[!]" not in output
+
+    def test_none_peak_vram_shows_na(self) -> None:
+        rows = [self._make_row(peak_vram_gb=None, total_vram_gb=24.0)]
+        output = _capture(rows)
+        assert "N/A" in output
+
+    def test_none_total_vram_shows_na(self) -> None:
+        rows = [self._make_row(peak_vram_gb=20.0, total_vram_gb=None)]
+        output = _capture(rows)
+        assert "N/A" in output
+
+    def test_both_none_shows_na(self) -> None:
+        rows = [self._make_row(peak_vram_gb=None, total_vram_gb=None)]
+        output = _capture(rows)
+        assert "N/A" in output
+
+    def test_vram_headroom_warn_gb_constant_is_float(self) -> None:
+        assert isinstance(VRAM_HEADROOM_WARN_GB, float)
+        assert VRAM_HEADROOM_WARN_GB == 2.0
 
 
 # ── print_ranking() concurrency efficiency column tests ───────────────────────


### PR DESCRIPTION
Closes WOR-204

VRAM headroom column in ranking; low-headroom configs flagged; N/A when data missing; tests pass.