### PR TITLE
Tune benchmark matrix: extend context range, drop concurrency=2

### DIFF
--- a/config/bench.toml
+++ b/config/bench.toml
@@ -18,18 +18,26 @@
 
 [matrix]
 # Non-boundary context windows (all tiers except boundary).
-#   4096  = speed/coding warm-up; fits in any KV budget
-#   16384 = realistic coding context
-#   32768 = 32K — common production window
-#   65536 = 64K — confirmed safe on RTX 5090 + qwen3-coder:30b (spike WOR-76)
-context_sizes = [4096, 16384, 32768, 65536]
-# Boundary tier only — OOM cliff probe per WOR-180 (96K / 128K / 160K).
-#   qwen2.5-coder:32b and qwen3-coder:30b will OOM here — that's expected and recorded.
-#   MoE models (35b-a3b, 27b) tolerate larger contexts due to sparse activation.
-boundary_context_sizes = [98304, 131072, 163840]
-# Concurrent requests per probe point.
-# Single Ollama GPU serialises beyond 2; 2 exposes queue-depth effects.
-concurrency_levels = [1, 2]
+#   16384  = realistic coding context; new floor (4K dropped — watcher sessions never start below 10K)
+#   32768  = 32K — common production window
+#   65536  = 64K — confirmed safe on RTX 5090 + qwen3-coder:30b (spike WOR-76)
+#   131072 = 128K — all models nominally support; larger models likely OOM-skip beyond here
+#   196608 = 192K — floor models (qwen3.5:9b) have headroom; larger models skipped_oom
+#   262144 = 256K — native limit of qwen3.5:9b; only floor models expected to reach this
+# NOTE: prefill_shared/unshared tiers use a 50K-token fixture regardless of context_size.
+# At 196K+ the fixture fills only ~20% of the allocated KV buffer — prefill numbers at those
+# sizes reflect VRAM pressure on an undersized fixture, not genuine long-context prefill.
+# Per-tier context_sizes override is a future improvement; interpret prefill results at 196K+
+# with this in mind.
+context_sizes = [16384, 32768, 65536, 131072, 196608, 262144]
+# Boundary tier — sole OOM cliff probe beyond the standard tier ceiling.
+# 96K/128K dropped: now covered by standard tier with OOM-skip safety net.
+# 320K: only qwen3.5:9b-q4_K_M has any realistic chance (~31 GB est.); all others skipped_oom.
+boundary_context_sizes = [327680]
+# Single concurrency only. Speed-tier data showed 98-105% efficiency at concurrency=2
+# across all 7 models — Ollama serialises requests on a single GPU as expected.
+# No differential signal; removing concurrency=2 halves the matrix with no data loss.
+concurrency_levels = [1]
 # Real (non-warmup) runs per probe point. 3 gives statistical confidence.
 repeats = 3
 

--- a/config/bench.toml
+++ b/config/bench.toml
@@ -21,6 +21,7 @@
 #   16384  = realistic coding context; new floor (4K dropped — watcher sessions never start below 10K)
 #   32768  = 32K — common production window
 #   65536  = 64K — confirmed safe on RTX 5090 + qwen3-coder:30b (spike WOR-76)
+#   98304  = 96K — calibration point between 64K and 128K; characterises devstral cliff + qwen3.6:35b-a3b VRAM squeeze
 #   131072 = 128K — all models nominally support; larger models likely OOM-skip beyond here
 #   196608 = 192K — floor models (qwen3.5:9b) have headroom; larger models skipped_oom
 #   262144 = 256K — native limit of qwen3.5:9b; only floor models expected to reach this
@@ -29,7 +30,7 @@
 # sizes reflect VRAM pressure on an undersized fixture, not genuine long-context prefill.
 # Per-tier context_sizes override is a future improvement; interpret prefill results at 196K+
 # with this in mind.
-context_sizes = [16384, 32768, 65536, 131072, 196608, 262144]
+context_sizes = [16384, 32768, 65536, 98304, 131072, 196608, 262144]
 # Boundary tier — sole OOM cliff probe beyond the standard tier ceiling.
 # 96K/128K dropped: now covered by standard tier with OOM-skip safety net.
 # 320K: only qwen3.5:9b-q4_K_M has any realistic chance (~31 GB est.); all others skipped_oom.
