### PR TITLE
Add worker efficiency guidance and mock patch path validation step

### DIFF
--- a/.claude/commands/implement-ticket.md
+++ b/.claude/commands/implement-ticket.md
@@ -55,6 +55,17 @@ Implement the work described in `objective` and `acceptance_criteria`. Obey thes
 
 **No re-planning** — do not re-read Linear, re-query the project, or change scope. If something in the codebase is surprising, implement defensively within the manifest scope and note it in the result artifact summary.
 
+### 3.5. Post-implementation checks (before required_checks)
+
+**If any files were moved or renamed to a different module path**, grep for string-based mock patch targets that reference the old path and update them — import fixers do not touch these:
+
+```bash
+# replace <old.module.path> with the module that was moved, e.g. app.core.watcher_subprocess
+grep -rn 'patch("' tests/ | grep '<old.module.path>'
+```
+
+Update every match to the new path before running pytest. Missing this causes tests that use `unittest.mock.patch()` to fail with `AttributeError` or `ModuleNotFoundError` even though all real imports are correct.
+
 ### 4. Run required checks
 
 After implementation, run each command in `required_checks` in order:

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -73,7 +73,15 @@
   "permissions": {
     "allow": [
       "Write(.claude/artifacts/**)",
-      "Edit(.claude/artifacts/**)"
+      "Edit(.claude/artifacts/**)",
+      "mcp__linear-server__get_issue",
+      "mcp__linear-server__list_issues",
+      "mcp__linear-server__list_milestones",
+      "mcp__linear-server__list_issue_statuses",
+      "mcp__linear-server__list_teams",
+      "mcp__linear-server__list_comments",
+      "Bash(ruff check *)",
+      "Bash(mypy app/)"
     ]
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -277,6 +277,40 @@ Test core logic only. Priority: config validation, preset selection, file genera
 
 ---
 
+## Worker efficiency
+
+Rules for local worker sessions (watcher-spawned `claude` processes). Each tool call is a ~40s round-trip — minimising call count directly reduces wall time.
+
+**No standalone `cd` commands.** Every `cd` is a wasted round-trip. Use absolute paths or chain with the actual command:
+```bash
+# bad  — two round-trips
+cd /path/to/dir
+ruff check .
+
+# good — one round-trip
+cd /path/to/dir && ruff check .
+# or use absolute path directly
+ruff check /path/to/dir
+```
+
+**Batch file reads.** When you need the contents of multiple related files, read them in one round-trip with a shell one-liner rather than issuing individual Read calls:
+```bash
+# reads 5 files in one tool call instead of 5
+python3 -c "
+import sys
+for f in ['app/core/watcher.py', 'app/core/watcher_types.py', ...]:
+    print(f'=== {f} ==='); print(open(f).read())
+"
+```
+
+**Update mock patch paths after any module move.** `unittest.mock.patch()` targets are string literals — they are not updated by import fixers and will silently break tests. After moving or renaming any module, run:
+```bash
+grep -rn 'patch("' tests/ | grep '<old.module.path>'
+```
+and update every match to the new path before running pytest.
+
+---
+
 ## Escalation policy
 
 The watcher reads `config/escalation_policy.toml` at startup to decide when to stop a local worker session and escalate to cloud LLM. Rules are data-driven — no hardcoded logic in the watcher.


### PR DESCRIPTION
## Summary

- **CLAUDE.md** — new _Worker efficiency_ section: no standalone `cd` commands (~30 min saved per session on WOR-216-class tickets), batch file reads pattern, grep step for mock `patch()` paths after module moves
- **implement-ticket.md** — step 3.5: explicit grep to catch stale `patch()` string targets before running pytest (prevents the WOR-232 failure class — 2h run that succeeded structurally but failed pytest due to unupdated patch paths)
- **settings.json** — read-only MCP tools and `ruff check`/`mypy` added to permissions allowlist (fewer prompts)

## Test plan

- [ ] No functional code changes — guidance and config only
- [ ] settings.json is valid JSON
- [ ] implement-ticket.md renders correctly in Claude Code

Closes WOR-255 (partial — guidance side; hook is WOR-256)