### PR TITLE
WOR-283 Sync CLAUDE.md, README.md, and Linear project page after WOR-52 + WOR-253

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,11 +18,15 @@ python -m app.cli generate --preset python_basic --repo-name myrepo --output ./o
 # With optional toggles: --pre-commit --ci --pr-template --issue-templates --codeowners --claude-files
 #                        --playwright (full_agentic only) --linear-mcp / --no-linear-mcp
 # With post-setup:       --git-init --install-precommit
+# With GitHub:           --github-create [--private | --public]    # create repo via API
+#                        --git-push [--remote-url <url>]            # initial commit + push
 
 # CLI — user preferences
 python -m app.cli config get
 python -m app.cli config set author-name "Your Name"
 python -m app.cli config set github-username "your-username"
+python -m app.cli config set github-token        # silent prompt; stored in OS keyring
+python -m app.cli config delete github-token
 
 # CLI — watcher (local worker orchestrator daemon)
 python -m app.cli watcher                        # respects each manifest's implementation_mode
@@ -34,6 +38,7 @@ python -m app.cli watcher --max-local-workers 8  # default 8; vLLM handles concu
 python -m app.cli watcher --max-cloud-workers 3  # default 3; parallelisable
 python -m app.cli watcher --max-workers 2        # backward-compat alias: sets both to 2
 python -m app.cli watcher --verbose              # stream worker stdout/stderr live, prefixed with [WOR-NN]
+python -m app.cli watcher --no-epic-shutdown     # keep daemon running after current epic completes
 
 # Benchmark runner (do not run without explicit instruction)
 python scripts/bench/run_bench.py --tier speed
@@ -80,12 +85,13 @@ Module responsibilities:
 - `config.py` — Pydantic input models (repo name, output path, preset, option toggles)
 - `presets.py` — preset definitions (maps preset name → file list + options)
 - `generator.py` — renders templates and writes files to disk
-- `post_setup.py` — side effects: `git init`, `pre-commit install`, etc.
+- `post_setup.py` — side effects: `git init`, `pre-commit install`, GitHub repo create/configure/push (`create_github_repo`, `configure_github_repo`, `run_initial_push`)
 - `user_prefs.py` — `UserPreferences` model + `PrefsStore` (platform-aware JSON persistence)
-- `manifest.py` — `ExecutionManifest` Pydantic model: cloud→local worker contract for hybrid execution
+- `credentials.py` — GitHub token storage via OS keyring (`save_token`, `get_token`, `delete_token`); falls back to `GITHUB_TOKEN` env var when keyring unavailable
+- `manifest.py` — `ExecutionManifest` Pydantic model: cloud→local worker contract; includes `effort` (low/medium/high/xhigh/max) and 7 taxonomy fields (`change_type`, `reasoning_demand`, `scope_clarity`, `constraint_density`, `ac_specificity`, `tech_stack`, `raw_extensions`) populated at /start-ticket plan time
 - `escalation_policy.py` — `EscalationPolicy` Pydantic model: loads `config/escalation_policy.toml`, classifies result-artifact flags and Sonar findings into watcher actions
 - `linear_client.py` — thin Linear GraphQL client (stdlib `urllib` only, no third-party HTTP deps); requires `LINEAR_API_KEY` env var
-- `metrics.py` — SQLite-backed store for per-ticket cost and execution metrics; watcher is sole writer, workers emit JSON result files only
+- `metrics.py` — SQLite-backed store for per-ticket cost and execution metrics; watcher is sole writer, workers emit JSON result files only. Tables: `ticket_metrics` (per-ticket summary, includes 7 taxonomy + cost columns), `ticket_run_log` (per-attempt records for retry analysis), `check_run_log` (per-check timing/outcome), `rework_events`
 - `watcher/` — watcher subpackage (subpackage boundary, not flat files):
   - `watcher.py` — orchestrator only: polls Linear for `ReadyForLocal` tickets, delegates to sub-modules above
   - `watcher_dispatch.py` — extracted ticket start logic: `start_ticket` module function plus thin class wrappers
@@ -222,6 +228,12 @@ The informational scan runs on `github.base_ref != 'main'`; the blocking scan ru
 - **PostToolUse** — `lint-imports` architecture contract check after any Python file edit
 - **PostToolUse** — pytest (no coverage) on the edited test file after changes to `tests/` files only
 - **PreToolUse** — blocks destructive shell commands and writes to sensitive files (`.env`, `.mcp.json`, `.claude/settings*`)