@@ -168,13 +169,13 @@ name = "coding"
 # Above 131072 the fixture becomes an increasingly small fraction of KV buffer,
 # making TTFT numbers reflect VRAM pressure rather than prefill performance.
 name = "prefill_shared"
-context_sizes = [16384, 32768, 65536, 131072]
+context_sizes = [16384, 32768, 65536, 98304, 131072]
 
 [[tiers]]
 # TTFT with same-length randomised content. APC null baseline (cold prefill every run).
 # Same context_sizes cap as prefill_shared — content scales to 75% fill at each size.
 name = "prefill_unshared"
-context_sizes = [16384, 32768, 65536, 131072]
+context_sizes = [16384, 32768, 65536, 98304, 131072]
 
 [[tiers]]
 # Long-context OOM cliff probe at boundary_context_sizes. OOM is recorded, not fatal.

--- a/config/bench.toml
+++ b/config/bench.toml
@@ -162,13 +162,19 @@ name = "speed"
 name = "coding"
 
 [[tiers]]
-# TTFT with shared 50k-token repo prefix. Measures vLLM APC reuse vs Ollama.
+# TTFT with shared repo-prefix fixture. Measures vLLM APC reuse vs Ollama.
 # First request per model = cache warm; subsequent = prefix_warm.
+# context_sizes capped at 131072: fixture fills ~75% of context at each size.
+# Above 131072 the fixture becomes an increasingly small fraction of KV buffer,
+# making TTFT numbers reflect VRAM pressure rather than prefill performance.
 name = "prefill_shared"
+context_sizes = [16384, 32768, 65536, 131072]
 
 [[tiers]]
-# TTFT with randomized same-length content. APC null baseline (cold prefill every run).
+# TTFT with same-length randomised content. APC null baseline (cold prefill every run).
+# Same context_sizes cap as prefill_shared — content scales to 75% fill at each size.
 name = "prefill_unshared"
+context_sizes = [16384, 32768, 65536, 131072]
 
 [[tiers]]
 # Long-context OOM cliff probe at boundary_context_sizes. OOM is recorded, not fatal.

--- a/docs/spikes/bench-model-selection-2026-04.md
+++ b/docs/spikes/bench-model-selection-2026-04.md
@@ -156,11 +156,19 @@ The 9B floor model can plausibly reach 256K, giving quality data at maximum nati
 
 Speed-tier data showed 98–105% concurrency efficiency across all 7 models. Ollama serialises requests on a single GPU — this is expected behaviour and will not change at higher context sizes. Removing `concurrency=2` halves the total matrix run count with no loss of useful data.
 
-### Prefill tiers at high context sizes — known limitation
+### Prefill tiers — size-matched fixture (implemented)
 
-The `prefill_shared` and `prefill_unshared` tiers use a fixed 50K-token fixture regardless of `context_size`. At 196K/256K context, the fixture fills only ~20% of the allocated KV buffer. TTFT numbers at those sizes reflect VRAM pressure from the large KV allocation, not genuine long-context prefill performance.
+`prefill_shared` and `prefill_unshared` now receive the current `context_size` at runtime and generate a prompt sized to **75% of that context** (e.g. ~49K tokens at 65K context, ~98K tokens at 131K context). The base fixture (`prefill_base.txt`, ~112K tokens / 450K chars) is generated once by `--generate-fixtures` and sliced per request.
 
-A **per-tier `context_sizes` override** in `BenchConfig` would fix this — prefill tiers could be capped at 65K (where 50K fills ~75% of context), and speed/coding tiers could run the full range independently. This is a worthwhile future config addition; interpret prefill results at 196K+ with the fixture-size limitation in mind.
+Both prefill tiers use a **per-tier `context_sizes` override** capped at 131072:
+
+```toml
+[[tiers]]
+name = "prefill_shared"
+context_sizes = [16384, 32768, 65536, 131072]
+```
+
+Speed and coding tiers continue to use the full `matrix.context_sizes` range. This decoupling is the key fix — prefill results now reflect genuine long-context prefill performance at each tested size, and the vLLM APC comparison is apples-to-apples across all four sizes.
 
 ### Final matrix configuration
 
