### PR TITLE
WOR-262 Implement ticket taxonomy profile columns

### DIFF
--- a/.claude/commands/start-ticket.md
+++ b/.claude/commands/start-ticket.md
@@ -115,6 +115,14 @@ If no siblings are In Progress, skip this block silently.
 - Note edge cases and overwrite behavior to consider
 - Assess local-model suitability: is the scope bounded (≤3 small/medium files, straightforward wiring)? Or does it touch large/complex modules (e.g. watcher.py, generator.py) requiring multi-step reasoning across many dependencies? Record your conclusion — it determines `implementation_mode` in the manifest.
 - Classify the ticket's effort level using this rule: simple/additive work touching ≤2 files → 'high'; bounded multi-file work → 'xhigh'; complex/large modules or deep cross-file reasoning → 'max'. Record your classification in the manifest.
+- **Taxonomy classification** (WOR-262) — record these 7 dimensions in the manifest. All optional but populate when you can:
+  - `change_type` — one of `additive` (new feature/file), `modification` (existing behavior changes), `refactor` (no behavior change), `removal` (deletion/cleanup), `docs` (markdown / comments only)
+  - `reasoning_demand` 1-5 — how much cross-file reasoning is needed (1 = local change in one function, 5 = touches many modules with non-obvious invariants)
+  - `scope_clarity` 1-5 — how explicit the AC is (1 = vague "improve X", 5 = exact file/line targets and expected behaviour)
+  - `constraint_density` 1-5 — number of hard rules in `implementation_constraints` (1 = none, 5 = many strict gates)
+  - `ac_specificity` 1-5 — how testable the AC is (1 = subjective only, 5 = each bullet maps to an assertion)
+  - `tech_stack` — comma-separated tags of the technologies involved, e.g. `python,sqlite,pydantic` or `markdown,yaml`
+  - `raw_extensions` — JSON array string of file extensions touched, e.g. `[".py",".md"]`
 
 ### 3. Create the branch and update Linear
 Using the branch name from Linear's "Copy branch name" format (usually `WOR-NNN-short-description`):
@@ -213,6 +221,13 @@ Construct the manifest from the planning context gathered in steps 1–4:
   "risk_flags": ["<any specific risk notes>"],
   "implementation_mode": "<local if ticket has local-ready label, otherwise cloud>",
   "effort": "<high|xhigh|max — effort classification from architect phase>",
+  "change_type": "<additive|modification|refactor|removal|docs — taxonomy>",
+  "reasoning_demand": <1-5: cross-file reasoning depth>,
+  "scope_clarity": <1-5: how explicit the AC is>,
+  "constraint_density": <1-5: number of hard rules>,
+  "ac_specificity": <1-5: how testable the AC is>,
+  "tech_stack": "<comma-separated tags, e.g. 'python,sqlite,pydantic'>",
+  "raw_extensions": "<JSON array string of extensions, e.g. '[\".py\",\".md\"]'>",
   "review_mode": "auto",
   "base_branch": "<epic-branch or main>",
   "worker_branch": "<sub-ticket-branch>",

