### PR TITLE
Raise coding max_tokens 8192 → 10240

### DIFF
--- a/scripts/bench/tasks/coding.py
+++ b/scripts/bench/tasks/coding.py
@@ -25,7 +25,7 @@ def make_coding_prompt() -> BenchPrompt:
         text=_TEXT,
         prompt_hash=prompt_hash,
         task_type="coding",
-        max_tokens=8192,
+        max_tokens=10240,
         temperature=0.0,
         seed=42,
     )

--- a/tests/bench/test_bench_tasks.py
+++ b/tests/bench/test_bench_tasks.py
@@ -76,7 +76,7 @@ def test_coding_prompt_returns_bench_prompt() -> None:
     assert prompt.task_type == "coding"
     assert len(prompt.text) > 0
     assert len(prompt.prompt_hash) == 64
-    assert prompt.max_tokens == 8192
+    assert prompt.max_tokens == 10240
     assert prompt.temperature == pytest.approx(0.0)
     assert prompt.seed == 42
 


### PR DESCRIPTION
## Summary

- Bump coding task `max_tokens` from 8192 → 10240
- `qwen3.5:9b-q4_K_M` consistently uses ~5417 tokens (thinking + answer). 8192 overflowed on 1/28 runs (32K context), leaving that row NULL.
- 10240 gives ~4800 tokens of headroom above typical usage, eliminating the occasional overflow.

Results are directly comparable across all context sizes — same fixed prompt, same task complexity, thinking trace length is driven by task not by allocated context window.

## Test plan

- [ ] `test_coding_prompt_returns_bench_prompt` asserts `max_tokens == 10240`
- [ ] Run `--model qwen3.5:9b-q4_K_M --tier coding` and confirm 0 NULL rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)