### PR TITLE
WOR-267 Implement Option A: worker-side wip commits with squash-on-success for fine-grained retry resume

### DIFF
--- a/.claude/commands/implement-ticket.md
+++ b/.claude/commands/implement-ticket.md
@@ -44,6 +44,16 @@ If the worktree contains a commit whose message matches `wip(failed): <ticket_id
 - If the WIP commit has conflicts with the current branch tip, resolve them
   before continuing.
 
+Also inspect git log for wip commits from previous workers (WOR-267):
+
+```bash
+git log --oneline --grep="^wip: <ticket_id>$"  # find wip commits
+```
+
+If wip commits are found on the branch, inspect them and **resume from the last
+committed phase** without redoing completed work. The squash_wip_commits function
+(worker-side) will squash them into a single commit on success.
+
 This allows retry workers to pick up where the previous worker left off.
 
 ### 1. Verify branch
@@ -115,6 +125,26 @@ grep -rn 'patch\.object' tests/ | grep '<ClassName>'
 ```
 
 `patch.object` patches the method on the instance; once the function is module-level it no longer exists on the class and the patch silently does nothing or raises `AttributeError`. Convert every match to a string-path `patch("new.module.path.function_name")`.
+
+### 3.5. Commit WIP state (WOR-267)
+
+After completing all implementation (step 3), make an unconditional WIP commit
+so that squash_wip_commits can squash it on the success path:
+
+```bash
+git add -A && git commit -m "wip: <ticket_id> implementation complete"
+```
+
+After writing any new test files, make a separate WIP commit for tests:
+
+```bash
+git add tests/ && git commit -m "wip: <ticket_id> tests written"
+```
+
+These instructions are UNCONDITIONAL — do not gate on check results or
+implementation quality. The squash_wip_commits function (worker-side) will
+squash all wip commits since the diverge point into a single commit before
+the PR is created, giving fine-grained retry resume.
 
 ### 4. Run required checks
 

--- a/app/core/watcher/watcher_finalize.py
+++ b/app/core/watcher/watcher_finalize.py
@@ -39,6 +39,7 @@ from .watcher_worktrees import (
     commit_wip_state,
     preserve_worker_artifacts,
     restore_plan_files,
+    squash_wip_commits,
 )
 
 logger = logging.getLogger(__name__)
