### PR TITLE
Fix vLLM readiness probe, LiteLLM HTTP check, log spam, hosted_vllm routing

### DIFF
--- a/app/core/watcher_services.py
+++ b/app/core/watcher_services.py
@@ -45,6 +45,7 @@ class ServiceManager:
         self._litellm_proc: subprocess.Popen[bytes] | None = None
         self._running = True
         self._vllm_terminal_opened = False
+        self._vllm_warned = False
 
     def probe_vllm_health(self) -> bool:
         """Check whether vLLM is ready to serve on localhost:_VLLM_PORT.
@@ -53,8 +54,9 @@ class ServiceManager:
         server starts, before model weights are loaded. /v1/models only returns
         200 once the model is registered and ready for inference.
 
-        Returns True if ready. If not, logs the FP8 server command at WARNING
-        level and on Windows opens a new WSL2 Windows Terminal tab.
+        Returns True if ready. Logs at WARNING level when not ready; the full
+        startup command is printed only on the first failure to avoid log spam.
+        On Windows opens a new WSL2 terminal tab on the first failure only.
         """
         try:
             conn = http.client.HTTPConnection("localhost", _VLLM_PORT, timeout=3)
@@ -66,11 +68,16 @@ class ServiceManager:
         except (OSError, http.client.HTTPException):
             pass
 
-        logger.warning(
-            "vLLM not responding on port %d — start the server in WSL2:\n\n  %s\n",
-            _VLLM_PORT,
-            _VLLM_FP8_CMD,
-        )
+        if not self._vllm_warned:
+            logger.warning(
+                "vLLM not responding on port %d — start the server in WSL2:\n\n  %s\n",
+                _VLLM_PORT,
+                _VLLM_FP8_CMD,
+            )
+            self._vllm_warned = True
+        else:
+            logger.warning("vLLM not ready yet on port %d — waiting…", _VLLM_PORT)
+
         if sys.platform == "win32" and not self._vllm_terminal_opened:
             self._open_vllm_terminal()
             self._vllm_terminal_opened = True

--- a/app/core/watcher_services.py
+++ b/app/core/watcher_services.py
@@ -47,18 +47,21 @@ class ServiceManager:
         self._vllm_terminal_opened = False
 
     def probe_vllm_health(self) -> bool:
-        """Check whether vLLM is responding on localhost:_VLLM_PORT/health.
+        """Check whether vLLM is ready to serve on localhost:_VLLM_PORT.
 
-        Returns True if healthy. If not responding, logs the FP8 server command
-        at WARNING level and on Windows opens a new WSL2 Windows Terminal tab
-        so the server can be started without leaving the watcher window.
+        Uses /v1/models (not /health): /health returns 200 as soon as the HTTP
+        server starts, before model weights are loaded. /v1/models only returns
+        200 once the model is registered and ready for inference.
+
+        Returns True if ready. If not, logs the FP8 server command at WARNING
+        level and on Windows opens a new WSL2 Windows Terminal tab.
         """
         try:
             conn = http.client.HTTPConnection("localhost", _VLLM_PORT, timeout=3)
-            conn.request("GET", "/health")
+            conn.request("GET", "/v1/models")
             resp = conn.getresponse()
             if resp.status == 200:
-                logger.info("vLLM health check passed (port %d)", _VLLM_PORT)
+                logger.info("vLLM ready (port %d)", _VLLM_PORT)
                 return True
         except (OSError, http.client.HTTPException):
             pass

--- a/app/core/watcher_services.py
+++ b/app/core/watcher_services.py
@@ -184,12 +184,19 @@ class ServiceManager:
                 env=env,
             )
 
+    def _litellm_serving(self) -> bool:
+        """Return True if LiteLLM is accepting HTTP requests on _LITELLM_PORT."""
+        try:
+            conn = http.client.HTTPConnection("localhost", _LITELLM_PORT, timeout=2)
+            conn.request("GET", "/health")
+            conn.getresponse()
+            return True
+        except (OSError, http.client.HTTPException):
+            return False
+
     def ensure_litellm_running(self) -> None:
         """Start the LiteLLM proxy if not already listening on _LITELLM_PORT."""
-        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-            already_up = sock.connect_ex(("localhost", _LITELLM_PORT)) == 0
-
-        if already_up:
+        if self._litellm_serving():
             logger.info("LiteLLM proxy already running on port %d", _LITELLM_PORT)
             return
 
@@ -231,7 +238,7 @@ class ServiceManager:
         self._wait_for_litellm_ready()
 
     def _wait_for_litellm_ready(self, timeout: float = 60.0) -> None:
-        """Poll TCP until LiteLLM's port accepts connections or process dies."""
+        """Poll HTTP until LiteLLM is serving or process dies."""
         deadline = time.monotonic() + timeout
         while time.monotonic() < deadline:
             if self._litellm_proc and self._litellm_proc.poll() is not None:
