### PR TITLE
WOR-42 Auto-create GitHub repository after scaffold generation

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -13,7 +13,12 @@ from app.core.config import RepoConfig
 from app.core.credentials import cli_delete_token, save_token
 from app.core.generator import generate
 from app.core.metrics import MetricsStore
-from app.core.post_setup import fetch_skills, run_git_init, run_precommit_install
+from app.core.post_setup import (
+    create_github_repo,
+    fetch_skills,
+    run_git_init,
+    run_precommit_install,
+)
 from app.core.presets import _PRESETS, get_preset
 from app.core.user_prefs import PrefsStore, UserPreferences
 
@@ -100,6 +105,16 @@ def _build_parser() -> argparse.ArgumentParser:
         "--install-precommit",
         action="store_true",
         help="Run pre-commit install in the output directory.",
+    )
+    gen.add_argument(
+        "--github-create", action="store_true", help="Create a GitHub repository."
+    )
+    github_group = gen.add_mutually_exclusive_group()
+    github_group.add_argument(
+        "--private", action="store_true", help="Create a private GitHub repository."
+    )
+    github_group.add_argument(
+        "--public", action="store_true", help="Create a public GitHub repository."
     )
 
     metrics = sub.add_parser("metrics", help="Metrics DB commands.")
@@ -333,6 +348,20 @@ def _run_generate(args: argparse.Namespace) -> int:
     except RuntimeError as exc:
         print(f"Error: {exc}", file=sys.stderr)
         return 1
+
+    if args.github_create:
+        prefs = PrefsStore.load()
+        github_private = not args.public
+        try:
+            clone_url = create_github_repo(
+                repo_name=config.repo_name,
+                prefs=prefs,
+                private=github_private,
+            )
+            print(f"✓ Created GitHub repo: {clone_url}")
+        except RuntimeError as exc:
+            print(f"Error: {exc}", file=sys.stderr)
+            return 1
 
     return 0
 

--- a/app/core/post_setup.py
+++ b/app/core/post_setup.py
@@ -7,6 +7,9 @@ from pathlib import Path
 
 from jinja2 import Environment, Undefined
 
+from app.core.credentials import get_token
+from app.core.user_prefs import UserPreferences
+
 _GITHUB_SOURCE_RE = re.compile(r"^github:([A-Za-z0-9_.-]+)/([A-Za-z0-9_.-]+)$")
 _SAFE_PATH_RE = re.compile(r"^[A-Za-z0-9_.\-/]+$")
 
@@ -126,3 +129,59 @@ def run_precommit_install(output_path: Path) -> None:
     except subprocess.CalledProcessError as exc:
         stderr = exc.stderr.decode(errors="replace").strip()
         raise RuntimeError(f"pre-commit install failed: {stderr}")
+
+
+def create_github_repo(
+    repo_name: str,
+    prefs: UserPreferences,
+    private: bool = True,
+    description: str = "",
+) -> str:
+    """Create a GitHub repository via the REST API and return its clone URL.
+
+    Requires a GitHub token configured via :func:`app.core.credentials.get_token`.
+    Raises ``RuntimeError`` if no token is configured or the API returns an error.
+    """
+    token = get_token()
+    if token is None:
+        raise RuntimeError(
+            "No GitHub token configured. Run: python -m app.cli config set github-token"
+        )
+
+    body = {
+        "name": repo_name,
+        "private": private,
+        "description": description,
+        "auto_init": False,
+    }
+    payload = json.dumps(body).encode("utf-8")
+
+    api_url = "https://api.github.com/user/repos"
+    req = urllib.request.Request(  # nosec B310
+        api_url,
+        data=payload,
+        method="POST",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "Content-Type": "application/json",
+        },
+    )
+
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:  # nosec B310  # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected
+            result = json.loads(resp.read())
+    except urllib.error.HTTPError as exc:
+        err_body = ""
+        try:
+            err_body = json.loads(exc.read()).get("message", str(exc))
+        except Exception:  # noqa: BLE001
+            err_body = str(exc)
+        if exc.code == 422:
+            raise RuntimeError(
+                f"Repository '{repo_name}' already exists — {err_body}"
+            ) from exc
+        raise RuntimeError(f"GitHub API error: {err_body}") from exc
+
+    clone_url: str = result["html_url"]
+    return clone_url

