### PR TITLE
WOR-281 Skills: enforce epic charter + sub-ticket budget

### DIFF
--- a/.claude/commands/groom-ticket.md
+++ b/.claude/commands/groom-ticket.md
@@ -21,6 +21,58 @@ Look up the Linear issue with identifier $ARGUMENTS in the {{ linear_project }} 
 
 Then spawn the **repo-investigator** subagent, passing the ticket title and description as the prompt. Use its returned summary as context for the analysis below — do not read any source files yourself.
 
+### Epic charter check (run FIRST when grooming an epic)
+
+If the issue has **no `parentId`** (it is itself an epic / umbrella ticket), enforce these gates before anything else:
+
+1. **Charter line**: the epic description must contain a single sentence describing the **user-visible outcome that ships at epic closure**. Look for a line of the form `**Charter:** <one sentence>` near the top of the description.
+   - If missing: prompt the human — "This epic has no Charter line. Add one now? (one sentence describing what ships when the epic closes)" — and propose a draft based on the epic title + description for the human to refine.
+   - If present but vague (e.g. starts with "improve" / "enhance" / "various"): warn that the charter risks drift, suggest a sharper rewrite, and ask the human to confirm or replace.
+
+2. **Sub-ticket budget**: the epic description must contain `**Sub-ticket budget:** <N>` where N is an integer 3–6 (default 5).
+   - If missing: prompt the human to set one (default 5 unless the human overrides).
+
+3. **Persistence**: once charter + budget are agreed, ensure they appear at the top of the epic description (before the "## Problem" or other sections). Update the description via `save_issue(id: "<EPIC>", description: "...")` if needed.
+
+4. **Refusal**: do NOT mark the epic state=Groomed until both charter and budget are persisted in the description.
+
+5. **Backward compatibility**: existing epics may not have a charter or budget. The skill must NOT block existing epics from grooming — it should prompt the human to add them and proceed once filled in. Never silently set state=Groomed on an epic with a missing charter.
+
+6. **Meta-epic exemption**: if the epic carries a `meta-epic` label, skip the budget check entirely (charter is still required). The label is for long-lived umbrella issues like "Watcher Reliability" that accumulate independent reliability fixes by design.
+
+### Sub-ticket budget check (run when grooming a non-epic ticket with a parent)
+
+If the issue has a `parentId`, fetch the parent epic with `get_issue(<parentId>)`:
+
+1. Read the **Sub-ticket budget** from the parent's description (parse the `**Sub-ticket budget:** <N>` line). If missing, default to 5 and warn the human.
+
+2. Skip this check entirely if the parent epic carries the `meta-epic` label.
+
+3. Count the parent's open sub-tickets via `list_issues(parentId: <parentId>)`, excluding any in state `Done`, `Cancelled`, `Duplicate`, `MergedToEpic`. **Note: count includes the ticket being groomed if it already has the parent set.**
+
+4. If `count >= budget`, surface this prompt to the human and require an explicit choice before proceeding:
+
+   ```
+   Parent epic <PARENT> "<parent title>" has <N> open sub-tickets (budget: <budget>).
+   Charter: "<charter line from parent description>"
+
+   Adding this ticket exceeds the budget. Choose:
+     1. Bump the budget (justify in one sentence — added to epic description)
+     2. Open a Wave 2 epic — create new sibling epic, move this ticket under it
+     3. Move to standalone — clear parentId on this ticket
+     4. The new ticket directly produces the charter outcome (proceed; budget assumed soft)
+
+   Which option?
+   ```
+
+5. After the human chooses:
+   - **(1) Bump**: update the parent epic description's budget line; append a one-sentence justification.
+   - **(2) Wave 2**: create a new epic with a draft charter (the human will edit), set this ticket's parentId to the new epic.
+   - **(3) Standalone**: call `save_issue(id: "<TICKET>", parentId: null)`.
+   - **(4) Proceed**: continue with grooming as planned; no Linear changes for budget.
+
+---
+
 As a Product Owner, evaluate the issue before development begins:
 
 1. **Restate** the requirement in one sentence in plain terms.

