### PR TITLE
Fix LiteLLM Responses API routing and vLLM terminal dedup

### DIFF
--- a/app/core/watcher_services.py
+++ b/app/core/watcher_services.py
@@ -44,6 +44,7 @@ class ServiceManager:
         self._repo_root = repo_root
         self._litellm_proc: subprocess.Popen[bytes] | None = None
         self._running = True
+        self._vllm_terminal_opened = False
 
     def probe_vllm_health(self) -> bool:
         """Check whether vLLM is responding on localhost:_VLLM_PORT/health.
@@ -67,8 +68,9 @@ class ServiceManager:
             _VLLM_PORT,
             _VLLM_FP8_CMD,
         )
-        if sys.platform == "win32":
+        if sys.platform == "win32" and not self._vllm_terminal_opened:
             self._open_vllm_terminal()
+            self._vllm_terminal_opened = True
         return False
 
     def _open_vllm_terminal(self) -> None:

--- a/litellm-local.yaml.example
+++ b/litellm-local.yaml.example
@@ -9,12 +9,12 @@ model_list:
     #     --enable-auto-tool-choice --tool-call-parser qwen3_coder
     - model_name: claude-sonnet-4-6
       litellm_params:
-        model: openai_chat//home/antti/models/Qwen3.6-35B-A3B-NVFP4
+        model: openai//home/antti/models/Qwen3.6-35B-A3B-NVFP4
         api_base: http://localhost:8000/v1
         api_key: dummy
     - model_name: "*"
       litellm_params:
-        model: openai_chat//home/antti/models/Qwen3.6-35B-A3B-NVFP4
+        model: openai//home/antti/models/Qwen3.6-35B-A3B-NVFP4
         api_base: http://localhost:8000/v1
         api_key: dummy
 
@@ -33,3 +33,6 @@ model_list:
     #     extra_body:
     #       options:
     #         num_ctx: 65536
+
+litellm_settings:
+  use_responses_api: false

--- a/tests/test_watcher_services.py
+++ b/tests/test_watcher_services.py
@@ -102,6 +102,20 @@ def test_probe_vllm_health_opens_terminal_on_windows(tmp_path: Path) -> None:
     assert "wsl" in cmd
 
 
+def test_probe_vllm_health_opens_terminal_only_once(tmp_path: Path) -> None:
+    mgr = ServiceManager(tmp_path)
+    with (
+        patch("http.client.HTTPConnection") as mock_conn_cls,
+        patch("sys.platform", "win32"),
+        patch("subprocess.Popen") as mock_popen,
+    ):
+        mock_conn_cls.return_value.request.side_effect = OSError("connection refused")
+        mgr.probe_vllm_health()
+        mgr.probe_vllm_health()  # second call — terminal must not open again
+
+    mock_popen.assert_called_once()
+
+
 def test_probe_vllm_health_handles_missing_wt_exe(tmp_path: Path) -> None:
     mgr = ServiceManager(tmp_path)
     with (


### PR DESCRIPTION
Two fixes on top of #440:

- **LiteLLM Responses API**: `openai_chat/` was not a valid provider prefix. Add `litellm_settings.use_responses_api: false` to force `/v1/chat/completions` — LiteLLM 1.83.x auto-routes `openai/` to the Responses API, which fails on tool-result content blocks (212 Pydantic validation errors).
- **vLLM terminal dedup**: `probe_vllm_health()` is called at watcher startup and again per ticket dispatch. Both fired when vLLM was down, opening two WSL2 tabs. `_vllm_terminal_opened` flag ensures only one tab opens per watcher session.