### PR TITLE
Fix worker compaction: use CLAUDE_CODE_AUTO_COMPACT_WINDOW env var

### DIFF
--- a/app/core/watcher_helpers.py
+++ b/app/core/watcher_helpers.py
@@ -133,6 +133,11 @@ def build_worker_env(
     elif mode == "local":
         env["ANTHROPIC_BASE_URL"] = _LITELLM_BASE_URL
         env.setdefault("ANTHROPIC_API_KEY", "sk-dummy")
+        # Treat the context window as 80K for compaction purposes: Claude Code
+        # compacts at ~95% of this value (~76K tokens), preventing the unbounded
+        # context growth observed in WOR-216/WOR-217/WOR-212 (peak 163K tokens).
+        # --context-window is not a valid CLI flag; this env var is the correct hook.
+        env.setdefault("CLAUDE_CODE_AUTO_COMPACT_WINDOW", "80000")
     return env
 
 
@@ -178,11 +183,8 @@ def build_worker_cmd(
         # --bare strips OAuth; safe for local (dummy API key via LiteLLM).
         # --effort normal: bounded implementation tasks don't benefit from max extended
         #   thinking budget; normal saves tokens without quality regression.
-        # --context-window 80000: force compaction at 80K tokens instead of letting
-        #   context drift to the model max, preventing late-session turns from bloating
-        #   to 140K+ input with near-zero output (observed in WOR-216 / WOR-217).
         base.insert(2, "--bare")
-        base += ["--effort", "normal", "--context-window", "80000"]
+        base += ["--effort", "normal"]
         base += ["--model", _LOCAL_MODEL]
     else:
         base += ["--effort", "max"]


### PR DESCRIPTION
## Summary

- `--context-window 80000` is not a valid Claude Code CLI flag — it was being silently ignored
- This caused local worker sessions to grow to 163K+ tokens with **0 compaction events** (observed in WOR-212 post-mortem: 2900s run, 28.6M input tokens, peak 163K context)
- Fix: set `CLAUDE_CODE_AUTO_COMPACT_WINDOW=80000` in the worker subprocess environment, which tells Claude Code to compact at ~95% of 80K (~76K tokens)

## What changed

`build_worker_env()` now injects `CLAUDE_CODE_AUTO_COMPACT_WINDOW=80000` for local workers. `build_worker_cmd()` drops the invalid `--context-window 80000` args.

## Test plan

- [x] `ruff check .` — clean
- [x] `mypy app/` — clean
- [x] `pytest` — 789 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)