--- a/.claude/commands/start-ticket.md
+++ b/.claude/commands/start-ticket.md
@@ -74,6 +74,40 @@ Check whether this ticket has a parent epic (`parentId` from `get_issue` relatio
 - Warn: "This ticket has no parent epic — branch will target main instead of an epic branch."
 - Continue with the normal main-targeting flow (step 3 will branch off main)
 
+### 0.55. Epic-size charter check (run when parent epic exists)
+
+When the ticket has a parent epic, count the parent's sub-tickets via `list_issues(parentId: <epicId>)` and inspect the parent description for a `**Charter:** <sentence>` line and a `**Sub-ticket budget:** <N>` line.
+
+Skip this check entirely if the parent epic carries the `meta-epic` label (these are long-lived umbrella issues like "Watcher Reliability" that accumulate independent reliability fixes by design).
+
+Exclude sub-tickets in `Done`, `Cancelled`, `Duplicate`, or `MergedToEpic` states from the count — only count open work.
+
+If `count >= 6` (or `count >= budget` if budget is set), surface this prompt to the human and wait for confirmation before proceeding with the rest of `/start-ticket`:
+
+```
+Parent epic <PARENT> "<parent title>" already has <N> open sub-tickets.
+Charter: "<charter line from parent description, or '(no charter set)'>"
+
+Does WOR-NNN "<this ticket title>" directly produce that charter outcome?
+
+  yes — proceed (the ticket aligns with charter; budget pressure noted)
+  no  — re-parent before proceeding:
+        1. Move to standalone (clear parentId)
+        2. Open a Wave 2 epic (sibling to current parent) and re-parent
+        3. Find a more-fit existing parent
+
+Which?
+```
+
+If the human picks `yes`, continue with the rest of `/start-ticket` unchanged.
+
+If the human picks a re-parent option:
+- **(1) Standalone**: `save_issue(id: "$ARGUMENTS", parentId: null)` and continue.
+- **(2) Wave 2**: create the new epic with `save_issue(team: ..., title: "Wave 2 — <theme>", labels: ["Refactor", ...])`, then `save_issue(id: "$ARGUMENTS", parentId: "<new-epic-id>")` and continue.
+- **(3) Different parent**: ask which one, then `save_issue(id: "$ARGUMENTS", parentId: "<new-parent>")` and continue.
+
+This check is the runtime enforcement of the budget that `/groom-ticket` set; it ensures the budget pressure surfaces at start time even if a sub-ticket was filed without re-grooming the parent.
+
 ### 0.6. Coordination check
 Query Linear for sibling tickets in the same epic that are currently In Progress:
 ```


### PR DESCRIPTION
## Summary
- `groom-ticket.md`: epic gate requires Charter + Sub-ticket budget in description before state=Groomed; sub-ticket gate prompts when budget would be exceeded
- `start-ticket.md`: new step 0.55 surfaces budget pressure at start time as defense-in-depth
- `meta-epic` label exemption for long-lived reliability umbrellas
- Backward compatible — existing epics prompted to add charter, never silently blocked
- Pure skill prose; no Python touched; 912 tests pass; ruff clean

## The drift this prevents

WOR-253 "Watcher Intelligence" shipped 24 sub-tickets over 3 weeks against a charter of "telemetry, self-improvement loops, routing calibration." About 14 of those 24 were drift: file splits, CI infra, WIP commits, blocker defense bugfixes. Concrete cost: cost tracking complete on 2026-04-30 but stuck behind 2 days of unrelated tickets before reaching main; WOR-269 manifest-blocker bug cost ~\$25/run while we waited.

WOR-52 GitHub Integration stayed at 4 sub-tickets and 0% drift because the charter ("4 sequential phases of one user journey") was self-evidently bounded. WOR-253 had no comparable cap.

## How it works

### groom-ticket
1. **First step when grooming an epic** (no parentId):
   - Require `**Charter:** <one sentence>` in description
   - Require `**Sub-ticket budget:** <N>` (3–6, default 5)
   - Refuse to set state=Groomed until both present
   - Backward compat: existing epics prompted, not blocked

2. **When grooming a sub-ticket** (with parentId):
   - Count open siblings (excludes Done/Cancelled/Duplicate/MergedToEpic)
   - At budget, surface 4-option prompt: bump / Wave 2 / standalone / proceed-as-charter-aligned

### start-ticket
- New step 0.55: defense-in-depth charter check at start time. If parent epic has ≥6 open sub-tickets (or ≥budget), prompt human to confirm the new ticket directly produces the charter outcome, with re-parent options if not.

### meta-epic exemption
- Both gates skip the budget check when the parent epic carries the `meta-epic` label
- For long-lived umbrellas like a hypothetical "Watcher Reliability" epic
- Charter is still required (helps focus even reliability work)

## Follow-ups
- After merge, run `/contribute-skill groom-ticket` and `/contribute-skill start-ticket` to push upstream
- Backfill charter + budget on the 4 currently-open epics: WOR-52 (4/5 done), WOR-225 (3/5), WOR-273 (5/5 — at cap), WOR-236 (TBD)

## Test plan
- [x] ruff check . — clean
- [x] mypy app/ — clean (no Python touched)
- [x] pytest — 912 passed
- [x] No code changes; pure skill text

Closes WOR-281