### PR TITLE
Add per-new-file mypy check and Write tool guidance to worker skills

### DIFF
--- a/.claude/commands/implement-ticket.md
+++ b/.claude/commands/implement-ticket.md
@@ -55,6 +55,10 @@ Implement the work described in `objective` and `acceptance_criteria`. Obey thes
 
 **No re-planning** — do not re-read Linear, re-query the project, or change scope. If something in the codebase is surprising, implement defensively within the manifest scope and note it in the result artifact summary.
 
+**New Python files** — after creating any new `.py` file (not editing an existing one), immediately run `mypy <that_file>` and fix all type errors before moving on. Do not defer to the final `required_checks` run — errors in new files compound when caught late and each fix-loop iteration costs a full tool round-trip. Read the type signatures of the source functions *before* writing the new file so annotations are correct on the first attempt.
+
+**Creating new files** — use the Write tool, not Bash heredocs. Heredocs with Python source have shell quoting issues on Windows (single quotes inside the body break the delimiter). The Write tool handles any content without escaping.
+
 ### 3.5. Post-implementation checks (before required_checks)
 
 **If any files were moved or renamed to a different module path**, grep for string-based mock patch targets that reference the old path and update them — import fixers do not touch these:

--- a/.claude/commands/start-ticket.md
+++ b/.claude/commands/start-ticket.md
@@ -106,6 +106,7 @@ If no siblings are In Progress, skip this block silently.
 
 ### 2. As Architect — plan the implementation
 - List which files need to change and what changes are needed
+- List what new files will be created (not just edited) — for each one, add to `risk_flags` in the manifest: `"<filename>.py is a new file — worker must read source type signatures before writing and run mypy on the file immediately after creation"`
 - List what new tests are needed (file, test name, what it verifies)
 - Flag any security surface introduced: new I/O, user input handling, file operations, subprocess calls
 - Note edge cases and overwrite behavior to consider

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -309,6 +309,10 @@ grep -rn 'patch("' tests/ | grep '<old.module.path>'
 ```
 and update every match to the new path before running pytest.
 
+**Create new files with the Write tool, not Bash heredocs.** Heredocs containing Python source break on Windows when the file body contains single quotes — the shell misinterprets them as closing the delimiter. The Write tool handles any content without escaping and avoids the multi-attempt retry loop.
+
+**Run mypy on each new Python file immediately after creating it.** Do not defer to the final `mypy app/` check — type errors in new files compound across the session and each late fix costs a full tool round-trip. Read the type signatures of the source functions *before* writing the new file so annotations are correct on the first attempt.
+
 ---
 
 ## Escalation policy


### PR DESCRIPTION
## Summary

- `implement-ticket.md`: two new hard rules — run `mypy <file>` immediately after creating any new `.py` file; use the Write tool for new files not Bash heredocs (Windows shell quoting breaks single-quoted file content)
- `start-ticket.md`: architect step now explicitly flags new files in `risk_flags` so the manifest pre-warns the worker
- `CLAUDE.md`: same two rules added to the Worker efficiency section

## Motivation

WOR-232 run 2 (52 min): worker created `watcher_dispatch.py` without type annotations, then spent 6 mypy fix iterations (reading the file 15 times) and still failed at the final `mypy app/` required check. Root causes:
1. No guidance to run mypy incrementally on new files
2. Heredoc quoting failures wasted 3+ tool calls before falling back to Python inline scripts

## Test plan
- [ ] Verify implement-ticket.md renders correctly in Claude Code session
- [ ] Verify start-ticket plan output includes new-file risk flag when applicable

🤖 Generated with [Claude Code](https://claude.com/claude-code)