### PR TITLE
WOR-206 Add automated regression detection to bench --compare

### DIFF
--- a/scripts/bench/reporter.py
+++ b/scripts/bench/reporter.py
@@ -574,35 +574,79 @@ def _fingerprint(run_id: str, sweep_id: str) -> str:
     return run_id
 
 
+def _metric_delta(
+    v1: float | None,
+    v2: float | None,
+    *,
+    abs_fmt: str,
+    higher_is_better: bool,
+    regression_threshold_pct: float,
+) -> tuple[str, bool]:
+    """Return (delta_string, is_regression) for a metric pair.
+
+    delta_string shows absolute change and % change (e.g. '+0.050(+15%)').
+    is_regression is True when the metric degrades beyond regression_threshold_pct.
+    None inputs always return ('--', False).
+    """
+    if v1 is None or v2 is None:
+        return "--", False
+    abs_d = v2 - v1
+    if v1 == 0.0:
+        return f"{abs_d:{abs_fmt}}(--)", False
+    pct_d = (v2 - v1) / abs(v1) * 100.0
+    delta_str = f"{abs_d:{abs_fmt}}({pct_d:+.0f}%)"
+    if higher_is_better:
+        is_regression = pct_d < -regression_threshold_pct
+    else:
+        is_regression = pct_d > regression_threshold_pct
+    return delta_str, is_regression
+
+
+_COMPARE_W = 160
+
+
 def print_compare_table(
     rows1: list[dict[str, Any]],
     rows2: list[dict[str, Any]],
     id1: str,
     id2: str,
-) -> None:
-    """Print side-by-side comparison for two sweep IDs with OOM/offload annotations."""
+    *,
+    regression_threshold_pct: float = 10.0,
+) -> bool:
+    """Print side-by-side comparison with delta columns and regression detection.
+
+    Adds ΔTTFT and ΔTok/s columns showing absolute and % change.
+    Rows where a metric degrades beyond regression_threshold_pct are prefixed with '!!'.
+    Returns True if any regression was detected, False otherwise.
+    """
     by_fp1 = {_fingerprint(r["run_id"], id1): r for r in rows1}
     by_fp2 = {_fingerprint(r["run_id"], id2): r for r in rows2}
     all_fps = sorted(set(by_fp1) | set(by_fp2))
 
     if not all_fps:
         print("No rows found for either sweep ID.")
-        return
+        return False
 
     id1_short = id1[:20]
     id2_short = id2[:20]
-    sep = "=" * 100
+    sep = "=" * _COMPARE_W
     print(f"\n{sep}")
-    print(f"COMPARISON: {id1_short}  vs  {id2_short}")
+    print(
+        f"COMPARISON: {id1_short}  vs  {id2_short}"
+        f"  (regression threshold: {regression_threshold_pct:.0f}%)"
+    )
     print(sep)
 
     hdr = (
-        f"{'Model':<20}  {'Tier':<14}  {'Ctx':>6}  {'C':>3}  {'R':>3}  "
-        f"{'TTFT-1(s)':>10}  {'TTFT-2(s)':>10}  {'Δ%':>8}  "
-        f"{'OOM1':>6}  {'OOM2':>6}  {'Off1':>5}  {'Off2':>5}"
+        f"   {'Model':<20}  {'Tier':<12}  {'Ctx':>6}  {'C':>3}  {'R':>3}  "
+        f"{'TTFT-1(s)':>9}  {'TTFT-2(s)':>9}  {'ΔTTFT':>17}  "
+        f"{'Tok/s-1':>8}  {'Tok/s-2':>8}  {'ΔTok/s':>14}  "
+        f"{'OOM1':>5}  {'OOM2':>5}  {'Off1':>5}  {'Off2':>5}"
     )
     print(hdr)
-    print("-" * 100)
+    print("-" * _COMPARE_W)
+
+    any_regression = False
 
     for fp in all_fps:
         r1 = by_fp1.get(fp)
