### PR TITLE
Set local worker default effort to xhigh (interim, pending WOR-265)

### DIFF
--- a/app/core/watcher_helpers.py
+++ b/app/core/watcher_helpers.py
@@ -175,9 +175,9 @@ def build_worker_cmd(
         "stream-json",
     ]
     if mode == "local":
-        # --effort high: bounded tasks don't need max thinking budget; saves tokens.
+        # --effort xhigh: interim default pending WOR-265 adaptive effort scaling.
         # (CLI values: low|medium|high|xhigh|max — "normal" was removed)
-        base += ["--effort", "high"]
+        base += ["--effort", "xhigh"]
         base += ["--model", _LOCAL_MODEL]
     else:
         base += ["--effort", "max"]


### PR DESCRIPTION
## Summary

- Changes `--effort high` → `--effort xhigh` for local LLM workers in `build_worker_cmd()`
- Raises reasoning depth to reduce cycling on complex structural tasks (e.g. WOR-232-style refactors took ~85 min at `high` due to patch-path cycling)
- WOR-265 will implement adaptive effort scaling based on task complexity; this is the interim default until that ships

## Test plan
- [ ] No test assertions on effort level value — no test changes needed
- [ ] Verify local worker sessions launch with `--effort xhigh` in the command log

🤖 Generated with [Claude Code](https://claude.com/claude-code)