### PR TITLE
WOR-269 Watcher coordination: manifest blocker check, blockedBy sync

### DIFF
--- a/.claude/commands/start-epic.md
+++ b/.claude/commands/start-epic.md
@@ -225,6 +225,8 @@ Write to `.claude/artifacts/<ticket_id_lower>/manifest.json` with these key diff
 
 All other fields the same as the Batch 1 template above.
 
+**5e.5. Sync Linear blockedBy with the manifest.** If `blocked_by_tickets` is non-empty, call `save_issue(id: "<ticket_id>", blockedBy: [...])` with the same identifiers. If empty, skip the call.
+
 **5f. Post a Linear comment (no state change)**
 `save_comment(issueId: "<ticket_id>", body: "Execution manifest written — watcher will auto-promote to ReadyForLocal once WOR-45 merges.")`
 

--- a/.claude/commands/start-ticket.md
+++ b/.claude/commands/start-ticket.md
@@ -249,6 +249,8 @@ Write this JSON to `.claude/artifacts/<ticket_id_lower>/manifest.json` (e.g. `.c
 
 > **Path normalization:** `<ticket_id_lower>` is `ticket_id.lower().replace("-", "_")` — hyphens become underscores (e.g. `WOR-127` → `wor_127`). This matches `ArtifactPaths.from_ticket_id()` in `app/core/manifest.py`. Using `wor-127` (hyphen) will cause a "No such file or directory" error at watcher startup.
 
+**Sync Linear blockedBy with the manifest.** If the manifest's `blocked_by_tickets` field is non-empty (e.g. `"blocked_by_tickets": ["WOR-266"]`), call `save_issue(id: "$ARGUMENTS", blockedBy: [...])` with the same set of ticket identifiers so that Linear's relation matches the manifest. If the list is empty, do not call `save_issue` for blockedBy.
+
 Then:
 1. Set the ticket to **ReadyForLocal** in Linear: `save_issue(id: "$ARGUMENTS", state: "ReadyForLocal")`
 2. Post a Linear comment with the manifest path: `save_comment(issueId: "$ARGUMENTS", body: "Execution manifest written to .claude/artifacts/<ticket_id_lower>/manifest.json — watcher may now pick up.")`

--- a/app/core/watcher/watcher.py
+++ b/app/core/watcher/watcher.py
@@ -373,6 +373,18 @@ class Watcher:
             logger.info("Skipping %s — open blockers: %s", ticket_id, open_blockers)
             return
 
+        # Manifest-based blocker check — defense-in-depth alongside Linear check.
+        for blocker_id in manifest.blocked_by_tickets:
+            state_type = self._linear.get_issue_state_type(blocker_id)
+            if state_type not in DONE_STATE_TYPES:
+                logger.info(
+                    "Skipping %s — manifest declares unmerged blocker %s (state=%s)",
+                    ticket_id,
+                    blocker_id,
+                    state_type,
+                )
+                return
+
         all_active = self._local_active + self._cloud_active
         conflicts = check_allowed_paths_overlap(all_active, manifest)
         if conflicts:

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -840,6 +840,8 @@ def test_dispatch_proceeds_when_manifest_blocked_by_tickets_is_empty(
             "app.core.watcher.watcher.launch_worker",
             return_value=fake_process,
         ),
+        patch.object(w._services, "ensure_ollama_running"),
+        patch.object(w._services, "ensure_litellm_running"),
         patch.object(w._services, "probe_vllm_health"),
     ):
         w._start_ticket("WOR-10", "fake-linear-id")
@@ -878,6 +880,8 @@ def test_dispatch_proceeds_when_all_manifest_blockers_are_merged(
             "app.core.watcher.watcher.launch_worker",
             return_value=fake_process,
         ),
+        patch.object(w._services, "ensure_ollama_running"),
+        patch.object(w._services, "ensure_litellm_running"),
         patch.object(w._services, "probe_vllm_health"),
     ):
         w._start_ticket("WOR-10", "fake-linear-id")

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -775,3 +775,112 @@ def test_enrich_with_retry_context_noop_without_failure_file(tmp_path: Path) -> 
     enriched = w._enrich_with_retry_context(manifest)
 
     assert enriched.implementation_constraints == ["original constraint"]
+
+
+# ---------------------------------------------------------------------------
+# Manifest blocker check — dispatch skips when manifest declares an unmerged blocker
+# ---------------------------------------------------------------------------
+
+
+def test_dispatch_skipped_when_manifest_declares_unmerged_blocker(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Dispatch must be skipped when the manifest declares a blocker that is not yet
+    in a Linear completed state, even if Linear's own blockedBy is empty."""
+    manifest = _make_manifest(
+        ticket_id="WOR-10",
+        worker_branch="wor-10-test-ticket",
+        blocked_by_tickets=["WOR-266"],
+    )
+    linear_mock = MagicMock()
+    linear_mock.get_open_blockers.return_value = []
+    linear_mock.get_issue_state_type.return_value = "started"  # not done
+
+    w = Watcher(linear_client=linear_mock, repo_root=tmp_path)
+
+    with (
+        patch.object(w, "_load_manifest", return_value=manifest),
+        caplog.at_level(logging.INFO, logger="app.core.watcher"),
+    ):
+        w._start_ticket("WOR-10", "fake-linear-id")
+
+    # No worktree should have been created — the ticket stays in ReadyForLocal
+    assert w._local_active == []
+    assert any(
+        "WOR-266" in msg and "unmerged blocker" in msg for msg in caplog.messages
+    )
+
+
+def test_dispatch_proceeds_when_manifest_blocked_by_tickets_is_empty(
+    tmp_path: Path,
+) -> None:
+    """Dispatch must proceed when the manifest declares no blocked_by_tickets."""
+    manifest = _make_manifest(
+        ticket_id="WOR-10",
+        worker_branch="wor-10-test-ticket",
+        blocked_by_tickets=[],
+    )
+    linear_mock = MagicMock()
+    linear_mock.get_open_blockers.return_value = []
+    linear_mock.get_issue_state_type.return_value = "started"
+
+    w = Watcher(linear_client=linear_mock, repo_root=tmp_path)
+    w._processed_tickets = []
+
+    fake_process = MagicMock(spec=subprocess.Popen)
+
+    with (
+        patch.object(w, "_load_manifest", return_value=manifest),
+        patch("app.core.watcher.watcher.create_worktree", return_value=tmp_path),
+        patch("app.core.watcher.watcher.copy_manifest_to_worktree"),
+        patch("app.core.watcher.watcher.write_worker_pytest_config"),
+        patch("app.core.watcher.watcher.safe_set_state"),
+        patch("app.core.watcher.watcher.backup_plan_files", return_value=[]),
+        patch(
+            "app.core.watcher.watcher.launch_worker",
+            return_value=fake_process,
+        ),
+        patch.object(w._services, "probe_vllm_health"),
+    ):
+        w._start_ticket("WOR-10", "fake-linear-id")
+
+    assert len(w._local_active) == 1
+    assert w._local_active[0].ticket_id == "WOR-10"
+
+
+def test_dispatch_proceeds_when_all_manifest_blockers_are_merged(
+    tmp_path: Path,
+) -> None:
+    """Dispatch must proceed when every manifest-declared blocker has reached
+    a Linear completed state (MergedToEpic / Done → state type 'completed')."""
+    manifest = _make_manifest(
+        ticket_id="WOR-10",
+        worker_branch="wor-10-test-ticket",
+        blocked_by_tickets=["WOR-266", "WOR-267"],
+    )
+    linear_mock = MagicMock()
+    linear_mock.get_open_blockers.return_value = []
+    linear_mock.get_issue_state_type.side_effect = lambda x: "completed"  # both done
+
+    w = Watcher(linear_client=linear_mock, repo_root=tmp_path)
+    w._processed_tickets = []
+
+    fake_process = MagicMock(spec=subprocess.Popen)
+
+    with (
+        patch.object(w, "_load_manifest", return_value=manifest),
+        patch("app.core.watcher.watcher.create_worktree", return_value=tmp_path),
+        patch("app.core.watcher.watcher.copy_manifest_to_worktree"),
+        patch("app.core.watcher.watcher.write_worker_pytest_config"),
+        patch("app.core.watcher.watcher.safe_set_state"),
+        patch("app.core.watcher.watcher.backup_plan_files", return_value=[]),
+        patch(
+            "app.core.watcher.watcher.launch_worker",
+            return_value=fake_process,
+        ),
+        patch.object(w._services, "probe_vllm_health"),
+    ):
+        w._start_ticket("WOR-10", "fake-linear-id")
+
+    assert len(w._local_active) == 1
+    assert w._local_active[0].ticket_id == "WOR-10"


### PR DESCRIPTION
## Summary
Two-part fix to prevent premature dispatch of WaitingForDeps tickets:

- **Skill-side:** `/start-ticket` and `/start-epic` now sync Linear's blockedBy relation with the manifest's `blocked_by_tickets` field when writing a manifest.
- **Watcher-side:** `_start_ticket` in `app/core/watcher/watcher.py` checks `manifest.blocked_by_tickets` against Linear ticket state types — dispatch is skipped if any manifest-declared blocker is not in a completed state (`DONE_STATE_TYPES`).
- **Tests:** Three new tests verify the manifest blocker check: skip when unmerged, proceed when empty, proceed when all blocked.

## Files changed
- `.claude/commands/start-ticket.md` — added blockedBy sync bullet after manifest write
- `.claude/commands/start-epic.md` — added 5e.5 blockedBy sync bullet for deferred manifests
- `app/core/watcher/watcher.py` — manifest blocker check in `_start_ticket`
- `tests/test_watcher.py` — three new tests for manifest blocker check

## Checks
- `ruff check .` — passed
- `mypy app/` — passed (25 files)
- `pytest` — 839 passed

Closes WOR-269