@@ -240,10 +247,8 @@ class ServiceManager:
                     f"LiteLLM proxy exited (rc={rc}). "
                     f"Check .claude/litellm.log for details."
                 )
-            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-                sock.settimeout(2)
-                if sock.connect_ex(("localhost", _LITELLM_PORT)) == 0:
-                    return
+            if self._litellm_serving():
+                return
             time.sleep(0.5)
         raise TimeoutError(
             f"LiteLLM proxy not ready after {timeout}s. "

--- a/litellm-local.yaml.example
+++ b/litellm-local.yaml.example
@@ -9,12 +9,12 @@ model_list:
     #     --enable-auto-tool-choice --tool-call-parser qwen3_coder
     - model_name: claude-sonnet-4-6
       litellm_params:
-        model: openai//home/antti/models/Qwen3.6-35B-A3B-NVFP4
+        model: hosted_vllm//home/antti/models/Qwen3.6-35B-A3B-NVFP4
         api_base: http://localhost:8000/v1
         api_key: dummy
     - model_name: "*"
       litellm_params:
-        model: openai//home/antti/models/Qwen3.6-35B-A3B-NVFP4
+        model: hosted_vllm//home/antti/models/Qwen3.6-35B-A3B-NVFP4
         api_base: http://localhost:8000/v1
         api_key: dummy
 

--- a/tests/test_watcher_services.py
+++ b/tests/test_watcher_services.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
 
-from app.core.watcher_services import ServiceManager
+from app.core.watcher_services import _VLLM_FP8_CMD, ServiceManager
 
 # ---------------------------------------------------------------------------
 # ServiceManager.stop  (formerly _stop_litellm_proxy via Watcher shim)
@@ -84,6 +84,27 @@ def test_probe_vllm_health_returns_false_and_logs_when_down(tmp_path: Path) -> N
         result = mgr.probe_vllm_health()
 
     assert result is False
+    assert mgr._vllm_warned is True
+
+
+def test_probe_vllm_health_logs_short_message_on_repeat_failure(
+    tmp_path: Path, caplog: Any
+) -> None:
+    import logging
+
+    mgr = ServiceManager(tmp_path)
+    with (
+        patch("http.client.HTTPConnection") as mock_conn_cls,
+        patch("sys.platform", "linux"),
+        caplog.at_level(logging.WARNING, logger="app.core.watcher_services"),
+    ):
+        mock_conn_cls.return_value.request.side_effect = OSError("connection refused")
+        mgr.probe_vllm_health()  # first call — logs full command
+        caplog.clear()
+        mgr.probe_vllm_health()  # second call — short message only
+
+    # Full vLLM command should NOT appear on the second call
+    assert _VLLM_FP8_CMD not in caplog.text
 
 
 def test_probe_vllm_health_opens_terminal_on_windows(tmp_path: Path) -> None:

--- a/tests/test_watcher_services.py
+++ b/tests/test_watcher_services.py
@@ -149,6 +149,75 @@ def test_probe_vllm_health_handles_missing_wt_exe(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# ServiceManager._litellm_serving / ensure_litellm_running
+# ---------------------------------------------------------------------------
+
+
+def test_litellm_serving_returns_true_when_http_responds(tmp_path: Path) -> None:
+    mgr = ServiceManager(tmp_path)
+    mock_conn = MagicMock()
+    with patch("http.client.HTTPConnection", return_value=mock_conn):
+        result = mgr._litellm_serving()
+    assert result is True
+    mock_conn.request.assert_called_once_with("GET", "/health")
+
+
+def test_litellm_serving_returns_false_on_connection_error(tmp_path: Path) -> None:
+    mgr = ServiceManager(tmp_path)
+    with patch("http.client.HTTPConnection") as mock_cls:
+        mock_cls.return_value.request.side_effect = OSError("connection refused")
+        result = mgr._litellm_serving()
+    assert result is False
+
+
+def test_ensure_litellm_running_skips_start_when_already_serving(
+    tmp_path: Path,
+) -> None:
+    mgr = ServiceManager(tmp_path)
+    with (
+        patch.object(mgr, "_litellm_serving", return_value=True),
+        patch("subprocess.Popen") as mock_popen,
+    ):
+        mgr.ensure_litellm_running()
+    mock_popen.assert_not_called()
+
+
+def test_wait_for_litellm_ready_retries_until_serving(tmp_path: Path) -> None:
+    mgr = ServiceManager(tmp_path)
+    call_count = 0
+
+    def _serving_side_effect() -> bool:
+        nonlocal call_count
+        call_count += 1
+        return call_count >= 3
+
+    with (
+        patch.object(mgr, "_litellm_serving", side_effect=_serving_side_effect),
+        patch("time.sleep"),
+    ):
+        mgr._wait_for_litellm_ready()
+
+    assert call_count == 3
+
+
+def test_wait_for_litellm_ready_raises_when_proc_exits(tmp_path: Path) -> None:
+    import pytest
+
+    mgr = ServiceManager(tmp_path)
+    mock_proc = MagicMock(spec=subprocess.Popen)
+    mock_proc.poll.return_value = 1
+    mock_proc.returncode = 1
+    mgr._litellm_proc = mock_proc
+
+    with (
+        patch.object(mgr, "_litellm_serving", return_value=False),
+        patch("time.sleep"),
+        pytest.raises(RuntimeError, match="exited"),
+    ):
+        mgr._wait_for_litellm_ready()
+
+
+# ---------------------------------------------------------------------------
 # ServiceManager._start_litellm_windows
 # ---------------------------------------------------------------------------
 

--- a/tests/test_watcher_services.py
+++ b/tests/test_watcher_services.py
@@ -71,7 +71,7 @@ def test_probe_vllm_health_returns_true_when_up(tmp_path: Path) -> None:
         result = mgr.probe_vllm_health()
 
     assert result is True
-    mock_conn.request.assert_called_once_with("GET", "/health")
+    mock_conn.request.assert_called_once_with("GET", "/v1/models")
 
 
 def test_probe_vllm_health_returns_false_and_logs_when_down(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- **`/v1/models` readiness probe**: `probe_vllm_health()` now checks `GET /v1/models` instead of `GET /health`; `/health` returns 200 before model weights are loaded, `/v1/models` only returns 200 when the model is ready for inference
- **LiteLLM HTTP check**: `_litellm_serving()` helper does `GET /health` over HTTP; replaces TCP-only `connect_ex` in both the fast-path check and `_wait_for_litellm_ready()` — prevents "port bound but HTTP not serving yet" race
- **vLLM log spam**: after the first failure, `probe_vllm_health()` switches to a one-line `"vLLM not ready yet"` message instead of reprinting the full startup command every 10s poll cycle
- **`hosted_vllm/` model prefix**: replaces `openai/` in `litellm-local.yaml.example`; `openai/` triggers LiteLLM's Responses API routing (`POST /v1/responses`) in LiteLLM 1.83.x which fails on tool-result content blocks; `hosted_vllm/` always calls `POST /v1/chat/completions`

## Test plan
- [x] 20 tests in `test_watcher_services.py` — all pass
- [x] `ruff`, `mypy` — clean
- [ ] Restart LiteLLM after updating `litellm-local.yaml` — verify `POST /v1/chat/completions` in vLLM log