--- a/tests/test_post_setup.py
+++ b/tests/test_post_setup.py
@@ -5,7 +5,12 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from app.core.post_setup import fetch_skills, run_git_init, run_precommit_install
+from app.core.post_setup import (
+    create_github_repo,
+    fetch_skills,
+    run_git_init,
+    run_precommit_install,
+)
 
 
 @pytest.fixture()
@@ -228,3 +233,94 @@ class TestRunPrecommitInstall:
         with patch("app.core.post_setup.subprocess.run", side_effect=FileNotFoundError):
             with pytest.raises(RuntimeError, match="pre-commit not found on PATH"):
                 run_precommit_install(repo_dir)
+
+
+class TestCreateGitHubRepo:
+    def _make_prefs(self, github_username: str = "testuser") -> MagicMock:
+        prefs = MagicMock()
+        prefs.github_username = github_username
+        return prefs
+
+    def test_creates_repo_and_returns_clone_url(self):
+        prefs = self._make_prefs()
+        response = MagicMock()
+        response.__enter__ = lambda s: s
+        response.__exit__ = MagicMock(return_value=False)
+        response.read = MagicMock(
+            return_value=b'{"html_url": "https://github.com/testuser/myrepo"}'
+        )
+
+        with (
+            patch(
+                "app.core.post_setup.urllib.request.urlopen",
+                return_value=response,
+            ) as mock_urlopen,
+            patch("app.core.post_setup.get_token", return_value="ghp_fake_token"),
+        ):
+            result = create_github_repo(
+                "myrepo", prefs, private=True, description="A test repo"
+            )
+
+        assert result == "https://github.com/testuser/myrepo"
+        mock_urlopen.assert_called_once()
+        req = mock_urlopen.call_args[0][0]
+        assert req.full_url == "https://api.github.com/user/repos"
+        assert req.get_method() == "POST"
+        body = json.loads(req.data)
+        assert body == {
+            "name": "myrepo",
+            "private": True,
+            "description": "A test repo",
+            "auto_init": False,
+        }
+
+    def test_raises_runtime_error_when_no_token(self):
+        prefs = self._make_prefs()
+        with patch("app.core.post_setup.get_token", return_value=None):
+            with pytest.raises(RuntimeError, match="No GitHub token configured"):
+                create_github_repo("myrepo", prefs)
+
+    def test_raises_runtime_error_on_422_conflict(self):
+        prefs = self._make_prefs()
+        response = MagicMock()
+        response.code = 422
+        response.read = MagicMock(
+            return_value=b'{"message": "Repository already exists"}'
+        )
+        exc = urllib.error.HTTPError(
+            "https://api.github.com/user/repos",
+            422,
+            "Unprocessable Entity",
+            {},
+            response,
+        )
+        with (
+            patch(
+                "app.core.post_setup.urllib.request.urlopen",
+                side_effect=exc,
+            ),
+            patch("app.core.post_setup.get_token", return_value="ghp_fake_token"),
+        ):
+            with pytest.raises(RuntimeError, match="already exists"):
+                create_github_repo("myrepo", prefs)
+
+    def test_public_flag_sets_private_false(self):
+        prefs = self._make_prefs()
+        response = MagicMock()
+        response.__enter__ = lambda s: s
+        response.__exit__ = MagicMock(return_value=False)
+        response.read = MagicMock(
+            return_value=b'{"html_url": "https://github.com/testuser/myrepo"}'
+        )
+
+        with (
+            patch(
+                "app.core.post_setup.urllib.request.urlopen",
+                return_value=response,
+            ) as mock_urlopen,
+            patch("app.core.post_setup.get_token", return_value="ghp_fake_token"),
+        ):
+            create_github_repo("myrepo", prefs, private=False)
+
+        body = json.loads(mock_urlopen.call_args[0][0].data)
+        assert body["private"] is False


### PR DESCRIPTION
Closes WOR-42

create_github_repo function calling POST /user/repos via urllib; --github-create CLI flag wired; tests cover success/no-token/conflict; ruff+mypy+pytest pass