### PR TITLE
WOR-264 Enable Linear MCP in watcher workers (replace --strict-mcp-config empty with project config)

### DIFF
--- a/.claude/commands/implement-ticket.md
+++ b/.claude/commands/implement-ticket.md
@@ -59,7 +59,7 @@ Check out the correct branch before running /implement-ticket.
 
 ### 2. Set ticket state to InProgressLocal
 
-**Skip this step in watcher-managed sessions.** The watcher calls `set_state("InProgressLocal")` before launching the worker. MCP is disabled in worker processes (`--mcp-config '{"mcpServers":{}}'`), so `save_issue` is not available and any attempt (including spawning an Agent) will fail silently. Do not call it and do not spawn a subagent for it.
+Call `save_issue(id: "<ticket_id>", state: "InProgressLocal")` at startup to signal that local implementation has begun.
 
 ### 3. Implement
 

--- a/app/core/watcher/watcher_helpers.py
+++ b/app/core/watcher/watcher_helpers.py
@@ -150,6 +150,7 @@ def build_worker_cmd(
     worktree_path: Path,
     prompt: str | None = None,
     disallowed_tools: list[str] | None = None,
+    mcp_config_json: str | None = None,
 ) -> list[str]:
     """Return the claude subprocess command list for the given mode.
 
@@ -158,11 +159,14 @@ def build_worker_cmd(
 
     disallowed_tools — list of tool-call patterns passed to --disallowed-tools
     (e.g. ["Read(*watcher.py)", "Read(*metrics.py)"]) to enforce context_snippets.
+
+    mcp_config_json — JSON string for --mcp-config. When None, uses an empty
+    server map ('{"mcpServers":{}}') to disable all MCP servers. Pass a
+    non-empty value to enable specific MCP servers (e.g. Linear).
     """
     if prompt is None:
         prompt = f"/implement-ticket {ticket_id}"
-    # --strict-mcp-config + empty config prevents the Linear HTTP MCP server
-    # from blocking ~180s on OAuth in non-interactive mode.
+    mcp_config = mcp_config_json if mcp_config_json is not None else '{"mcpServers":{}}'
     base = [
         "claude",
         "--dangerously-skip-permissions",
@@ -170,7 +174,7 @@ def build_worker_cmd(
         str(worktree_path),
         "--strict-mcp-config",
         "--mcp-config",
-        '{"mcpServers":{}}',
+        mcp_config,
         "--verbose",
         "--output-format",
         "stream-json",

--- a/app/core/watcher/watcher_subprocess.py
+++ b/app/core/watcher/watcher_subprocess.py
@@ -31,6 +31,7 @@ from .watcher_types import _CLAUDE_DIR
 logger = logging.getLogger(__name__)
 
 _SONAR_MAX_PAGES = 10
+_LINEAR_MCP = '{"mcpServers":{"linear-server":{"type":"http","url":"https://mcp.linear.app/mcp"}}}'
 
 
 def expand_skill(repo_root: Path, ticket_id: str) -> str | None:
@@ -97,7 +98,12 @@ def launch_worker(
             prompt = warning + (prompt or "")
 
     cmd = build_worker_cmd(
-        manifest.ticket_id, effective_mode, worktree_path, prompt, disallowed_tools
+        manifest.ticket_id,
+        effective_mode,
+        worktree_path,
+        prompt,
+        disallowed_tools,
+        mcp_config_json=_LINEAR_MCP,
     )
     env = build_worker_env(effective_mode, dict(os.environ))
 

--- a/tests/test_watcher_helpers.py
+++ b/tests/test_watcher_helpers.py
@@ -143,6 +143,21 @@ def test_cmd_no_disallowed_tools_when_none(tmp_path: Path) -> None:
     assert "--disallowed-tools" not in cmd
 
 
+def test_cmd_uses_empty_mcp_config_by_default(tmp_path: Path) -> None:
+    cmd = build_worker_cmd("WOR-10", "cloud", tmp_path)
+    assert "--mcp-config" in cmd
+    idx = cmd.index("--mcp-config")
+    assert cmd[idx + 1] == '{"mcpServers":{}}'
+
+
+def test_cmd_uses_custom_mcp_config_when_provided(tmp_path: Path) -> None:
+    config = '{"mcpServers":{"linear-server":{"type":"http","url":"https://mcp.linear.app/mcp"}}}'
+    cmd = build_worker_cmd("WOR-10", "cloud", tmp_path, mcp_config_json=config)
+    assert "--mcp-config" in cmd
+    idx = cmd.index("--mcp-config")
+    assert cmd[idx + 1] == config
+
+
 # ---------------------------------------------------------------------------
 # resolve_effective_mode
 # ---------------------------------------------------------------------------

--- a/tests/test_watcher_subprocess.py
+++ b/tests/test_watcher_subprocess.py
@@ -433,6 +433,7 @@ def test_launch_worker_cloud_mode_with_snippets_prepends_critical_warning(
         wt: Path,
         prompt: object,
         disallowed: object,
+        mcp_config_json: object = None,
     ) -> list[str]:
         captured_prompts.append(prompt)
         return ["claude"]
@@ -458,6 +459,43 @@ def test_launch_worker_cloud_mode_with_snippets_prepends_critical_warning(
     assert isinstance(captured_prompts[0], str)
     assert "CRITICAL" in captured_prompts[0]
     assert "watcher.py" in captured_prompts[0]
+
+
+def test_launch_worker_passes_linear_mcp_config_to_build_worker_cmd(
+    tmp_path: Path,
+) -> None:
+    manifest = _make_manifest()
+    mock_process = MagicMock()
+    captured_args: dict = {}
+
+    def capture_cmd(
+        ticket_id: str,
+        mode: str,
+        wt: Path,
+        prompt: object,
+        disallowed: object,
+        mcp_config_json: object = None,
+    ) -> list[str]:
+        captured_args["mcp_config_json"] = mcp_config_json
+        return ["claude"]
+
+    with (
+        patch("app.core.watcher.watcher_subprocess.expand_skill", return_value=None),
+        patch(
+            "app.core.watcher.watcher_subprocess.build_worker_cmd",
+            side_effect=capture_cmd,
+        ),
+        patch("app.core.watcher.watcher_subprocess.build_worker_env", return_value={}),
+        patch(
+            "app.core.watcher.watcher_subprocess.subprocess.Popen",
+            return_value=mock_process,
+        ),
+    ):
+        launch_worker(tmp_path, manifest, tmp_path, "cloud", verbose=False)
+
+    assert isinstance(captured_args["mcp_config_json"], str)
+    assert "linear-server" in captured_args["mcp_config_json"]
+    assert "mcp.linear.app" in captured_args["mcp_config_json"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes WOR-264

Workers launched with linear-server MCP enabled, implement-ticket.md step 2 calls save_issue, ruff+mypy+pytest pass