### PR TITLE
Reduce dispatch log spam and prevent pytest.ini commits from workers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ build/
 .pytest_cache/
 .coverage
 htmlcov/
+pytest.ini
 
 # Ruff
 .ruff_cache/

--- a/app/core/watcher_services.py
+++ b/app/core/watcher_services.py
@@ -63,7 +63,7 @@ class ServiceManager:
             conn.request("GET", "/v1/models")
             resp = conn.getresponse()
             if resp.status == 200:
-                logger.info("vLLM ready (port %d)", _VLLM_PORT)
+                logger.debug("vLLM ready (port %d)", _VLLM_PORT)
                 return True
         except (OSError, http.client.HTTPException):
             pass
@@ -197,7 +197,7 @@ class ServiceManager:
     def ensure_litellm_running(self) -> None:
         """Start the LiteLLM proxy if not already listening on _LITELLM_PORT."""
         if self._litellm_serving():
-            logger.info("LiteLLM proxy already running on port %d", _LITELLM_PORT)
+            logger.debug("LiteLLM proxy already running on port %d", _LITELLM_PORT)
             return
 
         config_path = self._repo_root / _LITELLM_CONFIG


### PR DESCRIPTION
## Summary
- `probe_vllm_health` and `ensure_litellm_running` ready/already-up messages downgraded INFO→DEBUG — fired on every dispatch cycle, pure noise when services are healthy
- `pytest.ini` added to `.gitignore` — `write_worker_pytest_config` writes this file into each worktree to suppress `--cov-fail-under` during worker runs; WOR-229's worker accidentally committed it, which would have silently disabled coverage enforcement when the epic merges to main

## Test plan
- [ ] `pytest tests/test_watcher_services.py` — 20 tests pass
- [ ] `ruff check .` clean

Closes no ticket (cleanup identified during WOR-226 parallel run review)

🤖 Generated with [Claude Code](https://claude.com/claude-code)