### PR TITLE
Add from-import grep to post-move checklist

### DIFF
--- a/.claude/commands/implement-ticket.md
+++ b/.claude/commands/implement-ticket.md
@@ -74,6 +74,15 @@ grep -rn 'patch("' tests/ | grep '<old.module.path>'
 
 Update every match to the new path before running pytest. Missing this causes tests that use `unittest.mock.patch()` to fail with `AttributeError` or `ModuleNotFoundError` even though all real imports are correct.
 
+**Also grep for bare from-imports** — `patch("...")` grep only finds mock strings, not `from app.core.old_module import X` in conftest.py, fixtures, or helper files. Run a second check:
+
+```bash
+# replace <old.module.path> with the moved module, e.g. app.core.watcher_types
+grep -rn 'from <old.module.path> import' tests/ app/
+```
+
+Update every from-import to the new path. Missing this causes `ModuleNotFoundError` in conftest.py or fixture files that fires before any test runs — all tests fail even though the implementation is correct.
+
 For module renames affecting many files, use `replace_all=True` on the Edit tool rather than updating occurrences one at a time — `Edit(file_path=..., old_string="app.core.old_module", new_string="app.core.new.module", replace_all=True)` replaces every occurrence in the file in one round-trip. One call per (file, module-name) pair covers the whole migration.
 
 **If any instance methods were extracted from a class into a new module-level function**, grep for `patch.object` calls targeting those methods — they must be converted from `patch.object(instance, "method")` to `patch("new.module.path.method")`:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -303,11 +303,12 @@ for f in ['app/core/watcher.py', 'app/core/watcher_types.py', ...]:
 "
 ```
 
-**Update mock patch paths after any module move.** `unittest.mock.patch()` targets are string literals — they are not updated by import fixers and will silently break tests. After moving or renaming any module, run:
+**Update mock patch paths after any module move.** `unittest.mock.patch()` targets are string literals — they are not updated by import fixers and will silently break tests. After moving or renaming any module, run two greps — one for mock strings, one for bare from-imports (conftest.py and fixture files use these and they are missed by the patch grep):
 ```bash
 grep -rn 'patch("' tests/ | grep '<old.module.path>'
+grep -rn 'from <old.module.path> import' tests/ app/
 ```
-and update every match to the new path before running pytest.
+and update every match to the new path before running pytest. Missing the from-import grep causes `ModuleNotFoundError` in conftest.py that fires before any test runs — all tests fail even though the implementation is correct.
 
 **Convert `patch.object` when extracting instance methods to module-level functions.** `patch.object(instance, "method")` patches the method on the class; once the function is module-level it no longer exists on the class and the patch silently does nothing. After extracting any method from a class, run:
 ```bash


### PR DESCRIPTION
## Summary
- Add a second `grep` to the post-module-move checklist in `implement-ticket.md` and `CLAUDE.md`
- The existing `patch("...")`  grep only catches `unittest.mock.patch()` string targets
- Bare `from old.module import X` in conftest.py and fixture files are invisible to it

## Root cause
WOR-232 run 6 failed because `tests/conftest.py` had:
```python
from app.core.watcher_types import ActiveWorker
```
After `watcher_types.py` was moved to `app/core/watcher/watcher_types.py`, the patch grep found 0 issues — but this from-import caused `ModuleNotFoundError` in conftest.py before any test ran, failing all 789 tests.

## What changed
Both `implement-ticket.md` (section 3.5) and `CLAUDE.md` (Worker efficiency section) now instruct workers to run two greps after any module move:
```bash
grep -rn 'patch("' tests/ | grep '<old.module.path>'        # mock strings
grep -rn 'from <old.module.path> import' tests/ app/        # bare from-imports
```

## Test plan
- [x] Pre-commit hooks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)