### PR TITLE
WOR-44 Configure GitHub repository settings post-creation

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -14,6 +14,7 @@ from app.core.credentials import cli_delete_token, save_token
 from app.core.generator import generate
 from app.core.metrics import MetricsStore
 from app.core.post_setup import (
+    configure_github_repo,
     create_github_repo,
     fetch_skills,
     run_git_init,
@@ -370,6 +371,12 @@ def _run_generate(args: argparse.Namespace) -> int:
                 private=github_private,
             )
             print(f"✓ Created GitHub repo: {clone_url}")
+            repo_full_name = clone_url.replace("https://github.com/", "").rstrip("/")
+            try:
+                configure_github_repo(repo_full_name, config.preset, config.include_ci)
+                print("✓ Configured GitHub repository settings")
+            except RuntimeError as exc:
+                print(f"Warning: {exc}", file=sys.stderr)
         except RuntimeError as exc:
             print(f"Error: {exc}", file=sys.stderr)
             return 1

--- a/app/core/post_setup.py
+++ b/app/core/post_setup.py
@@ -1,6 +1,7 @@
 import json
 import re
 import subprocess  # nosec B404 — controlled calls with hardcoded command lists, no shell=True
+import sys
 import urllib.error
 import urllib.request
 from pathlib import Path
@@ -12,6 +13,21 @@ from app.core.user_prefs import UserPreferences
 
 _GITHUB_SOURCE_RE = re.compile(r"^github:([A-Za-z0-9_.-]+)/([A-Za-z0-9_.-]+)$")
 _SAFE_PATH_RE = re.compile(r"^[A-Za-z0-9_.\-/]+$")
