### PR TITLE
Tune bench matrix: drop devstral/qwen2.5-coder:32b, raise coding max_tokens to 8192

### DIFF
--- a/config/bench.toml
+++ b/config/bench.toml
@@ -88,14 +88,9 @@ id = "qwen3-coder:30b"
 backend_id = "local_qwen"
 
 [[models]]
-# 19 GB | Dense 32B coder Q4_K_M — REFERENCE ONLY: previous-generation baseline.
-# Severe throughput cliff at 32K+ context (VRAM pressure); not a production candidate.
-# Kept to quantify Qwen3.6 MoE improvement over prior dense 32B generation.
-id = "qwen2.5-coder:32b-instruct-q4_K_M"
-backend_id = "local_qwen"
-
-[[models]]
 # 17 GB | Dense 27B — Gemma 3 cross-vendor comparison at the 27B size tier.
+# Flat 79-81 tok/s from 16K-320K. Does not follow JSON output format — coding quality 0%.
+# Keep for throughput characterisation; investigate JSON compliance separately.
 id = "gemma3:27b"
 backend_id = "local_qwen"
 
@@ -109,10 +104,6 @@ backend_id = "local_qwen"
 id = "qwen3.5:9b-q8_0"
 backend_id = "local_qwen"
 
-[[models]]
-# 14 GB | MoE 24B coding agent — Mistral Devstral, purpose-built for agentic coding, 128K context.
-id = "devstral:24b"
-backend_id = "local_qwen"
 
 
 # ── vLLM models (disabled via local_vllm backend) ─────────────────────────────
@@ -135,10 +126,6 @@ backend_id = "local_vllm"
 id = "Qwen/Qwen3-Coder-30B-Instruct"
 backend_id = "local_vllm"
 
-[[models]]
-# HF: Qwen/Qwen2.5-Coder-32B-Instruct (use unquantized; apply --quantization awq if needed)
-id = "Qwen/Qwen2.5-Coder-32B-Instruct"
-backend_id = "local_vllm"
 
 # ── Tiers ─────────────────────────────────────────────────────────────────────
 # All five tiers. Use --tier <name> for a single-tier run.

--- a/scripts/bench/tasks/coding.py
+++ b/scripts/bench/tasks/coding.py
@@ -25,7 +25,7 @@ def make_coding_prompt() -> BenchPrompt:
         text=_TEXT,
         prompt_hash=prompt_hash,
         task_type="coding",
-        max_tokens=4096,
+        max_tokens=8192,
         temperature=0.0,
         seed=42,
     )

--- a/tests/bench/test_bench_tasks.py
+++ b/tests/bench/test_bench_tasks.py
@@ -76,7 +76,7 @@ def test_coding_prompt_returns_bench_prompt() -> None:
     assert prompt.task_type == "coding"
     assert len(prompt.text) > 0
     assert len(prompt.prompt_hash) == 64
-    assert prompt.max_tokens == 4096
+    assert prompt.max_tokens == 8192
     assert prompt.temperature == pytest.approx(0.0)
     assert prompt.seed == 42
 


### PR DESCRIPTION
## Summary

- Drop `devstral:24b` from Ollama matrix: hard throughput cliff at 96K (108 → 16 tok/s), 0% ruff/quality score in overnight run, 128K native limit makes it non-viable above 64K
- Drop `qwen2.5-coder:32b-instruct-q4_K_M` from Ollama matrix: prior-gen reference baseline is complete; 32K throughput cliff confirmed (75 → 30 tok/s); no path to production candidacy
- Drop `Qwen/Qwen2.5-Coder-32B-Instruct` from vLLM candidates (same model, already characterized)
- Raise coding task `max_tokens` 4096 → 8192: `qwen3.5:9b-q4_K_M` and `qwen3.5:9b-q8_0` both exhausted 4096 tokens in the thinking phase before emitting any JSON, leaving all 28 coding rows NULL in the overnight run

Active Ollama matrix after this PR: `qwen3.6:35b-a3b`, `qwen3-coder:30b`, `gemma3:27b`, `qwen3.5:9b-q4_K_M`, `qwen3.5:9b-q8_0` (5 models)

## Test plan

- [ ] `test_coding_prompt_returns_bench_prompt` asserts `max_tokens == 8192`
- [ ] Run `--model qwen3.5:9b-q4_K_M --tier coding` to verify 9b models now complete reasoning + emit JSON within the higher budget

🤖 Generated with [Claude Code](https://claude.com/claude-code)