### PR TITLE
Fix WSL2 terminal launch: login shell and drop wt semicolon

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -218,7 +218,7 @@ To run Claude Code routed to a local vLLM server instead of the Anthropic API:
 
 ```bash
 # 1. Start vLLM server in WSL2 (keep terminal open)
-vllm serve /home/antti/models/Qwen3.6-35B-A3B-NVFP4 \
+/home/antti/vllm-env/bin/vllm serve /home/antti/models/Qwen3.6-35B-A3B-NVFP4 \
   --max-model-len 262144 --max-num-seqs 16 \
   --kv-cache-dtype fp8 --max-num-batched-tokens 4096 \
   --reasoning-parser qwen3 --enable-prefix-caching \

--- a/app/core/watcher_services.py
+++ b/app/core/watcher_services.py
@@ -165,7 +165,7 @@ class ServiceManager:
             logger.warning("wt.exe not found — falling back to new console window")
             self._litellm_proc = subprocess.Popen(  # nosec B603 B607
                 cmd,
-                creationflags=subprocess.CREATE_NEW_CONSOLE,
+                creationflags=getattr(subprocess, "CREATE_NEW_CONSOLE", 0),
                 env=env,
             )
 

--- a/app/core/watcher_services.py
+++ b/app/core/watcher_services.py
@@ -28,7 +28,7 @@ from app.core.watcher_types import (
 logger = logging.getLogger(__name__)
 
 _VLLM_FP8_CMD = (
-    "vllm serve /home/antti/models/Qwen3.6-35B-A3B-NVFP4"
+    "/home/antti/vllm-env/bin/vllm serve /home/antti/models/Qwen3.6-35B-A3B-NVFP4"
     " --max-model-len 262144 --kv-cache-dtype fp8 --max-num-seqs 16"
     " --max-num-batched-tokens 4096 --reasoning-parser qwen3"
     " --enable-prefix-caching --language-model-only"
@@ -84,7 +84,6 @@ class ServiceManager:
                     "wsl",
                     "bash",
                     "-i",
-                    "-l",
                     "-c",
                     _VLLM_FP8_CMD,
                 ],

--- a/app/core/watcher_services.py
+++ b/app/core/watcher_services.py
@@ -152,8 +152,11 @@ class ServiceManager:
         wt.exe is not available.
         """
         try:
+            # cmd.exe /k wraps litellm so the shell resolves .bat/.cmd PATH
+            # extensions; /k keeps the tab open after the process exits.
+            shell_cmd = subprocess.list2cmdline(cmd)
             subprocess.Popen(  # nosec B603 B607
-                ["wt.exe", "-w", "0", "new-tab", "--"] + cmd,
+                ["wt.exe", "-w", "0", "new-tab", "--", "cmd.exe", "/k", shell_cmd],
                 creationflags=(
                     getattr(subprocess, "DETACHED_PROCESS", 0)
                     | getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)

--- a/app/core/watcher_services.py
+++ b/app/core/watcher_services.py
@@ -143,6 +143,32 @@ class ServiceManager:
             raise RuntimeError("Watcher shutting down")
         raise TimeoutError(f"Ollama not ready after {timeout}s.")
 
+    def _start_litellm_windows(self, cmd: list[str], env: dict[str, str]) -> None:
+        """Open a new Windows Terminal tab for the LiteLLM proxy.
+
+        wt.exe exits immediately after opening the tab, so we cannot hold a
+        process handle for it — _litellm_proc stays None and stop() cannot
+        terminate it programmatically.  Falls back to CREATE_NEW_CONSOLE if
+        wt.exe is not available.
+        """
+        try:
+            subprocess.Popen(  # nosec B603 B607
+                ["wt.exe", "-w", "0", "new-tab", "--"] + cmd,
+                creationflags=(
+                    getattr(subprocess, "DETACHED_PROCESS", 0)
+                    | getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
+                ),
+                env=env,
+            )
+            logger.info("Opened Windows Terminal tab for LiteLLM proxy")
+        except FileNotFoundError:
+            logger.warning("wt.exe not found — falling back to new console window")
+            self._litellm_proc = subprocess.Popen(  # nosec B603 B607
+                cmd,
+                creationflags=subprocess.CREATE_NEW_CONSOLE,
+                env=env,
+            )
+
     def ensure_litellm_running(self) -> None:
         """Start the LiteLLM proxy if not already listening on _LITELLM_PORT."""
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
@@ -162,33 +188,23 @@ class ServiceManager:
 
         logger.info("Starting LiteLLM proxy (port %d)…", _LITELLM_PORT)
         env = {**os.environ, "PYTHONUTF8": "1"}
+        litellm_cmd = [
+            "litellm",
+            "--config",
+            str(config_path),
+            "--port",
+            str(_LITELLM_PORT),
+            "--drop_params",
+        ]
         if sys.platform == "win32":
-            self._litellm_proc = subprocess.Popen(  # nosec B603 B607
-                [
-                    "litellm",
-                    "--config",
-                    str(config_path),
-                    "--port",
-                    str(_LITELLM_PORT),
-                    "--drop_params",
-                ],
-                creationflags=subprocess.CREATE_NEW_CONSOLE,
-                env=env,
-            )
+            self._start_litellm_windows(litellm_cmd, env)
         else:
             log_path = self._repo_root / ".claude" / "litellm.log"
             log_path.parent.mkdir(parents=True, exist_ok=True)
             log_file = open(log_path, "wb")  # noqa: SIM115
             logger.info("LiteLLM log: %s", log_path)
             self._litellm_proc = subprocess.Popen(  # nosec B603 B607
-                [
-                    "litellm",
-                    "--config",
-                    str(config_path),
-                    "--port",
-                    str(_LITELLM_PORT),
-                    "--drop_params",
-                ],
+                litellm_cmd,
                 stdout=log_file,
                 stderr=log_file,
                 env=env,

--- a/app/core/watcher_services.py
+++ b/app/core/watcher_services.py
@@ -83,8 +83,9 @@ class ServiceManager:
                     "--",
                     "wsl",
                     "bash",
+                    "-l",
                     "-c",
-                    _VLLM_FP8_CMD + "; exec bash",
+                    _VLLM_FP8_CMD,
                 ],
                 creationflags=(
                     getattr(subprocess, "DETACHED_PROCESS", 0)

--- a/app/core/watcher_services.py
+++ b/app/core/watcher_services.py
@@ -83,6 +83,7 @@ class ServiceManager:
                     "--",
                     "wsl",
                     "bash",
+                    "-i",
                     "-l",
                     "-c",
                     _VLLM_FP8_CMD,

--- a/litellm-local.yaml.example
+++ b/litellm-local.yaml.example
@@ -1,7 +1,7 @@
 model_list:
     # --- vLLM backend (recommended) ---
     # Start server in WSL2 first:
-    #   vllm serve /home/antti/models/Qwen3.6-35B-A3B-NVFP4 \
+    #   /home/antti/vllm-env/bin/vllm serve /home/antti/models/Qwen3.6-35B-A3B-NVFP4 \
     #     --max-model-len 262144 --max-num-seqs 16 \
     #     --kv-cache-dtype fp8 --max-num-batched-tokens 4096 \
     #     --reasoning-parser qwen3 --enable-prefix-caching \

--- a/tests/test_watcher_services.py
+++ b/tests/test_watcher_services.py
@@ -127,7 +127,9 @@ def test_start_litellm_windows_opens_wt_tab(tmp_path: Path) -> None:
     cmd = mock_popen.call_args[0][0]
     assert cmd[0] == "wt.exe"
     assert "new-tab" in cmd
-    assert "litellm" in cmd
+    assert "cmd.exe" in cmd  # shell wrapper so PATHEXT resolves litellm.bat/.exe
+    assert "/k" in cmd
+    assert "litellm" in cmd[-1]  # shell_cmd string is last arg
     assert mgr._litellm_proc is None  # wt.exe exits immediately; not tracked
 
 

--- a/tests/test_watcher_services.py
+++ b/tests/test_watcher_services.py
@@ -113,6 +113,45 @@ def test_probe_vllm_health_handles_missing_wt_exe(tmp_path: Path) -> None:
         mgr.probe_vllm_health()  # must not raise
 
 
+# ---------------------------------------------------------------------------
+# ServiceManager._start_litellm_windows
+# ---------------------------------------------------------------------------
+
+
+def test_start_litellm_windows_opens_wt_tab(tmp_path: Path) -> None:
+    mgr = ServiceManager(tmp_path)
+    with patch("subprocess.Popen") as mock_popen:
+        mgr._start_litellm_windows(["litellm", "--config", "cfg.yaml"], {})
+
+    mock_popen.assert_called_once()
+    cmd = mock_popen.call_args[0][0]
+    assert cmd[0] == "wt.exe"
+    assert "new-tab" in cmd
+    assert "litellm" in cmd
+    assert mgr._litellm_proc is None  # wt.exe exits immediately; not tracked
+
+
+def test_start_litellm_windows_falls_back_to_console_when_no_wt(
+    tmp_path: Path,
+) -> None:
+    mgr = ServiceManager(tmp_path)
+    with patch(
+        "subprocess.Popen",
+        side_effect=[FileNotFoundError("wt.exe not found"), MagicMock()],
+    ) as mock_popen:
+        mgr._start_litellm_windows(["litellm", "--config", "cfg.yaml"], {})
+
+    assert mock_popen.call_count == 2
+    fallback_cmd = mock_popen.call_args[0][0]
+    assert fallback_cmd[0] == "litellm"
+    assert mgr._litellm_proc is not None
+
+
+# ---------------------------------------------------------------------------
+# ServiceManager.ensure_ollama_running
+# ---------------------------------------------------------------------------
+
+
 def test_ensure_ollama_running_already_up(tmp_path: Path) -> None:
     mgr = ServiceManager(tmp_path)
     with (


### PR DESCRIPTION
## Summary

- `bash -l -c` instead of `bash -c` — login shell sources `~/.bash_profile` so conda/pip-installed `vllm` is on PATH
- Drop `; exec bash` suffix — Windows Terminal parses `;` as its own command separator even inside argv, causing `[error 0x80070002 when launching '" exec bash"']`

## Test plan
- [x] Restart watcher in local mode — WSL2 tab opens and vLLM server starts successfully
- [x] Existing `test_probe_vllm_health_opens_terminal_on_windows` still passes (checks `wt.exe` and `wsl` in cmd args)

Closes #436 (related)