### PR TITLE
Fix coding quality_task_success always NULL; drop qwen3.6:27b

### DIFF
--- a/config/bench.toml
+++ b/config/bench.toml
@@ -82,11 +82,6 @@ id = "qwen3.6:35b-a3b"
 backend_id = "local_qwen"
 
 [[models]]
-# 17 GB | Dense 27B — mid-range candidate from WOR-180.
-id = "qwen3.6:27b"
-backend_id = "local_qwen"
-
-[[models]]
 # 19 GB | MoE 30B coder / 3.3B active — current production model (spike WOR-76 baseline).
 # 256K native context; same MoE efficiency profile as qwen3.6:35b-a3b.
 id = "qwen3-coder:30b"
@@ -100,7 +95,7 @@ id = "qwen2.5-coder:32b-instruct-q4_K_M"
 backend_id = "local_qwen"
 
 [[models]]
-# 17 GB | Dense 27B — Gemma 3 cross-vendor comparison at same size tier as qwen3.6:27b.
+# 17 GB | Dense 27B — Gemma 3 cross-vendor comparison at the 27B size tier.
 id = "gemma3:27b"
 backend_id = "local_qwen"
 
@@ -133,11 +128,6 @@ backend_id = "local_vllm"
 [[models]]
 # HF: verify exact repo name — may be Qwen/Qwen3.6-35B-A3B or similar
 id = "Qwen/Qwen3.6-35B-A3B"
-backend_id = "local_vllm"
-
-[[models]]
-# HF: verify exact repo name — may be Qwen/Qwen3.6-27B or similar
-id = "Qwen/Qwen3.6-27B"
 backend_id = "local_vllm"
 
 [[models]]

--- a/scripts/bench/drivers/ollama.py
+++ b/scripts/bench/drivers/ollama.py
@@ -108,6 +108,9 @@ class OllamaDriver:
         _THINK_TAG = "</think>"
         _TAIL_LEN = len(_THINK_TAG) - 1
         thinking_phase: bool = True
+        # True once Ollama's native "thinking" field has been seen; switches the
+        # end-of-thinking detector from </think> tag search to first-content-frame.
+        has_seen_ollama_thinking: bool = False
         tail_buf: str = ""
 
         while True:
@@ -124,23 +127,40 @@ class OllamaDriver:
 
             if not frame.get("done", False):
                 content: str = frame.get("message", {}).get("content", "")
-                if content and ttft_s is None:
+                ollama_thinking: str = frame.get("message", {}).get("thinking", "")
+
+                if ollama_thinking:
+                    has_seen_ollama_thinking = True
+
+                # TTFT from first token of any kind (thinking or content)
+                if (content or ollama_thinking) and ttft_s is None:
                     ttft_s = time.monotonic() - t_start
-                if thinking_phase and content:
-                    check = tail_buf + content
-                    idx = check.find(_THINK_TAG)
-                    if idx >= 0:
-                        thinking_phase = False
-                        after = check[idx + len(_THINK_TAG) :]
-                        if after:
-                            ttfut_s = time.monotonic() - t_start
-                        tail_buf = ""
-                    else:
-                        tail_buf = (
-                            check[-_TAIL_LEN:] if len(check) > _TAIL_LEN else check
-                        )
-                elif not thinking_phase and content and ttfut_s is None:
+
+                if thinking_phase:
+                    if has_seen_ollama_thinking:
+                        # Ollama native: thinking field present → still thinking;
+                        # first non-empty content frame → thinking done.
+                        if content and not ollama_thinking:
+                            thinking_phase = False
+                            if ttfut_s is None:
+                                ttfut_s = time.monotonic() - t_start
+                    elif content:
+                        # Embedded </think> tag approach (non-Ollama or older format)
+                        check = tail_buf + content
+                        idx = check.find(_THINK_TAG)
+                        if idx >= 0:
+                            thinking_phase = False
+                            after = check[idx + len(_THINK_TAG) :]
+                            if after and ttfut_s is None:
+                                ttfut_s = time.monotonic() - t_start
+                            tail_buf = ""
+                        else:
+                            tail_buf = (
+                                check[-_TAIL_LEN:] if len(check) > _TAIL_LEN else check
+                            )
+                elif content and ttfut_s is None:
                     ttfut_s = time.monotonic() - t_start
