### PR TITLE
Fix LiteLLM routing: use openai_chat/ to avoid Responses API

### DIFF
--- a/litellm-local.yaml.example
+++ b/litellm-local.yaml.example
@@ -9,12 +9,12 @@ model_list:
     #     --enable-auto-tool-choice --tool-call-parser qwen3_coder
     - model_name: claude-sonnet-4-6
       litellm_params:
-        model: openai//home/antti/models/Qwen3.6-35B-A3B-NVFP4
+        model: openai_chat//home/antti/models/Qwen3.6-35B-A3B-NVFP4
         api_base: http://localhost:8000/v1
         api_key: dummy
     - model_name: "*"
       litellm_params:
-        model: openai//home/antti/models/Qwen3.6-35B-A3B-NVFP4
+        model: openai_chat//home/antti/models/Qwen3.6-35B-A3B-NVFP4
         api_base: http://localhost:8000/v1
         api_key: dummy
 


### PR DESCRIPTION
LiteLLM 1.83.x auto-routes `openai/` models to the OpenAI Responses API (`/v1/responses`). Tool-result content blocks fail schema validation there — 212 Pydantic errors, `input` field expected to be a string. Workers fail with rc=1 after 2 turns.

`openai_chat/` prefix forces `/v1/chat/completions` which has full tool-use support.

Closes: fixes local worker tool-use failures introduced by LiteLLM 1.83.x routing change.