### PR TITLE
WOR-231 Improve execution manifest quality: context snippets, retry enrichment, tool constraints

### DIFF
--- a/.claude/commands/start-epic.md
+++ b/.claude/commands/start-epic.md
@@ -149,6 +149,15 @@ git checkout main
 
 **5b. Write the execution manifest**
 
+Before writing, run these three pre-flight checks for each ticket:
+
+**A. Context snippets** — Read the key functions the worker will call or test from `related_files_hint`. If any function's behaviour depends on a constant defined in another module or a non-obvious path indirection (e.g. `repo_root.parent / _WORKTREE_BASE` where `_WORKTREE_BASE` is in `watcher_types.py`), copy those lines verbatim into `context_snippets` as `"# <file>:<start>-<end>\n<lines>"`. Rule: if you needed to read a second file to understand the first, the worker needs it too — inline it as a snippet.
+
+**B. Tool constraint (test-only manifests)** — If every glob in `allowed_paths` targets only test files (e.g. `tests/**`, `tests/test_*.py`), prepend this entry to `implementation_constraints`:
+`"Fix code by editing test files directly with Edit/Write tools. Do not use Bash to experiment with Python path logic or prototype solutions — reason from the source code, then edit."`
+
+**C. AC function name validation** — For any function or method name mentioned in `acceptance_criteria`, verify it exists in the source: `grep -rn "def <name>" app/`. Correct any mismatch before writing — this prevents the worker from testing non-existent symbols.
+
 Write to `.claude/artifacts/<ticket_id_lower>/manifest.json`:
 
 ```json

--- a/.claude/commands/start-ticket.md
+++ b/.claude/commands/start-ticket.md
@@ -176,6 +176,15 @@ If all four apply, note it explicitly: *"This ticket is a good candidate for int
 
 Once the human says to proceed, generate and write an `ExecutionManifest` JSON to disk. This is the handoff artifact the local worker reads — it must not require re-reading Linear or re-planning.
 
+**Before writing the manifest, run these three pre-flight checks:**
+
+**A. Context snippets** — Read the key functions the worker will call or test from `related_files_hint`. If any function's behaviour depends on a constant defined in another module or a non-obvious path indirection (e.g. `repo_root.parent / _WORKTREE_BASE` where `_WORKTREE_BASE` is in `watcher_types.py`), copy those lines verbatim into `context_snippets` as `"# <file>:<start>-<end>\n<lines>"`. Rule: if you needed to read a second file to understand the first, the worker needs it too — inline it as a snippet rather than leaving it in `related_files_hint` alone.
+
+**B. Tool constraint (test-only manifests)** — If every glob in `allowed_paths` targets only test files (e.g. `tests/**`, `tests/test_*.py`), prepend this entry to `implementation_constraints`:
+`"Fix code by editing test files directly with Edit/Write tools. Do not use Bash to experiment with Python path logic or prototype solutions — reason from the source code, then edit."`
+
+**C. AC function name validation** — For any function or method name mentioned in `acceptance_criteria`, verify it exists in the relevant source file: `grep -rn "def <name>" app/`. Correct any mismatch before writing the manifest — this prevents the worker from writing tests for functions that don't exist.
+
 Construct the manifest from the planning context gathered in steps 1–4:
 
 ```json

--- a/app/core/watcher.py
+++ b/app/core/watcher.py
@@ -17,6 +17,7 @@ Worker modes:
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 import signal
@@ -361,6 +362,7 @@ class Watcher:
 
     def _start_ticket(self, ticket_id: str, linear_id: str) -> None:
         manifest = self._load_manifest(ticket_id)
+        manifest = self._enrich_with_retry_context(manifest)
 
         # Prerequisite checks
         open_blockers = self._linear.get_open_blockers(linear_id)
@@ -572,6 +574,56 @@ class Watcher:
     # ------------------------------------------------------------------
     # Manifest loading
     # ------------------------------------------------------------------
+
+    def _enrich_with_retry_context(
+        self, manifest: ExecutionManifest
+    ) -> ExecutionManifest:
+        """Prepend last_failure.json content to implementation_constraints on retry.
+
+        Promotes the failure context from a file the worker must discover into an
+        explicit directive at the top of the task list, so the worker addresses the
+        specific failure immediately rather than re-running the full suite blind.
+        """
+        artifact_dir = (self._repo_root / manifest.artifact_paths.result_json).parent
+        failure_path = artifact_dir / "last_failure.json"
+        if not failure_path.exists():
+            return manifest
+
+        try:
+            data = json.loads(failure_path.read_text(encoding="utf-8"))
+        except Exception as exc:
+            logger.warning(
+                "Could not read last_failure.json for %s: %s", manifest.ticket_id, exc
+            )
+            return manifest
+
+        check = data.get("check", "unknown")
+        stdout = data.get("stdout", "")
+        failure_line = next(
+            (
+                line.strip()
+                for line in stdout.splitlines()
+                if line.strip().startswith("FAILED")
+            ),
+            stdout[:200].strip(),
+        )
+        constraint = (
+            f"RETRY: Previous run failed check `{check}`. "
+            f"Fix this specific failure first: {failure_line}"
+        )
+        logger.info(
+            "Enriching %s manifest with retry context: %s",
+            manifest.ticket_id,
+            failure_line,
+        )
+        return manifest.model_copy(
+            update={
+                "implementation_constraints": [
+                    constraint,
+                    *manifest.implementation_constraints,
+                ]
+            }
+        )
 
     def _load_manifest(self, ticket_id: str) -> ExecutionManifest:
         from app.core.manifest import ArtifactPaths

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -478,3 +478,57 @@ def test_startup_info_default_mode_logs_both_pool_sizes(
     assert "mode=default" in msg
     assert "max_local_workers=8" in msg
     assert "max_cloud_workers=3" in msg
+
+
+# ---------------------------------------------------------------------------
+# _enrich_with_retry_context — injects constraint when last_failure.json exists
+# ---------------------------------------------------------------------------
+
+
+def test_enrich_with_retry_context_injects_constraint(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    import json
+
+    manifest = _make_manifest(implementation_constraints=["original constraint"])
+    artifact_dir = tmp_path / ".claude" / "artifacts" / "wor_10"
+    artifact_dir.mkdir(parents=True)
+    failure = {
+        "failed_at": "2026-04-30T10:00:00Z",
+        "check": "pytest",
+        "stdout": (
+            "FAILED tests/test_watcher_worktrees.py"
+            "::test_cleanup_orphaned_worktrees_removes_subdirs"
+            " - AssertionError: assert 0 == 2\n"
+        ),
+        "stderr": "",
+    }
+    (artifact_dir / "last_failure.json").write_text(
+        json.dumps(failure), encoding="utf-8"
+    )
+
+    w = Watcher(linear_client=MagicMock(), repo_root=tmp_path)
+    with caplog.at_level(logging.INFO, logger="app.core.watcher"):
+        enriched = w._enrich_with_retry_context(manifest)
+
+    assert enriched.implementation_constraints[0].startswith("RETRY:")
+    assert "pytest" in enriched.implementation_constraints[0]
+    assert (
+        "test_cleanup_orphaned_worktrees_removes_subdirs"
+        in (enriched.implementation_constraints[0])
+    )
+    assert enriched.implementation_constraints[1] == "original constraint"
+    assert any("retry context" in m for m in caplog.messages)
+
+
+# ---------------------------------------------------------------------------
+# _enrich_with_retry_context — no-op when last_failure.json absent
+# ---------------------------------------------------------------------------
+
+
+def test_enrich_with_retry_context_noop_without_failure_file(tmp_path: Path) -> None:
+    manifest = _make_manifest(implementation_constraints=["original constraint"])
+    w = Watcher(linear_client=MagicMock(), repo_root=tmp_path)
+    enriched = w._enrich_with_retry_context(manifest)
+
+    assert enriched.implementation_constraints == ["original constraint"]


### PR DESCRIPTION
## Summary

- Watcher injects `last_failure.json` into `implementation_constraints` before dispatching a retry, so the worker receives a `RETRY:` directive pointing at the exact failing test instead of discovering the file on its own
- `/start-ticket` and `/start-epic` skills gain three pre-manifest checks: inline context snippets for non-obvious path indirection, Edit/Write-only constraint for test-targeting manifests, and AC function name validation against source symbols
- Two new unit tests cover the enrich method: constraint injected when failure file exists; no-op when absent

**Milestone:** Post-MVP Explorations

> Note: `app/core/watcher.py` is 675 LOC (≥ 500 — advisory). Consider splitting before it grows further.

## Test plan
- [x] `test_enrich_with_retry_context_injects_constraint` — RETRY constraint prepended, correct check name and test name in message
- [x] `test_enrich_with_retry_context_noop_without_failure_file` — manifest unchanged when no failure file
- [x] Full suite: 749 passed, 89% coverage
- [x] ruff, mypy, bandit, semgrep all clean

Closes WOR-231