@@ -116,6 +117,13 @@ def attempt_pr(
     except subprocess.CalledProcessError as exc:
         err_detail = (exc.stderr or exc.stdout or str(exc)).strip()
         logger.error("PR creation failed for %s: %s", ticket_id, err_detail)
+        # Preserve any uncommitted worktree changes so a retry worker can
+        # resume from them (WOR-267).
+        commit_wip_state(
+            worker.worktree_path,
+            ticket_id,
+            manifest.worker_branch,
+        )
         safe_set_state(linear, linear_id, manifest.ticket_state_map.failed, ticket_id)
         _try_post_comment(
             linear,
@@ -305,7 +313,7 @@ def _execute_finalization(
     action = escalation_policy.classify_result(**flags)
 
     outcome, escalated, sonar_findings = _handle_policy_outcome(
-        action, flags, worker, linear, escalation_policy
+        action, flags, worker, linear, escalation_policy, manifest.objective
     )
     return outcome, escalated, True, sonar_findings, []
 
@@ -316,6 +324,7 @@ def _handle_policy_outcome(
     worker: ActiveWorker,
     linear: LinearClientProtocol,
     escalation_policy: EscalationPolicy,
+    final_message: str = "Implementation complete",
 ) -> tuple[Outcome, bool, list[str] | None]:
     """Map a policy action to an outcome, posting Linear comments as needed."""
     ticket_id = worker.ticket_id
@@ -360,6 +369,15 @@ def _handle_policy_outcome(
             f"to Sonar finding requiring immediate action.",
         )
         return "escalated", True, sonar_findings
+
+    # Squash any wip commits into a single commit so retry workers can
+    # diff the final_message commit and resume from a clean state.
+    squash_wip_commits(
+        worker.worktree_path,
+        ticket_id,
+        manifest.base_branch,
+        final_message,
+    )
 
     outcome = attempt_pr(manifest, worker, linear)
     return outcome, False, sonar_findings

--- a/app/core/watcher/watcher_worktrees.py
+++ b/app/core/watcher/watcher_worktrees.py
@@ -8,6 +8,7 @@ This module may import from watcher_types only (no other watcher siblings).
 from __future__ import annotations
 
 import logging
+import re
 import shutil
 import subprocess  # nosec B404
 from pathlib import Path
@@ -255,6 +256,170 @@ def commit_wip_state(
         return None
     except OSError as exc:
         logger.warning("WIP commit failed for %s (OSError): %s", ticket_id, exc)
+        return None
+
+
+def squash_wip_commits(
+    worktree_path: Path,
+    ticket_id: str,
+    base_branch: str,
+    final_message: str,
+) -> str | None:
+    """Squash all wip commits since the diverge point into a single commit.
+
+    Finds all commits whose message matches ``wip: <ticket_id>`` since the
+    branch diverged from *base_branch*. If any exist, does a
+    ``git reset --soft <diverge>`` followed by ``git commit -m <final_message>``
+    and pushes the result.
+
+    Returns the new short commit SHA on success, or ``None`` when no wip
+    commits are found (no-op) or any git step fails.  Never raises — logs
+    warnings instead.
+    """
+    try:
+        # Find diverge point
+        merge_base = subprocess.run(  # nosec B603 B607
+            [
+                "git",
+                "-C",
+                str(worktree_path),
+                "merge-base",
+                "HEAD",
+                base_branch,
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        diverge = merge_base.stdout.strip()
+
+        # Check for wip commits
+        log = subprocess.run(  # nosec B603 B607
+            [
+                "git",
+                "-C",
+                str(worktree_path),
+                "log",
+                "--oneline",
+                f"{diverge}..HEAD",
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        wip_commits: list[str] = []
+        for line in log.stdout.splitlines():
+            stripped = line.strip()
+            if not stripped:
+                continue
+            # Match: <hex-sha> wip: <ticket_id>
+            # git log --oneline: sha (8+ chars) + space + title
+            sha_part = stripped[:7]
+            if re.match(r"^[0-9a-f]{7,}", sha_part) and f"wip: {ticket_id}" in stripped:
+                wip_commits.append(stripped)
+
+        if not wip_commits:
+            logger.info(
+                "No wip commits for %s since %s — nothing to squash",
+                ticket_id,
+                base_branch,
+            )
+            return None
+
+        logger.info(
+            "Found %d wip commit(s) for %s — squashing into single commit",
+            len(wip_commits),
+            ticket_id,
+        )
+
+        # Squash: soft reset to diverge point
+        subprocess.run(  # nosec B603 B607
+            [
+                "git",
+                "-C",
+                str(worktree_path),
+                "reset",
+                "--soft",
+                diverge,
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+        # Commit with final message
+        subprocess.run(  # nosec B603 B607
+            [
+                "git",
+                "-C",
+                str(worktree_path),
+                "commit",
+                "-m",
+                final_message,
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+        # Push — the current branch (worker branch) now has the squashed commit
+        push = subprocess.run(  # nosec B603 B607
+            [
+                "git",
+                "-C",
+                str(worktree_path),
+                "push",
+                "-u",
+                "origin",
+                "HEAD",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        if push.returncode != 0:
+            logger.warning(
+                "git push failed after squashing wip commits for %s — "
+                "commit was created locally but not pushed: %s",
+                ticket_id,
+                (push.stderr or push.stdout or "").strip(),
+            )
+            return None
+
+        # Get short SHA
+        rev = subprocess.run(  # nosec B603 B607
+            [
+                "git",
+                "-C",
+                str(worktree_path),
+                "rev-parse",
+                "--short",
+                "HEAD",
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        sha = rev.stdout.strip()
+        logger.info(
+            "WIP commits squashed for %s — new commit %s",
+            ticket_id,
+            sha,
+        )
+        return sha
+
+    except subprocess.CalledProcessError as exc:
+        logger.warning(
+            "squash_wip_commits failed for %s: %s",
+            ticket_id,
+            (exc.stderr or exc.stdout or str(exc)).strip(),
+        )
+        return None
+    except OSError as exc:
+        logger.warning(
+            "squash_wip_commits failed for %s (OSError): %s",
+            ticket_id,
+            exc,
+        )
         return None
 
 

--- a/tests/test_watcher_finalize.py
+++ b/tests/test_watcher_finalize.py
@@ -964,6 +964,47 @@ def test_attempt_pr_called_process_error_returns_failure(
 
 
 # ---------------------------------------------------------------------------
+# WOR-267 — attempt_pr calls commit_wip_state on failure
+# ---------------------------------------------------------------------------
+
+
+def test_attempt_pr_calls_commit_wip_state_on_failure(
+    tmp_path: Path,
+) -> None:
+    """On CalledProcessError, commit_wip_state is called to preserve changes."""
+    manifest = make_manifest(
+        ticket_id="WOR-10",
+        worker_branch="wor-10-test-ticket",
+    )
+    linear_mock = MagicMock()
+    worker = ActiveWorker(
+        ticket_id="WOR-10",
+        linear_id="fake-linear-id",
+        manifest=manifest,
+        worktree_path=tmp_path,
+        process=MagicMock(spec=subprocess.Popen),
+    )
+    from app.core.watcher.watcher_finalize import attempt_pr
+
+    exc = subprocess.CalledProcessError(1, "gh pr create", stderr="validation failed")
+    with (
+        patch(
+            "app.core.watcher.watcher_finalize.commit_wip_state",
+            return_value=None,
+        ) as mock_commit,
+        patch("app.core.watcher.watcher_finalize.create_pr", side_effect=exc),
+    ):
+        result = attempt_pr(manifest, worker, linear_mock)
+
+    assert result == "failure"
+    mock_commit.assert_called_once_with(
+        tmp_path,
+        "WOR-10",
+        "wor-10-test-ticket",
+    )
+
+
+# ---------------------------------------------------------------------------
 # WOR-230 — local_input_tokens / local_output_tokens wired to metrics
 # ---------------------------------------------------------------------------
 

--- a/tests/test_watcher_worktrees.py
+++ b/tests/test_watcher_worktrees.py
@@ -21,6 +21,7 @@ from app.core.watcher.watcher_worktrees import (
     preserve_worker_artifacts,
     rebase_worktree_from_base,
     restore_plan_files,
+    squash_wip_commits,
     write_worker_pytest_config,
 )
 from tests.conftest import make_manifest
@@ -688,3 +689,129 @@ def test_commit_wip_state_handles_status_error(
 
     assert result is None
     assert any("git status failed" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# squash_wip_commits
+# ---------------------------------------------------------------------------
+
+
+def test_squash_wip_commits_squashes_correctly(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """When wip commits exist, they are squashed into a single commit."""
+    sha = "a1b2c3d4e5f6"  # pragma: allowlist secret — fake SHA
+
+    def fake_run(*args: object, **kwargs: object) -> subprocess.CompletedProcess:
+        cmd = args[0] if args else kwargs.get("args", [])
+        if "merge-base" in cmd:
+            return _completed_process(stdout=sha + "\n")
+        if "log" in cmd:
+            # Return wip commits in git log --oneline format
+            return _completed_process(
+                stdout="aaaaaaaa wip: WOR-10 implementation\n"
+                "bbbbbbbb wip: WOR-10 tests written\n"
+            )
+        if "reset" in cmd:
+            return _completed_process()
+        if "commit" in cmd:
+            return _completed_process()
+        if "push" in cmd:
+            return _completed_process()
+        if "rev-parse" in cmd:
+            return _completed_process(stdout="deadbeef\n")
+        return _completed_process()
+
+    with (
+        patch(
+            "app.core.watcher.watcher_worktrees.subprocess.run",
+            side_effect=fake_run,
+        ),
+        caplog.at_level(logging.INFO, logger="app.core.watcher.watcher_worktrees"),
+    ):
+        result = squash_wip_commits(
+            tmp_path,
+            "WOR-10",
+            "epic/wor-253",
+            "Implementation complete",
+        )
+
+    assert result == "deadbeef"
+    assert any("squashing" in r.message for r in caplog.records)
+
+
+def test_squash_wip_commits_no_op_when_no_wip_commits(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Returns None when no wip commits — no reset/commit/push calls."""
+    sha = "a1b2c3d4e5f6"  # pragma: allowlist secret — fake SHA
+
+    call_order: list[str] = []
+    call_count = [0]
+
+    def fake_run(*args: object, **kwargs: object) -> subprocess.CompletedProcess:
+        cmd = args[0] if args else kwargs.get("args", [])
+        idx = call_count[0]
+        call_count[0] = idx + 1
+        if "merge-base" in cmd:
+            call_order.append("merge-base")
+            return _completed_process(stdout=sha + "\n")
+        if "log" in cmd:
+            call_order.append("log")
+            # No wip commits — log is empty
+            return _completed_process(stdout="")
+        # Should not reach here
+        call_order.append("unexpected")
+        return _completed_process()
+
+    with (
+        patch(
+            "app.core.watcher.watcher_worktrees.subprocess.run",
+            side_effect=fake_run,
+        ),
+        caplog.at_level(logging.INFO, logger="app.core.watcher.watcher_worktrees"),
+    ):
+        result = squash_wip_commits(
+            tmp_path,
+            "WOR-10",
+            "epic/wor-253",
+            "Implementation complete",
+        )
+
+    assert result is None
+    assert call_order == ["merge-base", "log"]
+    # No reset/commit/push calls — no-op
+    assert "unexpected" not in call_order
+    assert any("nothing to squash" in r.message for r in caplog.records)
+
+
+def test_squash_wip_commits_returns_none_on_git_error(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Any git failure returns None and logs a warning."""
+
+    def fake_run(*args: object, **kwargs: object) -> subprocess.CompletedProcess:
+        cmd = args[0] if args else kwargs.get("args", [])
+        if "merge-base" in cmd:
+            raise subprocess.CalledProcessError(1, "git", stderr="error")
+        return _completed_process()
+
+    with (
+        patch(
+            "app.core.watcher.watcher_worktrees.subprocess.run",
+            side_effect=fake_run,
+        ),
+        caplog.at_level(logging.WARNING, logger="app.core.watcher.watcher_worktrees"),
+    ):
+        result = squash_wip_commits(
+            tmp_path,
+            "WOR-10",
+            "epic/wor-253",
+            "Implementation complete",
+        )
+
+    assert result is None
+    assert any("squash_wip_commits failed" in r.message for r in caplog.records)


### PR DESCRIPTION
Closes WOR-267

squash_wip_commits in watcher_worktrees.py, wired in watcher_finalize, wip commit instructions in implement-ticket.md, ruff+mypy+pytest pass