### PR TITLE
Reduce redundant worker tool calls via hooks for mypy and targeted pytest

### DIFF
--- a/.claude/commands/implement-ticket.md
+++ b/.claude/commands/implement-ticket.md
@@ -55,9 +55,11 @@ Implement the work described in `objective` and `acceptance_criteria`. Obey thes
 
 **No re-planning** — do not re-read Linear, re-query the project, or change scope. If something in the codebase is surprising, implement defensively within the manifest scope and note it in the result artifact summary.
 
-**New Python files** — after creating any new `.py` file (not editing an existing one), immediately run `mypy <that_file>` and fix all type errors before moving on. Do not defer to the final `required_checks` run — errors in new files compound when caught late and each fix-loop iteration costs a full tool round-trip. Read the type signatures of the source functions *before* writing the new file so annotations are correct on the first attempt.
+**Hooks run automatically — do not duplicate them manually.** After every Edit/Write to a `.py` file, PostToolUse hooks fire: `ruff check --fix` + `ruff format`, `mypy <file>`, `bandit`, and `lint-imports`. After every edit to a `tests/` file, the hook runs `pytest <that_file> --no-cov --tb=short -q`. You will see hook output in the tool result — trust it. Running these tools manually during implementation wastes a Bash round-trip per call (~40s each). Only run the final `required_checks` commands at step 4.
 
-**New test files** — after creating any new `tests/test_*.py` file, immediately run `pytest <that_file> -x --tb=short` and fix all failures before moving on. Before writing the file, read at least one existing sibling test file to understand the fixture patterns, mock conventions, and how real objects (not MagicMock) are constructed for this codebase.
+**New Python files** — read the type signatures of source functions *before* writing a new `.py` file so annotations are correct on the first attempt. The mypy hook will report errors immediately after Write — fix them before moving on.
+
+**New test files** — before writing a new `tests/test_*.py` file, read at least one existing sibling test file to understand the fixture patterns, mock conventions, and how real objects (not MagicMock) are constructed for this codebase. The pytest hook runs the file automatically after each edit — watch its output rather than triggering manual pytest runs.
 
 **Creating new files** — use the Write tool, not Bash heredocs. Heredocs with Python source have shell quoting issues on Windows (single quotes inside the body break the delimiter). The Write tool handles any content without escaping. If the Write tool is unavailable (local model sessions), use a single-quoted Bash heredoc instead — `python3 << 'PYEOF'` with the closing `PYEOF` at column 0; the single-quoted delimiter prevents the shell from interpreting any characters inside, including single quotes in Python source.
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -44,6 +44,15 @@
         "hooks": [
           {
             "type": "command",
+            "command": "FILE=\"$CLAUDE_TOOL_INPUT_FILE_PATH\"; if [[ \"$FILE\" == *.py ]]; then mypy \"$FILE\" 2>/dev/null || echo \"[mypy] Type errors in $FILE\"; fi"
+          }
+        ]
+      },
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
             "command": "FILE=\"$CLAUDE_TOOL_INPUT_FILE_PATH\"; if [[ \"$FILE\" == *.py ]] && command -v bandit >/dev/null 2>&1; then bandit -q \"$FILE\" 2>/dev/null || echo \"[bandit] Issues found \u00e2\u20ac\u201d run /security-check\"; fi"
           }
         ]
@@ -62,7 +71,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "FILE=\"$CLAUDE_TOOL_INPUT_FILE_PATH\"; if [[ \"$FILE\" == */tests/* ]]; then pytest --no-cov --tb=short -q; fi"
+            "command": "FILE=\"$CLAUDE_TOOL_INPUT_FILE_PATH\"; if [[ \"$FILE\" == */tests/* ]]; then pytest \"$FILE\" --no-cov --tb=short -q; fi"
           }
         ]
       }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -214,9 +214,10 @@ The informational scan runs on `github.base_ref != 'main'`; the blocking scan ru
 `.claude/settings.json` ships with hooks that run automatically:
 
 - **PostToolUse** — ruff lint + format after any Python file edit
+- **PostToolUse** — mypy type-check on the edited file after any Python file edit
 - **PostToolUse** — bandit security scan after any Python file edit (if bandit is installed)
 - **PostToolUse** — `lint-imports` architecture contract check after any Python file edit
-- **PostToolUse** — pytest (no coverage) after changes to `tests/` files only
+- **PostToolUse** — pytest (no coverage) on the edited test file after changes to `tests/` files only
 - **PreToolUse** — blocks destructive shell commands and writes to sensitive files (`.env`, `.mcp.json`, `.claude/settings*`)
 
 No setup needed — hooks activate as soon as Claude Code loads the project.


### PR DESCRIPTION
## Summary

- Add `mypy <file>` PostToolUse hook — fires on every `.py` edit so workers get immediate type feedback without a manual Bash call
- Narrow `tests/` pytest hook from full-suite to `pytest "$FILE"` — was running all 834 tests on every single test file edit; now runs only the edited file
- Update `implement-ticket` skill with an explicit **Hooks run automatically** rule telling workers not to duplicate ruff/mypy/bandit/lint-imports/pytest manually (~40s wasted per call)
- Update CLAUDE.md hooks section to document both new behaviors

## Motivation

WOR-129 and WOR-177 log analysis showed workers spending 3–6 Bash round-trips per ticket running ruff/mypy manually during implementation — all redundant because the PostToolUse hooks were already handling it. Workers didn't know hooks were firing because the skill said nothing about it. WOR-177 also triggered the full 834-test suite on every one of its 24 test-file edits via the old broad pytest hook.

## Test plan
- [ ] Edit a `.py` file and confirm mypy hook output appears in tool result
- [ ] Edit a `tests/test_*.py` file and confirm only that file's tests run (not full suite)
- [ ] Verify existing ruff/bandit/lint-imports hooks still fire as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)