@@ -610,40 +654,70 @@ def print_compare_table(
 
         if r1 is not None:
             model = str(r1.get("model_id") or "--")[:20]
-            tier = str(r1.get("tier") or "--")[:14]
+            tier = str(r1.get("tier") or "--")[:12]
             ctx = _fmt(r1.get("context_size"))
             concurrency = _fmt(r1.get("concurrency"))
             repeat = _fmt(r1.get("repeat_index"))
         elif r2 is not None:
             model = str(r2.get("model_id") or "--")[:20]
-            tier = str(r2.get("tier") or "--")[:14]
+            tier = str(r2.get("tier") or "--")[:12]
             ctx = _fmt(r2.get("context_size"))
             concurrency = _fmt(r2.get("concurrency"))
             repeat = _fmt(r2.get("repeat_index"))
         else:
             continue
 
-        ttft1 = r1.get("ttft_s") if r1 else None
-        ttft2 = r2.get("ttft_s") if r2 else None
+        ttft1: float | None = r1.get("ttft_s") if r1 else None
+        ttft2: float | None = r2.get("ttft_s") if r2 else None
+        tok1: float | None = r1.get("throughput_tok_s") if r1 else None
+        tok2: float | None = r2.get("throughput_tok_s") if r2 else None
         oom1 = "Yes" if (r1 and r1.get("outcome") == "oom") else "No"
         oom2 = "Yes" if (r2 and r2.get("outcome") == "oom") else "No"
         off1 = "Yes" if (r1 and r1.get("cpu_offload_detected")) else "No"
         off2 = "Yes" if (r2 and r2.get("cpu_offload_detected")) else "No"
 
-        if ttft1 is not None and ttft2 is not None and ttft1 > 0:
-            delta_pct = (ttft2 - ttft1) / ttft1 * 100.0
-            delta_str = f"{delta_pct:+.1f}%"
-        else:
-            delta_str = "--"
-
-        line = (
-            f"{model:<20}  {tier:<14}  {ctx:>6}  {concurrency:>3}  {repeat:>3}  "
-            f"{_fmt(ttft1, '.3f'):>10}  {_fmt(ttft2, '.3f'):>10}  {delta_str:>8}  "
-            f"{oom1:>6}  {oom2:>6}  {off1:>5}  {off2:>5}"
+        ttft_delta_str, ttft_reg = _metric_delta(
+            ttft1,
+            ttft2,
+            abs_fmt="+.3f",
+            higher_is_better=False,
+            regression_threshold_pct=regression_threshold_pct,
         )
-        print(line)
+        tok_delta_str, tok_reg = _metric_delta(
+            tok1,
+            tok2,
+            abs_fmt="+.0f",
+            higher_is_better=True,
+            regression_threshold_pct=regression_threshold_pct,
+        )
+
+        is_regression = ttft_reg or tok_reg
+        if is_regression:
+            any_regression = True
+        prefix = "!!" if is_regression else "  "
+
+        ttft_cols = (
+            f"{_fmt(ttft1, '.3f'):>9}  {_fmt(ttft2, '.3f'):>9}  {ttft_delta_str:>17}"
+        )
+        tok_cols = (
+            f"{_fmt(tok1, '.0f'):>8}  {_fmt(tok2, '.0f'):>8}  {tok_delta_str:>14}"
+        )
+        ann_cols = f"{oom1:>5}  {oom2:>5}  {off1:>5}  {off2:>5}"
+        id_cols = (
+            f"{prefix} {model:<20}  {tier:<12}  {ctx:>6}  {concurrency:>3}  {repeat:>3}"
+        )
+        print(f"{id_cols}  {ttft_cols}  {tok_cols}  {ann_cols}")
 
     print(sep + "\n")
+
+    if any_regression:
+        thr = f"{regression_threshold_pct:.0f}%"
+        print(
+            f"REGRESSIONS DETECTED (threshold: {thr})"
+            f"  [ttft_s increase >{thr} | tok/s decrease >{thr}]\n"
+        )
+
+    return any_regression
 
 
 # ── Export ────────────────────────────────────────────────────────────────────

--- a/scripts/bench/run_bench.py
+++ b/scripts/bench/run_bench.py
@@ -50,12 +50,20 @@ def _browse(db_path: Path) -> None:
 # ── Compare ───────────────────────────────────────────────────────────────────
 
 
-def _compare(id1: str, id2: str, db_path: Path) -> None:
+def _compare(
+    id1: str, id2: str, db_path: Path, *, regression_threshold_pct: float
+) -> bool:
     from scripts.bench import reporter
 
     rows1 = reporter.load_sweep(db_path, id1)
     rows2 = reporter.load_sweep(db_path, id2)
-    reporter.print_compare_table(rows1, rows2, id1, id2)
+    return reporter.print_compare_table(
+        rows1,
+        rows2,
+        id1,
+        id2,
+        regression_threshold_pct=regression_threshold_pct,
+    )
 
 
 # ── CLI ───────────────────────────────────────────────────────────────────────
@@ -112,6 +120,13 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Open bench.db in datasette browser",
     )
     parser.add_argument(
+        "--regression-threshold",
+        type=float,
+        default=10.0,
+        metavar="PCT",
+        help="Regression threshold %% for --compare (default: 10)",
+    )
+    parser.add_argument(
         "--db-path",
         default=None,
         help="Override default bench.db path",
@@ -146,8 +161,13 @@ def main() -> int:
         return 0
 
     if args.compare:
-        _compare(args.compare[0], args.compare[1], db_path)
-        return 0
+        regression = _compare(
+            args.compare[0],
+            args.compare[1],
+            db_path,
+            regression_threshold_pct=args.regression_threshold,
+        )
+        return 1 if regression else 0
 
     run(
         args.config,

--- a/tests/bench/test_reporter.py
+++ b/tests/bench/test_reporter.py
@@ -12,10 +12,12 @@ from scripts.bench.reporter import (
     VRAM_HEADROOM_WARN_GB,
     _cv,
     _is_eligible,
+    _metric_delta,
     _percentile,
     compute_apc_speedup,
     compute_concurrency_efficiency,
     print_apc_section,
+    print_compare_table,
     print_ranking,
 )
 
@@ -784,6 +786,349 @@ class TestComputeConcurrencyEfficiency:
         result = compute_concurrency_efficiency(rows)
         assert result[("x", "m", 4096, 2)] == pytest.approx(0.80)
         assert result[("y", "m", 4096, 2)] == pytest.approx(0.60)
+
+
+# ── _metric_delta() unit tests ────────────────────────────────────────────────
+
+
+class TestMetricDelta:
+    def test_none_v1_returns_dash_no_regression(self) -> None:
+        delta_str, is_reg = _metric_delta(
+            None,
+            1.0,
+            abs_fmt="+.3f",
+            higher_is_better=False,
+            regression_threshold_pct=10.0,
+        )
+        assert delta_str == "--"
+        assert is_reg is False
+
+    def test_none_v2_returns_dash_no_regression(self) -> None:
+        delta_str, is_reg = _metric_delta(
+            1.0,
+            None,
+            abs_fmt="+.3f",
+            higher_is_better=False,
+            regression_threshold_pct=10.0,
+        )
+        assert delta_str == "--"
+        assert is_reg is False
+
+    def test_both_none_returns_dash_no_regression(self) -> None:
+        delta_str, is_reg = _metric_delta(
+            None,
+            None,
+            abs_fmt="+.3f",
+            higher_is_better=False,
+            regression_threshold_pct=10.0,
+        )
+        assert delta_str == "--"
+        assert is_reg is False
+
+    def test_zero_v1_returns_abs_with_dash_pct(self) -> None:
+        delta_str, is_reg = _metric_delta(
+            0.0,
+            1.0,
+            abs_fmt="+.3f",
+            higher_is_better=False,
+            regression_threshold_pct=10.0,
+        )
+        assert "(--)" in delta_str
+        assert is_reg is False
+
+    def test_increase_lower_is_better_above_threshold_is_regression(self) -> None:
+        # TTFT: v1=1.0, v2=1.15 → +15% increase, threshold=10 → regression
+        _, is_reg = _metric_delta(
+            1.0,
+            1.15,
+            abs_fmt="+.3f",
+            higher_is_better=False,
+            regression_threshold_pct=10.0,
+        )
+        assert is_reg is True
+
+    def test_increase_lower_is_better_below_threshold_not_regression(self) -> None:
+        # TTFT: v1=1.0, v2=1.05 → +5% increase, threshold=10 → ok
+        _, is_reg = _metric_delta(
+            1.0,
+            1.05,
+            abs_fmt="+.3f",
+            higher_is_better=False,
+            regression_threshold_pct=10.0,
+        )
+        assert is_reg is False
+
+    def test_decrease_lower_is_better_is_improvement_not_regression(self) -> None:
+        # TTFT: v1=1.0, v2=0.5 → -50% (improvement)
+        _, is_reg = _metric_delta(
+            1.0,
+            0.5,
+            abs_fmt="+.3f",
+            higher_is_better=False,
+            regression_threshold_pct=10.0,
+        )
+        assert is_reg is False
+
+    def test_decrease_higher_is_better_above_threshold_is_regression(self) -> None:
+        # Tok/s: v1=100, v2=85 → -15%, threshold=10 → regression
+        _, is_reg = _metric_delta(
+            100.0,
+            85.0,
+            abs_fmt="+.0f",
+            higher_is_better=True,
+            regression_threshold_pct=10.0,
+        )
+        assert is_reg is True
+
+    def test_decrease_higher_is_better_below_threshold_not_regression(self) -> None:
+        # Tok/s: v1=100, v2=95 → -5%, threshold=10 → ok
+        _, is_reg = _metric_delta(
+            100.0,
+            95.0,
+            abs_fmt="+.0f",
+            higher_is_better=True,
+            regression_threshold_pct=10.0,
+        )
+        assert is_reg is False
+
+    def test_increase_higher_is_better_is_improvement_not_regression(self) -> None:
+        # Tok/s: v1=100, v2=150 → +50% (improvement)
+        _, is_reg = _metric_delta(
+            100.0,
+            150.0,
+            abs_fmt="+.0f",
+            higher_is_better=True,
+            regression_threshold_pct=10.0,
+        )
+        assert is_reg is False
+
+    def test_delta_string_shows_absolute_and_pct(self) -> None:
+        delta_str, _ = _metric_delta(
+            1.0,
+            1.2,
+            abs_fmt="+.3f",
+            higher_is_better=False,
+            regression_threshold_pct=10.0,
+        )
+        assert "+0.200" in delta_str
+        assert "+20%" in delta_str
+
+    def test_custom_threshold_respected(self) -> None:
+        # +8% increase, lower-is-better: regression at 5%, not at 10%
+        _, is_reg_5 = _metric_delta(
+            1.0,
+            1.08,
+            abs_fmt="+.3f",
+            higher_is_better=False,
+            regression_threshold_pct=5.0,
+        )
+        _, is_reg_10 = _metric_delta(
+            1.0,
+            1.08,
+            abs_fmt="+.3f",
+            higher_is_better=False,
+            regression_threshold_pct=10.0,
+        )
+        assert is_reg_5 is True
+        assert is_reg_10 is False
+
+    def test_well_below_threshold_not_regression(self) -> None:
+        # +9% increase (v1=100, v2=109), threshold=10 → clearly below → not a regression
+        _, is_reg = _metric_delta(
+            100.0,
+            109.0,
+            abs_fmt="+.3f",
+            higher_is_better=False,
+            regression_threshold_pct=10.0,
+        )
+        assert is_reg is False
+
+
+# ── print_compare_table() tests ───────────────────────────────────────────────
+
+
+def _cmp_row(
+    sweep_id: str,
+    fp: str = "case1",
+    *,
+    model_id: str = "m",
+    tier: str = "speed",
+    context_size: int = 4096,
+    concurrency: int = 1,
+    repeat_index: int = 1,
+    ttft_s: float | None = 1.0,
+    throughput_tok_s: float | None = 100.0,
+    outcome: str = "ok",
+    cpu_offload_detected: bool = False,
+) -> dict[str, Any]:
+    return {
+        "run_id": f"{sweep_id}::{fp}",
+        "model_id": model_id,
+        "tier": tier,
+        "context_size": context_size,
+        "concurrency": concurrency,
+        "repeat_index": repeat_index,
+        "ttft_s": ttft_s,
+        "throughput_tok_s": throughput_tok_s,
+        "outcome": outcome,
+        "cpu_offload_detected": cpu_offload_detected,
+    }
+
+
+def _capture_compare(
+    rows1: list[dict[str, Any]],
+    rows2: list[dict[str, Any]],
+    id1: str = "s1",
+    id2: str = "s2",
+    **kwargs: Any,
+) -> tuple[str, bool]:
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        result = print_compare_table(rows1, rows2, id1, id2, **kwargs)
+    return buf.getvalue(), result
+
+
+class TestPrintCompareTableBasic:
+    def test_no_rows_returns_false(self) -> None:
+        _, result = _capture_compare([], [], "s1", "s2")
+        assert result is False
+
+    def test_no_rows_prints_message(self) -> None:
+        output, _ = _capture_compare([], [], "s1", "s2")
+        assert "No rows found" in output
+
+    def test_returns_false_when_no_regression(self) -> None:
+        r1 = _cmp_row("s1", ttft_s=1.0, throughput_tok_s=100.0)
+        r2 = _cmp_row("s2", ttft_s=1.05, throughput_tok_s=95.0)  # <10% change
+        _, result = _capture_compare([r1], [r2])
+        assert result is False
+
+    def test_no_regression_rows_have_no_bang_prefix(self) -> None:
+        r1 = _cmp_row("s1", ttft_s=1.0, throughput_tok_s=100.0)
+        r2 = _cmp_row("s2", ttft_s=1.05, throughput_tok_s=95.0)
+        output, _ = _capture_compare([r1], [r2])
+        assert "!!" not in output
+
+    def test_header_includes_delta_columns(self) -> None:
+        r1 = _cmp_row("s1")
+        r2 = _cmp_row("s2")
+        output, _ = _capture_compare([r1], [r2])
+        assert "ΔTTFT" in output
+        assert "ΔTok/s" in output
+
+    def test_header_includes_tok_columns(self) -> None:
+        r1 = _cmp_row("s1")
+        r2 = _cmp_row("s2")
+        output, _ = _capture_compare([r1], [r2])
+        assert "Tok/s-1" in output
+        assert "Tok/s-2" in output
+
+    def test_regression_threshold_shown_in_header(self) -> None:
+        r1 = _cmp_row("s1")
+        r2 = _cmp_row("s2")
+        output, _ = _capture_compare([r1], [r2], regression_threshold_pct=15.0)
+        assert "15%" in output
+
+
+class TestPrintCompareTableRegressionDetection:
+    def test_ttft_increase_above_threshold_returns_true(self) -> None:
+        r1 = _cmp_row("s1", ttft_s=1.0, throughput_tok_s=100.0)
+        r2 = _cmp_row("s2", ttft_s=1.15, throughput_tok_s=100.0)  # +15%
+        _, result = _capture_compare([r1], [r2])
+        assert result is True
+
+    def test_ttft_regression_row_prefixed_with_bang(self) -> None:
+        r1 = _cmp_row("s1", ttft_s=1.0, throughput_tok_s=100.0)
+        r2 = _cmp_row("s2", ttft_s=1.15, throughput_tok_s=100.0)
+        output, _ = _capture_compare([r1], [r2])
+        assert "!!" in output
+
+    def test_tok_decrease_above_threshold_returns_true(self) -> None:
+        r1 = _cmp_row("s1", ttft_s=1.0, throughput_tok_s=100.0)
+        r2 = _cmp_row("s2", ttft_s=1.0, throughput_tok_s=85.0)  # -15%
+        _, result = _capture_compare([r1], [r2])
+        assert result is True
+
+    def test_tok_regression_row_prefixed_with_bang(self) -> None:
+        r1 = _cmp_row("s1", ttft_s=1.0, throughput_tok_s=100.0)
+        r2 = _cmp_row("s2", ttft_s=1.0, throughput_tok_s=85.0)
+        output, _ = _capture_compare([r1], [r2])
+        assert "!!" in output
+
+    def test_ttft_improvement_not_flagged(self) -> None:
+        r1 = _cmp_row("s1", ttft_s=1.0, throughput_tok_s=100.0)
+        r2 = _cmp_row("s2", ttft_s=0.5, throughput_tok_s=100.0)  # TTFT improved
+        _, result = _capture_compare([r1], [r2])
+        assert result is False
+
+    def test_tok_improvement_not_flagged(self) -> None:
+        r1 = _cmp_row("s1", ttft_s=1.0, throughput_tok_s=100.0)
+        r2 = _cmp_row("s2", ttft_s=1.0, throughput_tok_s=150.0)  # tok/s improved
+        _, result = _capture_compare([r1], [r2])
+        assert result is False
+
+    def test_none_ttft_not_flagged_as_regression(self) -> None:
+        r1 = _cmp_row("s1", ttft_s=None, throughput_tok_s=100.0)
+        r2 = _cmp_row("s2", ttft_s=None, throughput_tok_s=100.0)
+        _, result = _capture_compare([r1], [r2])
+        assert result is False
+
+    def test_none_tok_not_flagged_as_regression(self) -> None:
+        r1 = _cmp_row("s1", ttft_s=1.0, throughput_tok_s=None)
+        r2 = _cmp_row("s2", ttft_s=1.0, throughput_tok_s=None)
+        _, result = _capture_compare([r1], [r2])
+        assert result is False
+
+    def test_regression_summary_shown_when_regression_detected(self) -> None:
+        r1 = _cmp_row("s1", ttft_s=1.0, throughput_tok_s=100.0)
+        r2 = _cmp_row("s2", ttft_s=1.5, throughput_tok_s=100.0)
+        output, _ = _capture_compare([r1], [r2])
+        assert "REGRESSIONS DETECTED" in output
+
+    def test_no_summary_when_no_regression(self) -> None:
+        r1 = _cmp_row("s1", ttft_s=1.0, throughput_tok_s=100.0)
+        r2 = _cmp_row("s2", ttft_s=1.05, throughput_tok_s=100.0)
+        output, _ = _capture_compare([r1], [r2])
+        assert "REGRESSIONS DETECTED" not in output
+
+    def test_custom_threshold_applied(self) -> None:
+        # +8% TTFT: regression at threshold=5, not at threshold=10
+        r1 = _cmp_row("s1", ttft_s=1.0, throughput_tok_s=100.0)
+        r2 = _cmp_row("s2", ttft_s=1.08, throughput_tok_s=100.0)
+        _, result_strict = _capture_compare([r1], [r2], regression_threshold_pct=5.0)
+        assert result_strict is True
+        _, result_lax = _capture_compare([r1], [r2], regression_threshold_pct=10.0)
+        assert result_lax is False
+
+    def test_multiple_rows_any_regression_returns_true(self) -> None:
+        r1a = _cmp_row("s1", "case1", ttft_s=1.0, throughput_tok_s=100.0)
+        r1b = _cmp_row("s1", "case2", ttft_s=1.0, throughput_tok_s=100.0)
+        r2a = _cmp_row("s2", "case1", ttft_s=1.0, throughput_tok_s=100.0)  # ok
+        r2b = _cmp_row("s2", "case2", ttft_s=1.5, throughput_tok_s=100.0)  # regression
+        _, result = _capture_compare([r1a, r1b], [r2a, r2b])
+        assert result is True
+
+
+class TestPrintCompareTableDeltaValues:
+    def test_delta_string_contains_absolute_and_pct(self) -> None:
+        r1 = _cmp_row("s1", ttft_s=1.0, throughput_tok_s=100.0)
+        r2 = _cmp_row("s2", ttft_s=1.2, throughput_tok_s=100.0)
+        output, _ = _capture_compare([r1], [r2])
+        # +20% TTFT increase: absolute ~+0.200, pct +20%
+        assert "+20%" in output
+
+    def test_tok_delta_string_contains_pct(self) -> None:
+        r1 = _cmp_row("s1", ttft_s=1.0, throughput_tok_s=100.0)
+        r2 = _cmp_row("s2", ttft_s=1.0, throughput_tok_s=80.0)
+        output, _ = _capture_compare([r1], [r2])
+        # -20% tok/s
+        assert "-20%" in output
+
+    def test_missing_row_in_sweep2_shows_dashes(self) -> None:
+        r1 = _cmp_row("s1", "only_in_s1", ttft_s=1.0)
+        output, result = _capture_compare([r1], [], "s1", "s2")
+        assert "--" in output
+        assert result is False
 
 
 # ── print_ranking() VRAM headroom column tests ────────────────────────────────


### PR DESCRIPTION
Closes WOR-206

Î” column in compare table; regressions flagged visually; exit code 1 on regression; threshold configurable via CLI flag; tests pass.