--- a/app/core/manifest.py
+++ b/app/core/manifest.py
@@ -136,6 +136,33 @@ class ExecutionManifest(BaseModel):
     low, medium, high, xhigh, max."""
 
     # ------------------------------------------------------------------
+    # Ticket taxonomy (WOR-262) — written by /start-ticket architect phase,
+    # copied to ticket_metrics by finalize_worker. All optional.
+    # ------------------------------------------------------------------
+    change_type: (
+        Literal["additive", "modification", "refactor", "removal", "docs"] | None
+    ) = None
+    """Top-level change type."""
+
+    reasoning_demand: Annotated[int, Field(ge=1, le=5)] | None = None
+    """1-5: depth of cross-file reasoning needed."""
+
+    scope_clarity: Annotated[int, Field(ge=1, le=5)] | None = None
+    """1-5: how explicit the acceptance criteria are."""
+
+    constraint_density: Annotated[int, Field(ge=1, le=5)] | None = None
+    """1-5: number of hard rules in implementation_constraints."""
+
+    ac_specificity: Annotated[int, Field(ge=1, le=5)] | None = None
+    """1-5: how testable the acceptance criteria are."""
+
+    tech_stack: str | None = None
+    """Comma-separated tags, e.g. 'python,sqlite,pydantic'."""
+
+    raw_extensions: str | None = None
+    """JSON array string of file extensions touched, e.g. '[".py",".md"]'."""
+
+    # ------------------------------------------------------------------
     # Branch / worktree
     # ------------------------------------------------------------------
     base_branch: str

--- a/app/core/metrics.py
+++ b/app/core/metrics.py
@@ -77,6 +77,13 @@ CREATE TABLE IF NOT EXISTS ticket_metrics (
     files_changed         INTEGER,
     sonar_findings_count  INTEGER,
     context_compactions   INTEGER,
+    change_type           TEXT,
+    reasoning_demand      INTEGER,
+    scope_clarity         INTEGER,
+    constraint_density    INTEGER,
+    ac_specificity        INTEGER,
+    tech_stack            TEXT,
+    raw_extensions        TEXT,
     recorded_at           TEXT NOT NULL DEFAULT (datetime('now')),
     PRIMARY KEY (ticket_id, project_id)
 )
@@ -125,6 +132,37 @@ class TicketMetrics(BaseModel):
     context_compactions: int | None = Field(
         default=None,
         description="Claude Code context compaction count during the session",
+    )
+    # Ticket taxonomy fields (WOR-262) — populated at /start-ticket plan time and
+    # copied into the metrics row by finalize_worker. All Optional; no ticket is
+    # ever blocked by missing taxonomy.
+    change_type: str | None = Field(
+        default=None,
+        description="One of: additive, modification, refactor, removal, docs",
+    )
+    reasoning_demand: int | None = Field(
+        default=None,
+        description="1-5: depth of cross-file reasoning needed",
+    )
+    scope_clarity: int | None = Field(
+        default=None,
+        description="1-5: how explicit the acceptance criteria are",
+    )
+    constraint_density: int | None = Field(
+        default=None,
+        description="1-5: number of hard rules in the manifest",
+    )
+    ac_specificity: int | None = Field(
+        default=None,
+        description="1-5: how testable the acceptance criteria are",
+    )
+    tech_stack: str | None = Field(
+        default=None,
+        description="Comma-separated tags, e.g. 'python,sqlite,pydantic'",
+    )
+    raw_extensions: str | None = Field(
+        default=None,
+        description="JSON array string of file extensions touched",
     )
 
 
@@ -239,6 +277,25 @@ class MetricsStore:
                 "ALTER TABLE ticket_metrics "
                 "ADD COLUMN local_output_tokens_per_second REAL"
             )
+        # WOR-262 taxonomy columns
+        if "change_type" not in existing:
+            conn.execute("ALTER TABLE ticket_metrics ADD COLUMN change_type TEXT")
+        if "reasoning_demand" not in existing:
+            conn.execute(
+                "ALTER TABLE ticket_metrics ADD COLUMN reasoning_demand INTEGER"
+            )
+        if "scope_clarity" not in existing:
+            conn.execute("ALTER TABLE ticket_metrics ADD COLUMN scope_clarity INTEGER")
+        if "constraint_density" not in existing:
+            conn.execute(
+                "ALTER TABLE ticket_metrics ADD COLUMN constraint_density INTEGER"
+            )
+        if "ac_specificity" not in existing:
+            conn.execute("ALTER TABLE ticket_metrics ADD COLUMN ac_specificity INTEGER")
+        if "tech_stack" not in existing:
+            conn.execute("ALTER TABLE ticket_metrics ADD COLUMN tech_stack TEXT")
+        if "raw_extensions" not in existing:
+            conn.execute("ALTER TABLE ticket_metrics ADD COLUMN raw_extensions TEXT")
 
     @contextmanager
     def _connect(self) -> Generator[sqlite3.Connection, None, None]:
@@ -263,7 +320,9 @@ class MetricsStore:
                     escalated_to_cloud, outcome,
                     retry_count, check_failures_json,
                     lines_changed, files_changed,
-                    sonar_findings_count, context_compactions
+                    sonar_findings_count, context_compactions,
+                    change_type, reasoning_demand, scope_clarity,
+                    constraint_density, ac_specificity, tech_stack, raw_extensions
                 ) VALUES (
                     :ticket_id, :project_id, :epic_id, :implementation_mode,
                     :cloud_used, :cloud_model, :cloud_tokens, :cloud_cost_estimate,
@@ -274,7 +333,9 @@ class MetricsStore:
                     :escalated_to_cloud, :outcome,
                     :retry_count, :check_failures_json,
                     :lines_changed, :files_changed,
-                    :sonar_findings_count, :context_compactions
+                    :sonar_findings_count, :context_compactions,
+                    :change_type, :reasoning_demand, :scope_clarity,
+                    :constraint_density, :ac_specificity, :tech_stack, :raw_extensions
                 )
                 """,
                 {

--- a/app/core/watcher/watcher_finalize.py
+++ b/app/core/watcher/watcher_finalize.py
@@ -216,6 +216,14 @@ def finalize_worker(
             sonar_findings_count=(
                 len(sonar_findings) if sonar_findings is not None else None
             ),
+            # WOR-262: copy taxonomy fields from manifest into metrics
+            change_type=worker.manifest.change_type,
+            reasoning_demand=worker.manifest.reasoning_demand,
+            scope_clarity=worker.manifest.scope_clarity,
+            constraint_density=worker.manifest.constraint_density,
+            ac_specificity=worker.manifest.ac_specificity,
+            tech_stack=worker.manifest.tech_stack,
+            raw_extensions=worker.manifest.raw_extensions,
         )
     )
     metrics.record_run(

--- a/schemas/execution_manifest.schema.json
+++ b/schemas/execution_manifest.schema.json
@@ -162,6 +162,105 @@
       "default": null,
       "title": "Effort"
     },
