### PR TITLE
Sync CLAUDE.md and README.md with current codebase state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,7 @@ python -m app.main
 # CLI — scaffold
 python -m app.cli generate --preset python_basic --repo-name myrepo --output ./out
 # With optional toggles: --pre-commit --ci --pr-template --issue-templates --codeowners --claude-files
+#                        --playwright (full_agentic only) --linear-mcp / --no-linear-mcp
 # With post-setup:       --git-init --install-precommit
 
 # CLI — user preferences
@@ -31,7 +32,14 @@ python -m app.cli watcher --worker-mode local    # force local (LiteLLM proxy + 
 python -m app.cli watcher --max-local-workers 8  # default 8; vLLM handles concurrency
 python -m app.cli watcher --max-cloud-workers 3  # default 3; parallelisable
 python -m app.cli watcher --max-workers 2        # backward-compat alias: sets both to 2
+python -m app.cli watcher --verbose              # stream worker stdout/stderr live, prefixed with [WOR-NN]
 
+# Benchmark runner (do not run without explicit instruction)
+python scripts/bench/run_bench.py --tier speed
+python scripts/bench/run_bench.py --resume run_20240101_120000
+python scripts/bench/run_bench.py --compare run_20240101 run_20240102
+python scripts/bench/run_bench.py --generate-fixtures
+python scripts/bench/run_bench.py --browse       # open bench.db in Datasette
 
 # CLI — metrics
 python -m app.cli metrics browse   # open metrics DB in Datasette browser UI
@@ -63,6 +71,8 @@ templates/     # Jinja2 template files for scaffold output
 tests/         # Tests against core only
 schemas/       # Exported JSON Schemas for non-Python consumers
 docs/spikes/   # Spike investigation docs
+config/        # escalation_policy.toml + bench-*.toml run configs
+scripts/bench/ # run_bench.py CLI entry point + runner/fixtures helpers
 ```
 
 Module responsibilities:
@@ -80,6 +90,8 @@ Module responsibilities:
 - `watcher_subprocess.py` — worker subprocess lifecycle: `launch_worker`, `run_checks`, `fetch_sonar_findings`, `create_pr`, `build_snippet_tool_restrictions`
 - `watcher_worktrees.py` — git worktree lifecycle: `setup_worktree`, `teardown_worktree`, `rebase_worktree_from_base`, `preserve_worker_artifacts`
 - `watcher_services.py` — `ServiceManager` class: LiteLLM proxy and Ollama process management
+- `watcher_finalize.py` — worker finalization logic: `finalize_worker`, `attempt_pr`, `safe_set_state`; extracted from watcher to keep watcher.py below SonarCloud cognitive-complexity threshold
+- `bench_store.py` — `BenchRun` Pydantic model + `BenchStore`: SQLite-backed append-only store for benchmark run records (`bench.db`); mirrors `metrics.py` structure but stores hardware/timing/quality columns per run
 - `watcher.py` — orchestrator only: polls Linear for `ReadyForLocal` tickets, delegates to sub-modules above
 - `main.py` — PySide6 `QApplication` entry point
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ python -m app.cli generate --preset python_basic --repo-name myrepo --output ./o
 
 # With optional file toggles
 python -m app.cli generate --preset python_basic --repo-name myrepo --output ./out \
-  --pre-commit --ci --pr-template --issue-templates --codeowners --claude-files
+  --pre-commit --ci --pr-template --issue-templates --codeowners --claude-files \
+  --playwright --linear-mcp
 
 # With post-setup actions
 python -m app.cli generate --preset python_basic --repo-name myrepo --output ./out \
@@ -31,6 +32,9 @@ python -m app.cli config set github-username "your-username"
 python -m app.cli watcher                        # respects each manifest's implementation_mode
 python -m app.cli watcher --worker-mode cloud    # force cloud (Anthropic API)
 python -m app.cli watcher --worker-mode local    # force local (LiteLLM proxy)
+python -m app.cli watcher --max-local-workers 8  # default 8; vLLM handles concurrency
+python -m app.cli watcher --max-cloud-workers 3  # default 3
+python -m app.cli watcher --verbose              # stream worker output live to stderr
 
 # Metrics
 python -m app.cli metrics browse   # open metrics DB in Datasette browser UI
@@ -56,8 +60,9 @@ app/ui/        # PySide6 only — calls core, contains no logic
 templates/     # Jinja2 template files for scaffold output
 tests/         # Tests against core only
 schemas/       # Exported JSON Schemas for non-Python consumers
-config/        # escalation_policy.toml and other runtime config
+config/        # escalation_policy.toml + bench-*.toml run configs
 docs/spikes/   # Spike investigation docs
+scripts/bench/ # Benchmark runner CLI and helpers
 ```
 
 Module responsibilities:
