### PR TITLE
Reduce worker wasted tool calls: guard step 2 MCP, trust hooks

### DIFF
--- a/.claude/commands/implement-ticket.md
+++ b/.claude/commands/implement-ticket.md
@@ -41,7 +41,7 @@ Check out the correct branch before running /implement-ticket.
 
 ### 2. Set ticket state to InProgressLocal
 
-`save_issue(id: "<ticket_id>", state: "<ticket_state_map.in_progress_local>")`
+**Skip this step in watcher-managed sessions.** The watcher calls `set_state("InProgressLocal")` before launching the worker. MCP is disabled in worker processes (`--mcp-config '{"mcpServers":{}}'`), so `save_issue` is not available and any attempt (including spawning an Agent) will fail silently. Do not call it and do not spawn a subagent for it.
 
 ### 3. Implement
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -304,6 +304,8 @@ for f in ['app/core/watcher.py', 'app/core/watcher_types.py', ...]:
 "
 ```
 
+**Trust the Edit tool and hooks — do not re-read after editing.** The Edit tool confirms the change was applied. PostToolUse hooks (ruff, mypy, bandit, lint-imports) report any issues immediately in the tool result. Re-reading a file after editing to "verify" wastes a round-trip per edit. Only re-read if a hook explicitly reported an error you need to inspect in context.
+
 **Update mock patch paths after any module move.** `unittest.mock.patch()` targets are string literals — they are not updated by import fixers and will silently break tests. After moving or renaming any module, run two greps — one for mock strings, one for bare from-imports (conftest.py and fixture files use these and they are missed by the patch grep):
 ```bash
 grep -rn 'patch("' tests/ | grep '<old.module.path>'


### PR DESCRIPTION
## Summary

- **implement-ticket.md step 2**: mark as skip in watcher-managed sessions. MCP is disabled for workers (`--mcp-config '{"mcpServers":{}}'`), so `save_issue` is not available. Workers were spawning an Agent subagent to attempt the call — wasted ~40–80s + subagent token cost per run, with no effect.
- **CLAUDE.md worker-efficiency**: add "trust the Edit tool and hooks — do not re-read after editing" rule. PostToolUse hooks (ruff, mypy, bandit, lint-imports) report issues immediately in the tool result. Re-reading to verify wastes 2–4 round-trips per run (~80–160s).

Both identified from WOR-258 worker log analysis (49 tool calls: 1 Agent spawn for Linear MCP, 5× re-reads of implement-ticket.md, 4× re-reads of watcher_finalize.py).

## Test plan
- [ ] No tests needed — doc/skill changes only
- [ ] Verify next worker run has no Agent spawn at step 2
- [ ] Verify re-read count drops in subsequent worker logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)