@@ -182,4 +190,4 @@ New matrix (6 ctx × 1 conc × 3 repeats = 18 cases/model/tier): **25% fewer run
 - **qwen3.6:35b-a3b VRAM watch**: 3.9 GB headroom at speed tier; expect OOM somewhere between 131K and 196K. The adaptive skip records max working context automatically.
 - **devstral:24b 64K degradation**: coding tier will reveal whether quality compensates for the 50% throughput drop at 64K.
 - **qwen3.5:9b quant comparison**: Q4 vs Q8 quality delta in the coding tier is the key data point — if equivalent, Q4 at 6.6 GB is the clear production floor model.
-- **Per-tier context_sizes**: implement as a follow-on config addition to make prefill results at 196K+ meaningful.
+- **Per-tier context_sizes**: implemented — prefill tiers capped at 131K with 75%-fill fixture scaling.

--- a/docs/spikes/bench-model-selection-2026-04.md
+++ b/docs/spikes/bench-model-selection-2026-04.md
@@ -131,9 +131,55 @@ Fixed in PR #416: replaced with `peak_temp_c >= 83°C` (RTX 5090 throttle onset)
 
 ---
 
+## Matrix configuration decisions (post speed-tier)
+
+### Drop 4K, extend to 256K
+
+4K was dropped from `context_sizes` — watcher sessions never operate below 10K tokens once system prompt, CLAUDE.md, and initial file reads are loaded. The data point measures unconstrained throughput ceiling, which 16K already approximates.
+
+The upper range was extended to 256K in the standard tier. The key insight: **with `skip_oom_larger_ctx = true`, adding high context sizes is nearly free for models that cannot reach them.** An OOM at 131K causes all 196K and 256K cases for that model to be recorded as `skipped_oom` in milliseconds. You only pay run time for what actually executes.
+
+VRAM estimate for `qwen3.5:9b-q4_K_M` (6.6 GB weights, 20.2 GB headroom at speed tier):
+
+| Context | Est. KV cache | Est. total VRAM |
+|---|---|---|
+| 128K | ~10 GB | ~16.6 GB |
+| 196K | ~15 GB | ~21.6 GB |
+| 256K | ~20 GB | ~26.6 GB |
+| 320K | ~24 GB | ~30.6 GB |
+
+The 9B floor model can plausibly reach 256K, giving quality data at maximum native context. All larger models will OOM-skip cheaply past their limit.
+
+96K and 128K were removed from `boundary_context_sizes` — they are now covered by the standard tier. The boundary tier is reduced to a single 320K probe, which is genuinely beyond anything except the 9B Q4 model.
+
+### Drop concurrency=2
+
+Speed-tier data showed 98–105% concurrency efficiency across all 7 models. Ollama serialises requests on a single GPU — this is expected behaviour and will not change at higher context sizes. Removing `concurrency=2` halves the total matrix run count with no loss of useful data.
+
+### Prefill tiers at high context sizes — known limitation
+
+The `prefill_shared` and `prefill_unshared` tiers use a fixed 50K-token fixture regardless of `context_size`. At 196K/256K context, the fixture fills only ~20% of the allocated KV buffer. TTFT numbers at those sizes reflect VRAM pressure from the large KV allocation, not genuine long-context prefill performance.
+
+A **per-tier `context_sizes` override** in `BenchConfig` would fix this — prefill tiers could be capped at 65K (where 50K fills ~75% of context), and speed/coding tiers could run the full range independently. This is a worthwhile future config addition; interpret prefill results at 196K+ with the fixture-size limitation in mind.
+
+### Final matrix configuration
+
+```toml
+context_sizes      = [16384, 32768, 65536, 131072, 196608, 262144]
+boundary_context_sizes = [327680]
+concurrency_levels = [1]
+repeats            = 3
+```
+
+Original matrix (4 ctx × 2 conc × 3 repeats = 24 cases/model/tier) →
+New matrix (6 ctx × 1 conc × 3 repeats = 18 cases/model/tier): **25% fewer runs, substantially more useful coverage.**
+
+---
+
 ## What's next
 
