### PR TITLE
Fix local model doc, worker efficiency, and start-epic linear_id semantics

### DIFF
--- a/.claude/commands/implement-ticket.md
+++ b/.claude/commands/implement-ticket.md
@@ -61,6 +61,22 @@ Check out the correct branch before running /implement-ticket.
 
 `save_issue(id: "<ticket_id>", state: "<ticket_state_map.in_progress_local>")`
 
+### 2.7. Pre-read all implementation files (one pass, before writing any code)
+
+Read every file you will need to modify — in a single pass, before touching anything:
+- All files listed in `related_files_hint`
+- Any other `allowed_paths` files you know you will edit based on the objective
+
+Take inline notes about current structure, signatures, and invariants as you read. **Then stop reading and start writing.**
+
+**Context discipline — obey these rules for the entire session:**
+
+- **Each file gets one read.** Do not re-read a file you already read unless you made a structural change large enough that your notes are no longer accurate (rare — think "rewrote the whole class").
+- **Trust the Edit tool.** After an Edit call the file is updated — the diff in the tool result shows exactly what changed. Do NOT re-read the file to confirm the edit took effect.
+- **Do not re-read context_snippets.** They are pre-loaded verbatim — treat them as files you have already read.
+- **Batch your edits, then run checks once.** Write all code changes across all files first. Run `ruff`, `mypy`, and `pytest` as a single final pass — not after each individual edit.
+- **No exploratory Bash.** Do not run Python one-liners to probe module structure or test a hypothesis. Reason from the source code you have already read, then edit.
+
 ### 3. Implement
 
 Implement the work described in `objective` and `acceptance_criteria`. Obey these hard rules at all times:

--- a/.claude/commands/start-epic.md
+++ b/.claude/commands/start-epic.md
@@ -160,6 +160,8 @@ Before writing, run these three pre-flight checks for each ticket:
 
 Write to `.claude/artifacts/<ticket_id_lower>/manifest.json`:
 
+> **`linear_id` field:** For Batch 1 (ReadyForLocal) manifests, set `null` — the watcher resolves the Linear UUID at dispatch time from its poll response. For WaitingForDeps manifests, set the WOR-NNN identifier string (e.g. `"WOR-45"`). Linear's GraphQL `issueUpdate` accepts both UUID and identifier, so WOR-NNN is correct and sufficient. **Do not attempt to look up the internal UUID** — it is not needed. If `linear_id` is null on a WaitingForDeps manifest, `_notify_promotion()` silently skips the Linear state update and the ticket is permanently stuck after its blockers merge.
+
 ```json
 {
   "manifest_version": "1.0",
@@ -217,8 +219,8 @@ Write to `.claude/artifacts/<ticket_id_lower>/manifest.json`:
 
 Write to `.claude/artifacts/<ticket_id_lower>/manifest.json` with these key differences:
 - `"status": "WaitingForDeps"` — watcher will promote once blockers merge
-- `"linear_id": "<UUID from get_issue — NOT the WOR-XX identifier>"` — required for the watcher to call set_state when promoting
-- `"blocked_by_tickets": ["WOR-45"]` — list the Batch 1 ticket(s) whose file sets conflict with this ticket
+- `"linear_id": "WOR-45"` — use the WOR-NNN identifier directly (Linear's GraphQL `issueUpdate` accepts both UUID and identifier). **Required** for WaitingForDeps: `_notify_promotion()` uses this to set state to ReadyForLocal in Linear; if null, the manifest transitions locally but Linear is never updated and the watcher never picks the ticket up.
+- `"blocked_by_tickets": ["WOR-45"]` — list the Batch 1 ticket(s) whose file sets conflict with this ticket; also use WOR-NNN identifiers
 - `"parallel_safe": false`
 
 All other fields the same as the Batch 1 template above.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -243,10 +243,10 @@ litellm --config litellm-local.yaml --port 8082 --drop_params
 # 3. Launch Claude Code in a new terminal
 set ANTHROPIC_BASE_URL=http://localhost:8082   # Windows
 set ANTHROPIC_API_KEY=sk-dummy
-claude --model qwen3-coder:30b
+claude --model claude-sonnet-4-6
 ```
 
-`litellm-local.yaml` is gitignored. See `docs/spikes/local-model-setup.md` for VRAM budget, model selection, and benchmark results.
+`litellm-local.yaml` is gitignored. See `docs/spikes/vllm-benchmark-plan.md` for the current production model config (Qwen3.6-35B-A3B-NVFP4 via vLLM). `docs/spikes/local-model-setup.md` covers the original Ollama/qwen3-coder:30b setup (historical).
 
 ---
 

--- a/app/core/watcher_helpers.py
+++ b/app/core/watcher_helpers.py
@@ -170,18 +170,24 @@ def build_worker_cmd(
         "--strict-mcp-config",
         "--mcp-config",
         '{"mcpServers":{}}',
-        "--effort",
-        "max",
         "--verbose",
         "--output-format",
         "stream-json",
     ]
     if mode == "local":
+        # --bare strips OAuth; safe for local (dummy API key via LiteLLM).
+        # --effort normal: bounded implementation tasks don't benefit from max extended
+        #   thinking budget; normal saves tokens without quality regression.
+        # --context-window 80000: force compaction at 80K tokens instead of letting
+        #   context drift to the model max, preventing late-session turns from bloating
+        #   to 140K+ input with near-zero output (observed in WOR-216 / WOR-217).
         base.insert(2, "--bare")
+        base += ["--effort", "normal", "--context-window", "80000"]
+        base += ["--model", _LOCAL_MODEL]
+    else:
+        base += ["--effort", "max"]
     if disallowed_tools:
         base += ["--disallowed-tools", ",".join(disallowed_tools)]
-    if mode == "local":
-        return base + ["--model", _LOCAL_MODEL, "-p", prompt]
     return base + ["-p", prompt]
 
 


### PR DESCRIPTION
## Summary

- **CLAUDE.md**: update local dev command from `qwen3-coder:30b` to `claude-sonnet-4-6` (production model is `Qwen3.6-35B-A3B-NVFP4` via vLLM); update doc pointer to `vllm-benchmark-plan.md`
- **`watcher_helpers.py`**: local worker `build_worker_cmd` — `--effort normal` (bounded tasks don't benefit from max thinking budget) + `--context-window 80000` to force compaction before turns bloat to 140K+ input tokens; cloud workers unchanged
- **`implement-ticket.md`**: add §2.7 context discipline — read each file once upfront, trust the Edit tool diff, batch edits before running checks, no exploratory Bash; addresses ~50% wasted context observed in WOR-216/WOR-217 sessions
- **`start-epic.md`**: clarify `linear_id` semantics for WaitingForDeps manifests (WOR-NNN identifier, not UUID; `null` on Batch 1 is correct; required on Batch 2+ or promotion silently breaks)

## Test plan

- [ ] `pytest` passes (no logic changes, helpers tests cover `build_worker_cmd`)
- [ ] Verify next local worker session shows compaction events in log and lower per-turn token counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)