### PR TITLE
Defer local ticket dispatch if vLLM not ready

### DIFF
--- a/app/core/watcher.py
+++ b/app/core/watcher.py
@@ -384,6 +384,12 @@ class Watcher:
                 )
                 return
 
+        if effective_mode == "local":
+            if not self._services.probe_vllm_health():
+                logger.warning("Deferring %s — vLLM not ready yet", ticket_id)
+                return
+            self._services.ensure_litellm_running()
+
         worktree_path = create_worktree(self._repo_root, manifest)
         copy_manifest_to_worktree(self._repo_root, manifest, worktree_path)
         write_worker_pytest_config(worktree_path)
@@ -395,10 +401,6 @@ class Watcher:
             ticket_id,
         )
         logger.info("Launching worker for %s (mode=%s)", ticket_id, effective_mode)
-
-        if effective_mode == "local":
-            self._services.probe_vllm_health()
-            self._services.ensure_litellm_running()
 
         backed_up_plans = backup_plan_files()
         process = launch_worker(


### PR DESCRIPTION
## Summary
- Move `probe_vllm_health()` before worktree creation and `safe_set_state(InProgressLocal)`
- If vLLM is down, log a warning and return — ticket stays in `ReadyForLocal`, retried on the next 10s poll cycle
- Prevents an orphaned `InProgressLocal` state in Linear with no running worker

## Test plan
- [x] `ruff`, `mypy`, `pytest tests/test_watcher.py` — clean
- [ ] Start watcher with a `ReadyForLocal` ticket before vLLM is up — confirm ticket stays `ReadyForLocal` and dispatches once vLLM comes online

Closes (no Linear ticket — spotted while answering a question)