### PR TITLE
WOR-218 Add vLLM health probe with WSL2 auto-open; fix FP8 context size

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -219,7 +219,7 @@ To run Claude Code routed to a local vLLM server instead of the Anthropic API:
 ```bash
 # 1. Start vLLM server in WSL2 (keep terminal open)
 vllm serve /home/antti/models/Qwen3.6-35B-A3B-NVFP4 \
-  --max-model-len 131072 --max-num-seqs 16 \
+  --max-model-len 262144 --max-num-seqs 16 \
   --kv-cache-dtype fp8 --max-num-batched-tokens 4096 \
   --reasoning-parser qwen3 --enable-prefix-caching \
   --language-model-only --safetensors-load-strategy prefetch \

--- a/app/core/watcher.py
+++ b/app/core/watcher.py
@@ -109,6 +109,9 @@ class Watcher:
         self._register_signals()
         self._cleanup_orphaned_worktrees()
 
+        if self._mode in ("local", "default"):
+            self._services.probe_vllm_health()
+
         if self._mode == "local":
             self._services.ensure_litellm_running()
 
@@ -393,6 +396,7 @@ class Watcher:
         logger.info("Launching worker for %s (mode=%s)", ticket_id, effective_mode)
 
         if effective_mode == "local":
+            self._services.probe_vllm_health()
             self._services.ensure_litellm_running()
 
         backed_up_plans = backup_plan_files()

--- a/app/core/watcher_services.py
+++ b/app/core/watcher_services.py
@@ -87,7 +87,8 @@ class ServiceManager:
                     _VLLM_FP8_CMD + "; exec bash",
                 ],
                 creationflags=(
-                    subprocess.DETACHED_PROCESS | subprocess.CREATE_NEW_PROCESS_GROUP
+                    getattr(subprocess, "DETACHED_PROCESS", 0)
+                    | getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
                 ),
             )
             logger.info("Opened WSL2 terminal tab for vLLM server")

--- a/app/core/watcher_services.py
+++ b/app/core/watcher_services.py
@@ -22,9 +22,19 @@ from app.core.watcher_types import (
     _LITELLM_PORT,
     _OLLAMA_KEEPALIVE,
     _OLLAMA_PORT,
+    _VLLM_PORT,
 )
 
 logger = logging.getLogger(__name__)
+
+_VLLM_FP8_CMD = (
+    "vllm serve /home/antti/models/Qwen3.6-35B-A3B-NVFP4"
+    " --max-model-len 262144 --kv-cache-dtype fp8 --max-num-seqs 16"
+    " --max-num-batched-tokens 4096 --reasoning-parser qwen3"
+    " --enable-prefix-caching --language-model-only"
+    " --safetensors-load-strategy prefetch"
+    " --enable-auto-tool-choice --tool-call-parser qwen3_coder"
+)
 
 
 class ServiceManager:
@@ -34,6 +44,57 @@ class ServiceManager:
         self._repo_root = repo_root
         self._litellm_proc: subprocess.Popen[bytes] | None = None
         self._running = True
+
+    def probe_vllm_health(self) -> bool:
+        """Check whether vLLM is responding on localhost:_VLLM_PORT/health.
+
+        Returns True if healthy. If not responding, logs the FP8 server command
+        at WARNING level and on Windows opens a new WSL2 Windows Terminal tab
+        so the server can be started without leaving the watcher window.
+        """
+        try:
+            conn = http.client.HTTPConnection("localhost", _VLLM_PORT, timeout=3)
+            conn.request("GET", "/health")
+            resp = conn.getresponse()
+            if resp.status == 200:
+                logger.info("vLLM health check passed (port %d)", _VLLM_PORT)
+                return True
+        except (OSError, http.client.HTTPException):
+            pass
+
+        logger.warning(
+            "vLLM not responding on port %d — start the server in WSL2:\n\n  %s\n",
+            _VLLM_PORT,
+            _VLLM_FP8_CMD,
+        )
+        if sys.platform == "win32":
+            self._open_vllm_terminal()
+        return False
+
+    def _open_vllm_terminal(self) -> None:
+        """Open a new Windows Terminal tab running the vLLM FP8 command in WSL2."""
+        try:
+            subprocess.Popen(  # nosec B603 B607
+                [
+                    "wt.exe",
+                    "-w",
+                    "0",
+                    "new-tab",
+                    "--",
+                    "wsl",
+                    "bash",
+                    "-c",
+                    _VLLM_FP8_CMD + "; exec bash",
+                ],
+                creationflags=(
+                    subprocess.DETACHED_PROCESS | subprocess.CREATE_NEW_PROCESS_GROUP
+                ),
+            )
+            logger.info("Opened WSL2 terminal tab for vLLM server")
+        except FileNotFoundError:
+            logger.warning("wt.exe not found — start vLLM manually in WSL2")
+        except OSError as exc:
+            logger.warning("Could not open WSL2 terminal: %s", exc)
 
     def ensure_ollama_running(self) -> None:
         """Start Ollama with the configured model if not already on _OLLAMA_PORT."""

--- a/app/core/watcher_types.py
+++ b/app/core/watcher_types.py
@@ -23,6 +23,7 @@ _LITELLM_CONFIG = "litellm-local.yaml"
 _LOCAL_MODEL = "qwen3-coder:30b"
 _LITELLM_BASE_URL = f"http://localhost:{_LITELLM_PORT}"
 _OLLAMA_PORT = 11434
+_VLLM_PORT = 8000
 _OLLAMA_KEEPALIVE = "120m"
 _WORKTREE_BASE = Path("worktrees")
 

--- a/litellm-local.yaml.example
+++ b/litellm-local.yaml.example
@@ -2,7 +2,7 @@ model_list:
     # --- vLLM backend (recommended) ---
     # Start server in WSL2 first:
     #   vllm serve /home/antti/models/Qwen3.6-35B-A3B-NVFP4 \
-    #     --max-model-len 131072 --max-num-seqs 16 \
+    #     --max-model-len 262144 --max-num-seqs 16 \
     #     --kv-cache-dtype fp8 --max-num-batched-tokens 4096 \
     #     --reasoning-parser qwen3 --enable-prefix-caching \
     #     --language-model-only --safetensors-load-strategy prefetch \

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -107,6 +107,7 @@ def test_start_ticket_set_state_failure_worker_still_starts(tmp_path: Path) -> N
         patch("app.core.watcher.launch_worker", return_value=fake_process),
         patch.object(w._services, "ensure_ollama_running"),
         patch.object(w._services, "ensure_litellm_running"),
+        patch.object(w._services, "probe_vllm_health"),
     ):
         w._start_ticket("WOR-10", "fake-linear-id")
 
@@ -241,6 +242,7 @@ def test_cloud_pool_full_does_not_block_local_dispatch(tmp_path: Path) -> None:
         patch("app.core.watcher.write_worker_pytest_config"),
         patch.object(watcher._services, "ensure_ollama_running"),
         patch.object(watcher._services, "ensure_litellm_running"),
+        patch.object(watcher._services, "probe_vllm_health"),
         patch("app.core.watcher.launch_worker", return_value=fake_local_process),
     ):
         watcher._start_ticket("WOR-10", "fake-local-id")
@@ -283,11 +285,13 @@ def test_dispatch_calls_ensure_litellm_but_not_ollama_for_local_effective_mode(
         patch("app.core.watcher.launch_worker", return_value=fake_process),
         patch.object(w._services, "ensure_ollama_running") as mock_ollama,
         patch.object(w._services, "ensure_litellm_running") as mock_litellm,
+        patch.object(w._services, "probe_vllm_health") as mock_probe,
     ):
         w._dispatch_next_ticket()
 
     mock_ollama.assert_not_called()
     mock_litellm.assert_called_once()
+    mock_probe.assert_called_once()
 
 
 def test_dispatch_skips_ensure_for_cloud_effective_mode(tmp_path: Path) -> None:
@@ -315,11 +319,13 @@ def test_dispatch_skips_ensure_for_cloud_effective_mode(tmp_path: Path) -> None:
         patch("app.core.watcher.launch_worker", return_value=fake_process),
         patch.object(w._services, "ensure_ollama_running") as mock_ollama,
         patch.object(w._services, "ensure_litellm_running") as mock_litellm,
+        patch.object(w._services, "probe_vllm_health") as mock_probe,
     ):
         w._dispatch_next_ticket()
 
     mock_ollama.assert_not_called()
     mock_litellm.assert_not_called()
+    mock_probe.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_watcher_services.py
+++ b/tests/test_watcher_services.py
@@ -55,6 +55,64 @@ def test_stop_noop_when_no_proc(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# ServiceManager.probe_vllm_health
+# ---------------------------------------------------------------------------
+
+
+def test_probe_vllm_health_returns_true_when_up(tmp_path: Path) -> None:
+    mgr = ServiceManager(tmp_path)
+    mock_resp = MagicMock()
+    mock_resp.status = 200
+    mock_conn = MagicMock()
+    mock_conn.getresponse.return_value = mock_resp
+
+    with patch("http.client.HTTPConnection", return_value=mock_conn):
+        result = mgr.probe_vllm_health()
+
+    assert result is True
+    mock_conn.request.assert_called_once_with("GET", "/health")
+
+
+def test_probe_vllm_health_returns_false_and_logs_when_down(tmp_path: Path) -> None:
+    mgr = ServiceManager(tmp_path)
+    with (
+        patch("http.client.HTTPConnection") as mock_conn_cls,
+        patch("sys.platform", "linux"),  # non-Windows: no terminal spawn
+    ):
+        mock_conn_cls.return_value.request.side_effect = OSError("connection refused")
+        result = mgr.probe_vllm_health()
+
+    assert result is False
+
+
+def test_probe_vllm_health_opens_terminal_on_windows(tmp_path: Path) -> None:
+    mgr = ServiceManager(tmp_path)
+    with (
+        patch("http.client.HTTPConnection") as mock_conn_cls,
+        patch("sys.platform", "win32"),
+        patch("subprocess.Popen") as mock_popen,
+    ):
+        mock_conn_cls.return_value.request.side_effect = OSError("connection refused")
+        mgr.probe_vllm_health()
+
+    mock_popen.assert_called_once()
+    cmd = mock_popen.call_args[0][0]
+    assert "wt.exe" in cmd
+    assert "wsl" in cmd
+
+
+def test_probe_vllm_health_handles_missing_wt_exe(tmp_path: Path) -> None:
+    mgr = ServiceManager(tmp_path)
+    with (
+        patch("http.client.HTTPConnection") as mock_conn_cls,
+        patch("sys.platform", "win32"),
+        patch("subprocess.Popen", side_effect=FileNotFoundError("wt.exe not found")),
+    ):
+        mock_conn_cls.return_value.request.side_effect = OSError("connection refused")
+        mgr.probe_vllm_health()  # must not raise
+
+
 def test_ensure_ollama_running_already_up(tmp_path: Path) -> None:
     mgr = ServiceManager(tmp_path)
     with (


### PR DESCRIPTION
## Summary

- Add `probe_vllm_health()` to `ServiceManager`: probes `localhost:8000/health` at watcher startup (local + auto mode) and before each local-mode dispatch; logs the FP8 server command at WARNING if vLLM is down; on Windows opens a new WSL2 Windows Terminal tab automatically
- Fix `--max-model-len 131072 → 262144` in `CLAUDE.md` and `litellm-local.yaml.example` (131072 is the BF16 context size; FP8 supports 262144)
- Add `_VLLM_PORT = 8000` constant to `watcher_types`; add 4 unit tests for the health probe

**Milestone:** Post-MVP Explorations

> **Note:** The health probe is advisory — it warns and optionally opens a terminal, but does not block the watcher if vLLM is unavailable. The watcher proceeds; the first worker request will fail if vLLM never starts. This is intentional (watcher lifecycle management is out of scope per WOR-218).

## Test plan

- [ ] `test_probe_vllm_health_returns_true_when_up` — 200 OK → returns True
- [ ] `test_probe_vllm_health_returns_false_and_logs_when_down` — OSError → returns False, logs warning
- [ ] `test_probe_vllm_health_opens_terminal_on_windows` — `wt.exe` + `wsl` in Popen args
- [ ] `test_probe_vllm_health_handles_missing_wt_exe` — FileNotFoundError does not raise
- [ ] Existing dispatch tests updated: `ensure_ollama_running` not called, `probe_vllm_health` called for local mode

Closes WOR-218