+
+
+def _parse_repo_full_name(clone_url: str) -> str:
+    """Extract owner/repo from a GitHub clone URL.
+
+    Handles both ``https://github.com/owner/repo`` and trailing-slash variants.
+    Returns the value as-is when no GitHub URL pattern is detected — the caller
+    should already have validated the format, so this is a fast path that does not
+    raise for non-GitHub URLs.
+    """
+    prefix = "https://github.com/"
+    if clone_url.startswith(prefix):
+        result = clone_url[len(prefix) :]
+        return result.rstrip("/")
+    return clone_url
 
 
 def fetch_skills(
@@ -261,3 +277,179 @@ def create_github_repo(
 
     clone_url: str = result["html_url"]
     return clone_url
+
+
+# ── Topic maps ─────────────────────────────────────────────────────────────────
+
+_TOPICS_BY_PRESET: dict[str, list[str]] = {
+    "python_basic": ["python"],
+    "python_desktop": ["python", "pyside6", "desktop"],
+    "full_agentic": ["python", "claude", "agentic", "linear"],
+}
+
+
+def configure_github_repo(
+    repo_full_name: str,
+    preset: str,
+    include_ci: bool,
+) -> None:
+    """Apply opinionated settings to a freshly created GitHub repository.
+
+    Makes three API calls:
+
+    1. **PUT /repos/{owner}/{repo}/topics** — sets the repository topic list
+       derived from the chosen preset.
+
+    2. **PATCH /repos/{owner}/{repo}** — disables wiki and projects.
+
+    3. **PUT /repos/{owner}/{repo}/branches/main/protection** (conditional) —
+       enables branch protection when ``include_ci`` is ``True`` (requires one
+       pull-request review and status checks).
+
+    All parameters are validated *before* any authentication or network calls.
+    Topics, wiki, and projects steps raise ``RuntimeError`` on 4xx/5xx.  Branch
+    protection failure is logged but does not break the overall flow — a
+    failed branch-protection step only warns; topics/wiki failures are fatal.
+    """
+    # Validate full_name format BEFORE calling get_token()
+    if "/" not in repo_full_name or repo_full_name.count("/") != 1:
+        raise ValueError(
+            f"Invalid repo_full_name {repo_full_name!r}. "
+            "Expected format: <owner>/<repo>"
+        )
+
+    owner, repo = repo_full_name.split("/")
+    topics = _TOPICS_BY_PRESET.get(preset, ["python"])
+
+    token = get_token()
+    if token is None:
+        raise RuntimeError(
+            "No GitHub token configured. Run: python -m app.cli config set github-token"
+        )
+
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github.mercy-preview+json",
+    }
+
+    # 1. Set topics
+    _put(
+        f"https://api.github.com/repos/{owner}/{repo}/topics",
+        {"names": topics},
+        headers=headers,
+    )
+
+    # 2. Disable wiki and projects
+    _patch(
+        f"https://api.github.com/repos/{owner}/{repo}",
+        {"has_wiki": False, "has_projects": False},
+        headers=headers,
+    )
+
+    # 3. Branch protection (conditional)
+    if include_ci:
+        _set_branch_protection(owner, repo, headers)
+
+
+def _put(url: str, body: dict[str, object], headers: dict[str, str]) -> None:
+    """Send a PUT request. Raises ``RuntimeError`` on HTTP errors."""
+    payload = json.dumps(body).encode("utf-8")
+    req = urllib.request.Request(  # nosec B310
+        url,
+        data=payload,
+        method="PUT",
+        headers=headers,
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:  # nosec B310  # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected
+            if resp.status >= 400:
+                err_body = ""
+                try:
+                    err_body = json.loads(resp.read()).get("message", str(resp))
+                except Exception:  # noqa: BLE001
+                    err_body = str(resp)
+                raise RuntimeError(f"GitHub API error ({resp.status}): {err_body}")
+    except urllib.error.HTTPError as exc:
+        err_body = ""
+        try:
+            err_body = json.loads(exc.read()).get("message", str(exc))
+        except Exception:  # noqa: BLE001
+            err_body = str(exc)
+        raise RuntimeError(f"GitHub API error: {err_body}") from exc
+
+
+def _patch(url: str, body: dict[str, object], headers: dict[str, str]) -> None:
+    """Send a PATCH request. Raises ``RuntimeError`` on HTTP errors."""
+    payload = json.dumps(body).encode("utf-8")
+    req = urllib.request.Request(  # nosec B310
+        url,
+        data=payload,
+        method="PATCH",
+        headers=headers,
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:  # nosec B310  # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected
+            if resp.status >= 400:
+                err_body = ""
+                try:
+                    err_body = json.loads(resp.read()).get("message", str(resp))
+                except Exception:  # noqa: BLE001
+                    err_body = str(resp)
+                raise RuntimeError(f"GitHub API error ({resp.status}): {err_body}")
+    except urllib.error.HTTPError as exc:
+        err_body = ""
+        try:
+            err_body = json.loads(exc.read()).get("message", str(exc))
+        except Exception:  # noqa: BLE001
+            err_body = str(exc)
+        raise RuntimeError(f"GitHub API error: {err_body}") from exc
+
+
+def _set_branch_protection(owner: str, repo: str, headers: dict[str, str]) -> None:
+    """Enable branch protection on main.
+
+    Logs a warning on failure rather than raising — a failed branch-protection
+    step should not break the overall flow.
+    """
+    body = {
+        "required_pull_request_reviews": {
+            "dismissal_restrictions": {},
+            "require_code_owner_reviews": True,
+            "required_approving_review_count": 1,
+        },
+        "required_status_checks": {
+            "strict": True,
+            "contexts": [],
+        },
+        "restrictions": None,
+    }
+    payload = json.dumps(body).encode("utf-8")
+    url = f"https://api.github.com/repos/{owner}/{repo}/branches/main/protection"
+    req = urllib.request.Request(  # nosec B310
+        url,
+        data=payload,
+        method="PUT",
+        headers=headers,
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:  # nosec B310  # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected
+            if resp.status >= 400:
+                err_body = ""
+                try:
+                    err_body = json.loads(resp.read()).get("message", str(resp))
+                except Exception:  # noqa: BLE001
+                    err_body = str(resp)
+                print(
+                    f"Warning: branch protection for main failed: {err_body}",
+                    file=sys.stderr,
+                )
+    except urllib.error.HTTPError as exc:
+        err_body = ""
+        try:
+            err_body = json.loads(exc.read()).get("message", str(exc))
+        except Exception:  # noqa: BLE001
+            err_body = str(exc)
+        print(
+            f"Warning: branch protection for main failed: {err_body}",
+            file=sys.stderr,
+        )

--- a/tests/test_post_setup.py
+++ b/tests/test_post_setup.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, call, patch
 import pytest
 
 from app.core.post_setup import (
+    configure_github_repo,
     create_github_repo,
     fetch_skills,
     run_git_init,
@@ -421,3 +422,231 @@ class TestRunInitialPush:
         with patch("app.core.post_setup.subprocess.run", side_effect=err):
             with pytest.raises(RuntimeError, match="'origin' already exists"):
                 run_initial_push(Path("/tmp"), self.URL, UserPreferences())
+
+
+class TestConfigureGithubRepo:
+    def _make_response(self, status: int = 200, body: dict | None = None) -> MagicMock:
+        cm = MagicMock()
+        cm.__enter__ = lambda s: s
+        cm.__exit__ = MagicMock(return_value=False)
+        cm.read = MagicMock(return_value=json.dumps(body or {}).encode())
+        type(cm).status = status
+        return cm
+
+    def _make_http_error(
+        self, code: int, body: str, msg: str = ""
+    ) -> urllib.error.HTTPError:
+        fp = MagicMock()
+        fp.read = MagicMock(return_value=body.encode())
+        if not msg:
+            msg = body
+        return urllib.error.HTTPError(
+            "https://api.github.com/repos/test/repo",
+            code,
+            msg,
+            {},
+            fp,
+        )
+
+    def _make_urlopen_side_effect(self, responses: list) -> MagicMock:
+        idx = [0]
+
+        def side_effect(req_or_url, timeout=None):  # noqa: ARG001
+            if idx[0] < len(responses):
+                resp = responses[idx[0]]
+                idx[0] += 1
+                return resp
+            raise RuntimeError("Unexpected call")
+
+        return side_effect
+
+    def test_sets_topics_from_preset(self):
+        resp = self._make_response(200, {"repository": {"topics": ["python"]}})
+        with (
+            patch(
+                "app.core.post_setup.urllib.request.urlopen",
+                return_value=resp,
+            ) as mock_urlopen,
+            patch("app.core.post_setup.get_token", return_value="ghp_fake"),
+        ):
+            configure_github_repo("test/repo", "python_basic", False)
+
+        assert mock_urlopen.call_count == 2  # topics + PATCH
+        topics_req = mock_urlopen.call_args_list[0][0][0]
+        assert topics_req.method == "PUT"
+        assert "topics" in topics_req.full_url
+        body = json.loads(topics_req.data)
+        assert body == {"names": ["python"]}
+
+    def test_topics_for_python_desktop_preset(self):
+        resp = self._make_response(200)
+        with (
+            patch(
+                "app.core.post_setup.urllib.request.urlopen",
+                return_value=resp,
+            ) as mock_urlopen,
+            patch("app.core.post_setup.get_token", return_value="ghp_fake"),
+        ):
+            configure_github_repo("test/repo", "python_desktop", False)
+
+        topics_req = mock_urlopen.call_args_list[0][0][0]
+        body = json.loads(topics_req.data)
+        assert body == {"names": ["python", "pyside6", "desktop"]}
+
+    def test_topics_for_full_agentic_preset(self):
+        resp = self._make_response(200)
+        with (
+            patch(
+                "app.core.post_setup.urllib.request.urlopen",
+                return_value=resp,
+            ) as mock_urlopen,
+            patch("app.core.post_setup.get_token", return_value="ghp_fake"),
+        ):
+            configure_github_repo("test/repo", "full_agentic", False)
+
+        topics_req = mock_urlopen.call_args_list[0][0][0]
+        body = json.loads(topics_req.data)
+        assert sorted(body["names"]) == sorted(
+            ["python", "claude", "agentic", "linear"]
+        )
+
+    def test_disables_wiki_and_projects(self):
+        resp = self._make_response(200)
+        with (
+            patch(
+                "app.core.post_setup.urllib.request.urlopen",
+                return_value=resp,
+            ) as mock_urlopen,
+            patch("app.core.post_setup.get_token", return_value="ghp_fake"),
+        ):
+            configure_github_repo("test/repo", "python_basic", False)
+
+        assert mock_urlopen.call_count == 2  # topics + PATCH
+        patch_req = mock_urlopen.call_args_list[1][0][0]
+        assert patch_req.method == "PATCH"
+        assert "/repos/test/repo" in patch_req.full_url
+        assert "/topics" not in patch_req.full_url
+        body = json.loads(patch_req.data)
+        assert body == {"has_wiki": False, "has_projects": False}
+
+    def test_sets_branch_protection_when_include_ci_true(self):
+        resp = self._make_response(200)
+        with (
+            patch(
+                "app.core.post_setup.urllib.request.urlopen",
+                return_value=resp,
+            ) as mock_urlopen,
+            patch("app.core.post_setup.get_token", return_value="ghp_fake"),
+        ):
+            configure_github_repo("test/repo", "python_basic", include_ci=True)
+
+        assert mock_urlopen.call_count == 3
+        protection_req = mock_urlopen.call_args_list[2][0][0]
+        assert protection_req.method == "PUT"
+        assert "/branches/main/protection" in protection_req.full_url
+        body = json.loads(protection_req.data)
+        review = body["required_pull_request_reviews"]
+        assert review["required_approving_review_count"] == 1
+        assert review["require_code_owner_reviews"] is True
+        assert body["required_status_checks"]["strict"] is True
+
+    def test_skips_branch_protection_when_include_ci_false(self):
+        resp = self._make_response(200)
+        with (
+            patch(
+                "app.core.post_setup.urllib.request.urlopen",
+                return_value=resp,
+            ) as mock_urlopen,
+            patch("app.core.post_setup.get_token", return_value="ghp_fake"),
+        ):
+            configure_github_repo("test/repo", "python_basic", include_ci=False)
+
+        assert mock_urlopen.call_count == 2  # topics + PATCH only
+        protection_url = (
+            "https://api.github.com/repos/test/repo/branches/main/protection"
+        )
+        for call_item in mock_urlopen.call_args_list:
+            req = call_item[0][0]
+            assert protection_url not in req.full_url
+
+    def test_invalid_full_name_format_raises_value_error(self):
+        with pytest.raises(ValueError, match="Invalid repo_full_name"):
+            configure_github_repo("badformat", "python_basic", False)
+
+    def test_invalid_full_name_multiple_slashes_raises_value_error(self):
+        with pytest.raises(ValueError, match="Invalid repo_full_name"):
+            configure_github_repo("test/repo/extra", "python_basic", False)
+
+    def test_no_slash_raises_value_error(self):
+        with pytest.raises(ValueError, match="Invalid repo_full_name"):
+            configure_github_repo("test", "python_basic", False)
+
+    def test_invalid_full_name_before_token_check(self):
+        """Format validation must happen BEFORE get_token() is called."""
+        with patch(
+            "app.core.post_setup.get_token", return_value="ghp_fake"
+        ) as mock_get_token:
+            with pytest.raises(ValueError, match="Invalid repo_full_name"):
+                configure_github_repo("badformat", "python_basic", False)
+
+        # get_token must NOT have been called for invalid full_name
+        mock_get_token.assert_not_called()
+
+    def test_topics_raises_runtime_error_on_4xx(self):
+        exc = self._make_http_error(403, "forbidden")
+        with (
+            patch(
+                "app.core.post_setup.urllib.request.urlopen",
+                side_effect=exc,
+            ),
+            patch("app.core.post_setup.get_token", return_value="ghp_fake"),
+        ):
+            with pytest.raises(RuntimeError, match="forbidden"):
+                configure_github_repo("test/repo", "python_basic", False)
+
+    def test_topics_raises_runtime_error_on_5xx(self):
+        exc = self._make_http_error(500, "internal server error")
+        with (
+            patch(
+                "app.core.post_setup.urllib.request.urlopen",
+                side_effect=exc,
+            ),
+            patch("app.core.post_setup.get_token", return_value="ghp_fake"),
+        ):
+            with pytest.raises(RuntimeError, match="internal server error"):
+                configure_github_repo("test/repo", "python_basic", False)
+
+    def test_patch_raises_runtime_error_on_4xx(self):
+        # First call (topics) succeeds, second call (PATCH) fails
+        resp = self._make_response(200)
+        exc = self._make_http_error(404, "not found")
+        side_effect = [resp, exc]
+        with (
+            patch(
+                "app.core.post_setup.urllib.request.urlopen",
+                side_effect=side_effect,
+            ),
+            patch("app.core.post_setup.get_token", return_value="ghp_fake"),
+        ):
+            with pytest.raises(RuntimeError, match="not found"):
+                configure_github_repo("test/repo", "python_basic", False)
+
+    def test_get_token_none_raises_runtime_error(self):
+        with patch("app.core.post_setup.get_token", return_value=None):
+            with pytest.raises(RuntimeError, match="No GitHub token configured"):
+                configure_github_repo("test/repo", "python_basic", False)
+
+    def test_unknown_preset_uses_python_fallback(self):
+        resp = self._make_response(200)
+        with (
+            patch(
+                "app.core.post_setup.urllib.request.urlopen",
+                return_value=resp,
+            ) as mock_urlopen,
+            patch("app.core.post_setup.get_token", return_value="ghp_fake"),
+        ):
+            configure_github_repo("test/repo", "unknown_preset", False)
+
+        topics_req = mock_urlopen.call_args_list[0][0][0]
+        body = json.loads(topics_req.data)
+        assert body == {"names": ["python"]}  # fallback


### PR DESCRIPTION
Closes WOR-44

configure_github_repo function with topics + wiki/projects disable + conditional branch protection; auto-invoked after create_github_repo when --github-create set; tests cover all 3 API calls and CI-conditional branch; ruff+mypy+pytest pass