### PR TITLE
WOR-230 Store local_input_tokens, local_output_tokens, and local_output_tokens_per_second in TicketMetrics

### DIFF
--- a/app/core/metrics.py
+++ b/app/core/metrics.py
@@ -47,8 +47,11 @@ CREATE TABLE IF NOT EXISTS ticket_metrics (
     cloud_cost_estimate   REAL,
     local_used            INTEGER NOT NULL DEFAULT 0,
     local_model           TEXT,
+    local_input_tokens    INTEGER,
+    local_output_tokens   INTEGER,
     local_tokens          INTEGER,
     local_wall_time       REAL,
+    local_output_tokens_per_second REAL,
     escalated_to_cloud    INTEGER NOT NULL DEFAULT 0,
     outcome               TEXT NOT NULL,
     retry_count           INTEGER NOT NULL DEFAULT 0,
@@ -78,7 +81,12 @@ class TicketMetrics(BaseModel):
     cloud_cost_estimate: float | None = None
     local_used: bool = False
     local_model: str | None = None
+    local_input_tokens: int | None = None
+    local_output_tokens: int | None = None
     local_tokens: int | None = None
+    local_output_tokens_per_second: float | None = Field(
+        default=None, description="output_tokens / wall_time when both present"
+    )
     local_wall_time: float | None = Field(default=None, description="Seconds")
     escalated_to_cloud: bool = False
     outcome: Outcome
@@ -169,6 +177,27 @@ class MetricsStore:
         with self._connect() as conn:
             conn.execute(_CREATE_TABLE)
             conn.execute(_CREATE_CHECK_RUN_LOG)
+            self._migrate(conn)
+
+    def _migrate(self, conn: sqlite3.Connection) -> None:
+        """Add new columns to existing databases using PRAGMA table_info."""
+        existing = {
+            row[1]
+            for row in conn.execute("PRAGMA table_info(ticket_metrics)").fetchall()
+        }
+        if "local_input_tokens" not in existing:
+            conn.execute(
+                "ALTER TABLE ticket_metrics ADD COLUMN local_input_tokens INTEGER"
+            )
+        if "local_output_tokens" not in existing:
+            conn.execute(
+                "ALTER TABLE ticket_metrics ADD COLUMN local_output_tokens INTEGER"
+            )
+        if "local_output_tokens_per_second" not in existing:
+            conn.execute(
+                "ALTER TABLE ticket_metrics "
+                "ADD COLUMN local_output_tokens_per_second REAL"
+            )
 
     @contextmanager
     def _connect(self) -> Generator[sqlite3.Connection, None, None]:
@@ -188,7 +217,8 @@ class MetricsStore:
                 INSERT OR REPLACE INTO ticket_metrics (
                     ticket_id, project_id, epic_id, implementation_mode,
                     cloud_used, cloud_model, cloud_tokens, cloud_cost_estimate,
-                    local_used, local_model, local_tokens, local_wall_time,
+                    local_used, local_model, local_input_tokens, local_output_tokens,
+                    local_tokens, local_wall_time, local_output_tokens_per_second,
                     escalated_to_cloud, outcome,
                     retry_count, check_failures_json,
                     lines_changed, files_changed,
@@ -196,7 +226,10 @@ class MetricsStore:
                 ) VALUES (
                     :ticket_id, :project_id, :epic_id, :implementation_mode,
                     :cloud_used, :cloud_model, :cloud_tokens, :cloud_cost_estimate,
-                    :local_used, :local_model, :local_tokens, :local_wall_time,
+                    :local_used, :local_model,
+                    :local_input_tokens, :local_output_tokens,
+                    :local_tokens, :local_wall_time,
+                    :local_output_tokens_per_second,
                     :escalated_to_cloud, :outcome,
                     :retry_count, :check_failures_json,
                     :lines_changed, :files_changed,

--- a/app/core/watcher_finalize.py
+++ b/app/core/watcher_finalize.py
@@ -98,7 +98,17 @@ def finalize_worker(
     )
 
     log_path = worker.worktree_path / f".claude/worker_{worker.ticket_id.lower()}.log"
-    local_tokens, context_compactions = _parse_worker_usage(log_path)
+    input_tokens, output_tokens, context_compactions = _parse_worker_usage(log_path)
+    # Backward-compat: local_tokens = input + output (None when either is None)
+    local_tokens: int | None = (
+        (input_tokens or 0) + (output_tokens or 0)
+        if input_tokens is not None and output_tokens is not None
+        else None
+    )
+    # Derive throughput when both output tokens and wall time are available
+    local_output_tokens_per_second: float | None = None
+    if output_tokens is not None and wall_time and wall_time > 0:
+        local_output_tokens_per_second = output_tokens / wall_time
     eff = resolve_effective_mode(mode, worker.manifest.implementation_mode)
     metrics.record(
         TicketMetrics(
@@ -109,8 +119,11 @@ def finalize_worker(
             local_used=(eff == "local"),
             local_model=(_LOCAL_MODEL if eff == "local" else None),
             cloud_used=(eff == "cloud"),
+            local_input_tokens=input_tokens,
+            local_output_tokens=output_tokens,
             local_tokens=local_tokens,
             local_wall_time=wall_time,
+            local_output_tokens_per_second=local_output_tokens_per_second,
             escalated_to_cloud=escalated,
             outcome=outcome,
             retry_count=worker.retry_count,

--- a/app/core/watcher_helpers.py
+++ b/app/core/watcher_helpers.py
@@ -24,8 +24,14 @@ from app.core.watcher_types import (
 # ---------------------------------------------------------------------------
 
 
-def _parse_worker_usage(log_path: Path) -> tuple[int | None, int | None]:
-    """Read stream-json worker log and return (local_tokens, context_compactions)."""
+def _parse_worker_usage(
+    log_path: Path,
+) -> tuple[int | None, int | None, int | None]:
+    """Read stream-json worker log and return (input_tokens, output_tokens,
+
+    context_compactions).  Returns three-tuple to separate prefill tokens
+    from generation tokens, enabling per-second throughput tracking.
+    """
     try:
         with log_path.open(encoding="utf-8") as f:
             for raw in f:
@@ -38,14 +44,17 @@ def _parse_worker_usage(log_path: Path) -> tuple[int | None, int | None]:
                     continue
                 if obj.get("type") == "result":
                     usage = obj.get("usage") or {}
-                    local_tokens = (usage.get("input_tokens") or 0) + (
-                        usage.get("output_tokens") or 0
-                    )
+                    input_tokens = usage.get("input_tokens")
+                    output_tokens = usage.get("output_tokens")
                     context_compactions = obj.get("context_compactions")
-                    return local_tokens, context_compactions
+                    # Return None when either token field is missing so the
+                    # caller can decide whether to compute a sum.
+                    if input_tokens is None or output_tokens is None:
+                        return None, None, context_compactions
+                    return int(input_tokens), int(output_tokens), context_compactions
     except Exception:
-        return None, None
-    return None, None
+        return None, None, None
+    return None, None, None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -302,3 +302,59 @@ class TestCheckRunLog:
         result = store.get_by_ticket("WOR-1", "proj-a")
         assert result is not None
         assert result.ticket_id == "WOR-1"
+
+
+class TestMigration:
+    def test_migration_adds_new_columns(self, tmp_path):
+        """Existing DB gets local_input_tokens, local_output_tokens,
+        local_output_tokens_per_second without error."""
+        store = MetricsStore(db_path=tmp_path / "metrics.db")
+        # Write and read before _migrate runs to establish baseline
+        store.record(_ticket())
+        result = store.get_by_ticket("WOR-1", "proj-a")
+        assert result is not None
+        # Re-create store (simulating re-open after DB init)
+        store2 = MetricsStore(db_path=tmp_path / "metrics.db")
+        store2.record(_ticket())
+        result2 = store2.get_by_ticket("WOR-1", "proj-a")
+        assert result2 is not None
+
+    def test_new_columns_stored_and_retrieved(self, tmp_path):
+        """New token fields round-trip through the DB."""
+        store = _store(tmp_path)
+        store.record(
+            _ticket(
+                local_input_tokens=10000,
+                local_output_tokens=500,
+                local_output_tokens_per_second=4.17,
+            )
+        )
+        result = store.get_by_ticket("WOR-1", "proj-a")
+        assert result is not None
+        assert result.local_input_tokens == 10000
+        assert result.local_output_tokens == 500
+        assert result.local_output_tokens_per_second == pytest.approx(4.17)
+
+    def test_new_columns_none_default(self, tmp_path):
+        """Fields default to None when not provided."""
+        store = _store(tmp_path)
+        store.record(_ticket())
+        result = store.get_by_ticket("WOR-1", "proj-a")
+        assert result.local_input_tokens is None
+        assert result.local_output_tokens is None
+        assert result.local_output_tokens_per_second is None
+
+    def test_backward_compat_local_tokens_preserved(self, tmp_path):
+        """local_tokens remains valid alongside new fields."""
+        store = _store(tmp_path)
+        store.record(
+            _ticket(
+                local_input_tokens=10000,
+                local_output_tokens=500,
+                local_tokens=10500,
+            )
+        )
+        result = store.get_by_ticket("WOR-1", "proj-a")
+        assert result.local_tokens == 10500
+        assert result.local_input_tokens == 10000
+        assert result.local_output_tokens == 500

--- a/tests/test_watcher_finalize.py
+++ b/tests/test_watcher_finalize.py
@@ -947,3 +947,85 @@ def test_attempt_pr_called_process_error_returns_failure(
     comment_body = linear_mock.post_comment.call_args[0][1]
     assert "WOR-10" in comment_body
     assert "validation failed" in comment_body
+
+
+# ---------------------------------------------------------------------------
+# WOR-230 — local_input_tokens / local_output_tokens wired to metrics
+# ---------------------------------------------------------------------------
+
+
+def test_finalize_worker_writes_separate_token_fields(tmp_path: Path) -> None:
+    """input_tokens and output_tokens are passed to TicketMetrics."""
+    manifest = make_manifest(ticket_id="WOR-10", worker_branch="wor-10-test-ticket")
+    metrics_mock = MagicMock()
+
+    log_dir = tmp_path / ".claude"
+    log_dir.mkdir(parents=True)
+    log_file = log_dir / "worker_wor-10.log"
+    log_file.write_text(
+        json.dumps(
+            {
+                "type": "result",
+                "usage": {"input_tokens": 15000, "output_tokens": 600},
+                "context_compactions": 2,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    worker = ActiveWorker(
+        ticket_id="WOR-10",
+        linear_id="fake-linear-id",
+        manifest=manifest,
+        worktree_path=tmp_path,
+        process=MagicMock(spec=subprocess.Popen),
+    )
+
+    with (
+        patch("app.core.watcher_finalize.run_checks", return_value=True),
+        patch(
+            "app.core.watcher_finalize.create_pr",
+            return_value="https://github.com/example/pr/1",
+        ),
+        patch("app.core.watcher_finalize.cleanup_worktree"),
+    ):
+        _call_finalize(worker, wall_time=10.0, metrics=metrics_mock)
+
+    m = metrics_mock.record.call_args[0][0]
+    assert m.local_input_tokens == 15000
+    assert m.local_output_tokens == 600
+    assert m.local_tokens == 15600  # backward-compat sum
+    assert m.local_output_tokens_per_second == pytest.approx(60.0)  # 600/10
+
+
+def test_finalize_worker_token_fields_none_when_no_log(
+    tmp_path: Path,
+) -> None:
+    """When log is missing, all new token fields are None."""
+    manifest = make_manifest(ticket_id="WOR-10", worker_branch="wor-10-test-ticket")
+    metrics_mock = MagicMock()
+
+    worker = ActiveWorker(
+        ticket_id="WOR-10",
+        linear_id="fake-linear-id",
+        manifest=manifest,
+        worktree_path=tmp_path,
+        process=MagicMock(spec=subprocess.Popen),
+    )
+
+    with (
+        patch("app.core.watcher_finalize.run_checks", return_value=True),
+        patch(
+            "app.core.watcher_finalize.create_pr",
+            return_value="https://github.com/example/pr/1",
+        ),
+        patch("app.core.watcher_finalize.cleanup_worktree"),
+    ):
+        _call_finalize(worker, metrics=metrics_mock)
+
+    m = metrics_mock.record.call_args[0][0]
+    assert m.local_input_tokens is None
+    assert m.local_output_tokens is None
+    assert m.local_tokens is None
+    assert m.local_output_tokens_per_second is None

--- a/tests/test_watcher_helpers.py
+++ b/tests/test_watcher_helpers.py
@@ -189,8 +189,9 @@ def test_parse_worker_usage_success(tmp_path: Path) -> None:
         }
     )
     log = _write_log(tmp_path, ['{"type":"other","x":1}', result_line])
-    tokens, compactions = _parse_worker_usage(log)
-    assert tokens == 1200
+    input_tok, output_tok, compactions = _parse_worker_usage(log)
+    assert input_tok == 1000
+    assert output_tok == 200
     assert compactions == 3
 
 
@@ -199,14 +200,17 @@ def test_parse_worker_usage_no_context_compactions(tmp_path: Path) -> None:
         {"type": "result", "usage": {"input_tokens": 500, "output_tokens": 50}}
     )
     log = _write_log(tmp_path, [result_line])
-    tokens, compactions = _parse_worker_usage(log)
-    assert tokens == 550
+    input_tok, output_tok, compactions = _parse_worker_usage(log)
+    assert input_tok == 500
+    assert output_tok == 50
     assert compactions is None
 
 
 def test_parse_worker_usage_missing_log(tmp_path: Path) -> None:
-    tokens, compactions = _parse_worker_usage(tmp_path / "no_such_file.log")
-    assert tokens is None
+    log = tmp_path / "no_such_file.log"
+    input_tok, output_tok, compactions = _parse_worker_usage(log)
+    assert input_tok is None
+    assert output_tok is None
     assert compactions is None
 
 
@@ -218,16 +222,18 @@ def test_parse_worker_usage_no_result_line(tmp_path: Path) -> None:
             json.dumps({"type": "assistant", "content": "hello"}),
         ],
     )
-    tokens, compactions = _parse_worker_usage(log)
-    assert tokens is None
+    input_tok, output_tok, compactions = _parse_worker_usage(log)
+    assert input_tok is None
+    assert output_tok is None
     assert compactions is None
 
 
 def test_parse_worker_usage_malformed_json(tmp_path: Path) -> None:
     log = tmp_path / "worker.log"
     log.write_text("not json at all\n{broken\n", encoding="utf-8")
-    tokens, compactions = _parse_worker_usage(log)
-    assert tokens is None
+    input_tok, output_tok, compactions = _parse_worker_usage(log)
+    assert input_tok is None
+    assert output_tok is None
     assert compactions is None
 
 
@@ -241,8 +247,9 @@ def test_parse_worker_usage_mixed_valid_invalid_lines(tmp_path: Path) -> None:
     )
     log = tmp_path / "worker.log"
     log.write_text("garbage line\n" + result_line + "\n", encoding="utf-8")
-    tokens, compactions = _parse_worker_usage(log)
-    assert tokens == 400
+    input_tok, output_tok, compactions = _parse_worker_usage(log)
+    assert input_tok == 300
+    assert output_tok == 100
     assert compactions == 1
 
 
@@ -254,15 +261,17 @@ def test_parse_worker_usage_returns_first_result_line(tmp_path: Path) -> None:
         {"type": "result", "usage": {"input_tokens": 999, "output_tokens": 999}}
     )
     log = _write_log(tmp_path, [first, second])
-    tokens, _ = _parse_worker_usage(log)
-    assert tokens == 15
+    input_tok, output_tok, _ = _parse_worker_usage(log)
+    assert input_tok == 10
+    assert output_tok == 5
 
 
 def test_parse_worker_usage_empty_file(tmp_path: Path) -> None:
     log = tmp_path / "empty.log"
     log.write_text("", encoding="utf-8")
-    tokens, compactions = _parse_worker_usage(log)
-    assert tokens is None
+    input_tok, output_tok, compactions = _parse_worker_usage(log)
+    assert input_tok is None
+    assert output_tok is None
     assert compactions is None
 
 
@@ -297,3 +306,44 @@ def test_parse_ollama_model_raises_when_file_missing(tmp_path: Path) -> None:
 
     with pytest.raises(FileNotFoundError):
         _parse_ollama_model(tmp_path / "nonexistent.yaml")
+
+
+# ---------------------------------------------------------------------------
+# _parse_worker_usage — 3-tuple return (WOR-230)
+# ---------------------------------------------------------------------------
+
+
+def test_parse_worker_usage_returns_separate_tokens(tmp_path: Path) -> None:
+    """input_tokens and output_tokens are returned separately."""
+    result_line = json.dumps(
+        {
+            "type": "result",
+            "usage": {"input_tokens": 12000, "output_tokens": 800},
+        }
+    )
+    log = _write_log(tmp_path, [result_line])
+    input_tok, output_tok, _ = _parse_worker_usage(log)
+    assert input_tok == 12000
+    assert output_tok == 800
+
+
+def test_parse_worker_usage_missing_input_token_returns_none(
+    tmp_path: Path,
+) -> None:
+    """When input_tokens is absent, all tokens are None."""
+    result_line = json.dumps({"type": "result", "usage": {"output_tokens": 500}})
+    log = _write_log(tmp_path, [result_line])
+    input_tok, output_tok, _ = _parse_worker_usage(log)
+    assert input_tok is None
+    assert output_tok is None
+
+
+def test_parse_worker_usage_missing_output_token_returns_none(
+    tmp_path: Path,
+) -> None:
+    """When output_tokens is absent, all tokens are None."""
+    result_line = json.dumps({"type": "result", "usage": {"input_tokens": 3000}})
+    log = _write_log(tmp_path, [result_line])
+    input_tok, output_tok, _ = _parse_worker_usage(log)
+    assert input_tok is None
+    assert output_tok is None


### PR DESCRIPTION
Closes WOR-230

ruff, mypy, and pytest all pass. _parse_worker_usage returns a 3-tuple. TicketMetrics has the three new fields. MetricsStore._migrate adds new columns to existing DBs. local_tokens is preserved as backward-compatible sum.