### PR TITLE
Prevent watcher from auto-merging PRs targeting main

### DIFF
--- a/app/core/watcher_subprocess.py
+++ b/app/core/watcher_subprocess.py
@@ -175,7 +175,11 @@ def run_checks(manifest: ExecutionManifest, worktree_path: Path) -> bool:
 
 
 def create_pr(manifest: ExecutionManifest, worktree_path: Path) -> str:
-    """Push the worker branch and open a GitHub PR, enabling auto-merge."""
+    """Push the worker branch and open a GitHub PR.
+
+    Auto-merge is enabled only when targeting an epic branch. PRs targeting
+    main are left open for human review — auto-merging to main is forbidden.
+    """
     subprocess.run(  # nosec B603 B607
         ["git", "push", "-u", "origin", manifest.worker_branch],
         cwd=str(worktree_path),
@@ -224,6 +228,14 @@ def create_pr(manifest: ExecutionManifest, worktree_path: Path) -> str:
         check=True,
     )
     pr_url = result.stdout.strip()
+
+    if manifest.base_branch == "main":
+        logger.info(
+            "PR %s targets main — leaving open for human review (no auto-merge)",
+            pr_url,
+        )
+        return pr_url
+
     merge_result = subprocess.run(  # nosec B603 B607
         ["gh", "pr", "merge", "--auto", "--squash", pr_url],
         cwd=str(worktree_path),
@@ -233,7 +245,7 @@ def create_pr(manifest: ExecutionManifest, worktree_path: Path) -> str:
     )
     if merge_result.returncode != 0:
         output = (merge_result.stderr or merge_result.stdout).strip()
-        # "clean status" means no required checks on the target branch (e.g. epic
+        # "clean status" means no required checks on the target branch (epic
         # branches) — PR is already mergeable, so fall back to immediate merge.
         if "enablePullRequestAutoMerge" in output or "clean status" in output:
             logger.info(

--- a/tests/test_watcher_subprocess.py
+++ b/tests/test_watcher_subprocess.py
@@ -77,7 +77,7 @@ def test_create_pr_pushes_branch_before_gh_pr(tmp_path: Path) -> None:
 def test_create_pr_logs_warning_on_auto_merge_failure(
     tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:
-    manifest = _make_manifest()
+    manifest = _make_manifest(base_branch="epic/wor-96-parent")
     pr_url = "https://github.com/example/pr/1"
 
     def fake_run(cmd: list[str], **_kwargs: object) -> MagicMock:
@@ -601,6 +601,39 @@ def test_run_checks_last_failure_overwritten_by_last_failing_check(
 
 
 # ---------------------------------------------------------------------------
+# create_pr — main-targeting guard (no auto-merge)
+# ---------------------------------------------------------------------------
+
+
+def test_create_pr_skips_auto_merge_when_targeting_main(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    manifest = _make_manifest(base_branch="main")
+    pr_url = "https://github.com/example/pr/99"
+    called_cmds: list[list[str]] = []
+
+    def fake_run(cmd: list[str], **kwargs: object) -> MagicMock:
+        called_cmds.append(cmd)
+        result = MagicMock()
+        result.returncode = 0
+        result.stdout = (
+            pr_url if cmd[:3] == ["gh", "pr", "create"] else "abc1234 some commit"
+        )
+        result.stderr = ""
+        return result
+
+    with (
+        patch("app.core.watcher_subprocess.subprocess.run", side_effect=fake_run),
+        caplog.at_level(logging.INFO, logger="app.core.watcher_subprocess"),
+    ):
+        returned_url = create_pr(manifest, tmp_path)
+
+    assert returned_url == pr_url
+    assert any("targets main" in msg for msg in caplog.messages)
+    assert not any(cmd[:3] == ["gh", "pr", "merge"] for cmd in called_cmds)
+
+
+# ---------------------------------------------------------------------------
 # create_pr — additional failure paths
 # ---------------------------------------------------------------------------
 
@@ -625,7 +658,7 @@ def test_create_pr_raises_when_no_commits_ahead(tmp_path: Path) -> None:
 def test_create_pr_falls_back_to_immediate_merge_on_auto_merge_api_error(
     tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:
-    manifest = _make_manifest()
+    manifest = _make_manifest(base_branch="epic/wor-96-parent")
     pr_url = "https://github.com/example/pr/42"
 
     def fake_run(cmd: list[str], **kwargs: object) -> MagicMock:
@@ -655,7 +688,7 @@ def test_create_pr_falls_back_to_immediate_merge_on_auto_merge_api_error(
 def test_create_pr_warns_when_immediate_merge_also_fails(
     tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:
-    manifest = _make_manifest()
+    manifest = _make_manifest(base_branch="epic/wor-96-parent")
     pr_url = "https://github.com/example/pr/42"
 
     def fake_run(cmd: list[str], **kwargs: object) -> MagicMock:


### PR DESCRIPTION
## Summary
- `create_pr()` now returns early when `base_branch == "main"`, leaving the PR open for human review
- Auto-merge (`gh pr merge --auto --squash`) is only called for PRs targeting epic branches
- Added `test_create_pr_skips_auto_merge_when_targeting_main` to verify the guard
- Fixed 3 existing tests that tested auto-merge fallback paths but were using `base_branch="main"` (now use `epic/wor-96-parent`)

## Test plan
- [ ] `pytest tests/test_watcher_subprocess.py` — 29 tests, all pass
- [ ] `ruff check .` and `mypy app/` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)