### PR TITLE
Fix CLAUDE.md: correct Claude Code hooks documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,8 +216,7 @@ The informational scan runs on `github.base_ref != 'main'`; the blocking scan ru
 - **PostToolUse** — ruff lint + format after any Python file edit
 - **PostToolUse** — bandit security scan after any Python file edit (if bandit is installed)
 - **PostToolUse** — `lint-imports` architecture contract check after any Python file edit
-- **PostToolUse** — pytest with coverage after changes to `app/` or `tests/`
-- **Stop** — `pre-commit run --all-files` at the end of every turn
+- **PostToolUse** — pytest (no coverage) after changes to `tests/` files only
 - **PreToolUse** — blocks destructive shell commands and writes to sensitive files (`.env`, `.mcp.json`, `.claude/settings*`)
 
 No setup needed — hooks activate as soon as Claude Code loads the project.


### PR DESCRIPTION
## Summary

- Remove inaccurate Stop hook claim (`pre-commit run --all-files` at end of turn — this hook does not exist in `.claude/settings.json`)
- Fix pytest hook description: fires on `tests/` edits only, no coverage flag, not triggered by `app/` changes

Identified during repo quality audit (WOR-236).

🤖 Generated with [Claude Code](https://claude.com/claude-code)