### PR TITLE
WOR-129 Populate check_run_log during ticket execution

### DIFF
--- a/app/core/watcher_finalize.py
+++ b/app/core/watcher_finalize.py
@@ -96,7 +96,13 @@ def finalize_worker(
 ) -> None:
     outcome, escalated, artifacts_preserved, sonar_findings, result_data = (
         _execute_finalization(
-            worker, returncode, linear, escalation_policy, repo_root, metrics
+            worker,
+            returncode,
+            linear,
+            escalation_policy,
+            repo_root,
+            metrics,
+            project_id,
         )
     )
 
@@ -168,6 +174,7 @@ def _execute_finalization(
     escalation_policy: EscalationPolicy,
     repo_root: Path,
     metrics: MetricsStore,
+    project_id: str,
 ) -> tuple[Outcome, bool, bool, list[str] | None, dict[str, object] | None]:
     """Determine outcome, escalation status, and artifact state.
 
@@ -212,7 +219,7 @@ def _execute_finalization(
             )
         return "failure", escalated, False, None, result_data
 
-    checks_ok = run_checks(manifest, worker.worktree_path)
+    checks_ok = run_checks(manifest, worker.worktree_path, metrics, project_id)
     if not checks_ok:
         worker.retry_count += 1
         metrics.record_rework_event(

--- a/app/core/watcher_subprocess.py
+++ b/app/core/watcher_subprocess.py
@@ -15,11 +15,13 @@ import shlex
 import subprocess  # nosec B404
 import sys
 import threading
+import time
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import IO
 
 from app.core.manifest import ExecutionManifest
+from app.core.metrics import CheckOutcome, CheckRunEntry, MetricsStore
 from app.core.watcher_helpers import (
     _tee_worker_output,
     build_worker_cmd,
@@ -136,7 +138,12 @@ def launch_worker(
 _LAST_FAILURE_FILENAME = "last_failure.json"
 
 
-def run_checks(manifest: ExecutionManifest, worktree_path: Path) -> bool:
+def run_checks(
+    manifest: ExecutionManifest,
+    worktree_path: Path,
+    metrics: MetricsStore,
+    project_id: str,
+) -> bool:
     """Run manifest.required_checks in the worktree. Returns True if all pass."""
     artifact_dir = worktree_path / Path(manifest.artifact_paths.result_json).parent
     failure_artifact = artifact_dir / _LAST_FAILURE_FILENAME
@@ -144,11 +151,23 @@ def run_checks(manifest: ExecutionManifest, worktree_path: Path) -> bool:
     all_passed = True
     for check_cmd in manifest.required_checks:
         logger.info("Running check: %s", check_cmd)
+        start = time.monotonic()
         result = subprocess.run(  # nosec B603
             shlex.split(check_cmd),
             cwd=str(worktree_path),
             capture_output=True,
             text=True,
+        )
+        elapsed = time.monotonic() - start
+        outcome: CheckOutcome = "passed" if result.returncode == 0 else "failed"
+        metrics.record_check_run(
+            CheckRunEntry(
+                ticket_id=manifest.ticket_id,
+                project_id=project_id,
+                check_cmd=check_cmd,
+                outcome=outcome,
+                duration_s=elapsed,
+            )
         )
         if result.returncode != 0:
             logger.error(

--- a/tests/test_watcher_finalize.py
+++ b/tests/test_watcher_finalize.py
@@ -741,7 +741,13 @@ def test_execute_finalization_nonzero_returncode_returns_failure(
     from app.core.watcher_finalize import _execute_finalization
 
     result = _execute_finalization(
-        worker, 1, linear_mock, EscalationPolicy.from_toml(), tmp_path, MagicMock()
+        worker,
+        1,
+        linear_mock,
+        EscalationPolicy.from_toml(),
+        tmp_path,
+        MagicMock(),
+        "proj-1",
     )
     outcome, escalated, preserved, findings, _result_data = result
 
@@ -772,7 +778,13 @@ def test_execute_finalization_check_failure_abort_returns_failure(
 
     with patch("app.core.watcher_finalize.run_checks", return_value=False):
         result = _execute_finalization(
-            worker, 0, linear_mock, EscalationPolicy.from_toml(), tmp_path, MagicMock()
+            worker,
+            0,
+            linear_mock,
+            EscalationPolicy.from_toml(),
+            tmp_path,
+            MagicMock(),
+            "proj-1",
         )
     outcome, escalated, preserved, findings, _result_data = result
 

--- a/tests/test_watcher_subprocess.py
+++ b/tests/test_watcher_subprocess.py
@@ -11,6 +11,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from app.core.manifest import ArtifactPaths, ExecutionManifest
+from app.core.metrics import MetricsStore
 from app.core.watcher_helpers import _tee_worker_output
 from app.core.watcher_subprocess import (
     build_snippet_tool_restrictions,
@@ -460,6 +461,8 @@ def test_launch_worker_cloud_mode_with_snippets_prepends_critical_warning(
 
 def test_run_checks_returns_true_when_all_pass(tmp_path: Path) -> None:
     manifest = _make_manifest(required_checks=["ruff check .", "mypy app/"])
+    db_path = tmp_path / "metrics.db"
+    metrics = MetricsStore(db_path=db_path)
 
     def fake_run(cmd: list[str], **kwargs: object) -> MagicMock:
         result = MagicMock()
@@ -469,13 +472,15 @@ def test_run_checks_returns_true_when_all_pass(tmp_path: Path) -> None:
         return result
 
     with patch("app.core.watcher_subprocess.subprocess.run", side_effect=fake_run):
-        assert run_checks(manifest, tmp_path) is True
+        assert run_checks(manifest, tmp_path, metrics, "proj-1") is True
 
 
 def test_run_checks_returns_false_on_check_failure(
     tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:
     manifest = _make_manifest(required_checks=["ruff check .", "mypy app/"])
+    db_path = tmp_path / "metrics.db"
+    metrics = MetricsStore(db_path=db_path)
     call_count = 0
 
     def fake_run(cmd: list[str], **kwargs: object) -> MagicMock:
@@ -491,7 +496,7 @@ def test_run_checks_returns_false_on_check_failure(
         patch("app.core.watcher_subprocess.subprocess.run", side_effect=fake_run),
         caplog.at_level(logging.ERROR, logger="app.core.watcher_subprocess"),
     ):
-        passed = run_checks(manifest, tmp_path)
+        passed = run_checks(manifest, tmp_path, metrics, "proj-1")
 
     assert passed is False
     assert any("Check failed" in msg for msg in caplog.messages)
@@ -500,6 +505,8 @@ def test_run_checks_returns_false_on_check_failure(
 
 def test_run_checks_writes_last_failure_json_on_failure(tmp_path: Path) -> None:
     manifest = _make_manifest(required_checks=["ruff check ."])
+    db_path = tmp_path / "metrics.db"
+    metrics = MetricsStore(db_path=db_path)
 
     def fake_run(cmd: list[str], **kwargs: object) -> MagicMock:
         result = MagicMock()
@@ -509,7 +516,7 @@ def test_run_checks_writes_last_failure_json_on_failure(tmp_path: Path) -> None:
         return result
 
     with patch("app.core.watcher_subprocess.subprocess.run", side_effect=fake_run):
-        run_checks(manifest, tmp_path)
+        run_checks(manifest, tmp_path, metrics, "proj-1")
 
     artifact_dir = tmp_path / Path(manifest.artifact_paths.result_json).parent
     failure_file = artifact_dir / "last_failure.json"
@@ -526,6 +533,8 @@ def test_run_checks_writes_last_failure_json_on_failure(tmp_path: Path) -> None:
 
 def test_run_checks_stdout_trimmed_to_4000_chars(tmp_path: Path) -> None:
     manifest = _make_manifest(required_checks=["ruff check ."])
+    db_path = tmp_path / "metrics.db"
+    metrics = MetricsStore(db_path=db_path)
     long_stdout = "x" * 8000
 
     def fake_run(cmd: list[str], **kwargs: object) -> MagicMock:
@@ -536,7 +545,7 @@ def test_run_checks_stdout_trimmed_to_4000_chars(tmp_path: Path) -> None:
         return result
 
     with patch("app.core.watcher_subprocess.subprocess.run", side_effect=fake_run):
-        run_checks(manifest, tmp_path)
+        run_checks(manifest, tmp_path, metrics, "proj-1")
 
     artifact_dir = tmp_path / Path(manifest.artifact_paths.result_json).parent
     import json as json_mod
@@ -549,6 +558,8 @@ def test_run_checks_stdout_trimmed_to_4000_chars(tmp_path: Path) -> None:
 
 def test_run_checks_deletes_last_failure_json_on_success(tmp_path: Path) -> None:
     manifest = _make_manifest(required_checks=["ruff check ."])
+    db_path = tmp_path / "metrics.db"
+    metrics = MetricsStore(db_path=db_path)
 
     # Pre-create a stale last_failure.json in the artifact dir
     artifact_dir = tmp_path / Path(manifest.artifact_paths.result_json).parent
@@ -564,7 +575,7 @@ def test_run_checks_deletes_last_failure_json_on_success(tmp_path: Path) -> None
         return result
 
     with patch("app.core.watcher_subprocess.subprocess.run", side_effect=fake_run):
-        assert run_checks(manifest, tmp_path) is True
+        assert run_checks(manifest, tmp_path, metrics, "proj-1") is True
 
     assert not stale.exists(), (
         "last_failure.json should be deleted after successful run"
@@ -575,6 +586,8 @@ def test_run_checks_last_failure_overwritten_by_last_failing_check(
     tmp_path: Path,
 ) -> None:
     manifest = _make_manifest(required_checks=["ruff check .", "mypy app/"])
+    db_path = tmp_path / "metrics.db"
+    metrics = MetricsStore(db_path=db_path)
     call_count = 0
 
     def fake_run(cmd: list[str], **kwargs: object) -> MagicMock:
@@ -587,7 +600,7 @@ def test_run_checks_last_failure_overwritten_by_last_failing_check(
         return result
 
     with patch("app.core.watcher_subprocess.subprocess.run", side_effect=fake_run):
-        run_checks(manifest, tmp_path)
+        run_checks(manifest, tmp_path, metrics, "proj-1")
 
     artifact_dir = tmp_path / Path(manifest.artifact_paths.result_json).parent
     import json as json_mod
@@ -598,6 +611,45 @@ def test_run_checks_last_failure_overwritten_by_last_failing_check(
     # Last failing check (mypy) should overwrite the first (ruff)
     assert data["check"] == "mypy app/"
     assert data["stdout"] == "output from check 2"
+
+
+def test_run_checks_records_check_runs_in_metrics(tmp_path: Path) -> None:
+    """Verify that run_checks writes CheckRunEntry rows with correct outcomes."""
+    manifest = _make_manifest(required_checks=["echo ok", "false"])
+    db_path = tmp_path / "check_run.db"
+    metrics = MetricsStore(db_path=db_path)
+
+    call_order: list[str] = []
+
+    def fake_run(cmd: list[str], **kwargs: object) -> MagicMock:
+        call_order.append(cmd[0])
+        result = MagicMock()
+        # First command (echo ok) succeeds, second (false) fails
+        result.returncode = 0 if cmd[0] == "echo" else 1
+        result.stdout = ""
+        result.stderr = ""
+        return result
+
+    with patch("app.core.watcher_subprocess.subprocess.run", side_effect=fake_run):
+        run_checks(manifest, tmp_path, metrics, "proj-1")
+
+    stats = metrics.get_check_stats("proj-1")
+    assert len(stats) == 2
+
+    passed_stats = [s for s in stats if s.pass_count == 1][0]
+    failed_stats = [s for s in stats if s.fail_count == 1][0]
+
+    assert passed_stats.check_cmd == "echo ok"
+    assert passed_stats.pass_count == 1
+    assert passed_stats.fail_count == 0
+    assert passed_stats.pass_pct == 100.0
+    assert passed_stats.avg_duration_s is not None and passed_stats.avg_duration_s > 0
+
+    assert failed_stats.check_cmd == "false"
+    assert failed_stats.fail_count == 1
+    assert failed_stats.pass_count == 0
+    assert failed_stats.pass_pct == 0.0
+    assert failed_stats.avg_duration_s is not None and failed_stats.avg_duration_s > 0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes WOR-129

run_checks() times each check and calls record_check_run(); watcher_finalize passes metrics and project_id through; test verifies get_check_stats() returns rows with correct outcome and timing; all existing tests pass; ruff and mypy clean.