+    "change_type": {
+      "anyOf": [
+        {
+          "enum": [
+            "additive",
+            "modification",
+            "refactor",
+            "removal",
+            "docs"
+          ],
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Change Type"
+    },
+    "reasoning_demand": {
+      "anyOf": [
+        {
+          "maximum": 5,
+          "minimum": 1,
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Reasoning Demand"
+    },
+    "scope_clarity": {
+      "anyOf": [
+        {
+          "maximum": 5,
+          "minimum": 1,
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Scope Clarity"
+    },
+    "constraint_density": {
+      "anyOf": [
+        {
+          "maximum": 5,
+          "minimum": 1,
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Constraint Density"
+    },
+    "ac_specificity": {
+      "anyOf": [
+        {
+          "maximum": 5,
+          "minimum": 1,
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Ac Specificity"
+    },
+    "tech_stack": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Tech Stack"
+    },
+    "raw_extensions": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Raw Extensions"
+    },
     "base_branch": {
       "title": "Base Branch",
       "type": "string"

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -114,6 +114,45 @@ class TestCheckFailures:
         assert result.check_failures == []
 
 
+class TestTaxonomyColumns:
+    """WOR-262: 7 ticket taxonomy columns (change_type, reasoning_demand, etc.)."""
+
+    def test_taxonomy_round_trip(self, tmp_path):
+        store = _store(tmp_path)
+        m = _ticket(
+            change_type="additive",
+            reasoning_demand=4,
+            scope_clarity=5,
+            constraint_density=2,
+            ac_specificity=4,
+            tech_stack="python,sqlite,pydantic",
+            raw_extensions='[".py",".md"]',
+        )
+        store.record(m)
+        result = store.get_by_ticket("WOR-1", "proj-a")
+        assert result is not None
+        assert result.change_type == "additive"
+        assert result.reasoning_demand == 4
+        assert result.scope_clarity == 5
+        assert result.constraint_density == 2
+        assert result.ac_specificity == 4
+        assert result.tech_stack == "python,sqlite,pydantic"
+        assert result.raw_extensions == '[".py",".md"]'
+
+    def test_taxonomy_defaults_to_none(self, tmp_path):
+        store = _store(tmp_path)
+        store.record(_ticket())
+        result = store.get_by_ticket("WOR-1", "proj-a")
+        assert result is not None
+        assert result.change_type is None
+        assert result.reasoning_demand is None
+        assert result.scope_clarity is None
+        assert result.constraint_density is None
+        assert result.ac_specificity is None
+        assert result.tech_stack is None
+        assert result.raw_extensions is None
+
+
 class TestAdditionalMetrics:
     def test_retry_and_diff_metrics_round_trip(self, tmp_path):
         store = _store(tmp_path)

--- a/tests/test_watcher_finalize.py
+++ b/tests/test_watcher_finalize.py
@@ -290,6 +290,85 @@ def test_finalize_worker_usage_none_when_no_log(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# WOR-262: taxonomy fields propagate from manifest to ticket_metrics
+# ---------------------------------------------------------------------------
+
+
+def test_finalize_worker_copies_taxonomy_fields_to_metrics(tmp_path: Path) -> None:
+    manifest = make_manifest(
+        ticket_id="WOR-10",
+        worker_branch="wor-10-test-ticket",
+        change_type="additive",
+        reasoning_demand=4,
+        scope_clarity=5,
+        constraint_density=2,
+        ac_specificity=4,
+        tech_stack="python,sqlite,pydantic",
+        raw_extensions='[".py",".md"]',
+    )
+    metrics_mock = MagicMock()
+
+    worker = ActiveWorker(
+        ticket_id="WOR-10",
+        linear_id="fake-linear-id",
+        manifest=manifest,
+        worktree_path=tmp_path,
+        process=MagicMock(spec=subprocess.Popen),
+    )
+
+    with (
+        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(True, [])),
+        patch(
+            "app.core.watcher.watcher_finalize.create_pr",
+            return_value="https://github.com/example/pr/1",
+        ),
+        patch("app.core.watcher.watcher_finalize.cleanup_worktree"),
+    ):
+        _call_finalize(worker, metrics=metrics_mock)
+
+    m = metrics_mock.record.call_args[0][0]
+    assert m.change_type == "additive"
+    assert m.reasoning_demand == 4
+    assert m.scope_clarity == 5
+    assert m.constraint_density == 2
+    assert m.ac_specificity == 4
+    assert m.tech_stack == "python,sqlite,pydantic"
+    assert m.raw_extensions == '[".py",".md"]'
+
+
+def test_finalize_worker_taxonomy_none_when_manifest_lacks_them(tmp_path: Path) -> None:
+    manifest = make_manifest(ticket_id="WOR-10", worker_branch="wor-10-test-ticket")
+    metrics_mock = MagicMock()
+
+    worker = ActiveWorker(
+        ticket_id="WOR-10",
+        linear_id="fake-linear-id",
+        manifest=manifest,
+        worktree_path=tmp_path,
+        process=MagicMock(spec=subprocess.Popen),
+    )
+
+    with (
+        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(True, [])),
+        patch(
+            "app.core.watcher.watcher_finalize.create_pr",
+            return_value="https://github.com/example/pr/1",
+        ),
+        patch("app.core.watcher.watcher_finalize.cleanup_worktree"),
+    ):
+        _call_finalize(worker, metrics=metrics_mock)
+
+    m = metrics_mock.record.call_args[0][0]
+    assert m.change_type is None
+    assert m.reasoning_demand is None
+    assert m.scope_clarity is None
+    assert m.constraint_density is None
+    assert m.ac_specificity is None
+    assert m.tech_stack is None
+    assert m.raw_extensions is None
+
+
+# ---------------------------------------------------------------------------
 # sonar_findings_count wired to metrics
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Add 7 taxonomy fields to `TicketMetrics` (Pydantic + SQLite schema + migration)
- Add 7 corresponding fields to `ExecutionManifest`
- Regenerate `schemas/execution_manifest.schema.json`
- `finalize_worker` copies taxonomy from manifest → ticket_metrics row
- `/start-ticket` architect phase gains a taxonomy classification block; manifest template updated
- Tests cover round-trip + finalize wiring (4 new tests)

## The 7 fields

| Field | Type | Purpose |
|---|---|---|
| `change_type` | `Literal["additive","modification","refactor","removal","docs"]` | Top-level change category |
| `reasoning_demand` | int 1-5 | Cross-file reasoning depth |
| `scope_clarity` | int 1-5 | How explicit the AC is |
| `constraint_density` | int 1-5 | Number of hard rules in implementation_constraints |
| `ac_specificity` | int 1-5 | How testable the AC is |
| `tech_stack` | str | Comma-separated tags |
| `raw_extensions` | str | JSON array string of file extensions |

All optional — no ticket is ever blocked by missing taxonomy.

## Notes

Manual implementation after 3 worker rounds failed:
- Round 1: ruff line length on a Field(description=) string
- Round 2: schema regen drift (test_committed_schema_file_matches_model)
- Round 3: pytest fixture-pattern error in new tests

Total cloud burn before manual takeover: ~\$25. Single-pass manual implementation: 877 tests pass, ruff + mypy clean.

## Test plan
- [x] `ruff check .` — clean
- [x] `mypy app/` — 25 source files clean
- [x] `pytest --no-cov` — 877 passed
- [x] `tests/test_manifest.py::test_committed_schema_file_matches_model` — passes (schema regenerated)
- [x] New tests verify taxonomy round-trips through metrics.db
- [x] New tests verify finalize_worker copies taxonomy from manifest

Closes WOR-262