### PR TITLE
WOR-41 Secure GitHub credential storage

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -1,13 +1,16 @@
 import argparse
+import getpass
 import os
 import subprocess  # nosec B404
 import sys
 from pathlib import Path
 
 from dotenv import load_dotenv
+from keyring.errors import KeyringError, NoKeyringError
 from pydantic import ValidationError
 
 from app.core.config import RepoConfig
+from app.core.credentials import cli_delete_token, save_token
 from app.core.generator import generate
 from app.core.metrics import MetricsStore
 from app.core.post_setup import fetch_skills, run_git_init, run_precommit_install
@@ -33,10 +36,17 @@ def _build_parser() -> argparse.ArgumentParser:
     cfg_set = cfg_sub.add_parser("set", help="Set a preference value.")
     cfg_set.add_argument(
         "key",
-        choices=sorted(_KEY_TO_FIELD),
+        choices=set(sorted(_KEY_TO_FIELD)) | {"github-token"},
         help="Preference key (use hyphens, e.g. author-name).",
     )
-    cfg_set.add_argument("value", help="Value to store.")
+    cfg_set.add_argument("value", nargs="?", default=None, help="Value to store.")
+
+    cfg_del = cfg_sub.add_parser("delete", help="Delete a credential.")
+    cfg_del.add_argument(
+        "key",
+        choices=set(sorted(_KEY_TO_FIELD)) | {"github-token"},
+        help="Credential key to delete.",
+    )
 
     gen = sub.add_parser("generate", help="Generate scaffold files.")
     gen.add_argument(
@@ -208,6 +218,27 @@ def _run_config(args: argparse.Namespace) -> int:
         return 0
 
     if args.config_cmd == "set":
+        if args.key == "github-token":
+            raw = args.value
+            if not raw:
+                raw = getpass.getpass(
+                    "GitHub token: ",
+                    stream=sys.stderr,
+                )
+            if not raw:
+                print("Error: empty token", file=sys.stderr)
+                return 1
+            try:
+                save_token(raw)
+                print("Done.", file=sys.stderr)
+            except (NoKeyringError, KeyringError) as exc:
+                print(
+                    f"Error: unable to store token ({type(exc).__name__})",
+                    file=sys.stderr,
+                )
+                return 1
+            return 0
+
         field = _KEY_TO_FIELD[args.key]
         prefs = PrefsStore.load()
         raw = args.value
@@ -227,8 +258,17 @@ def _run_config(args: argparse.Namespace) -> int:
         print(f"✓ {args.key} = {value}")
         return 0
 
+    if args.config_cmd == "delete":
+        if args.key == "github-token":
+            return cli_delete_token()
+        print(
+            f"Error: unknown credential '{args.key}'",
+            file=sys.stderr,
+        )
+        return 1
+
     # config with no sub-subcommand
-    print("Usage: scaffold config {get,set}", file=sys.stderr)
+    print("Usage: scaffold config {get,set,delete}", file=sys.stderr)
     return 1
 
 

--- a/app/core/credentials.py
+++ b/app/core/credentials.py
@@ -1,0 +1,79 @@
+import os
+import sys
+
+import keyring
+from keyring.errors import KeyringError, NoKeyringError
+
+_SERVICE = "repo-scaffold-desktop"
+_ACCOUNT = "github_token"
+
+
+def save_token(token: str) -> None:
+    """Store a GitHub token in the OS credential store."""
+    keyring.set_password(_SERVICE, _ACCOUNT, token)
+
+
+def get_token() -> str | None:
+    """Retrieve the stored GitHub token.
+
+    Falls back to the GITHUB_TOKEN environment variable when keyring
+    returns None (no stored token) or raises (e.g. headless CI).
+    """
+    try:
+        token = keyring.get_password(_SERVICE, _ACCOUNT)
+    except (NoKeyringError, KeyringError):
+        token = None
+    if token:
+        return str(token)
+    return os.environ.get("GITHUB_TOKEN")
+
+
+def delete_token() -> None:
+    """Remove the stored GitHub token from the credential store."""
+    try:
+        keyring.delete_password(_SERVICE, _ACCOUNT)
+    except (NoKeyringError, KeyringError):
+        pass
+
+
+def cli_set_token() -> int:
+    """Prompt for a GitHub token via getpass and store it."""
+    try:
+        token = __import__("getpass", fromlist=["getpass"]).getpass(
+            "GitHub token: ",
+            stream=sys.stderr,
+        )
+    except (EOFError, KeyboardInterrupt):
+        print(file=sys.stderr)
+        return 1
+
+    if not token:
+        print("Error: empty token", file=sys.stderr)
+        return 1
+
+    try:
+        save_token(token)
+        print("Done.", file=sys.stderr)
+    except (NoKeyringError, KeyringError) as exc:
+        print(
+            f"Error: unable to store token ({type(exc).__name__})",
+            file=sys.stderr,
+        )
+        return 1
+
+    return 0
+
+
+def cli_delete_token() -> int:
+    """Remove the stored GitHub token."""
+    try:
+        delete_token()
+    except (NoKeyringError, KeyringError) as exc:
+        print(
+            f"Error: unable to delete token ({type(exc).__name__})",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("Done.", file=sys.stderr)
+    return 0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pydantic>=2.0
 jinja2>=3.0
 pyside6>=6.0
 python-dotenv>=1.0
+keyring>=24.0

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -1,0 +1,70 @@
+from unittest.mock import patch
+
+import app.core.credentials as cred
+
+SERVICE = "repo-scaffold-desktop"
+ACCOUNT = "github_token"
+
+
+def test_save_token():
+    with patch.object(cred, "keyring", create=True) as kr:
+        cred.save_token("ghp_abc123")
+        kr.set_password.assert_called_once_with(SERVICE, ACCOUNT, "ghp_abc123")
+
+
+def test_get_token_from_keyring():
+    with patch.object(cred, "keyring", create=True) as kr:
+        kr.get_password.return_value = "ghp_from_keyring"
+        result = cred.get_token()
+    kr.get_password.assert_called_once_with(SERVICE, ACCOUNT)
+    assert result == "ghp_from_keyring"
+
+
+def test_get_token_falls_back_to_env_when_keyring_returns_none():
+    with patch.object(cred, "keyring", create=True) as kr:
+        kr.get_password.return_value = None
+        with patch.dict("os.environ", {"GITHUB_TOKEN": "ghp_from_env"}):
+            result = cred.get_token()
+    assert result == "ghp_from_env"
+
+
+def test_get_token_returns_keyring_value_over_env():
+    with patch.object(cred, "keyring", create=True) as kr:
+        kr.get_password.return_value = "ghp_from_keyring"
+        with patch.dict("os.environ", {"GITHUB_TOKEN": "ghp_from_env"}):
+            result = cred.get_token()
+    assert result == "ghp_from_keyring"
+
+
+def test_get_token_falls_back_to_env_on_no_keyring_error():
+    from keyring.errors import NoKeyringError
+
+    with patch.object(cred, "keyring", create=True) as kr:
+        kr.get_password.side_effect = NoKeyringError("no keyring")
+        with patch.dict("os.environ", {"GITHUB_TOKEN": "ghp_from_env"}):
+            result = cred.get_token()
+    assert result == "ghp_from_env"
+
+
+def test_get_token_returns_none_when_keyring_fails_and_no_env():
+    from keyring.errors import NoKeyringError
+
+    with patch.object(cred, "keyring", create=True) as kr:
+        kr.get_password.side_effect = NoKeyringError("no keyring")
+        with patch.dict("os.environ", {}, clear=True):
+            result = cred.get_token()
+    assert result is None
+
+
+def test_delete_token():
+    with patch.object(cred, "keyring", create=True) as kr:
+        cred.delete_token()
+        kr.delete_password.assert_called_once_with(SERVICE, ACCOUNT)
+
+
+def test_delete_token_ignores_keyring_errors():
+    from keyring.errors import NoKeyringError
+
+    with patch.object(cred, "keyring", create=True) as kr:
+        kr.delete_password.side_effect = NoKeyringError("no keyring")
+        cred.delete_token()  # should not raise


### PR DESCRIPTION
Closes WOR-41

credentials.py exposes save/get/delete with keyring + env fallback; CLI config set/delete github-token wired; tests pass; ruff+mypy+pytest pass