### PR TITLE
WOR-212 Track rework events in metrics.db to calibrate model selection cost model

### DIFF
--- a/app/core/metrics.py
+++ b/app/core/metrics.py
@@ -35,6 +35,20 @@ CREATE TABLE IF NOT EXISTS check_run_log (
 )
 """
 
+_CREATE_REWORK_EVENTS = """
+CREATE TABLE IF NOT EXISTS rework_events (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    ticket_id       TEXT NOT NULL,
+    model_id        TEXT NOT NULL,
+    backend_id      TEXT,
+    context_size    INTEGER,
+    task_complexity TEXT,
+    rework_reason   TEXT NOT NULL,
+    rework_cost_minutes REAL,
+    recorded_at     TEXT NOT NULL DEFAULT (datetime('now'))
+)
+"""
+
 _CREATE_TABLE = """
 CREATE TABLE IF NOT EXISTS ticket_metrics (
     ticket_id                      TEXT NOT NULL,
@@ -199,6 +213,24 @@ class CheckStats(BaseModel):
     max_duration_s: float | None
 
 
+ReworkReason = Literal["local_retry", "escalated", "human_revision", "ci_failure"]
+
+
+class ReworkEvent(BaseModel):
+    """A single rework event — a local worker was re-dispatched or escalated."""
+
+    model_config = {"extra": "forbid"}
+
+    ticket_id: str
+    model_id: str
+    backend_id: str | None = None
+    context_size: int | None = None
+    task_complexity: str | None = None
+    rework_reason: ReworkReason
+    rework_cost_minutes: float
+    recorded_at: str | None = None
+
+
 class MetricsStore:
     """SQLite-backed store for ticket execution metrics."""
 
@@ -221,6 +253,7 @@ class MetricsStore:
         with self._connect() as conn:
             conn.execute(_CREATE_TABLE)
             conn.execute(_CREATE_CHECK_RUN_LOG)
+            conn.execute(_CREATE_REWORK_EVENTS)
             self._migrate(conn)
 
     def _migrate(self, conn: sqlite3.Connection) -> None:
@@ -460,6 +493,48 @@ class MetricsStore:
             )
             for r in rows
         ]
+
+    def record_rework_event(self, entry: ReworkEvent) -> None:
+        """Append a single rework event row."""
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO rework_events
+                    (ticket_id, model_id, backend_id, context_size,
+                     task_complexity, rework_reason, rework_cost_minutes)
+                VALUES
+                    (:ticket_id, :model_id, :backend_id, :context_size,
+                     :task_complexity, :rework_reason, :rework_cost_minutes)
+                """,
+                entry.model_dump(exclude={"recorded_at"}),
+            )
+
+    def get_rework_rate(self, model_id: str, task_complexity: str) -> float | None:
+        """Return rework probability for (model_id, task_complexity).
+
+        Returns ``None`` when fewer than 10 rework events exist for that
+        pair — callers should fall back to the bench proxy (1 -
+        quality_task_success).
+        """
+        with self._connect() as conn:
+            row = conn.execute(
+                """
+                SELECT
+                    COUNT(*) AS total,
+                    SUM(CASE WHEN rework_reason = 'local_retry' THEN 1 ELSE 0 END)
+                        AS local_retry_count,
+                    SUM(CASE WHEN rework_reason = 'escalated' THEN 1 ELSE 0 END)
+                        AS escalated_count
+                FROM rework_events
+                WHERE model_id = ? AND task_complexity = ?
+                """,
+                (model_id, task_complexity),
+            ).fetchone()
+        total = row["total"] if row["total"] is not None else 0
+        if total < 10:
+            return None
+        rework_count = (row["local_retry_count"] or 0) + (row["escalated_count"] or 0)
+        return round(rework_count / total, 4)
 
 
 def _row_to_metrics(row: sqlite3.Row) -> TicketMetrics:

--- a/app/core/watcher_finalize.py
+++ b/app/core/watcher_finalize.py
@@ -14,7 +14,7 @@ from pathlib import Path
 from app.core.escalation_policy import EscalationPolicy, ImprovementLogConfig
 from app.core.linear_client import LinearError
 from app.core.manifest import ExecutionManifest
-from app.core.metrics import MetricsStore, Outcome, TicketMetrics
+from app.core.metrics import MetricsStore, Outcome, ReworkEvent, TicketMetrics
 from app.core.watcher_helpers import (
     _POLICY_FLAGS,
     _parse_worker_usage,
@@ -95,7 +95,9 @@ def finalize_worker(
     project_id: str,
 ) -> None:
     outcome, escalated, artifacts_preserved, sonar_findings, result_data = (
-        _execute_finalization(worker, returncode, linear, escalation_policy, repo_root)
+        _execute_finalization(
+            worker, returncode, linear, escalation_policy, repo_root, metrics
+        )
     )
 
     log_path = worker.worktree_path / f".claude/worker_{worker.ticket_id.lower()}.log"
@@ -165,6 +167,7 @@ def _execute_finalization(
     linear: LinearClientProtocol,
     escalation_policy: EscalationPolicy,
     repo_root: Path,
+    metrics: MetricsStore,
 ) -> tuple[Outcome, bool, bool, list[str] | None, dict[str, object] | None]:
     """Determine outcome, escalation status, and artifact state.
 