+
+`.pre-commit-config.yaml` adds repo-level checks (run on `git commit`):
+
+- **trailing-whitespace / end-of-file-fixer / check-yaml / check-toml / check-merge-conflict**
+- **ruff** + **ruff-format** + **bandit** + **mypy** + **semgrep** + **detect-secrets**
+- **check-patch-paths** — local hook (`scripts/check_patch_paths.py`) that validates `unittest.mock.patch("app...")` strings against the actual module structure (catches stale paths after package reorganization before commit)
 
 No setup needed — hooks activate as soon as Claude Code loads the project.
 

--- a/README.md
+++ b/README.md
@@ -23,10 +23,17 @@ python -m app.cli generate --preset python_basic --repo-name myrepo --output ./o
 python -m app.cli generate --preset python_basic --repo-name myrepo --output ./out \
   --git-init --install-precommit
 
+# With GitHub integration (creates repo + initial push)
+python -m app.cli generate --preset python_basic --repo-name myrepo --output ./out \
+  --github-create --git-push                     # create repo on GitHub, push initial commit
+# Optional: --private (default) | --public, --remote-url <url> for existing repos
+
 # User preferences
 python -m app.cli config get
 python -m app.cli config set author-name "Your Name"
 python -m app.cli config set github-username "your-username"
+python -m app.cli config set github-token        # silent prompt; stored in OS keyring
+python -m app.cli config delete github-token
 
 # Watcher daemon (local worker orchestrator)
 python -m app.cli watcher                        # respects each manifest's implementation_mode
@@ -35,6 +42,7 @@ python -m app.cli watcher --worker-mode local    # force local (LiteLLM proxy)
 python -m app.cli watcher --max-local-workers 8  # default 8; vLLM handles concurrency
 python -m app.cli watcher --max-cloud-workers 3  # default 3
 python -m app.cli watcher --verbose              # stream worker output live to stderr
+python -m app.cli watcher --no-epic-shutdown     # keep daemon running past current epic
 
 # Metrics
 python -m app.cli metrics browse   # open metrics DB in Datasette browser UI
@@ -70,19 +78,23 @@ Module responsibilities:
 - `config.py` — Pydantic input models and validation
 - `presets.py` — preset definitions (maps preset name → file list + toggles)
 - `generator.py` — renders templates and writes files to disk
-- `post_setup.py` — side effects: `git init`, `pre-commit install`
+- `post_setup.py` — side effects: `git init`, `pre-commit install`, GitHub repo create/configure/push
 - `user_prefs.py` — `UserPreferences` model + `PrefsStore` (platform-aware JSON persistence)
-- `manifest.py` — `ExecutionManifest` Pydantic model: cloud→local worker contract
-- `watcher.py` — orchestrator only: polls Linear for `ReadyForLocal` tickets, delegates to sub-modules
-- `watcher_finalize.py` — worker finalization: outcome classification, PR creation, escalation
-- `watcher_subprocess.py` — worker subprocess lifecycle, checks, Sonar integration
-- `watcher_worktrees.py` — git worktree setup, teardown, artifact preservation
-- `watcher_helpers.py` — pure stateless helpers used by watcher sub-modules
-- `watcher_services.py` — LiteLLM proxy and Ollama process management
+- `credentials.py` — GitHub token storage via OS keyring; `GITHUB_TOKEN` env var fallback
+- `manifest.py` — `ExecutionManifest` Pydantic model: cloud→local worker contract; carries `effort` and 7 ticket taxonomy fields
 - `linear_client.py` — thin Linear GraphQL client (stdlib `urllib` only); requires `LINEAR_API_KEY`
-- `metrics.py` — SQLite-backed per-ticket cost and execution metrics store
+- `metrics.py` — SQLite-backed per-ticket cost and execution metrics; tables `ticket_metrics`, `ticket_run_log`, `check_run_log`, `rework_events`
 - `bench_store.py` — SQLite-backed benchmark run records store (`bench.db`)
 - `escalation_policy.py` — loads `config/escalation_policy.toml`, classifies failures into watcher actions
