### PR TITLE
WOR-228 Add tests for watcher_finalize module

### DIFF
--- a/tests/test_watcher_finalize.py
+++ b/tests/test_watcher_finalize.py
@@ -675,3 +675,275 @@ def test_execute_finalization_nonzero_exit_escalates_to_cloud(tmp_path: Path) ->
     linear_mock.post_comment.assert_called_once()
     m = metrics_mock.record.call_args[0][0]
     assert m.escalated_to_cloud is True
+
+
+# ---------------------------------------------------------------------------
+# _execute_finalization — explicit return-value assertions (AC)
+# ---------------------------------------------------------------------------
+
+
+def test_execute_finalization_nonzero_returncode_returns_failure(
+    tmp_path: Path,
+) -> None:
+    """non-zero returncode → 'failure' returned (not just logged)."""
+    manifest = make_manifest(ticket_id="WOR-10", worker_branch="wor-10-test-ticket")
+    linear_mock = MagicMock()
+    worker = ActiveWorker(
+        ticket_id="WOR-10",
+        linear_id="fake-linear-id",
+        manifest=manifest,
+        worktree_path=tmp_path,
+        process=MagicMock(spec=subprocess.Popen),
+    )
+    from app.core.watcher_finalize import _execute_finalization
+
+    outcome, escalated, preserved, findings = _execute_finalization(
+        worker, 1, linear_mock, EscalationPolicy.from_toml(), tmp_path
+    )
+
+    assert outcome == "failure"
+    assert escalated is False
+    assert preserved is False
+    assert findings is None
+
+
+def test_execute_finalization_check_failure_abort_returns_failure(
+    tmp_path: Path,
+) -> None:
+    """checks fail with on_check_failure='abort' → 'failure' returned."""
+    manifest = make_manifest(
+        ticket_id="WOR-10",
+        worker_branch="wor-10-test-ticket",
+        failure_policy=FailurePolicy(on_check_failure="abort"),
+    )
+    linear_mock = MagicMock()
+    worker = ActiveWorker(
+        ticket_id="WOR-10",
+        linear_id="fake-linear-id",
+        manifest=manifest,
+        worktree_path=tmp_path,
+        process=MagicMock(spec=subprocess.Popen),
+    )
+    from app.core.watcher_finalize import _execute_finalization
+
+    with patch("app.core.watcher_finalize.run_checks", return_value=False):
+        outcome, escalated, preserved, findings = _execute_finalization(
+            worker, 0, linear_mock, EscalationPolicy.from_toml(), tmp_path
+        )
+
+    assert outcome == "failure"
+    assert escalated is False
+    assert preserved is False
+    assert findings is None
+
+
+# ---------------------------------------------------------------------------
+# _handle_policy_outcome — explicit return-value assertions (AC)
+# ---------------------------------------------------------------------------
+
+
+def test_handle_policy_outcome_escalate_returns_escalated(
+    tmp_path: Path,
+) -> None:
+    """action='escalate' → returns 'escalated'."""
+    linear_mock = MagicMock()
+    manifest = make_manifest(ticket_id="WOR-10", worker_branch="wor-10-test-ticket")
+    worker = ActiveWorker(
+        ticket_id="WOR-10",
+        linear_id="fake-linear-id",
+        manifest=manifest,
+        worktree_path=tmp_path,
+        process=MagicMock(spec=subprocess.Popen),
+    )
+    from app.core.watcher_finalize import _handle_policy_outcome
+
+    outcome, escalated, findings = _handle_policy_outcome(
+        "escalate",
+        {"scope_drift": True},
+        worker,
+        linear_mock,
+        EscalationPolicy.from_toml(),
+    )
+
+    assert outcome == "escalated"
+    assert escalated is True
+    assert findings is None
+
+
+def test_handle_policy_outcome_human_returns_aborted(tmp_path: Path) -> None:
+    """action='human' → returns 'aborted'."""
+    linear_mock = MagicMock()
+    manifest = make_manifest(ticket_id="WOR-10", worker_branch="wor-10-test-ticket")
+    worker = ActiveWorker(
+        ticket_id="WOR-10",
+        linear_id="fake-linear-id",
+        manifest=manifest,
+        worktree_path=tmp_path,
+        process=MagicMock(spec=subprocess.Popen),
+    )
+    from app.core.watcher_finalize import _handle_policy_outcome
+
+    outcome, escalated, findings = _handle_policy_outcome(
+        "human",
+        {"scope_drift": True},
+        worker,
+        linear_mock,
+        EscalationPolicy.from_toml(),
+    )
+
+    assert outcome == "aborted"
+    assert escalated is False
+    assert findings is None
+
+
+# ---------------------------------------------------------------------------
+# _sonar_requires_escalation — boundary cases (AC)
+# ---------------------------------------------------------------------------
+
+
+def test_sonar_requires_escalation_empty_list(tmp_path: Path) -> None:
+    """returns False for empty findings list."""
+    linear_mock = MagicMock()
+    from app.core.watcher_finalize import _sonar_requires_escalation
+
+    assert (
+        _sonar_requires_escalation(
+            [], "WOR-10", "fake-id", linear_mock, EscalationPolicy.from_toml()
+        )
+        is False
+    )
+
+
+def test_sonar_requires_escalation_severity_triggers_true() -> None:
+    """returns True when escalation_policy maps severity to 'escalate'."""
+    linear_mock = MagicMock()
+    from app.core.watcher_finalize import _sonar_requires_escalation
+
+    # Default policy: BLOCKER → escalate
+    assert (
+        _sonar_requires_escalation(
+            ["BLOCKER"], "WOR-10", "fake-id", linear_mock, EscalationPolicy.from_toml()
+        )
+        is True
+    )
+    assert (
+        _sonar_requires_escalation(
+            ["CRITICAL"], "WOR-10", "fake-id", linear_mock, EscalationPolicy.from_toml()
+        )
+        is True
+    )
+
+
+def test_sonar_requires_escalation_no_triggers_false() -> None:
+    """returns False when no severity maps to 'escalate'."""
+    linear_mock = MagicMock()
+    from app.core.watcher_finalize import _sonar_requires_escalation
+
+    # Default policy: MAJOR, MINOR, INFO → fix_locally (not escalate)
+    assert (
+        _sonar_requires_escalation(
+            ["MAJOR", "MINOR", "INFO"],
+            "WOR-10",
+            "fake-id",
+            linear_mock,
+            EscalationPolicy.from_toml(),
+        )
+        is False
+    )
+
+
+# ---------------------------------------------------------------------------
+# safe_set_state — direct (AC: LinearError caught and logged as warning)
+# ---------------------------------------------------------------------------
+
+
+def test_safe_set_state_linear_error_logged_as_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """LinearError is caught and logged as warning (does not raise)."""
+    linear_mock = MagicMock()
+    linear_mock.set_state.side_effect = LinearError("network timeout")
+
+    with caplog.at_level(logging.WARNING, logger="app.core.watcher_finalize"):
+        # Should NOT raise — catches LinearError internally
+        from app.core.watcher_finalize import safe_set_state
+
+        safe_set_state(linear_mock, "fake-linear-id", "Blocked", "WOR-10")
+
+    # set_state was called but the exception was caught and not re-raised
+    linear_mock.set_state.assert_called_once_with("fake-linear-id", "Blocked")
+    assert any("set_state failed" in msg for msg in caplog.messages)
+
+
+def test_safe_set_state_success_no_warning(caplog: pytest.LogCaptureFixture) -> None:
+    """Successful set_state produces no warning log."""
+    linear_mock = MagicMock()
+    with caplog.at_level(logging.WARNING, logger="app.core.watcher_finalize"):
+        from app.core.watcher_finalize import safe_set_state
+
+        safe_set_state(linear_mock, "fake-linear-id", "In Progress", "WOR-10")
+
+    assert not caplog.text or "set_state failed" not in caplog.text
+    linear_mock.set_state.assert_called_once_with("fake-linear-id", "In Progress")
+
+
+# ---------------------------------------------------------------------------
+# attempt_pr — direct (AC: success path returns 'success'; error → 'failure')
+# ---------------------------------------------------------------------------
+
+
+def test_attempt_pr_success_returns_success(
+    tmp_path: Path,
+) -> None:
+    """PR creation succeeds → 'success' returned."""
+    manifest = make_manifest(ticket_id="WOR-10", worker_branch="wor-10-test-ticket")
+    worker = ActiveWorker(
+        ticket_id="WOR-10",
+        linear_id="fake-linear-id",
+        manifest=manifest,
+        worktree_path=tmp_path,
+        process=MagicMock(spec=subprocess.Popen),
+    )
+    linear_mock = MagicMock()
+    from app.core.watcher_finalize import attempt_pr
+
+    with patch(
+        "app.core.watcher_finalize.create_pr",
+        return_value="https://github.com/example/pr/1",
+    ):
+        result = attempt_pr(manifest, worker, linear_mock)
+
+    assert result == "success"
+    linear_mock.set_state.assert_not_called()
+    linear_mock.post_comment.assert_not_called()
+
+
+def test_attempt_pr_called_process_error_returns_failure(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """CalledProcessError → state set to failed, returns 'failure'."""
+    manifest = make_manifest(
+        ticket_id="WOR-10",
+        worker_branch="wor-10-test-ticket",
+    )
+    linear_mock = MagicMock()
+    worker = ActiveWorker(
+        ticket_id="WOR-10",
+        linear_id="fake-linear-id",
+        manifest=manifest,
+        worktree_path=tmp_path,
+        process=MagicMock(spec=subprocess.Popen),
+    )
+    from app.core.watcher_finalize import attempt_pr
+
+    exc = subprocess.CalledProcessError(1, "gh pr create", stderr="validation failed")
+    with patch("app.core.watcher_finalize.create_pr", side_effect=exc):
+        result = attempt_pr(manifest, worker, linear_mock)
+
+    assert result == "failure"
+    linear_mock.set_state.assert_called_with("fake-linear-id", "Blocked")
+    linear_mock.post_comment.assert_called_once()
+    comment_body = linear_mock.post_comment.call_args[0][1]
+    assert "WOR-10" in comment_body
+    assert "validation failed" in comment_body


### PR DESCRIPTION
Closes WOR-228

tests/test_watcher_finalize.py exists, all key paths in watcher_finalize.py have at least one test, pytest passes, ruff and mypy are clean.