### PR TITLE
Add per-new-test-file pytest rule and patch.object conversion guidance

### DIFF
--- a/.claude/commands/implement-ticket.md
+++ b/.claude/commands/implement-ticket.md
@@ -57,6 +57,8 @@ Implement the work described in `objective` and `acceptance_criteria`. Obey thes
 
 **New Python files** — after creating any new `.py` file (not editing an existing one), immediately run `mypy <that_file>` and fix all type errors before moving on. Do not defer to the final `required_checks` run — errors in new files compound when caught late and each fix-loop iteration costs a full tool round-trip. Read the type signatures of the source functions *before* writing the new file so annotations are correct on the first attempt.
 
+**New test files** — after creating any new `tests/test_*.py` file, immediately run `pytest <that_file> -x --tb=short` and fix all failures before moving on. Before writing the file, read at least one existing sibling test file to understand the fixture patterns, mock conventions, and how real objects (not MagicMock) are constructed for this codebase.
+
 **Creating new files** — use the Write tool, not Bash heredocs. Heredocs with Python source have shell quoting issues on Windows (single quotes inside the body break the delimiter). The Write tool handles any content without escaping.
 
 ### 3.5. Post-implementation checks (before required_checks)

--- a/.claude/commands/implement-ticket.md
+++ b/.claude/commands/implement-ticket.md
@@ -72,6 +72,15 @@ grep -rn 'patch("' tests/ | grep '<old.module.path>'
 
 Update every match to the new path before running pytest. Missing this causes tests that use `unittest.mock.patch()` to fail with `AttributeError` or `ModuleNotFoundError` even though all real imports are correct.
 
+**If any instance methods were extracted from a class into a new module-level function**, grep for `patch.object` calls targeting those methods — they must be converted from `patch.object(instance, "method")` to `patch("new.module.path.method")`:
+
+```bash
+# replace <ClassName> with the class methods were extracted from, e.g. Watcher
+grep -rn 'patch\.object' tests/ | grep '<ClassName>'
+```
+
+`patch.object` patches the method on the instance; once the function is module-level it no longer exists on the class and the patch silently does nothing or raises `AttributeError`. Convert every match to a string-path `patch("new.module.path.function_name")`.
+
 ### 4. Run required checks
 
 After implementation, run each command in `required_checks` in order:

--- a/.claude/commands/start-ticket.md
+++ b/.claude/commands/start-ticket.md
@@ -108,6 +108,7 @@ If no siblings are In Progress, skip this block silently.
 - List which files need to change and what changes are needed
 - List what new files will be created (not just edited) — for each one, add to `risk_flags` in the manifest: `"<filename>.py is a new file — worker must read source type signatures before writing and run mypy on the file immediately after creation"`
 - List what new test files will be created — for each one, add to `risk_flags`: `"<test_file>.py is a new test file — worker must read a sibling test file first for fixture/mock patterns, then run pytest <file> -x immediately after creation"`
+- If any instance methods are being extracted from a class into module-level functions, add to `risk_flags`: `"methods extracted from <ClassName> — grep for patch.object(instance, '<method>') in tests/ and convert to patch('new.module.path.<method>') — patch.object silently does nothing once the method is no longer on the class"`
 - List what new tests are needed (file, test name, what it verifies)
 - Flag any security surface introduced: new I/O, user input handling, file operations, subprocess calls
 - Note edge cases and overwrite behavior to consider

--- a/.claude/commands/start-ticket.md
+++ b/.claude/commands/start-ticket.md
@@ -107,6 +107,7 @@ If no siblings are In Progress, skip this block silently.
 ### 2. As Architect — plan the implementation
 - List which files need to change and what changes are needed
 - List what new files will be created (not just edited) — for each one, add to `risk_flags` in the manifest: `"<filename>.py is a new file — worker must read source type signatures before writing and run mypy on the file immediately after creation"`
+- List what new test files will be created — for each one, add to `risk_flags`: `"<test_file>.py is a new test file — worker must read a sibling test file first for fixture/mock patterns, then run pytest <file> -x immediately after creation"`
 - List what new tests are needed (file, test name, what it verifies)
 - Flag any security surface introduced: new I/O, user input handling, file operations, subprocess calls
 - Note edge cases and overwrite behavior to consider

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -309,6 +309,12 @@ grep -rn 'patch("' tests/ | grep '<old.module.path>'
 ```
 and update every match to the new path before running pytest.
 
+**Convert `patch.object` when extracting instance methods to module-level functions.** `patch.object(instance, "method")` patches the method on the class; once the function is module-level it no longer exists on the class and the patch silently does nothing. After extracting any method from a class, run:
+```bash
+grep -rn 'patch\.object' tests/ | grep '<ClassName>'
+```
+and convert every match to `patch("new.module.path.function_name")`.
+
 **Create new files with the Write tool, not Bash heredocs.** Heredocs containing Python source break on Windows when the file body contains single quotes — the shell misinterprets them as closing the delimiter. The Write tool handles any content without escaping and avoids the multi-attempt retry loop.
 
 **Run mypy on each new Python file immediately after creating it.** Do not defer to the final `mypy app/` check — type errors in new files compound across the session and each late fix costs a full tool round-trip. Read the type signatures of the source functions *before* writing the new file so annotations are correct on the first attempt.


### PR DESCRIPTION
## Summary
- Worker must run `pytest <test_file> -x --tb=short` immediately after creating any new test file (mirrors the mypy-on-new-file rule from #505)
- Worker must grep for `patch.object` calls and convert them to string-path `patch()` when instance methods are extracted to module-level functions — silent failure mode documented
- Both rules added to `implement-ticket.md`, `start-ticket.md` architect phase risk_flag templates, and `CLAUDE.md` worker efficiency section

## Test plan
- [ ] Verify `.claude/commands/implement-ticket.md` contains the new test file and patch.object rules
- [ ] Verify `.claude/commands/start-ticket.md` architect step has all three risk_flag bullet templates
- [ ] Verify `CLAUDE.md` worker efficiency section covers all three rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)