### PR TITLE
WOR-261 check_failures_json and sonar_findings_count never written to metrics DB

### DIFF
--- a/app/core/metrics.py
+++ b/app/core/metrics.py
@@ -108,9 +108,10 @@ class TicketMetrics(BaseModel):
     escalated_to_cloud: bool = False
     outcome: Outcome
     retry_count: int = 0
-    check_failures: dict[str, int] | None = Field(
+    check_failures: list[dict[str, int | str]] | None = Field(
         default=None,
-        description="Per-check failure counts, e.g. {'mypy': 2, 'pytest': 1}",
+        description="Per-check failures from run_checks, e.g. "
+        "[{'check': 'mypy', 'exit_code': 1}]",
     )
     lines_changed: int | None = Field(
         default=None, description="Lines added + removed in the PR diff"

--- a/app/core/watcher/watcher_finalize.py
+++ b/app/core/watcher/watcher_finalize.py
@@ -96,8 +96,8 @@ def finalize_worker(
     mode: str,
     project_id: str,
 ) -> None:
-    outcome, escalated, artifacts_preserved, sonar_findings = _execute_finalization(
-        worker, returncode, linear, escalation_policy, repo_root
+    outcome, escalated, artifacts_preserved, sonar_findings, failed_checks = (
+        _execute_finalization(worker, returncode, linear, escalation_policy, repo_root)
     )
 
     log_path = worker.worktree_path / f".claude/worker_{worker.ticket_id.lower()}.log"
@@ -113,6 +113,13 @@ def finalize_worker(
     if output_tokens is not None and wall_time and wall_time > 0:
         local_output_tokens_per_second = output_tokens / wall_time
     eff = resolve_effective_mode(mode, worker.manifest.implementation_mode)
+    # Derive the first failed check name for TicketRunLog (WOR-261)
+    first_failed_check: str | None = (
+        str(failed_checks[0]["check"]) if failed_checks else None
+    )
+    # check_failures: store the list when non-empty, else None
+    check_failures = failed_checks if failed_checks else None
+
     metrics.record(
         TicketMetrics(
             ticket_id=worker.ticket_id,
@@ -131,6 +138,7 @@ def finalize_worker(
             outcome=outcome,
             retry_count=worker.retry_count,
             context_compactions=context_compactions,
+            check_failures=check_failures,
             sonar_findings_count=(
                 len(sonar_findings) if sonar_findings is not None else None
             ),
@@ -142,7 +150,7 @@ def finalize_worker(
             attempt=worker.retry_count + 1,
             implementation_mode=_to_metrics_mode(eff),
             outcome=outcome,
-            failed_check=None,
+            failed_check=first_failed_check,
             wall_time_s=wall_time,
             input_tokens=input_tokens,
             output_tokens=output_tokens,
@@ -176,10 +184,11 @@ def _execute_finalization(
     linear: LinearClientProtocol,
     escalation_policy: EscalationPolicy,
     repo_root: Path,
-) -> tuple[Outcome, bool, bool, list[str] | None]:
+) -> tuple[Outcome, bool, bool, list[str] | None, list[dict[str, int | str]]]:
     """Determine outcome, escalation status, and artifact state.
 
-    Returns (outcome, escalated, artifacts_preserved, sonar_findings).
+    Returns (outcome, escalated, artifacts_preserved, sonar_findings,
+             failed_checks).
     """
     manifest = worker.manifest
     ticket_id = worker.ticket_id
@@ -202,9 +211,9 @@ def _execute_finalization(
             safe_set_state(
                 linear, linear_id, manifest.ticket_state_map.failed, ticket_id
             )
-        return "failure", escalated, False, None
+        return "failure", escalated, False, None, []
 
-    checks_ok = run_checks(manifest, worker.worktree_path)
+    checks_ok, failed_checks = run_checks(manifest, worker.worktree_path)
     if not checks_ok:
         worker.retry_count += 1
     if not checks_ok and manifest.failure_policy.on_check_failure == "abort":
@@ -223,7 +232,7 @@ def _execute_finalization(
             safe_set_state(
                 linear, linear_id, manifest.ticket_state_map.failed, ticket_id
             )
-        return "failure", escalated, False, None
+        return "failure", escalated, False, None, failed_checks
 
     preserve_worker_artifacts(repo_root, worker)
     flags = _read_result_flags(repo_root / manifest.artifact_paths.result_json)
@@ -232,7 +241,7 @@ def _execute_finalization(
     outcome, escalated, sonar_findings = _handle_policy_outcome(
         action, flags, worker, linear, escalation_policy
     )
-    return outcome, escalated, True, sonar_findings
+    return outcome, escalated, True, sonar_findings, []
 
 
 def _handle_policy_outcome(

--- a/app/core/watcher/watcher_subprocess.py
+++ b/app/core/watcher/watcher_subprocess.py
@@ -143,12 +143,18 @@ def launch_worker(
 _LAST_FAILURE_FILENAME = "last_failure.json"
 
 
-def run_checks(manifest: ExecutionManifest, worktree_path: Path) -> bool:
-    """Run manifest.required_checks in the worktree. Returns True if all pass."""
+def run_checks(
+    manifest: ExecutionManifest, worktree_path: Path
+) -> tuple[bool, list[dict[str, int | str]]]:
+    """Run manifest.required_checks in the worktree.
+
+    Returns (all_passed, failed_checks) where *failed_checks* is a list of
+    ``{check: str, exit_code: int}`` for each check that returned non-zero.
+    """
     artifact_dir = worktree_path / Path(manifest.artifact_paths.result_json).parent
     failure_artifact = artifact_dir / _LAST_FAILURE_FILENAME
 
-    all_passed = True
+    failed_checks: list[dict[str, int | str]] = []
     for check_cmd in manifest.required_checks:
         logger.info("Running check: %s", check_cmd)
         result = subprocess.run(  # nosec B603
@@ -161,7 +167,7 @@ def run_checks(manifest: ExecutionManifest, worktree_path: Path) -> bool:
             logger.error(
                 "Check failed: %s\n%s", check_cmd, result.stdout + result.stderr
             )
-            all_passed = False
+            failed_checks.append({"check": check_cmd, "exit_code": result.returncode})
             artifact_dir.mkdir(parents=True, exist_ok=True)
             failure_artifact.write_text(
                 json.dumps(
@@ -175,10 +181,10 @@ def run_checks(manifest: ExecutionManifest, worktree_path: Path) -> bool:
                 encoding="utf-8",
             )
 
-    if all_passed and failure_artifact.exists():
+    if not failed_checks and failure_artifact.exists():
         failure_artifact.unlink()
 
-    return all_passed
+    return (len(failed_checks) == 0, failed_checks)
 
 
 def create_pr(manifest: ExecutionManifest, worktree_path: Path) -> str:

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -90,7 +90,10 @@ class TestRecordAndRetrieve:
 class TestCheckFailures:
     def test_check_failures_round_trip(self, tmp_path):
         store = _store(tmp_path)
-        failures = {"mypy": 2, "pytest": 1}
+        failures = [
+            {"check": "mypy", "exit_code": 1},
+            {"check": "pytest", "exit_code": 2},
+        ]
         store.record(_ticket(check_failures=failures))
         result = store.get_by_ticket("WOR-1", "proj-a")
         assert result is not None
@@ -102,6 +105,13 @@ class TestCheckFailures:
         result = store.get_by_ticket("WOR-1", "proj-a")
         assert result is not None
         assert result.check_failures is None
+
+    def test_empty_check_failures_round_trip(self, tmp_path):
+        store = _store(tmp_path)
+        store.record(_ticket(check_failures=[]))
+        result = store.get_by_ticket("WOR-1", "proj-a")
+        assert result is not None
+        assert result.check_failures == []
 
 
 class TestAdditionalMetrics:

--- a/tests/test_watcher_finalize.py
+++ b/tests/test_watcher_finalize.py
@@ -71,7 +71,7 @@ def test_finalize_worker_pr_failure_marks_blocked(tmp_path: Path) -> None:
     exc = subprocess.CalledProcessError(1, "gh", stderr="Head sha can't be blank")
 
     with (
-        patch("app.core.watcher.watcher_finalize.run_checks", return_value=True),
+        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(True, [])),
         patch("app.core.watcher.watcher_finalize.create_pr", side_effect=exc),
         patch("app.core.watcher.watcher_finalize.cleanup_worktree"),
     ):
@@ -101,7 +101,7 @@ def test_finalize_worker_retry_count_zero_on_success(tmp_path: Path) -> None:
         process=MagicMock(spec=subprocess.Popen),
     )
     with (
-        patch("app.core.watcher.watcher_finalize.run_checks", return_value=True),
+        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(True, [])),
         patch(
             "app.core.watcher.watcher_finalize.create_pr",
             return_value="https://github.com/example/pr/1",
@@ -126,7 +126,7 @@ def test_finalize_worker_retry_count_increments_on_check_failure(
         process=MagicMock(spec=subprocess.Popen),
     )
     with (
-        patch("app.core.watcher.watcher_finalize.run_checks", return_value=False),
+        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(False, [])),
         patch("app.core.watcher.watcher_finalize.cleanup_worktree"),
     ):
         _call_finalize(worker)
@@ -147,7 +147,7 @@ def test_finalize_worker_retry_count_two_failures_then_success(
         worktree_path=tmp_path,
         process=MagicMock(spec=subprocess.Popen),
     )
-    check_results = [False, False, True]
+    check_results = [(False, []), (False, []), (True, [])]
     with (
         patch(
             "app.core.watcher.watcher_finalize.run_checks", side_effect=check_results
@@ -204,7 +204,7 @@ def test_finalize_worker_set_state_failure_success_path_no_crash(
     )
 
     with (
-        patch("app.core.watcher.watcher_finalize.run_checks", return_value=True),
+        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(True, [])),
         patch(
             "app.core.watcher.watcher_finalize.create_pr",
             return_value="https://github.com/example/pr/1",
@@ -247,7 +247,7 @@ def test_finalize_worker_passes_usage_to_metrics(tmp_path: Path) -> None:
     )
 
     with (
-        patch("app.core.watcher.watcher_finalize.run_checks", return_value=True),
+        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(True, [])),
         patch(
             "app.core.watcher.watcher_finalize.create_pr",
             return_value="https://github.com/example/pr/1",
@@ -274,7 +274,7 @@ def test_finalize_worker_usage_none_when_no_log(tmp_path: Path) -> None:
     )
 
     with (
-        patch("app.core.watcher.watcher_finalize.run_checks", return_value=True),
+        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(True, [])),
         patch(
             "app.core.watcher.watcher_finalize.create_pr",
             return_value="https://github.com/example/pr/1",
@@ -304,7 +304,7 @@ def test_finalize_worker_sonar_count_wired_to_metrics(tmp_path: Path) -> None:
         process=MagicMock(spec=subprocess.Popen),
     )
     with (
-        patch("app.core.watcher.watcher_finalize.run_checks", return_value=True),
+        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(True, [])),
         patch(
             "app.core.watcher.watcher_finalize.create_pr",
             return_value="https://github.com/example/pr/1",
@@ -332,7 +332,7 @@ def test_finalize_worker_sonar_count_none_when_unavailable(tmp_path: Path) -> No
         process=MagicMock(spec=subprocess.Popen),
     )
     with (
-        patch("app.core.watcher.watcher_finalize.run_checks", return_value=True),
+        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(True, [])),
         patch(
             "app.core.watcher.watcher_finalize.create_pr",
             return_value="https://github.com/example/pr/1",
@@ -377,7 +377,7 @@ def test_finalize_worker_sonar_blocker_escalates(tmp_path: Path) -> None:
     linear_mock, worker = _make_worker_with_result(tmp_path, {})
     metrics_mock = MagicMock()
     with (
-        patch("app.core.watcher.watcher_finalize.run_checks", return_value=True),
+        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(True, [])),
         patch("app.core.watcher.watcher_finalize.preserve_worker_artifacts"),
         patch(
             "app.core.watcher.watcher_finalize.fetch_sonar_findings",
@@ -404,7 +404,7 @@ def test_finalize_worker_sonar_major_advisory_warning(
     linear_mock, worker = _make_worker_with_result(tmp_path, {})
     metrics_mock = MagicMock()
     with (
-        patch("app.core.watcher.watcher_finalize.run_checks", return_value=True),
+        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(True, [])),
         patch("app.core.watcher.watcher_finalize.preserve_worker_artifacts"),
         patch(
             "app.core.watcher.watcher_finalize.fetch_sonar_findings",
@@ -432,7 +432,7 @@ def test_finalize_worker_sonar_none_no_escalation(tmp_path: Path) -> None:
     linear_mock, worker = _make_worker_with_result(tmp_path, {})
     metrics_mock = MagicMock()
     with (
-        patch("app.core.watcher.watcher_finalize.run_checks", return_value=True),
+        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(True, [])),
         patch("app.core.watcher.watcher_finalize.preserve_worker_artifacts"),
         patch(
             "app.core.watcher.watcher_finalize.fetch_sonar_findings", return_value=None
@@ -462,7 +462,7 @@ def test_finalize_worker_scope_drift_escalates(tmp_path: Path) -> None:
     linear_mock, worker = _make_worker_with_result(tmp_path, {"scope_drift": True})
     metrics_mock = MagicMock()
     with (
-        patch("app.core.watcher.watcher_finalize.run_checks", return_value=True),
+        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(True, [])),
         patch("app.core.watcher.watcher_finalize.preserve_worker_artifacts"),
         patch("app.core.watcher.watcher_finalize.create_pr") as mock_create_pr,
         patch("app.core.watcher.watcher_finalize.cleanup_worktree"),
@@ -486,7 +486,7 @@ def test_finalize_worker_forbidden_path_touched_escalates(tmp_path: Path) -> Non
     )
     metrics_mock = MagicMock()
     with (
-        patch("app.core.watcher.watcher_finalize.run_checks", return_value=True),
+        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(True, [])),
         patch("app.core.watcher.watcher_finalize.preserve_worker_artifacts"),
         patch("app.core.watcher.watcher_finalize.create_pr") as mock_create_pr,
         patch("app.core.watcher.watcher_finalize.cleanup_worktree"),
@@ -508,7 +508,7 @@ def test_finalize_worker_no_flags_proceeds_normally(tmp_path: Path) -> None:
     linear_mock, worker = _make_worker_with_result(tmp_path, {})
     metrics_mock = MagicMock()
     with (
-        patch("app.core.watcher.watcher_finalize.run_checks", return_value=True),
+        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(True, [])),
         patch("app.core.watcher.watcher_finalize.preserve_worker_artifacts"),
         patch(
             "app.core.watcher.watcher_finalize.create_pr",
@@ -538,7 +538,7 @@ def test_finalize_worker_missing_result_json_proceeds_normally(tmp_path: Path) -
         process=MagicMock(spec=subprocess.Popen),
     )
     with (
-        patch("app.core.watcher.watcher_finalize.run_checks", return_value=True),
+        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(True, [])),
         patch("app.core.watcher.watcher_finalize.preserve_worker_artifacts"),
         patch(
             "app.core.watcher.watcher_finalize.create_pr",
@@ -566,7 +566,7 @@ def test_finalize_worker_human_policy_posts_comment_and_aborts(
     linear_mock, worker = _make_worker_with_result(tmp_path, {})
     metrics_mock = MagicMock()
     with (
-        patch("app.core.watcher.watcher_finalize.run_checks", return_value=True),
+        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(True, [])),
         patch("app.core.watcher.watcher_finalize.preserve_worker_artifacts"),
         patch("app.core.watcher.watcher_finalize.create_pr") as mock_create_pr,
         patch("app.core.watcher.watcher_finalize.cleanup_worktree"),
@@ -625,7 +625,7 @@ def test_execute_finalization_check_failure_escalates_to_cloud(tmp_path: Path) -
         process=MagicMock(spec=subprocess.Popen),
     )
     with (
-        patch("app.core.watcher.watcher_finalize.run_checks", return_value=False),
+        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(False, [])),
         patch("app.core.watcher.watcher_finalize.cleanup_worktree"),
     ):
         _call_finalize(worker, linear=linear_mock, metrics=metrics_mock)
@@ -653,7 +653,7 @@ def test_execute_finalization_check_failure_blocked_when_no_escalate(
         process=MagicMock(spec=subprocess.Popen),
     )
     with (
-        patch("app.core.watcher.watcher_finalize.run_checks", return_value=False),
+        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(False, [])),
         patch("app.core.watcher.watcher_finalize.cleanup_worktree"),
     ):
         _call_finalize(worker, linear=linear_mock, metrics=metrics_mock)
@@ -707,7 +707,7 @@ def test_execute_finalization_nonzero_returncode_returns_failure(
     )
     from app.core.watcher.watcher_finalize import _execute_finalization
 
-    outcome, escalated, preserved, findings = _execute_finalization(
+    outcome, escalated, preserved, findings, _ = _execute_finalization(
         worker, 1, linear_mock, EscalationPolicy.from_toml(), tmp_path
     )
 
@@ -736,8 +736,11 @@ def test_execute_finalization_check_failure_abort_returns_failure(
     )
     from app.core.watcher.watcher_finalize import _execute_finalization
 
-    with patch("app.core.watcher.watcher_finalize.run_checks", return_value=False):
-        outcome, escalated, preserved, findings = _execute_finalization(
+    with patch(
+        "app.core.watcher.watcher_finalize.run_checks",
+        return_value=(False, []),
+    ):
+        outcome, escalated, preserved, findings, _ = _execute_finalization(
             worker, 0, linear_mock, EscalationPolicy.from_toml(), tmp_path
         )
 
@@ -993,7 +996,7 @@ def test_finalize_worker_writes_separate_token_fields(tmp_path: Path) -> None:
     )
 
     with (
-        patch("app.core.watcher.watcher_finalize.run_checks", return_value=True),
+        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(True, [])),
         patch(
             "app.core.watcher.watcher_finalize.create_pr",
             return_value="https://github.com/example/pr/1",
@@ -1025,7 +1028,7 @@ def test_finalize_worker_token_fields_none_when_no_log(
     )
 
     with (
-        patch("app.core.watcher.watcher_finalize.run_checks", return_value=True),
+        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(True, [])),
         patch(
             "app.core.watcher.watcher_finalize.create_pr",
             return_value="https://github.com/example/pr/1",
@@ -1065,7 +1068,7 @@ def test_finalize_worker_calls_commit_wip_state_on_check_failure(
     )
 
     with (
-        patch("app.core.watcher.watcher_finalize.run_checks", return_value=False),
+        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(False, [])),
         patch(
             "app.core.watcher.watcher_finalize.commit_wip_state",
             return_value="a1b2c3d4",
@@ -1106,7 +1109,7 @@ def test_finalize_worker_writes_last_failure_json_on_wip_commit(
     failure_file.write_text('{"failed_at": "2026-01-01"}', encoding="utf-8")
 
     with (
-        patch("app.core.watcher.watcher_finalize.run_checks", return_value=False),
+        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(False, [])),
         patch(
             "app.core.watcher.watcher_finalize.commit_wip_state",
             return_value="a1b2c3d4",
@@ -1143,7 +1146,7 @@ def test_finalize_worker_last_failure_json_created_when_absent(
     # No last_failure.json exists
 
     with (
-        patch("app.core.watcher.watcher_finalize.run_checks", return_value=False),
+        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(False, [])),
         patch(
             "app.core.watcher.watcher_finalize.commit_wip_state",
             return_value="a1b2c3d4",
@@ -1175,7 +1178,7 @@ def test_finalize_worker_skips_commit_wip_when_no_sha(tmp_path: Path) -> None:
     )
 
     with (
-        patch("app.core.watcher.watcher_finalize.run_checks", return_value=False),
+        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(False, [])),
         patch(
             "app.core.watcher.watcher_finalize.commit_wip_state",
             return_value=None,
@@ -1189,3 +1192,155 @@ def test_finalize_worker_skips_commit_wip_when_no_sha(tmp_path: Path) -> None:
     artifact_dir = tmp_path / ".claude" / "artifacts" / "wor_10"
     failure_file = artifact_dir / "last_failure.json"
     assert not failure_file.exists()
+
+
+# ---------------------------------------------------------------------------
+# WOR-261 — check_failures_json and sonar_findings_count wired to metrics
+# ---------------------------------------------------------------------------
+
+
+def test_finalize_worker_check_failures_populated_on_check_failure(
+    tmp_path: Path,
+) -> None:
+    """A failing check produces check_failures with the correct check name."""
+    manifest = make_manifest(
+        ticket_id="WOR-10",
+        worker_branch="wor-10-test-ticket",
+        required_checks=["ruff check .", "mypy app/", "pytest"],
+    )
+    linear_mock = MagicMock()
+    metrics_mock = MagicMock()
+    worker = ActiveWorker(
+        ticket_id="WOR-10",
+        linear_id="fake-linear-id",
+        manifest=manifest,
+        worktree_path=tmp_path,
+        process=MagicMock(spec=subprocess.Popen),
+    )
+    with (
+        patch(
+            "app.core.watcher.watcher_finalize.run_checks",
+            return_value=(
+                False,
+                [{"check": "mypy app/", "exit_code": 1}],
+            ),
+        ),
+        patch("app.core.watcher.watcher_finalize.cleanup_worktree"),
+    ):
+        _call_finalize(worker, linear=linear_mock, metrics=metrics_mock)
+
+    m = metrics_mock.record.call_args[0][0]
+    assert m.check_failures is not None
+    assert len(m.check_failures) == 1
+    assert m.check_failures[0]["check"] == "mypy app/"
+    assert m.check_failures[0]["exit_code"] == 1
+
+
+def test_finalize_worker_check_failures_empty_on_success(
+    tmp_path: Path,
+) -> None:
+    """All checks pass → check_failures is None (serialises to '[]')."""
+    manifest = make_manifest(
+        ticket_id="WOR-10",
+        worker_branch="wor-10-test-ticket",
+    )
+    linear_mock = MagicMock()
+    metrics_mock = MagicMock()
+    worker = ActiveWorker(
+        ticket_id="WOR-10",
+        linear_id="fake-linear-id",
+        manifest=manifest,
+        worktree_path=tmp_path,
+        process=MagicMock(spec=subprocess.Popen),
+    )
+    with (
+        patch(
+            "app.core.watcher.watcher_finalize.run_checks",
+            return_value=(True, []),
+        ),
+        patch(
+            "app.core.watcher.watcher_finalize.create_pr",
+            return_value="https://github.com/example/pr/1",
+        ),
+        patch("app.core.watcher.watcher_finalize.cleanup_worktree"),
+    ):
+        _call_finalize(worker, linear=linear_mock, metrics=metrics_mock)
+
+    m = metrics_mock.record.call_args[0][0]
+    assert m.check_failures is None
+
+
+def test_finalize_worker_sonar_count_zero_on_empty_findings(
+    tmp_path: Path,
+) -> None:
+    """Success-path finalization with fetch_sonar_findings returning []
+    produces sonar_findings_count=0 (not null)."""
+    manifest = make_manifest(
+        ticket_id="WOR-10",
+        worker_branch="wor-10-test-ticket",
+    )
+    linear_mock = MagicMock()
+    metrics_mock = MagicMock()
+    worker = ActiveWorker(
+        ticket_id="WOR-10",
+        linear_id="fake-linear-id",
+        manifest=manifest,
+        worktree_path=tmp_path,
+        process=MagicMock(spec=subprocess.Popen),
+    )
+    with (
+        patch(
+            "app.core.watcher.watcher_finalize.run_checks",
+            return_value=(True, []),
+        ),
+        patch(
+            "app.core.watcher.watcher_finalize.create_pr",
+            return_value="https://github.com/example/pr/1",
+        ),
+        patch("app.core.watcher.watcher_finalize.cleanup_worktree"),
+        patch(
+            "app.core.watcher.watcher_finalize.fetch_sonar_findings",
+            return_value=[],
+        ),
+    ):
+        _call_finalize(worker, linear=linear_mock, metrics=metrics_mock)
+
+    m = metrics_mock.record.call_args[0][0]
+    assert m.sonar_findings_count == 0
+
+
+def test_finalize_worker_failed_check_in_run_log_on_failure(
+    tmp_path: Path,
+) -> None:
+    """TicketRunLog.failed_check is set to the first failed check name."""
+    manifest = make_manifest(
+        ticket_id="WOR-10",
+        worker_branch="wor-10-test-ticket",
+        required_checks=["ruff check .", "mypy app/"],
+    )
+    linear_mock = MagicMock()
+    metrics_mock = MagicMock()
+    worker = ActiveWorker(
+        ticket_id="WOR-10",
+        linear_id="fake-linear-id",
+        manifest=manifest,
+        worktree_path=tmp_path,
+        process=MagicMock(spec=subprocess.Popen),
+    )
+    with (
+        patch(
+            "app.core.watcher.watcher_finalize.run_checks",
+            return_value=(
+                False,
+                [
+                    {"check": "ruff check .", "exit_code": 1},
+                    {"check": "mypy app/", "exit_code": 2},
+                ],
+            ),
+        ),
+        patch("app.core.watcher.watcher_finalize.cleanup_worktree"),
+    ):
+        _call_finalize(worker, linear=linear_mock, metrics=metrics_mock)
+
+    run_call = metrics_mock.record_run.call_args[0][0]
+    assert run_call.failed_check == "ruff check ."

--- a/tests/test_watcher_subprocess.py
+++ b/tests/test_watcher_subprocess.py
@@ -516,7 +516,9 @@ def test_run_checks_returns_true_when_all_pass(tmp_path: Path) -> None:
     with patch(
         "app.core.watcher.watcher_subprocess.subprocess.run", side_effect=fake_run
     ):
-        assert run_checks(manifest, tmp_path) is True
+        passed, failures = run_checks(manifest, tmp_path)
+        assert passed is True
+        assert failures == []
 
 
 def test_run_checks_returns_false_on_check_failure(
@@ -540,9 +542,12 @@ def test_run_checks_returns_false_on_check_failure(
         ),
         caplog.at_level(logging.ERROR, logger="app.core.watcher.watcher_subprocess"),
     ):
-        passed = run_checks(manifest, tmp_path)
+        passed, failures = run_checks(manifest, tmp_path)
 
     assert passed is False
+    assert len(failures) == 1
+    assert failures[0]["check"] == "ruff check ."
+    assert failures[0]["exit_code"] == 1
     assert any("Check failed" in msg for msg in caplog.messages)
     assert call_count == 2
 
@@ -619,7 +624,9 @@ def test_run_checks_deletes_last_failure_json_on_success(tmp_path: Path) -> None
     with patch(
         "app.core.watcher.watcher_subprocess.subprocess.run", side_effect=fake_run
     ):
-        assert run_checks(manifest, tmp_path) is True
+        passed, failures = run_checks(manifest, tmp_path)
+        assert passed is True
+        assert failures == []
 
     assert not stale.exists(), (
         "last_failure.json should be deleted after successful run"


### PR DESCRIPTION
Closes WOR-261

check_failures_json non-null in metrics DB on every failed run; sonar_findings_count=0 on empty sonar result; ruff+mypy+pytest pass