### PR TITLE
WOR-259 Track per-attempt metrics so retry runs can be compared

### DIFF
--- a/app/core/metrics.py
+++ b/app/core/metrics.py
@@ -35,6 +35,23 @@ CREATE TABLE IF NOT EXISTS check_run_log (
 )
 """
 
+_CREATE_RUN_LOG = """
+CREATE TABLE IF NOT EXISTS ticket_run_log (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    ticket_id       TEXT NOT NULL,
+    attempt         INTEGER NOT NULL,
+    implementation_mode TEXT NOT NULL,
+    outcome         TEXT NOT NULL,
+    failed_check    TEXT,
+    wall_time_s     REAL,
+    input_tokens    INTEGER,
+    output_tokens   INTEGER,
+    output_tok_per_s REAL,
+    context_compactions INTEGER,
+    recorded_at     TEXT NOT NULL DEFAULT (datetime('now'))
+)
+"""
+
 _CREATE_TABLE = """
 CREATE TABLE IF NOT EXISTS ticket_metrics (
     ticket_id             TEXT NOT NULL,
@@ -129,6 +146,28 @@ class EpicSummary(BaseModel):
     sonar_findings_total: int
 
 
+class TicketRunLog(BaseModel):
+    """Per-attempt run log for a single ticket execution."""
+
+    model_config = {"extra": "forbid"}
+
+    ticket_id: str
+    attempt: int = Field(description="1-based attempt number (retry_count + 1)")
+    implementation_mode: ImplementationMode
+    outcome: Outcome
+    failed_check: str | None = None
+    wall_time_s: float | None = Field(default=None, description="Wall time in seconds")
+    input_tokens: int | None = None
+    output_tokens: int | None = None
+    output_tok_per_s: float | None = Field(
+        default=None, description="output_tokens / wall_time when both present"
+    )
+    context_compactions: int | None = Field(
+        default=None,
+        description="Claude Code context compaction count during the session",
+    )
+
+
 class CheckRunEntry(BaseModel):
     """A single execution of one required_check command."""
 
@@ -177,6 +216,7 @@ class MetricsStore:
         with self._connect() as conn:
             conn.execute(_CREATE_TABLE)
             conn.execute(_CREATE_CHECK_RUN_LOG)
+            conn.execute(_CREATE_RUN_LOG)
             self._migrate(conn)
 
     def _migrate(self, conn: sqlite3.Connection) -> None:
@@ -304,6 +344,23 @@ class MetricsStore:
             files_changed_total=row["files_changed_total"],
             sonar_findings_total=row["sonar_findings_total"],
         )