-- **Full matrix run** (all 5 tiers): run after merging the throttle fix. Estimated 4–8 hours on RTX 5090. Start with `--tier coding` after `--tier speed` to get quality scores before the long prefill tiers.
-- **qwen3.6:35b-a3b VRAM watch**: expect OOM at some boundary-tier sizes. The adaptive skip logic will handle it; the max working context recorded at sweep end will be the key number.
-- **devstral:24b 64K degradation**: the coding tier will reveal whether quality compensates for the speed drop at large contexts.
-- **qwen3.5:9b quant comparison**: Q4 vs Q8 quality delta in the coding tier is the main data point — if quality is equivalent, Q4 is the clear production choice at 6.6 GB.
+- **Full matrix run** (all 5 tiers): estimated 4–7 hours on RTX 5090 with the tuned matrix. Start with `--tier coding` after `--tier speed` to get quality scores before the long prefill tiers.
+- **qwen3.6:35b-a3b VRAM watch**: 3.9 GB headroom at speed tier; expect OOM somewhere between 131K and 196K. The adaptive skip records max working context automatically.
+- **devstral:24b 64K degradation**: coding tier will reveal whether quality compensates for the 50% throughput drop at 64K.
+- **qwen3.5:9b quant comparison**: Q4 vs Q8 quality delta in the coding tier is the key data point — if equivalent, Q4 at 6.6 GB is the clear production floor model.
+- **Per-tier context_sizes**: implement as a follow-on config addition to make prefill results at 196K+ meaningful.

--- a/scripts/bench/config.py
+++ b/scripts/bench/config.py
@@ -67,6 +67,7 @@ class TierConfig(BaseModel):
     model_config = {"extra": "forbid"}
 
     name: str
+    context_sizes: list[int] | None = None
 
 
 class BenchConfig(BaseModel):
@@ -107,11 +108,12 @@ class BenchConfig(BaseModel):
 
         for model in enabled_models:
             for tier in self.tiers:
-                ctx_sizes = (
-                    self.matrix.boundary_context_sizes
-                    if tier.name == "boundary"
-                    else self.matrix.context_sizes
-                )
+                if tier.name == "boundary":
+                    ctx_sizes = self.matrix.boundary_context_sizes
+                elif tier.context_sizes is not None:
+                    ctx_sizes = tier.context_sizes
+                else:
+                    ctx_sizes = self.matrix.context_sizes
 
                 for ctx_size in ctx_sizes:
                     cases.append(

--- a/scripts/bench/fixtures.py
+++ b/scripts/bench/fixtures.py
@@ -76,11 +76,16 @@ local worker sessions in isolated git worktrees.
 
 
 def generate_fixtures() -> None:
-    """Create scripts/bench/fixtures/prefill_50k.txt (~50k tokens)."""
+    """Create scripts/bench/fixtures/prefill_base.txt (~100k tokens / 400k chars).
+
+    The base fixture is sliced at runtime by prefill_shared/unshared prompts to
+    match each context_size (75% fill). At the largest prefill context (131072
+    tokens), 75% fill = ~98k tokens = ~393k chars, so 450k chars gives headroom.
+    """
     _FIXTURES_DIR.mkdir(parents=True, exist_ok=True)
-    target = _FIXTURES_DIR / "prefill_50k.txt"
-    # Target: ~50k tokens ≈ 200k chars at 4 chars/token
-    target_chars = 200_000
+    target = _FIXTURES_DIR / "prefill_base.txt"
+    # 450k chars ≈ 112k tokens — covers 131k context at 75% fill with headroom
+    target_chars = 450_000
     base = _PROJECT_SUMMARY_TEMPLATE
     parts = [base]
     section_idx = 0

--- a/scripts/bench/run_bench.py
+++ b/scripts/bench/run_bench.py
@@ -112,7 +112,10 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--generate-fixtures",
         action="store_true",
-        help="Create scripts/bench/fixtures/prefill_50k.txt",
+        help=(
+            "Create scripts/bench/fixtures/prefill_base.txt"
+            " (~100k tokens; sliced per context_size at runtime)"
+        ),
     )
     parser.add_argument(
         "--browse",

--- a/scripts/bench/runner.py
+++ b/scripts/bench/runner.py
@@ -51,15 +51,17 @@ def _is_oom(error: str) -> bool:
     )
 
 
-def _make_prompt(tier: str, repeat_index: int) -> BenchPrompt:
+def _make_prompt(tier: str, repeat_index: int, context_size: int) -> BenchPrompt:
     if tier == "speed":
         return make_speed_prompt()
     if tier == "coding":
         return make_coding_prompt()
     if tier == "prefill_shared":
