### PR TITLE
Add package reorganization sequencing rule to worker skills

### DIFF
--- a/.claude/commands/implement-ticket.md
+++ b/.claude/commands/implement-ticket.md
@@ -61,6 +61,8 @@ Implement the work described in `objective` and `acceptance_criteria`. Obey thes
 
 **Creating new files** — use the Write tool, not Bash heredocs. Heredocs with Python source have shell quoting issues on Windows (single quotes inside the body break the delimiter). The Write tool handles any content without escaping.
 
+**Package reorganizations** — when moving multiple files into a new subpackage directory: (1) move ALL source files first, (2) update ALL imports in every consumer file, (3) write `__init__.py` LAST. Do not run pytest at any intermediate step — the package is broken until every file is in place and every import is updated, so any pytest run before that is noise and will always produce `ModuleNotFoundError`.
+
 ### 3.5. Post-implementation checks (before required_checks)
 
 **If any files were moved or renamed to a different module path**, grep for string-based mock patch targets that reference the old path and update them — import fixers do not touch these:

--- a/.claude/commands/start-ticket.md
+++ b/.claude/commands/start-ticket.md
@@ -109,6 +109,7 @@ If no siblings are In Progress, skip this block silently.
 - List what new files will be created (not just edited) — for each one, add to `risk_flags` in the manifest: `"<filename>.py is a new file — worker must read source type signatures before writing and run mypy on the file immediately after creation"`
 - List what new test files will be created — for each one, add to `risk_flags`: `"<test_file>.py is a new test file — worker must read a sibling test file first for fixture/mock patterns, then run pytest <file> -x immediately after creation"`
 - If any instance methods are being extracted from a class into module-level functions, add to `risk_flags`: `"methods extracted from <ClassName> — grep for patch.object(instance, '<method>') in tests/ and convert to patch('new.module.path.<method>') — patch.object silently does nothing once the method is no longer on the class"`
+- If the ticket involves moving files into a new subpackage, add to `risk_flags`: `"package reorganization — move ALL source files into the subpackage first, update ALL imports in consumers, then write __init__.py LAST — do not run pytest until the move is complete or ModuleNotFoundError will appear on every intermediate check"`
 - List what new tests are needed (file, test name, what it verifies)
 - Flag any security surface introduced: new I/O, user input handling, file operations, subprocess calls
 - Note edge cases and overwrite behavior to consider

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -319,6 +319,8 @@ and convert every match to `patch("new.module.path.function_name")`.
 
 **Run mypy on each new Python file immediately after creating it.** Do not defer to the final `mypy app/` check — type errors in new files compound across the session and each late fix costs a full tool round-trip. Read the type signatures of the source functions *before* writing the new file so annotations are correct on the first attempt.
 
+**Package reorganizations: move all files first, __init__.py last.** When moving multiple files into a new subpackage: (1) move all source files, (2) update all imports in every consumer, (3) write `__init__.py` last. Do not run pytest at any intermediate step — the package is invalid mid-move and pytest will always fail with `ModuleNotFoundError` until every file is in place.
+
 ---
 
 ## Escalation policy


### PR DESCRIPTION
## Summary
- Worker must move ALL source files into a new subpackage first, update ALL imports in consumers, then write `__init__.py` LAST
- Premature `__init__.py` creation causes every intermediate pytest run to fail with `ModuleNotFoundError`, making the check output misleading
- Added to `implement-ticket.md` (hard rule in step 3), `start-ticket.md` architect phase risk_flag template, and `CLAUDE.md` worker efficiency section

Discovered during WOR-232 run 4: worker created `__init__.py` first, immediately ran pytest, got `ModuleNotFoundError`, and aborted without completing the file moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)