### PR TITLE
Add composite quality-tier ranking to benchmark reporter

### DIFF
--- a/scripts/bench/reporter_ranking.py
+++ b/scripts/bench/reporter_ranking.py
@@ -11,10 +11,31 @@ from scripts.bench._reporter_helpers import (
     _cv,
     _fmt,
     _median,
-    _pct,
     _percentile,
 )
 from scripts.bench.reporter_apc import print_apc_section
+
+
+def _quality_tier_rank(
+    task_pct: float | None,
+    high_pct: float,
+    med_pct: float,
+) -> int:
+    """0 = HIGH (≥high_pct), 1 = MED (≥med_pct), 2 = speed-only (no coding data).
+
+    Lower rank sorts first — quality beats speed within the composite ordering.
+    Models with no coding data are not penalised by the eligibility gate but
+    sort after all models with quality measurements.
+    """
+    if task_pct is None:
+        return 2
+    if task_pct >= high_pct:
+        return 0
+    return 1
+
+
+def _quality_tier_label(task_pct: float | None, high_pct: float, med_pct: float) -> str:
+    return ("HIGH", "MED", "—")[_quality_tier_rank(task_pct, high_pct, med_pct)]
 
 
 def _is_eligible(
@@ -22,6 +43,7 @@ def _is_eligible(
     *,
     min_useful_ctx: int = 4096,
     min_throughput_toks_per_s: float = 5.0,
+    min_task_success_pct: float = 70.0,
 ) -> str | None:
     """Return None if the config passes all quality gates, or a rejection reason string.
 
@@ -88,7 +110,7 @@ def _is_eligible(
         floor = min_throughput_toks_per_s
         return f"throughput too low ({median_tok:.1f} tok/s < {floor} tok/s)"
 
-    # task_success >= 70% for coding rows that have quality data
+    # task_success >= min_task_success_pct for coding rows that have quality data
     coding_with_quality = [
         r
         for r in real_runs
@@ -96,8 +118,9 @@ def _is_eligible(
     ]
     if coding_with_quality:
         successes = sum(1 for r in coding_with_quality if r.get("quality_task_success"))
-        if successes / len(coding_with_quality) < 0.70:
-            return f"task success {successes / len(coding_with_quality):.0%} < 70%"
+        rate = successes / len(coding_with_quality)
+        if rate < min_task_success_pct / 100:
+            return f"task success {rate:.0%} < {min_task_success_pct:.0f}%"
 
     return None
 
@@ -201,13 +224,16 @@ def print_ranking(
     min_useful_ctx: int = 4096,
     min_throughput_toks_per_s: float = 5.0,
     cv_threshold: float = 0.3,
+    high_quality_pct: float = 85.0,
+    medium_quality_pct: float = 70.0,
 ) -> None:
-    """Print quality-gated ranking with recommendation banner.
+    """Print composite-scored ranking with recommendation banner.
 
-    Ineligible configs are listed below the ranking table with their rejection reason.
-    Threshold parameters keep defaults so existing callers need no changes.
-    When a config has > 1 repeat, ttft_p95 and ttft_cv are computed and the config is
-    flagged unstable when ttft_cv exceeds cv_threshold (default 0.3).
+    Sort order: quality tier first (HIGH ≥ high_quality_pct > MED ≥ medium_quality_pct >
+    speed-only), then tok/s descending within each tier, then TTFT ascending.
+    Models below medium_quality_pct are ineligible when coding data is present.
+    Configs without coding data are eligible but sort after all quality-measured
+    configs.
     """
     if not rows:
         return
@@ -230,6 +256,7 @@ def print_ranking(
             config_rows,
             min_useful_ctx=min_useful_ctx,
             min_throughput_toks_per_s=min_throughput_toks_per_s,
+            min_task_success_pct=medium_quality_pct,
         )
         if reason is not None:
             ineligible.append((config_key, reason))
@@ -311,21 +338,26 @@ def print_ranking(
         print_concurrency_scaling_section(rows)
         return
 
-    # Sort by TTFT p50 ascending (lower is better); fall back to tok/s descending
+    # Composite sort: quality tier → tok/s descending → TTFT ascending
     eligible.sort(
         key=lambda e: (
-            e["ttft_p50"] if e["ttft_p50"] is not None else float("inf"),
+            _quality_tier_rank(e["task_pct"], high_quality_pct, medium_quality_pct),
             -(e["tok_p50"] if e["tok_p50"] is not None else 0.0),
+            e["ttft_p50"] if e["ttft_p50"] is not None else float("inf"),
         )
     )
 
     print("=" * _W)
-    print("QUALITY-ELIGIBLE RANKING  (oom=No, offload=No, err≤5%, task≥70%)")
+    print(
+        f"COMPOSITE RANKING  "
+        f"(HIGH≥{high_quality_pct:.0f}% → MED≥{medium_quality_pct:.0f}%"
+        f" → speed-only  |  within tier: tok/s↓ then TTFT↑)"
+    )
     print("=" * _W)
     header = (
         f"{'Rank':>4}  {'Config (backend/model/ctx/c)':<44}  "
         f"{'TTFT p50(s)':>10}  {'TTFT p95(s)':>10}  {'CV':>6}  "
-        f"{'Tok/s p50':>9}  {'Task%':>5}  {'Stable':>6}  "
+        f"{'Tok/s p50':>9}  {'Q.Tier':>6}  {'Stable':>6}  "
         f"{'VRAM Hdrm':>9}  {'Conc.Eff':>9}"
     )
     print(header)
@@ -336,7 +368,9 @@ def print_ranking(
         ttft_p95_str = _fmt(entry["ttft_p95"], ".3f")
         cv_str = _fmt(entry["ttft_cv"], ".3f")
         tok_str = _fmt(entry["tok_p50"], ".0f")
-        task_str = _pct(entry["task_pct"])
+        tier_str = _quality_tier_label(
+            entry["task_pct"], high_quality_pct, medium_quality_pct
+        )
         if entry["unstable"] is None:
             stable_str = "--"
         elif entry["unstable"]:
@@ -354,14 +388,17 @@ def print_ranking(
         row_str = (
             f"{rank:>4}  {entry['config_key']:<44}  "
             f"{ttft_p50_str:>10}  {ttft_p95_str:>10}  {cv_str:>6}  "
-            f"{tok_str:>9}  {task_str:>5}  {stable_str:>6}  "
+            f"{tok_str:>9}  {tier_str:>6}  {stable_str:>6}  "
             f"{headroom_str:>9}  {eff_str:>9}"
         )
         print(row_str)
 
     print("-" * _W)
     best = eligible[0]
-    print(f"\n  *** RECOMMENDED: {best['config_key']} ***")
+    best_tier = _quality_tier_label(
+        best["task_pct"], high_quality_pct, medium_quality_pct
+    )
+    print(f"\n  *** RECOMMENDED: {best['config_key']}  [Q.Tier: {best_tier}] ***")
     parts = []
     if best["ttft_p50"] is not None:
         parts.append(f"TTFT p50={best['ttft_p50']:.3f}s")

--- a/tests/bench/test_reporter_ranking.py
+++ b/tests/bench/test_reporter_ranking.py
@@ -351,6 +351,11 @@ class TestPrintRankingConcurrencyEfficiency:
         output = _capture(rows)
         assert "N/A" in output
 
+    def test_conc_eff_header_present(self) -> None:
+        rows = [self._make_row()]
+        output = _capture(rows)
+        assert "Conc.Eff" in output
+
     def test_super_linear_efficiency_displayed(self) -> None:
         rows = [
             self._make_row(concurrency=1, throughput_tok_s=50.0, ttft_s=0.3),
@@ -359,3 +364,148 @@ class TestPrintRankingConcurrencyEfficiency:
         output = _capture(rows)
         # efficiency = 150 / (2 * 50) = 1.500
         assert "1.500" in output
+
+
+# ── composite quality-tier ranking tests ──────────────────────────────────────
+
+
+class TestCompositeRanking:
+    def _make_speed_row(
+        self,
+        *,
+        model_id: str,
+        backend_id: str = "b",
+        context_size: int = 65536,
+        concurrency: int = 1,
+        repeat_index: int = 1,
+        throughput_tok_s: float = 80.0,
+        ttft_s: float = 0.5,
+        outcome: str = "ok",
+    ) -> dict[str, Any]:
+        return {
+            "backend_id": backend_id,
+            "model_id": model_id,
+            "context_size": context_size,
+            "concurrency": concurrency,
+            "repeat_index": repeat_index,
+            "ttft_s": ttft_s,
+            "throughput_tok_s": throughput_tok_s,
+            "outcome": outcome,
+            "cpu_offload_detected": False,
+            "tier": "speed",
+            "quality_task_success": None,
+        }
+
+    def _make_coding_row(
+        self,
+        *,
+        model_id: str,
+        backend_id: str = "b",
+        context_size: int = 65536,
+        concurrency: int = 1,
+        repeat_index: int = 1,
+        throughput_tok_s: float = 60.0,
+        task_success: bool = True,
+        outcome: str = "ok",
+    ) -> dict[str, Any]:
+        return {
+            "backend_id": backend_id,
+            "model_id": model_id,
+            "context_size": context_size,
+            "concurrency": concurrency,
+            "repeat_index": repeat_index,
+            "ttft_s": 1.0,
+            "throughput_tok_s": throughput_tok_s,
+            "outcome": outcome,
+            "cpu_offload_detected": False,
+            "tier": "coding",
+            "quality_task_success": task_success,
+        }
+
+    def test_high_quality_ranks_above_faster_speed_only(self) -> None:
+        # "quality" has 90% task_success but only 50 tok/s
+        # "fast" has no coding data but 200 tok/s
+        rows = [
+            self._make_speed_row(model_id="fast", throughput_tok_s=200.0),
+            self._make_speed_row(model_id="quality", throughput_tok_s=50.0),
+            self._make_coding_row(model_id="quality", task_success=True),
+        ]
+        output = _capture(rows)
+        quality_pos = output.index("quality")
+        fast_pos = output.index("fast")
+        assert quality_pos < fast_pos
+
+    def test_med_quality_ranks_above_speed_only(self) -> None:
+        # "med" is 75% task_success (MED tier); "fast" has no coding data
+        rows = [
+            self._make_speed_row(model_id="fast", throughput_tok_s=200.0),
+            self._make_speed_row(model_id="med", throughput_tok_s=50.0),
+            self._make_coding_row(model_id="med", task_success=True),
+            self._make_coding_row(model_id="med", task_success=True),
+            self._make_coding_row(model_id="med", task_success=True),
+            self._make_coding_row(model_id="med", task_success=False),
+        ]
+        output = _capture(rows)
+        med_pos = output.index("med")
+        fast_pos = output.index("fast")
+        assert med_pos < fast_pos
+
+    def test_within_same_tier_higher_tok_ranks_first(self) -> None:
+        # Both HIGH quality; "turbo" has more tok/s → should rank first
+        rows = [
+            self._make_speed_row(model_id="slow", throughput_tok_s=40.0),
+            self._make_speed_row(model_id="turbo", throughput_tok_s=120.0),
+            self._make_coding_row(model_id="slow", task_success=True),
+            self._make_coding_row(model_id="turbo", task_success=True),
+        ]
+        output = _capture(rows)
+        turbo_pos = output.index("turbo")
+        slow_pos = output.index("slow")
+        assert turbo_pos < slow_pos
+
+    def test_quality_tier_column_in_header(self) -> None:
+        rows = [self._make_speed_row(model_id="m")]
+        output = _capture(rows)
+        assert "Q.Tier" in output
+
+    def test_high_quality_label_shown(self) -> None:
+        rows = [
+            self._make_speed_row(model_id="m"),
+            self._make_coding_row(model_id="m", task_success=True),
+        ]
+        output = _capture(rows)
+        assert "HIGH" in output
+
+    def test_speed_only_dash_shown_when_no_coding_data(self) -> None:
+        rows = [self._make_speed_row(model_id="m")]
+        output = _capture(rows)
+        assert "—" in output
+
+    def test_recommendation_includes_quality_tier(self) -> None:
+        rows = [
+            self._make_speed_row(model_id="m"),
+            self._make_coding_row(model_id="m", task_success=True),
+        ]
+        output = _capture(rows)
+        assert "Q.Tier:" in output
+
+    def test_custom_high_quality_threshold(self) -> None:
+        # With high_quality_pct=95, a model at 90% falls to MED
+        rows = [
+            self._make_speed_row(model_id="m"),
+            self._make_coding_row(model_id="m", task_success=True),
+            self._make_coding_row(model_id="m", task_success=True),
+            self._make_coding_row(model_id="m", task_success=True),
+            self._make_coding_row(model_id="m", task_success=True),
+            self._make_coding_row(model_id="m", task_success=True),
+            self._make_coding_row(model_id="m", task_success=True),
+            self._make_coding_row(model_id="m", task_success=True),
+            self._make_coding_row(model_id="m", task_success=True),
+            self._make_coding_row(model_id="m", task_success=True),
+            self._make_coding_row(model_id="m", task_success=False),  # 90%
+        ]
+        output_default = _capture(rows)  # high_quality_pct=85 → HIGH
+        assert "HIGH" in output_default
+
+        output_strict = _capture(rows, high_quality_pct=95.0)  # 90% < 95 → MED
+        assert "MED" in output_strict


### PR DESCRIPTION
## Summary

- Ranking now sorts **quality tier first** (HIGH ≥ 85% → MED ≥ 70% → speed-only), then tok/s descending within each tier, then TTFT ascending
- Previously sorted by TTFT only — the fastest model (9B Q4) was always recommended regardless of coding quality
- Models without coding-tier data remain eligible but sort after all quality-measured configs
- `high_quality_pct` (85) and `medium_quality_pct` (70) are configurable params on `print_ranking`
- Table column `Task%` replaced by `Q.Tier` showing HIGH / MED / — 
- Recommendation banner now shows `[Q.Tier: HIGH/MED/—]`
- `_is_eligible` gains `min_task_success_pct` param (was hardcoded 0.70); wired to `medium_quality_pct`

## Why quality-first

For the watcher use case the right question is: which model actually completes coding tasks correctly? A 9B model at 178 tok/s that fails 40% of tasks is worse than a 30B model at 90 tok/s that passes 90%. TTFT-first was the wrong primary axis.

Speed-only configs (no coding tier data yet) still appear in the ranking — they just sort last. So the ranking is useful immediately after a speed-tier-only run, and becomes quality-aware once coding data is present.

## Test plan

- [x] All 38 existing `test_reporter_ranking.py` tests pass unchanged
- [x] `test_high_quality_ranks_above_faster_speed_only` — HIGH quality + low tok/s beats speed-only + high tok/s
- [x] `test_med_quality_ranks_above_speed_only` — MED quality also beats speed-only
- [x] `test_within_same_tier_higher_tok_ranks_first` — tok/s is tiebreaker within same tier
- [x] `test_quality_tier_column_in_header` — Q.Tier in header
- [x] `test_high_quality_label_shown` / `test_speed_only_dash_shown` — label display
- [x] `test_recommendation_includes_quality_tier` — banner shows Q.Tier
- [x] `test_custom_high_quality_threshold` — threshold param works

🤖 Generated with [Claude Code](https://claude.com/claude-code)