### PR TITLE
WOR-218 Wire vLLM as the default local backend for the watcher

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ python -m app.cli watcher --worker-mode cloud    # force cloud (Anthropic API) f
 python -m app.cli watcher --worker-mode local    # force local (LiteLLM proxy + RTX 5090)
 # Also: WORKER_MODE=cloud python -m app.cli watcher
 # Concurrency (pools are independent — local is never starved by cloud burst):
-python -m app.cli watcher --max-local-workers 1  # default 1; GPU serial bottleneck
+python -m app.cli watcher --max-local-workers 8  # default 8; vLLM handles concurrency
 python -m app.cli watcher --max-cloud-workers 3  # default 3; parallelisable
 python -m app.cli watcher --max-workers 2        # backward-compat alias: sets both to 2
 
@@ -214,14 +214,22 @@ No setup needed — hooks activate as soon as Claude Code loads the project.
 
 ## Local model development
 
-To run Claude Code routed to a local model (Ollama) instead of the Anthropic API:
+To run Claude Code routed to a local vLLM server instead of the Anthropic API:
 
 ```bash
-# 1. Copy the example config and start LiteLLM proxy (keep terminal open)
+# 1. Start vLLM server in WSL2 (keep terminal open)
+vllm serve /home/antti/models/Qwen3.6-35B-A3B-NVFP4 \
+  --max-model-len 131072 --max-num-seqs 16 \
+  --kv-cache-dtype fp8 --max-num-batched-tokens 4096 \
+  --reasoning-parser qwen3 --enable-prefix-caching \
+  --language-model-only --safetensors-load-strategy prefetch \
+  --enable-auto-tool-choice --tool-call-parser qwen3_coder
+
+# 2. Copy the example config and start LiteLLM proxy (keep terminal open)
 cp litellm-local.yaml.example litellm-local.yaml
 litellm --config litellm-local.yaml --port 8082 --drop_params
 
-# 2. Launch Claude Code in a new terminal
+# 3. Launch Claude Code in a new terminal
 set ANTHROPIC_BASE_URL=http://localhost:8082   # Windows
 set ANTHROPIC_API_KEY=sk-dummy
 claude --model qwen3-coder:30b

--- a/app/cli.py
+++ b/app/cli.py
@@ -114,8 +114,8 @@ def _build_parser() -> argparse.ArgumentParser:
     watcher.add_argument(
         "--max-local-workers",
         type=int,
-        default=1,
-        help="Maximum concurrent local worker sessions (default: 1).",
+        default=8,
+        help="Maximum concurrent local worker sessions (default: 8).",
     )
     watcher.add_argument(
         "--max-cloud-workers",

--- a/app/core/watcher.py
+++ b/app/core/watcher.py
@@ -70,7 +70,7 @@ class Watcher:
     def __init__(
         self,
         worker_mode: str = "default",
-        max_local_workers: int = 1,
+        max_local_workers: int = 8,
         max_cloud_workers: int = 3,
         linear_client: LinearClientProtocol | None = None,
         metrics_store: MetricsStore | None = None,
@@ -393,7 +393,6 @@ class Watcher:
         logger.info("Launching worker for %s (mode=%s)", ticket_id, effective_mode)
 
         if effective_mode == "local":
-            self._services.ensure_ollama_running()
             self._services.ensure_litellm_running()
 
         backed_up_plans = backup_plan_files()

--- a/litellm-local.yaml.example
+++ b/litellm-local.yaml.example
@@ -1,15 +1,12 @@
 model_list:
     # --- vLLM backend (recommended) ---
     # Start server in WSL2 first:
-    #   VLLM_MOE_BACKEND=FLASHINFER_TRTLLM vllm serve /home/antti/models/Qwen3.6-35B-A3B-NVFP4 \
-    #     --max-model-len 131072 --max-num-seqs 200 \
+    #   vllm serve /home/antti/models/Qwen3.6-35B-A3B-NVFP4 \
+    #     --max-model-len 131072 --max-num-seqs 16 \
+    #     --kv-cache-dtype fp8 --max-num-batched-tokens 4096 \
     #     --reasoning-parser qwen3 --enable-prefix-caching \
     #     --language-model-only --safetensors-load-strategy prefetch \
     #     --enable-auto-tool-choice --tool-call-parser qwen3_coder
-    #
-    # --enable-auto-tool-choice and --tool-call-parser qwen3_coder are required for
-    # tool use (function calling). Not yet validated in the watcher setup — add and
-    # test when wiring up the first real worker session against vLLM.
     - model_name: claude-sonnet-4-6
       litellm_params:
         model: openai//home/antti/models/Qwen3.6-35B-A3B-NVFP4

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -307,3 +307,15 @@ def test_watcher_max_workers_alias_sets_both():
     _, kwargs = MockWatcher.call_args
     assert kwargs.get("max_local_workers") == 4
     assert kwargs.get("max_cloud_workers") == 4
+
+
+def test_watcher_max_local_workers_default_is_8():
+    from unittest.mock import MagicMock, patch
+
+    mock_instance = MagicMock()
+    mock_instance.run.return_value = None
+    with patch("app.core.watcher.Watcher", return_value=mock_instance) as MockWatcher:
+        rc = main(["watcher"])
+    assert rc == 0
+    _, kwargs = MockWatcher.call_args
+    assert kwargs.get("max_local_workers") == 8

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -256,7 +256,7 @@ def test_cloud_pool_full_does_not_block_local_dispatch(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_dispatch_calls_ensure_ollama_and_litellm_for_local_effective_mode(
+def test_dispatch_calls_ensure_litellm_but_not_ollama_for_local_effective_mode(
     tmp_path: Path,
 ) -> None:
     manifest = _make_manifest(
@@ -286,7 +286,7 @@ def test_dispatch_calls_ensure_ollama_and_litellm_for_local_effective_mode(
     ):
         w._dispatch_next_ticket()
 
-    mock_ollama.assert_called_once()
+    mock_ollama.assert_not_called()
     mock_litellm.assert_called_once()
 
 


### PR DESCRIPTION
Closes WOR-218

All six acceptance criteria pass. ruff, mypy, and pytest all green. CLAUDE.md shows the FP8 vLLM command. watcher no longer calls ensure_ollama_running() for local/auto mode. --max-local-workers defaults to 8.