+
                 text_parts.append(content)
             else:
                 final_frame = frame

--- a/scripts/bench/quality.py
+++ b/scripts/bench/quality.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 import shutil
 import subprocess  # nosec B404
 import sys
@@ -29,11 +30,17 @@ def _apply_patch(patch: dict[str, str], dest: Path) -> None:
     target.write_text(patch["content"], encoding="utf-8")
 
 
+def _extract_response(text: str) -> str:
+    """Strip <think>...</think> blocks; return remaining text (or original if empty)."""
+    stripped = re.sub(r"<think>.*?</think>", "", text, flags=re.DOTALL).strip()
+    return stripped if stripped else text
+
+
 def evaluate_coding_output(model_output: str, repo_path: Path) -> QualityResult:
     """Parse model_output as tool-call JSON, apply to a temp repo copy, run checks."""
     temp_dir = tempfile.mkdtemp()
     try:
-        patch = json.loads(model_output)
+        patch = json.loads(_extract_response(model_output))
         if not isinstance(patch, dict) or "path" not in patch or "content" not in patch:
             return QualityResult(
                 task_success=False,

--- a/scripts/bench/tasks/coding.py
+++ b/scripts/bench/tasks/coding.py
@@ -25,7 +25,7 @@ def make_coding_prompt() -> BenchPrompt:
         text=_TEXT,
         prompt_hash=prompt_hash,
         task_type="coding",
-        max_tokens=512,
+        max_tokens=4096,
         temperature=0.0,
         seed=42,
     )

--- a/tests/bench/test_bench_tasks.py
+++ b/tests/bench/test_bench_tasks.py
@@ -76,7 +76,7 @@ def test_coding_prompt_returns_bench_prompt() -> None:
     assert prompt.task_type == "coding"
     assert len(prompt.text) > 0
     assert len(prompt.prompt_hash) == 64
-    assert prompt.max_tokens == 512
+    assert prompt.max_tokens == 4096
     assert prompt.temperature == pytest.approx(0.0)
     assert prompt.seed == 42
 


### PR DESCRIPTION
## Summary

- **Root cause**: Ollama streams thinking tokens in `message.thinking` with `message.content=""` every frame. The driver only read `message.content`, so `text_parts` accumulated empty strings → `result.text=""` → quality evaluator condition was always `False` → `NULL` stored for all coding rows instead of pass/fail
- **Fix 1 (driver)**: detect Ollama's native `thinking` field; transition out of thinking phase on first non-empty `content` frame rather than scanning for `</think>` tag in content (which never arrives via this path)
- **Fix 2 (max_tokens)**: raise coding tier `max_tokens` 512 → 4096 — qwen3's reasoning phase alone consumes 500–2000 tokens, leaving zero budget for the actual JSON response at 512
- **Fix 3 (quality.py)**: strip `<think>...</think>` blocks before `json.loads` as defence for backends that embed thinking in content rather than using a separate field
- **Drop qwen3.6:27b**: dominated on every measured axis by both `qwen3-coder:30b` (2.5× faster at all contexts, lower VRAM, coding-specialist) and `qwen3.6:35b-a3b` at large contexts (5–6× faster at 196K+). No scenario where 27b wins. Removed from both Ollama and vLLM model lists.

## Test plan

- [x] Run coding tier smoke test on single model before overnight matrix run: `python scripts/bench/run_bench.py --tier coding --model qwen3.6:35b-a3b`
- [x] Confirm `quality_task_success` is no longer `NULL` in DB (should be `0` or `1`)
- [x] All 354 bench tests pass (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)