### PR TITLE
Raise coding max_tokens 10240 → 16384

### DIFF
--- a/scripts/bench/tasks/coding.py
+++ b/scripts/bench/tasks/coding.py
@@ -25,7 +25,7 @@ def make_coding_prompt() -> BenchPrompt:
         text=_TEXT,
         prompt_hash=prompt_hash,
         task_type="coding",
-        max_tokens=10240,
+        max_tokens=16384,
         temperature=0.0,
         seed=42,
     )

--- a/tests/bench/test_bench_tasks.py
+++ b/tests/bench/test_bench_tasks.py
@@ -76,7 +76,7 @@ def test_coding_prompt_returns_bench_prompt() -> None:
     assert prompt.task_type == "coding"
     assert len(prompt.text) > 0
     assert len(prompt.prompt_hash) == 64
-    assert prompt.max_tokens == 10240
+    assert prompt.max_tokens == 16384
     assert prompt.temperature == pytest.approx(0.0)
     assert prompt.seed == 42
 


### PR DESCRIPTION
## Summary

- Bump coding task `max_tokens` 10240 → 16384
- `qwen3.5:9b-q4_K_M` thinking variance is high — observed range 4284–10240+ tokens across identical runs of the same task. 10240 (PR #423) still overflows occasionally.
- 16384 gives ~6K headroom above the highest observed usage. Premium models (30b-coder: ~62 tok, 35b-a3b: ~1473 tok) are unaffected.

## Test plan

- [ ] `test_coding_prompt_returns_bench_prompt` asserts `max_tokens == 16384`
- [ ] Run `--model qwen3.5:9b-q4_K_M --tier coding` and confirm zero NULL rows across all 28 probe points

🤖 Generated with [Claude Code](https://claude.com/claude-code)