@@ -68,9 +73,15 @@ Module responsibilities:
 - `post_setup.py` — side effects: `git init`, `pre-commit install`
 - `user_prefs.py` — `UserPreferences` model + `PrefsStore` (platform-aware JSON persistence)
 - `manifest.py` — `ExecutionManifest` Pydantic model: cloud→local worker contract
-- `watcher.py` — orchestrator daemon: polls Linear, manages worktrees, launches workers, creates PRs
+- `watcher.py` — orchestrator only: polls Linear for `ReadyForLocal` tickets, delegates to sub-modules
+- `watcher_finalize.py` — worker finalization: outcome classification, PR creation, escalation
+- `watcher_subprocess.py` — worker subprocess lifecycle, checks, Sonar integration
+- `watcher_worktrees.py` — git worktree setup, teardown, artifact preservation
+- `watcher_helpers.py` — pure stateless helpers used by watcher sub-modules
+- `watcher_services.py` — LiteLLM proxy and Ollama process management
 - `linear_client.py` — thin Linear GraphQL client (stdlib `urllib` only); requires `LINEAR_API_KEY`
 - `metrics.py` — SQLite-backed per-ticket cost and execution metrics store
+- `bench_store.py` — SQLite-backed benchmark run records store (`bench.db`)
 - `escalation_policy.py` — loads `config/escalation_policy.toml`, classifies failures into watcher actions
 - `cli.py` — CLI entry point
 - `main.py` — PySide6 app entry point (V2)
@@ -95,6 +106,8 @@ Data flows one way: CLI → config model → generator → disk. Post-setup runs
 | `--issue-templates` | Include bug report and feature request templates |
 | `--codeowners` | Include `CODEOWNERS` file |
 | `--claude-files` | Include `CLAUDE.md` and `.mcp.json` |
+| `--playwright` | Include Playwright browser-test scaffold (`full_agentic` only) |
+| `--linear-mcp` / `--no-linear-mcp` | Include/exclude Linear MCP server in `.mcp.json` |
 | `--git-init` | Run `git init` in the output directory after generation |
 | `--install-precommit` | Run `pre-commit install` in the output directory |
 
@@ -114,11 +127,16 @@ Data flows one way: CLI → config model → generator → disk. Post-setup runs
 
 ## Local model development
 
-To run Claude Code against a local model via Ollama instead of the Anthropic API:
+To run Claude Code against a local vLLM server instead of the Anthropic API:
 
 ```bash
-# 1. Pull the model
-ollama pull qwen3-coder:30b
+# 1. Start vLLM server in WSL2 (keep terminal open)
+/home/antti/vllm-env/bin/vllm serve /home/antti/models/Qwen3.6-35B-A3B-NVFP4 \
+  --max-model-len 262144 --max-num-seqs 16 \
+  --kv-cache-dtype fp8 --max-num-batched-tokens 4096 \
+  --reasoning-parser qwen3 --enable-prefix-caching \
+  --language-model-only --safetensors-load-strategy prefetch \
+  --enable-auto-tool-choice --tool-call-parser qwen3_coder
 
 # 2. Copy the example config and start LiteLLM proxy (keep terminal open)
 cp litellm-local.yaml.example litellm-local.yaml
@@ -130,7 +148,7 @@ set ANTHROPIC_API_KEY=sk-dummy
 claude --model qwen3-coder:30b
 ```
 
-`litellm-local.yaml` is gitignored. See [`docs/spikes/local-model-setup.md`](docs/spikes/local-model-setup.md) for VRAM requirements, benchmark results, and go/no-go recommendation.
+`litellm-local.yaml` is gitignored. See [`docs/spikes/local-model-setup.md`](docs/spikes/local-model-setup.md) for VRAM budget, model selection, and benchmark results.
 
 ## Claude Code and MCP setup
 


### PR DESCRIPTION
## Summary

- Add missing modules to Architecture sections: `watcher_finalize.py` and `bench_store.py`
- Add missing CLI flags: `--verbose` (watcher), `--playwright` and `--linear-mcp` (generate)
- Add benchmark runner (`scripts/bench/run_bench.py`) to Commands and directory tree
- Update local model section in README from Ollama pull to vLLM production setup

## Test plan

- [ ] Docs-only change — no code modified, no test needed
- [ ] Verify module names match actual files in `app/core/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)