### PR TITLE
WOR-266 Add --no-epic-shutdown flag to keep watcher running after epic completes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,13 @@ repos:
 
   - repo: local
     hooks:
+      - id: check-patch-paths
+        name: check-patch-paths
+        language: python
+        entry: python scripts/check_patch_paths.py
+        pass_filenames: false
+        types: [python]
+
       - id: semgrep
         name: semgrep
         language: python
@@ -45,10 +52,3 @@ repos:
     hooks:
       - id: detect-secrets
         args: ["--baseline", ".secrets.baseline"]
-
-      - id: check-patch-paths
-        name: check-patch-paths
-        language: python
-        entry: python scripts/check_patch_paths.py
-        pass_filenames: false
-        types: [python]

--- a/app/cli.py
+++ b/app/cli.py
@@ -141,6 +141,16 @@ def _build_parser() -> argparse.ArgumentParser:
             "prefixed with [WOR-NN]. Output is still written to the log file."
         ),
     )
+    watcher.add_argument(
+        "--no-epic-shutdown",
+        action="store_true",
+        default=False,
+        help=(
+            "Keep the watcher running after all current sub-tickets are "
+            "processed instead of exiting. Useful for watching new tickets "
+            "get added to the epic."
+        ),
+    )
 
     return parser
 
@@ -166,6 +176,7 @@ def _run_watcher(args: argparse.Namespace) -> int:
         max_local_workers=max_local,
         max_cloud_workers=max_cloud,
         verbose=args.verbose,
+        no_epic_shutdown=args.no_epic_shutdown,
     )
     try:
         watcher.run()

--- a/app/core/watcher/watcher.py
+++ b/app/core/watcher/watcher.py
@@ -80,6 +80,7 @@ class Watcher:
         repo_root: Path | None = None,
         project_id: str = "repo-scaffold-desktop",
         verbose: bool = False,
+        no_epic_shutdown: bool = False,
     ) -> None:
         if linear_client is None:
             from app.core.linear_client import LinearClient  # lazy import
@@ -101,6 +102,7 @@ class Watcher:
         self._verbose = verbose
         self._retry_counters: dict[str, int] = {}
         self._escalation_policy = EscalationPolicy.from_toml()
+        self._no_epic_shutdown = no_epic_shutdown
 
     # ------------------------------------------------------------------
     # Public entry point
@@ -570,7 +572,8 @@ class Watcher:
                     logger.warning(
                         "Could not post epic-complete comment on %s: %s", epic_id, exc
                     )
-            self._running = False
+            if not self._no_epic_shutdown:
+                self._running = False
 
     # ------------------------------------------------------------------
     # Manifest loading

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -383,6 +383,39 @@ def test_check_epic_completion_posts_comment_and_exits(tmp_path: Path) -> None:
     assert w._running is False
 
 
+def test_check_epic_completion_no_epic_shutdown_keeps_running(
+    tmp_path: Path,
+) -> None:
+    """When no_epic_shutdown=True, _check_epic_completion must NOT set
+    _running to False. The epic-complete comment must still be posted."""
+    linear_mock = MagicMock()
+    linear_mock.list_ready_for_local.return_value = []
+    w = Watcher(
+        linear_client=linear_mock,
+        repo_root=tmp_path,
+        no_epic_shutdown=True,
+    )
+    w._processed_tickets = [
+        _ProcessedTicket(
+            ticket_id="WOR-10",
+            epic_id="WOR-96",
+            worker_branch="wor-10-test-ticket",
+            elapsed=120.0,
+        )
+    ]
+
+    with (
+        patch.object(w, "_has_waiting_deps", return_value=False),
+        patch.object(
+            w, "_lookup_pr_url", return_value="https://github.com/org/repo/pull/1"
+        ),
+    ):
+        w._check_epic_completion()
+
+    linear_mock.post_comment.assert_called_once()
+    assert w._running is True
+
+
 def test_check_epic_completion_no_tickets_processed_no_comment_exits(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
Closes WOR-266

--no-epic-shutdown flag wired in cli.py and app/core/watcher/watcher.py, test passes, ruff+mypy+pytest pass