@@ -181,6 +184,15 @@ def _execute_finalization(
     if returncode != 0:
         logger.error("Worker %s exited non-zero (%d)", ticket_id, returncode)
         escalated = bool(manifest.failure_policy.escalate_to_cloud)
+        if escalated:
+            metrics.record_rework_event(
+                ReworkEvent(
+                    ticket_id=ticket_id,
+                    model_id=worker.manifest.epic_id or "",
+                    rework_reason="escalated",
+                    rework_cost_minutes=0.0,
+                )
+            )
         if escalated:
             logger.info("Escalating %s to cloud per failure policy", ticket_id)
             safe_set_state(linear, linear_id, "In Progress", ticket_id)
@@ -200,9 +212,25 @@ def _execute_finalization(
     checks_ok = run_checks(manifest, worker.worktree_path)
     if not checks_ok:
         worker.retry_count += 1
+        metrics.record_rework_event(
+            ReworkEvent(
+                ticket_id=ticket_id,
+                model_id=worker.manifest.epic_id or "",
+                rework_reason="local_retry",
+                rework_cost_minutes=0.0,
+            )
+        )
     if not checks_ok and manifest.failure_policy.on_check_failure == "abort":
         escalated = bool(manifest.failure_policy.escalate_to_cloud)
         if escalated:
+            metrics.record_rework_event(
+                ReworkEvent(
+                    ticket_id=ticket_id,
+                    model_id=worker.manifest.epic_id or "",
+                    rework_reason="escalated",
+                    rework_cost_minutes=0.0,
+                )
+            )
             logger.info("Escalating %s to cloud after check failure", ticket_id)
             safe_set_state(linear, linear_id, "In Progress", ticket_id)
             _try_post_comment(
@@ -223,7 +251,7 @@ def _execute_finalization(
     action = escalation_policy.classify_result(**flags)
 
     outcome, escalated, sonar_findings = _handle_policy_outcome(
-        action, flags, worker, linear, escalation_policy
+        action, flags, worker, linear, escalation_policy, metrics
     )
     return outcome, escalated, True, sonar_findings, result_data
 
@@ -234,6 +262,7 @@ def _handle_policy_outcome(
     worker: ActiveWorker,
     linear: LinearClientProtocol,
     escalation_policy: EscalationPolicy,
+    metrics: MetricsStore,
 ) -> tuple[Outcome, bool, list[str] | None]:
     """Map a policy action to an outcome, posting Linear comments as needed."""
     ticket_id = worker.ticket_id
@@ -243,6 +272,14 @@ def _handle_policy_outcome(
     if action == "escalate":
         triggering = next((f for f in _POLICY_FLAGS if flags.get(f)), "unknown")
         logger.info("Escalating %s to cloud (flag=%s)", ticket_id, triggering)
+        metrics.record_rework_event(
+            ReworkEvent(
+                ticket_id=ticket_id,
+                model_id=worker.manifest.epic_id or "",
+                rework_reason="escalated",
+                rework_cost_minutes=0.0,
+            )
+        )
         safe_set_state(linear, linear_id, "In Progress", ticket_id)
         _try_post_comment(
             linear,
@@ -269,6 +306,14 @@ def _handle_policy_outcome(
     if _sonar_requires_escalation(
         sonar_findings, ticket_id, linear_id, linear, escalation_policy
     ):
+        metrics.record_rework_event(
+            ReworkEvent(
+                ticket_id=ticket_id,
+                model_id=worker.manifest.epic_id or "",
+                rework_reason="escalated",
+                rework_cost_minutes=0.0,
+            )
+        )
         safe_set_state(linear, linear_id, "In Progress", ticket_id)
         _try_post_comment(
             linear,

--- a/tests/test_watcher_finalize.py
+++ b/tests/test_watcher_finalize.py
@@ -14,6 +14,7 @@ import pytest
 from app.core.escalation_policy import EscalationPolicy
 from app.core.linear_client import LinearError
 from app.core.manifest import FailurePolicy
+from app.core.metrics import ReworkEvent
 from app.core.watcher_finalize import (
     _infer_category,
     _read_result_data,
@@ -708,7 +709,7 @@ def test_execute_finalization_nonzero_returncode_returns_failure(
     from app.core.watcher_finalize import _execute_finalization
 
     result = _execute_finalization(
-        worker, 1, linear_mock, EscalationPolicy.from_toml(), tmp_path
+        worker, 1, linear_mock, EscalationPolicy.from_toml(), tmp_path, MagicMock()
     )
     outcome, escalated, preserved, findings, _result_data = result
 
@@ -739,7 +740,7 @@ def test_execute_finalization_check_failure_abort_returns_failure(
 
     with patch("app.core.watcher_finalize.run_checks", return_value=False):
         result = _execute_finalization(
-            worker, 0, linear_mock, EscalationPolicy.from_toml(), tmp_path
+            worker, 0, linear_mock, EscalationPolicy.from_toml(), tmp_path, MagicMock()
         )
     outcome, escalated, preserved, findings, _result_data = result
 
@@ -775,6 +776,7 @@ def test_handle_policy_outcome_escalate_returns_escalated(
         worker,
         linear_mock,
         EscalationPolicy.from_toml(),
+        MagicMock(),
     )
 
     assert outcome == "escalated"
@@ -801,6 +803,7 @@ def test_handle_policy_outcome_human_returns_aborted(tmp_path: Path) -> None:
         worker,
         linear_mock,
         EscalationPolicy.from_toml(),
+        MagicMock(),
     )
 
     assert outcome == "aborted"
@@ -1570,3 +1573,256 @@ def test_finalize_worker_no_crash_without_improvement_log_config(
     )
     # Normal operations still happen
     linear_mock.set_state.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Rework event recording (WOR-212)
+# ---------------------------------------------------------------------------
+
+
+class TestReworkEventRecording:
+    """Tests that rework_events rows are written by _execute_finalization."""
+
+    def test_rework_on_check_failure_local_retry(self, tmp_path: Path) -> None:
+        """Check failure records rework_event with reason=local_retry."""
+        manifest = make_manifest(
+            ticket_id="WOR-10",
+            worker_branch="wor-10-test-ticket",
+        )
+        metrics_mock = MagicMock()
+        worker = ActiveWorker(
+            ticket_id="WOR-10",
+            linear_id="fake-linear-id",
+            manifest=manifest,
+            worktree_path=tmp_path,
+            process=MagicMock(spec=subprocess.Popen),
+        )
+
+        with (
+            patch("app.core.watcher_finalize.run_checks", return_value=False),
+            patch("app.core.watcher_finalize.cleanup_worktree"),
+        ):
+            _call_finalize(worker, metrics=metrics_mock)
+
+        calls = metrics_mock.record_rework_event.call_args_list
+        assert len(calls) == 1
+        entry: ReworkEvent = calls[0][0][0]
+        assert entry.rework_reason == "local_retry"
+        assert entry.ticket_id == "WOR-10"
+
+    def test_rework_on_check_failure_escalation_records_escalated(
+        self, tmp_path: Path
+    ) -> None:
+        """Check failure with escalation records both local_retry and escalated."""
+        manifest = make_manifest(
+            ticket_id="WOR-10",
+            worker_branch="wor-10-test-ticket",
+            failure_policy=FailurePolicy(
+                on_check_failure="abort", escalate_to_cloud=True
+            ),
+        )
+        metrics_mock = MagicMock()
+        worker = ActiveWorker(
+            ticket_id="WOR-10",
+            linear_id="fake-linear-id",
+            manifest=manifest,
+            worktree_path=tmp_path,
+            process=MagicMock(spec=subprocess.Popen),
+        )
+
+        with (
+            patch("app.core.watcher_finalize.run_checks", return_value=False),
+            patch("app.core.watcher_finalize.cleanup_worktree"),
+        ):
+            _call_finalize(worker, metrics=metrics_mock)
+
+        calls = metrics_mock.record_rework_event.call_args_list
+        assert len(calls) == 2
+        local_retry = calls[0][0][0]
+        assert local_retry.rework_reason == "local_retry"
+        escalated = calls[1][0][0]
+        assert escalated.rework_reason == "escalated"
+
+    def test_rework_on_nonzero_exit_escalated(self, tmp_path: Path) -> None:
+        """Non-zero returncode with escalation records reason=escalated."""
+        manifest = make_manifest(
+            ticket_id="WOR-10",
+            worker_branch="wor-10-test-ticket",
+            failure_policy=FailurePolicy(escalate_to_cloud=True),
+        )
+        metrics_mock = MagicMock()
+        worker = ActiveWorker(
+            ticket_id="WOR-10",
+            linear_id="fake-linear-id",
+            manifest=manifest,
+            worktree_path=tmp_path,
+            process=MagicMock(spec=subprocess.Popen),
+        )
+
+        with patch("app.core.watcher_finalize.cleanup_worktree"):
+            _call_finalize(worker, returncode=1, metrics=metrics_mock)
+
+        calls = metrics_mock.record_rework_event.call_args_list
+        assert len(calls) == 1
+        entry: ReworkEvent = calls[0][0][0]
+        assert entry.rework_reason == "escalated"
+        assert entry.ticket_id == "WOR-10"
+
+    def test_no_rework_on_nonzero_exit_no_escalation(self, tmp_path: Path) -> None:
+        """Non-zero returncode without escalation does not record rework."""
+        manifest = make_manifest(
+            ticket_id="WOR-10",
+            worker_branch="wor-10-test-ticket",
+        )
+        metrics_mock = MagicMock()
+        worker = ActiveWorker(
+            ticket_id="WOR-10",
+            linear_id="fake-linear-id",
+            manifest=manifest,
+            worktree_path=tmp_path,
+            process=MagicMock(spec=subprocess.Popen),
+        )
+
+        with patch("app.core.watcher_finalize.cleanup_worktree"):
+            _call_finalize(worker, returncode=1, metrics=metrics_mock)
+
+        metrics_mock.record_rework_event.assert_not_called()
+
+    def test_rework_on_escalate_action(self, tmp_path: Path) -> None:
+        """_handle_policy_outcome action=escalate records reason=escalated."""
+        manifest = make_manifest(
+            ticket_id="WOR-10",
+            worker_branch="wor-10-test-ticket",
+        )
+        metrics_mock = MagicMock()
+        linear_mock = MagicMock()
+
+        worker = ActiveWorker(
+            ticket_id="WOR-10",
+            linear_id="fake-linear-id",
+            manifest=manifest,
+            worktree_path=tmp_path,
+            process=MagicMock(spec=subprocess.Popen),
+        )
+
+        result_dir = tmp_path / ".claude" / "artifacts" / "wor_10"
+        result_dir.mkdir(parents=True, exist_ok=True)
+        result_path = result_dir / "result.json"
+        result_path.write_text(
+            json.dumps({"status": "success", "scope_drift": True}),
+            encoding="utf-8",
+        )
+
+        with (
+            patch("app.core.watcher_finalize.run_checks", return_value=True),
+            patch("app.core.watcher_finalize.preserve_worker_artifacts"),
+            patch(
+                "app.core.watcher_finalize.create_pr",
+                return_value="https://github.com/example/pr/1",
+            ),
+            patch("app.core.watcher_finalize.cleanup_worktree"),
+        ):
+            finalize_worker(
+                worker,
+                returncode=0,
+                wall_time=1.0,
+                linear=linear_mock,
+                metrics=metrics_mock,
+                escalation_policy=EscalationPolicy.from_toml(),
+                repo_root=tmp_path,
+                mode="default",
+                project_id=_DEFAULT_PROJECT,
+            )
+
+        calls = metrics_mock.record_rework_event.call_args_list
+        assert len(calls) == 1
+        entry: ReworkEvent = calls[0][0][0]
+        assert entry.rework_reason == "escalated"
+        assert entry.ticket_id == "WOR-10"
+
+    def test_rework_on_sonar_escalation(self, tmp_path: Path) -> None:
+        """Sonar blocker triggers escalation and records reason=escalated."""
+        manifest = make_manifest(
+            ticket_id="WOR-10",
+            worker_branch="wor-10-test-ticket",
+        )
+        metrics_mock = MagicMock()
+        linear_mock = MagicMock()
+
+        worker = ActiveWorker(
+            ticket_id="WOR-10",
+            linear_id="fake-linear-id",
+            manifest=manifest,
+            worktree_path=tmp_path,
+            process=MagicMock(spec=subprocess.Popen),
+        )
+
+        result_dir = tmp_path / ".claude" / "artifacts" / "wor_10"
+        result_dir.mkdir(parents=True, exist_ok=True)
+        result_path = result_dir / "result.json"
+        result_path.write_text(
+            json.dumps({"status": "success"}),
+            encoding="utf-8",
+        )
+
+        with (
+            patch("app.core.watcher_finalize.run_checks", return_value=True),
+            patch("app.core.watcher_finalize.preserve_worker_artifacts"),
+            patch("app.core.watcher_finalize.create_pr") as mock_create_pr,
+            patch("app.core.watcher_finalize.cleanup_worktree"),
+            patch(
+                "app.core.watcher_finalize.fetch_sonar_findings",
+                return_value=["BLOCKER"],
+            ),
+        ):
+            finalize_worker(
+                worker,
+                returncode=0,
+                wall_time=1.0,
+                linear=linear_mock,
+                metrics=metrics_mock,
+                escalation_policy=EscalationPolicy.from_toml(),
+                repo_root=tmp_path,
+                mode="default",
+                project_id=_DEFAULT_PROJECT,
+            )
+
+        calls = metrics_mock.record_rework_event.call_args_list
+        assert len(calls) == 1
+        entry: ReworkEvent = calls[0][0][0]
+        assert entry.rework_reason == "escalated"
+        assert entry.ticket_id == "WOR-10"
+        mock_create_pr.assert_not_called()
+
+    def test_no_rework_on_success(self, tmp_path: Path) -> None:
+        """Successful finalization does not record any rework events."""
+        manifest = make_manifest(
+            ticket_id="WOR-10",
+            worker_branch="wor-10-test-ticket",
+        )
+        metrics_mock = MagicMock()
+        linear_mock = MagicMock()
+
+        worker = ActiveWorker(
+            ticket_id="WOR-10",
+            linear_id="fake-linear-id",
+            manifest=manifest,
+            worktree_path=tmp_path,
+            process=MagicMock(spec=subprocess.Popen),
+        )
+
+        with (
+            patch("app.core.watcher_finalize.run_checks", return_value=True),
+            patch(
+                "app.core.watcher_finalize.create_pr",
+                return_value="https://github.com/example/pr/1",
+            ),
+            patch("app.core.watcher_finalize.cleanup_worktree"),
+        ):
+            _call_finalize(
+                worker,
+                metrics=metrics_mock,
+                linear=linear_mock,
+            )
+
+        metrics_mock.record_rework_event.assert_not_called()


### PR DESCRIPTION
Closes WOR-212

rework_events table in metrics.db; ReworkEvent model and record_rework_event() in MetricsStore; get_rework_rate() returning probability or None; watcher_finalize writes rows on escalation and retry; tests verify proportion and None-below-threshold; all checks pass.