+
+    def record_run(self, entry: TicketRunLog) -> None:
+        """Append a single run-log row per attempt (append-only, not upsert)."""
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO ticket_run_log
+                    (ticket_id, attempt, implementation_mode, outcome,
+                     failed_check, wall_time_s, input_tokens, output_tokens,
+                     output_tok_per_s, context_compactions)
+                VALUES
+                    (:ticket_id, :attempt, :implementation_mode, :outcome,
+                     :failed_check, :wall_time_s, :input_tokens, :output_tokens,
+                     :output_tok_per_s, :context_compactions)
+                """,
+                entry.model_dump(),
+            )
 
     def record_check_run(self, entry: CheckRunEntry) -> None:
         """Append a single check execution row to check_run_log."""

--- a/app/core/watcher/watcher_finalize.py
+++ b/app/core/watcher/watcher_finalize.py
@@ -14,7 +14,7 @@ from pathlib import Path
 from app.core.escalation_policy import EscalationPolicy
 from app.core.linear_client import LinearError
 from app.core.manifest import ExecutionManifest
-from app.core.metrics import MetricsStore, Outcome, TicketMetrics
+from app.core.metrics import MetricsStore, Outcome, TicketMetrics, TicketRunLog
 
 from .watcher_helpers import (
     _POLICY_FLAGS,
@@ -134,6 +134,20 @@ def finalize_worker(
             sonar_findings_count=(
                 len(sonar_findings) if sonar_findings is not None else None
             ),
+        )
+    )
+    metrics.record_run(
+        TicketRunLog(
+            ticket_id=worker.ticket_id,
+            attempt=worker.retry_count + 1,
+            implementation_mode=_to_metrics_mode(eff),
+            outcome=outcome,
+            failed_check=None,
+            wall_time_s=wall_time,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            output_tok_per_s=local_output_tokens_per_second,
+            context_compactions=context_compactions,
         )
     )
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -10,6 +10,7 @@ from app.core.metrics import (
     EpicSummary,
     MetricsStore,
     TicketMetrics,
+    TicketRunLog,
 )
 
 
@@ -358,3 +359,87 @@ class TestMigration:
         assert result.local_tokens == 10500
         assert result.local_input_tokens == 10000
         assert result.local_output_tokens == 500
+
+
+def _run_log(**kwargs) -> TicketRunLog:
+    defaults: dict = {
+        "ticket_id": "WOR-1",
+        "attempt": 1,
+        "implementation_mode": "local",
+        "outcome": "success",
+        "wall_time_s": 120.5,
+        "input_tokens": 10000,
+        "output_tokens": 500,
+        "output_tok_per_s": 4.17,
+    }
+    defaults.update(kwargs)
+    return TicketRunLog(**defaults)
+
+
+class TestTicketRunLog:
+    def test_multi_attempt_produces_two_rows(self, tmp_path):
+        """Two finalize calls for the same ticket produce two run_log rows
+        with attempt=1 and attempt=2 (WOR-259)."""
+        store = _store(tmp_path)
+        store.record_run(_run_log(attempt=1, wall_time_s=100.0))
+        store.record_run(_run_log(attempt=2, wall_time_s=150.0))
+        with store._connect() as conn:
+            rows = conn.execute(
+                "SELECT id, attempt, wall_time_s FROM ticket_run_log ORDER BY attempt"
+            ).fetchall()
+        assert len(rows) == 2
+        assert rows[0]["attempt"] == 1
+        assert rows[0]["wall_time_s"] == 100.0
+        assert rows[1]["attempt"] == 2
+        assert rows[1]["wall_time_s"] == 150.0
+
+    def test_append_only_no_overwrite(self, tmp_path):
+        """Same attempt appended again — does not replace existing row."""
+        store = _store(tmp_path)
+        store.record_run(_run_log(attempt=1, output_tokens=500))
+        store.record_run(_run_log(attempt=1, output_tokens=600))
+        with store._connect() as conn:
+            rows = conn.execute(
+                "SELECT output_tokens FROM ticket_run_log WHERE attempt = 1"
+            ).fetchall()
+        assert len(rows) == 2
+        assert rows[0]["output_tokens"] == 500
+        assert rows[1]["output_tokens"] == 600
+
+    def test_same_ticket_different_attempts(self, tmp_path):
+        """Multiple tickets can each have multi-attempt rows."""
+        store = _store(tmp_path)
+        store.record_run(_run_log(ticket_id="WOR-1", attempt=1))
+        store.record_run(_run_log(ticket_id="WOR-1", attempt=2))
+        store.record_run(_run_log(ticket_id="WOR-2", attempt=1))
+        with store._connect() as conn:
+            w1 = conn.execute(
+                "SELECT COUNT(*) AS c FROM ticket_run_log WHERE ticket_id = 'WOR-1'"
+            ).fetchone()
+            w2 = conn.execute(
+                "SELECT COUNT(*) AS c FROM ticket_run_log WHERE ticket_id = 'WOR-2'"
+            ).fetchone()
+        assert w1["c"] == 2
+        assert w2["c"] == 1
+
+    def test_null_fields_round_trip(self, tmp_path):
+        """Nullable fields stored as NULL in SQLite."""
+        store = _store(tmp_path)
+        store.record_run(
+            _run_log(
+                failed_check=None,
+                wall_time_s=None,
+                input_tokens=None,
+                output_tokens=None,
+                output_tok_per_s=None,
+                context_compactions=None,
+            )
+        )
+        with store._connect() as conn:
+            row = conn.execute("SELECT * FROM ticket_run_log").fetchone()
+        assert row["failed_check"] is None
+        assert row["wall_time_s"] is None
+        assert row["input_tokens"] is None
+        assert row["output_tokens"] is None
+        assert row["output_tok_per_s"] is None
+        assert row["context_compactions"] is None


### PR DESCRIPTION
Closes WOR-259

ticket_run_log table exists in DB, finalize_worker writes one row per attempt, ruff+mypy+pytest pass