### PR TITLE
WOR-43 Auto-push initial commit to GitHub after scaffold generation

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -17,6 +17,7 @@ from app.core.post_setup import (
     create_github_repo,
     fetch_skills,
     run_git_init,
+    run_initial_push,
     run_precommit_install,
 )
 from app.core.presets import _PRESETS, get_preset
@@ -108,6 +109,14 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     gen.add_argument(
         "--github-create", action="store_true", help="Create a GitHub repository."
+    )
+    gen.add_argument(
+        "--git-push", action="store_true", help="Push initial commit to remote."
+    )
+    gen.add_argument(
+        "--remote-url",
+        default=None,
+        help="Remote URL to push to (used with --git-push).",
     )
     github_group = gen.add_mutually_exclusive_group()
     github_group.add_argument(
@@ -293,6 +302,7 @@ def _run_generate(args: argparse.Namespace) -> int:
         include_linear_mcp = get_preset(args.preset).context_defaults.get(
             "include_linear_mcp", False
         )
+
     try:
         config = RepoConfig(
             repo_name=args.repo_name,
@@ -349,6 +359,7 @@ def _run_generate(args: argparse.Namespace) -> int:
         print(f"Error: {exc}", file=sys.stderr)
         return 1
 
+    clone_url: str | None = None
     if args.github_create:
         prefs = PrefsStore.load()
         github_private = not args.public
@@ -359,6 +370,16 @@ def _run_generate(args: argparse.Namespace) -> int:
                 private=github_private,
             )
             print(f"✓ Created GitHub repo: {clone_url}")
+        except RuntimeError as exc:
+            print(f"Error: {exc}", file=sys.stderr)
+            return 1
+
+    if args.git_push:
+        push_url = clone_url if clone_url is not None else args.remote_url
+        prefs = PrefsStore.load()
+        try:
+            run_initial_push(args.output, push_url, prefs)
+            print(f"✓ Pushed initial commit to {push_url}")
         except RuntimeError as exc:
             print(f"Error: {exc}", file=sys.stderr)
             return 1
@@ -381,6 +402,17 @@ def main(argv: list[str] | None = None) -> int:
     if args.command is None:
         parser.print_help()
         return 1
+
+    if args.command == "generate":
+        # --git-push implies --git-init
+        if getattr(args, "git_push", False):
+            args.git_init = True
+        # --git-push requires either --github-create or --remote-url
+        has_remote = args.github_create or getattr(args, "remote_url", None)
+        if getattr(args, "git_push", False) and not has_remote:
+            parser.error(
+                "argument --git-push: must also specify --github-create or --remote-url"
+            )
 
     if args.command == "config":
         return _run_config(args)

--- a/app/core/post_setup.py
+++ b/app/core/post_setup.py
@@ -131,6 +131,82 @@ def run_precommit_install(output_path: Path) -> None:
         raise RuntimeError(f"pre-commit install failed: {stderr}")
 
 
+def run_initial_push(
+    output_path: Path, remote_url: str, prefs: UserPreferences
+) -> None:
+    """Stage all files, create initial commit, set remote origin, and push to main.
+
+    Raises ``RuntimeError`` on any subprocess failure with a clear message
+    including stderr.
+    """
+    try:
+        subprocess.run(  # nosec B603 B607 — hardcoded command, no user input, no shell
+            ["git", "add", "."],
+            cwd=output_path,
+            check=True,
+            capture_output=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        stderr = exc.stderr.decode(errors="replace").strip()
+        raise RuntimeError(f"git add failed: {stderr}")
+
+    commit_args: list[str] = ["git", "commit", "-m", "Initial scaffold"]
+    if prefs.author_name and prefs.author_email:
+        commit_args = [
+            "git",
+            "-c",
+            f"user.name={prefs.author_name}",
+            "-c",
+            f"user.email={prefs.author_email}",
+            "commit",
+            "-m",
+            "Initial scaffold",
+        ]
+    try:
+        subprocess.run(  # nosec B603 B607 — hardcoded command, no user input, no shell
+            commit_args,
+            cwd=output_path,
+            check=True,
+            capture_output=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        stderr = exc.stderr.decode(errors="replace").strip()
+        raise RuntimeError(f"git commit failed: {stderr}")
+
+    try:
+        subprocess.run(  # nosec B603 B607 — hardcoded command, no user input, no shell
+            ["git", "remote", "add", "origin", remote_url],
+            cwd=output_path,
+            check=True,
+            capture_output=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        stderr = exc.stderr.decode(errors="replace").strip()
+        raise RuntimeError(f"git remote add origin failed: {stderr}")
+
+    try:
+        subprocess.run(  # nosec B603 B607 — hardcoded command, no user input, no shell
+            ["git", "branch", "-M", "main"],
+            cwd=output_path,
+            check=True,
+            capture_output=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        stderr = exc.stderr.decode(errors="replace").strip()
+        raise RuntimeError(f"git branch -M main failed: {stderr}")
+
+    try:
+        subprocess.run(  # nosec B603 B607 — hardcoded command, no user input, no shell
+            ["git", "push", "-u", "origin", "main"],
+            cwd=output_path,
+            check=True,
+            capture_output=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        stderr = exc.stderr.decode(errors="replace").strip()
+        raise RuntimeError(f"git push failed: {stderr}")
+
+
 def create_github_repo(
     repo_name: str,
     prefs: UserPreferences,

--- a/tests/test_post_setup.py
+++ b/tests/test_post_setup.py
@@ -1,7 +1,8 @@
 import json
 import subprocess
 import urllib.error
-from unittest.mock import MagicMock, patch
+from pathlib import Path
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 
@@ -9,8 +10,10 @@ from app.core.post_setup import (
     create_github_repo,
     fetch_skills,
     run_git_init,
+    run_initial_push,
     run_precommit_install,
 )
+from app.core.user_prefs import UserPreferences
 
 
 @pytest.fixture()
@@ -324,3 +327,97 @@ class TestCreateGitHubRepo:
 
         body = json.loads(mock_urlopen.call_args[0][0].data)
         assert body["private"] is False
+
+
+class TestRunInitialPush:
+    URL = "https://github.com/user/repo"
+
+    def _expected_calls(self, repo_dir, with_auth=False):
+        kw = {"cwd": repo_dir, "check": True, "capture_output": True}
+        base = [
+            call(["git", "add", "."], **kw),
+        ]
+        if with_auth:
+            base.append(
+                call(
+                    [
+                        "git",
+                        "-c",
+                        "user.name=Alice",
+                        "-c",
+                        "user.email=alice@example.com",
+                        "commit",
+                        "-m",
+                        "Initial scaffold",
+                    ],
+                    **kw,
+                )
+            )
+        else:
+            base.append(
+                call(
+                    ["git", "commit", "-m", "Initial scaffold"],
+                    **kw,
+                )
+            )
+        return base + [
+            call(
+                ["git", "remote", "add", "origin", self.URL],
+                **kw,
+            ),
+            call(
+                ["git", "branch", "-M", "main"],
+                **kw,
+            ),
+            call(
+                ["git", "push", "-u", "origin", "main"],
+                **kw,
+            ),
+        ]
+
+    def test_executes_full_command_sequence(self, repo_dir):
+        with patch("app.core.post_setup.subprocess.run") as mock_run:
+            run_initial_push(repo_dir, self.URL, UserPreferences())
+
+        expected = self._expected_calls(repo_dir, with_auth=False)
+        assert mock_run.call_args_list == expected
+
+    def test_includes_author_name_and_email_when_both_set(self, repo_dir):
+        prefs = UserPreferences(author_name="Alice", author_email="alice@example.com")
+        with patch("app.core.post_setup.subprocess.run") as mock_run:
+            run_initial_push(repo_dir, self.URL, prefs)
+
+        expected = self._expected_calls(repo_dir, with_auth=True)
+        assert mock_run.call_args_list == expected
+
+    def test_falls_back_to_git_default_when_only_name_set(self, repo_dir):
+        prefs = UserPreferences(author_name="Alice")
+        with patch("app.core.post_setup.subprocess.run") as mock_run:
+            run_initial_push(repo_dir, self.URL, prefs)
+
+        expected = self._expected_calls(repo_dir, with_auth=False)
+        assert mock_run.call_args_list == expected
+
+    def test_falls_back_to_git_default_when_only_email_set(self, repo_dir):
+        prefs = UserPreferences(author_email="alice@example.com")
+        with patch("app.core.post_setup.subprocess.run") as mock_run:
+            run_initial_push(repo_dir, self.URL, prefs)
+
+        expected = self._expected_calls(repo_dir, with_auth=False)
+        assert mock_run.call_args_list == expected
+
+    def test_raises_runtime_error_on_subprocess_failure(self):
+        err = subprocess.CalledProcessError(
+            1, "git", stderr=b"fatal: not a git repository"
+        )
+        with patch("app.core.post_setup.subprocess.run", side_effect=err):
+            with pytest.raises(RuntimeError, match="not a git repository"):
+                run_initial_push(Path("/tmp"), self.URL, UserPreferences())
+
+    def test_runtime_error_includes_stderr(self):
+        err = subprocess.CalledProcessError(
+            128, "git", stderr=b"fatal: 'origin' already exists"
+        )
+        with patch("app.core.post_setup.subprocess.run", side_effect=err):
+            with pytest.raises(RuntimeError, match="'origin' already exists"):
+                run_initial_push(Path("/tmp"), self.URL, UserPreferences())


### PR DESCRIPTION
Closes WOR-43

run_initial_push function in post_setup.py; --git-push + --remote-url CLI flags wired; tests verify command sequence and error paths; ruff+mypy+pytest pass