+- `watcher/` — orchestrator subpackage (`app/core/watcher/`):
+  - `watcher.py` — main loop; polls Linear, delegates dispatch
+  - `watcher_dispatch.py` — `start_ticket` extracted dispatch logic
+  - `watcher_finalize.py` — worker finalization: outcome classification, PR creation, metrics record, escalation
+  - `watcher_subprocess.py` — worker subprocess lifecycle, checks, Sonar integration
+  - `watcher_worktrees.py` — git worktree setup, teardown, artifact preservation, wip-state preservation, wip squash
+  - `watcher_helpers.py` — pure stateless helpers (cmd builder, env, log parsing)
+  - `watcher_services.py` — LiteLLM proxy and Ollama process management
+  - `watcher_types.py` — shared types: `ActiveWorker`, `LinearClientProtocol`
 - `cli.py` — CLI entry point
 - `main.py` — PySide6 app entry point (V2)
 
@@ -110,20 +122,25 @@ Data flows one way: CLI → config model → generator → disk. Post-setup runs
 | `--linear-mcp` / `--no-linear-mcp` | Include/exclude Linear MCP server in `.mcp.json` |
 | `--git-init` | Run `git init` in the output directory after generation |
 | `--install-precommit` | Run `pre-commit install` in the output directory |
+| `--github-create` | Create a GitHub repository for the scaffolded output (requires `config set github-token` first) |
+| `--private` / `--public` | Visibility for `--github-create` (default `--private`) |
+| `--git-push` | Stage, commit, and push initial scaffold to a remote (requires `--github-create` or `--remote-url`) |
+| `--remote-url <url>` | Existing remote URL for `--git-push` when not pairing with `--github-create` |
 
 ## Stack
 
 - Python 3.12+
 - Pydantic — config validation
 - Jinja2 — template rendering
-- PyYAML — YAML parsing
-- PySide6 — desktop UI (V2)
+- python-dotenv — env-var loading
+- keyring — OS credential store for GitHub token
+- PySide6 — desktop UI (V2, `requirements-ui.txt`)
 - pytest + pytest-cov — testing
 - Ruff — linting and formatting
 - mypy — type checking
 - bandit — security scanning
 - Import Linter — architecture contract enforcement
-- pre-commit — git hooks
+- pre-commit — git hooks (ruff, mypy, bandit, semgrep, detect-secrets, check-patch-paths)
 
 ## Local model development
 
@@ -145,10 +162,10 @@ litellm --config litellm-local.yaml --port 8082 --drop_params
 # 3. Launch Claude Code in a new terminal
 set ANTHROPIC_BASE_URL=http://localhost:8082   # Windows
 set ANTHROPIC_API_KEY=sk-dummy
-claude --model qwen3-coder:30b
+claude --model claude-sonnet-4-6
 ```
 
-`litellm-local.yaml` is gitignored. See [`docs/spikes/local-model-setup.md`](docs/spikes/local-model-setup.md) for VRAM budget, model selection, and benchmark results.
+`litellm-local.yaml` is gitignored. See [`docs/spikes/vllm-benchmark-plan.md`](docs/spikes/vllm-benchmark-plan.md) for the production vLLM model config and benchmark results. [`docs/spikes/local-model-setup.md`](docs/spikes/local-model-setup.md) covers the historical Ollama setup.
 
 ## Claude Code and MCP setup
 


### PR DESCRIPTION
## Summary
- CLAUDE.md and README.md updated to reflect today's two epic merges (WOR-52 GitHub Integration, WOR-253 Watcher Intelligence)
- Linear project description block re-written to current state (already pushed via save_project)

## Drift fixed

### CLAUDE.md
- Added `--no-epic-shutdown` to watcher commands
- Added `--github-create / --git-push / --remote-url / --private / --public` to generate commands
- Added `config set/delete github-token` subcommands
- Added `credentials.py` to module list
- Expanded `manifest.py` + `metrics.py` descriptions (effort, taxonomy, run_log, rework_events)
- Added pre-commit hook list including `check-patch-paths`

### README.md
- Restructured module list to show `app/core/watcher/` subpackage layout (was flat)
- Added GitHub integration usage block + credential subcommands
- Added 4 GitHub-related CLI toggles to the table
- Corrected local-model example from `qwen3-coder:30b` to `claude-sonnet-4-6` (matches CLAUDE.md vLLM production config)
- Stack: added python-dotenv + keyring; expanded pre-commit hook list

### Linear project description
- Already updated via `save_project` — current state, accurate milestone progress, current "Next up" list (WOR-281 Urgent, WOR-225 Phase 1, WOR-273 Wave 2), recent shipped epics

## Test plan
- [x] ruff check . — clean
- [x] mypy app/ — clean (unchanged; no Python touched)
- [x] pytest — 912 passed

## Notes

This is a docs-only change. Filed as a standalone ticket per the WOR-281 lesson — never fold doc-sync into a feature epic.

Closes WOR-283