-        return make_prefill_shared_prompt(suffix_index=repeat_index)
+        return make_prefill_shared_prompt(
+            suffix_index=repeat_index, context_size=context_size
+        )
     if tier == "prefill_unshared":
-        return make_prefill_unshared_prompt()
+        return make_prefill_unshared_prompt(context_size=context_size)
     if tier == "boundary":
         return make_boundary_prompt()
     raise ValueError(f"Unknown tier: {tier!r}")
@@ -269,7 +271,7 @@ def run(
             else:
                 cache_state = "prefix_warm"
 
-        prompt = _make_prompt(case.tier, case.repeat_index)
+        prompt = _make_prompt(case.tier, case.repeat_index, case.context_size)
 
         gpu_mon = GpuMonitor()
         sys_mon = SysMonitor()

--- a/scripts/bench/tasks/prefill_shared.py
+++ b/scripts/bench/tasks/prefill_shared.py
@@ -7,20 +7,32 @@ from pathlib import Path
 
 from . import BenchPrompt
 
-FIXTURE_PATH = Path(__file__).parent.parent / "fixtures" / "prefill_50k.txt"
+FIXTURE_PATH = Path(__file__).parent.parent / "fixtures" / "prefill_base.txt"
+
+_FILL_RATIO = 0.75
+_CHARS_PER_TOKEN = 4
 
 _SUFFIX_TEMPLATE = (
     "\n\n[Query {index}] Summarise the document above in three bullet points."
 )
 
 
-def make_prefill_shared_prompt(suffix_index: int = 0) -> BenchPrompt:
+def make_prefill_shared_prompt(
+    suffix_index: int = 0, context_size: int = 65536
+) -> BenchPrompt:
+    """Build a prefill_shared prompt sized to 75% of context_size.
+
+    The shared prefix is the same content for every request at a given
+    context_size, enabling KV-cache reuse measurement (vLLM APC).
+    suffix_index varies per repeat so each repeat has a distinct prompt hash.
+    """
     if not FIXTURE_PATH.exists():
         raise FileNotFoundError(
             f"Fixture file not found: {FIXTURE_PATH}. "
             "Generate it first: python scripts/bench/run_bench.py --generate-fixtures"
         )
-    doc = FIXTURE_PATH.read_text(encoding="utf-8")
+    target_chars = int(context_size * _FILL_RATIO * _CHARS_PER_TOKEN)
+    doc = FIXTURE_PATH.read_text(encoding="utf-8")[:target_chars]
     suffix = _SUFFIX_TEMPLATE.format(index=suffix_index)
     text = doc + suffix
     prompt_hash = hashlib.sha256(text.encode()).hexdigest()

--- a/scripts/bench/tasks/prefill_unshared.py
+++ b/scripts/bench/tasks/prefill_unshared.py
@@ -48,9 +48,16 @@ _WORDS = [
 _CHARS_PER_TOKEN = 4
 
 
-def make_prefill_unshared_prompt(target: int = 50000, seed: int = 42) -> BenchPrompt:
+def make_prefill_unshared_prompt(
+    context_size: int = 65536, seed: int = 42
+) -> BenchPrompt:
+    """Build a prefill_unshared prompt sized to 75% of context_size.
+
+    Content is freshly randomised each call (no shared prefix) — this is the
+    cold-prefill baseline against which prefill_shared APC gains are measured.
+    """
     rng = random.Random(seed)
-    target_chars = target * _CHARS_PER_TOKEN
+    target_chars = int(context_size * 0.75) * _CHARS_PER_TOKEN
     words: list[str] = []
     total = 0
     while total < target_chars:
@@ -60,8 +67,7 @@ def make_prefill_unshared_prompt(target: int = 50000, seed: int = 42) -> BenchPr
     text = " ".join(words)
     token_count_estimate = len(text) // _CHARS_PER_TOKEN
     prompt_hash = hashlib.sha256(text.encode()).hexdigest()
-    # seed here is the RNG seed for text generation, not the LLM generation seed.
-    # BenchPrompt.seed (None) controls LLM reproducibility separately.
+    # seed is the RNG seed for text generation, not the LLM generation seed.
     return BenchPrompt(
         text=text,
         prompt_hash=prompt_hash,

--- a/tests/bench/test_bench_config.py
+++ b/tests/bench/test_bench_config.py
@@ -267,6 +267,70 @@ name = "speed"
     assert cfg.matrix.skip_oom_larger_ctx is False
 
 
+def test_tier_context_sizes_overrides_matrix(tmp_path: Path) -> None:
+    """Per-tier context_sizes replaces matrix.context_sizes for that tier only."""
+    toml = """
+[matrix]
+context_sizes = [1024, 4096]
+boundary_context_sizes = [8192]
+concurrency_levels = [1]
+repeats = 1
+
+[[backends]]
+id = "local_a"
+enabled = true
+base_url = "http://localhost:1/"
+api_key = "x"
+
+[[models]]
+id = "m"
+backend_id = "local_a"
+
+[[tiers]]
+name = "speed"
+
+[[tiers]]
+name = "prefill_shared"
+context_sizes = [2048]
+"""
+    cfg = BenchConfig.from_toml(_write_toml(tmp_path, toml))
+    cases = cfg.expand_matrix()
+
+    speed_ctx = {c.context_size for c in cases if c.tier == "speed"}
+    prefill_ctx = {c.context_size for c in cases if c.tier == "prefill_shared"}
+
+    assert speed_ctx == {1024, 4096}
+    assert prefill_ctx == {2048}
+
+
+def test_tier_context_sizes_none_uses_matrix(tmp_path: Path) -> None:
+    """TierConfig without context_sizes falls back to matrix.context_sizes."""
+    toml = """
+[matrix]
+context_sizes = [1024, 4096]
+boundary_context_sizes = [8192]
+concurrency_levels = [1]
+repeats = 1
+
+[[backends]]
+id = "local_a"
+enabled = true
+base_url = "http://localhost:1/"
+api_key = "x"
+
+[[models]]
+id = "m"
+backend_id = "local_a"
+
+[[tiers]]
+name = "speed"
+"""
+    cfg = BenchConfig.from_toml(_write_toml(tmp_path, toml))
+    cases = cfg.expand_matrix()
+    ctx = {c.context_size for c in cases if c.tier == "speed"}
+    assert ctx == {1024, 4096}
+
+
 def test_matrix_require_single_concurrency_first_can_be_disabled(
     tmp_path: Path,
 ) -> None:

--- a/tests/bench/test_bench_tasks.py
+++ b/tests/bench/test_bench_tasks.py
@@ -44,31 +44,30 @@ def test_prefill_shared_different_suffix_produces_different_hash(
 
 
 def test_prefill_unshared_token_count_within_5pct() -> None:
-    target = 50000
-    prompt = make_prefill_unshared_prompt(target=target, seed=42)
+    context_size = 65536
+    expected_tokens = int(context_size * 0.75)
+    prompt = make_prefill_unshared_prompt(context_size=context_size, seed=42)
     assert prompt.token_count_estimate is not None
-    tolerance = target * 0.05
-    assert abs(prompt.token_count_estimate - target) <= tolerance
+    tolerance = expected_tokens * 0.05
+    assert abs(prompt.token_count_estimate - expected_tokens) <= tolerance
 
 
 def test_prefill_unshared_llm_seed_is_none() -> None:
-    prompt = make_prefill_unshared_prompt(target=100, seed=42)
-    # seed=42 above is the RNG seed for text generation
-    # BenchPrompt.seed (None) is the LLM generation seed — a separate concept
+    prompt = make_prefill_unshared_prompt(context_size=1024, seed=42)
     assert prompt.seed is None
     assert prompt.max_tokens == 128
 
 
 def test_prefill_unshared_deterministic() -> None:
-    p1 = make_prefill_unshared_prompt(target=1000, seed=42)
-    p2 = make_prefill_unshared_prompt(target=1000, seed=42)
+    p1 = make_prefill_unshared_prompt(context_size=4096, seed=42)
+    p2 = make_prefill_unshared_prompt(context_size=4096, seed=42)
     assert p1.text == p2.text
     assert p1.prompt_hash == p2.prompt_hash
 
 
 def test_prefill_unshared_different_seeds_differ() -> None:
-    p1 = make_prefill_unshared_prompt(target=1000, seed=42)
-    p2 = make_prefill_unshared_prompt(target=1000, seed=99)
+    p1 = make_prefill_unshared_prompt(context_size=4096, seed=42)
+    p2 = make_prefill_unshared_prompt(context_size=4096, seed=99)
     assert p1.text != p2.text
 
 

--- a/tests/bench/test_runner.py
+++ b/tests/bench/test_runner.py
@@ -79,26 +79,26 @@ def test_make_driver_returns_ollama_as_default() -> None:
 
 
 def test_make_prompt_speed() -> None:
-    prompt = _make_prompt("speed", 0)
+    prompt = _make_prompt("speed", 0, 65536)
     assert isinstance(prompt, BenchPrompt)
     assert prompt.task_type == "speed"
 
 
 def test_make_prompt_coding() -> None:
-    prompt = _make_prompt("coding", 0)
+    prompt = _make_prompt("coding", 0, 65536)
     assert isinstance(prompt, BenchPrompt)
     assert prompt.task_type == "coding"
 
 
 def test_make_prompt_boundary() -> None:
-    prompt = _make_prompt("boundary", 0)
+    prompt = _make_prompt("boundary", 0, 65536)
     assert isinstance(prompt, BenchPrompt)
     assert prompt.task_type == "boundary"
 
 
 def test_make_prompt_raises_for_unknown_tier() -> None:
     with pytest.raises(ValueError, match="Unknown tier"):
-        _make_prompt("nonexistent", 0)
+        _make_prompt("nonexistent", 0, 65536)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `context_sizes` extended to `[16K, 32K, 64K, 96K, 128K, 192K, 256K]`
- 96K added as a calibration point between 64K and 128K (devstral cliff + qwen3.6:35b-a3b VRAM squeeze)
- `boundary_context_sizes` reduced to `[320K]`
- `concurrency_levels` reduced from `[1, 2]` to `[1]`
- Per-tier `context_sizes` override implemented in `TierConfig` + `expand_matrix()`
- Prefill tiers capped at `[16K, 32K, 64K, 96K, 128K]` — prompt content scales to 75% fill at each size
- Fixture generator updated: `prefill_base.txt` (~112K tokens / 450K chars) replaces `prefill_50k.txt`
- `make_prefill_shared_prompt` and `make_prefill_unshared_prompt` accept `context_size` and slice accordingly
- Findings doc updated throughout

## Rationale

**4K dropped:** watcher sessions never start below 10K tokens once system prompt + CLAUDE.md + file reads are loaded. 16K is the meaningful floor.

**96K added:** The 64K→128K jump is 2× in KV cache size — the largest relative gap in the matrix. `devstral:24b` already showed a 102→53 tok/s drop at 64K; 96K characterises whether that's a cliff or a gradual squeeze. `qwen3.6:35b-a3b` at 3.9 GB headroom may also start showing pressure here.

**256K added:** `skip_oom_larger_ctx = true` makes high context sizes nearly free — models that can't reach them record `skipped_oom` in milliseconds. Only `qwen3.5:9b-q4_K_M` (6.6 GB weights, 20 GB headroom) is expected to reach 256K natively.

**Concurrency=2 dropped:** speed-tier data showed 98–105% efficiency for all 7 models. Ollama serialises on a single GPU — expected, won't change at higher contexts. Halves the matrix with no data loss.

**Per-tier context_sizes + size-matched fixtures:** `prefill_shared/unshared` previously used a fixed 50K-token fixture regardless of context size — at 196K+ context that's ~20% fill, measuring VRAM pressure rather than prefill performance. Prefill tiers now cap at 128K and the fixture is sliced to 75% of the actual context_size per request, making the vLLM APC comparison meaningful at every tested size.

**Net matrix:** 7 context sizes × 1 concurrency × 3 repeats = 21 cases/model/tier for speed/coding; 5 sizes for prefill tiers.

## Test plan

- [x] All existing `test_bench_config.py` tests pass
- [x] `test_tier_context_sizes_overrides_matrix` — per-tier override uses tier's list
- [x] `test_tier_context_sizes_none_uses_matrix` — absent override falls back to matrix
- [ ] Run `--generate-fixtures` to create `prefill_base.txt` before next prefill run

🤖 Generated with [Claude Code](https://claude.com/claude-code)