### PR TITLE
WOR-286 + WOR-288: stop watcher from silently destroying worker WIP

### DIFF
--- a/app/core/watcher/watcher_finalize.py
+++ b/app/core/watcher/watcher_finalize.py
@@ -29,6 +29,7 @@ from .watcher_subprocess import (
     run_checks,
 )
 from .watcher_types import (
+    _CLAUDE_DIR,
     _LOCAL_MODEL,
     ActiveWorker,
     LinearClientProtocol,
@@ -118,7 +119,10 @@ def attempt_pr(
         err_detail = (exc.stderr or exc.stdout or str(exc)).strip()
         logger.error("PR creation failed for %s: %s", ticket_id, err_detail)
         # Preserve any uncommitted worktree changes so a retry worker can
-        # resume from them (WOR-267).
+        # resume from them (WOR-267, WOR-288). attempt_pr does not own the
+        # worktree teardown decision — finalize_worker handles that based on
+        # the returned WipPreservationResult — but we still call commit_wip_state
+        # here so the WIP commit happens before checks/PR phase artifacts diverge.
         commit_wip_state(
             worker.worktree_path,
             ticket_id,
@@ -242,22 +246,70 @@ def finalize_worker(
     )
 
     restore_plan_files(worker.backed_up_plans)
-    if not artifacts_preserved:
-        # Preserve work-in-progress state for retry workers (WOR-258)
-        wip_sha = commit_wip_state(
-            worker.worktree_path,
+    if artifacts_preserved:
+        # Success path — artifacts already saved upstream; remove worktree.
+        cleanup_worktree(repo_root, worker.worktree_path)
+        return
+
+    # Failure path — preserve WIP before considering teardown (WOR-258, WOR-288).
+    backup_root = repo_root / _CLAUDE_DIR / "artifacts"
+    wip_result = commit_wip_state(
+        worker.worktree_path,
+        worker.ticket_id,
+        worker.manifest.worker_branch,
+        backup_root=backup_root,
+    )
+    if wip_result.sha is not None:
+        _write_wip_sha_to_last_failure(worker, wip_result.sha)
+    preserve_worker_artifacts(repo_root, worker)
+
+    if wip_result.status in ("clean", "pushed", "backup"):
+        cleanup_worktree(repo_root, worker.worktree_path)
+    else:
+        # WOR-288: WIP preservation failed (commit_wip_state could not push
+        # AND could not back up the dirty tree). Removing the worktree now
+        # would destroy uncommitted work — leave it in place for human
+        # salvage. The worktree path appears in the ERROR log so the
+        # operator can git status / commit / push manually.
+        logger.error(
+            "WIP preservation failed for %s — leaving worktree in place at %s "
+            "for manual recovery (error: %s). Run `git -C <path> status` to "
+            "inspect, then commit + push to %s manually.",
             worker.ticket_id,
+            worker.worktree_path,
+            wip_result.error or "unknown",
             worker.manifest.worker_branch,
         )
-        if wip_sha is not None:
-            _write_wip_sha_to_last_failure(worker, wip_sha)
-        preserve_worker_artifacts(repo_root, worker)
-    cleanup_worktree(repo_root, worker.worktree_path)
 
 
 # ---------------------------------------------------------------------------
 # Internal helpers (reduce cognitive complexity of finalize_worker)
 # ---------------------------------------------------------------------------
+
+
+def _read_result_status(repo_root: Path, manifest: ExecutionManifest) -> str | None:
+    """Return the worker's self-reported status from result.json, or None.
+
+    Workers write a ``status`` field of ``"success"`` or ``"failure"`` (or
+    similar) to ``result.json`` immediately before exiting. This is the
+    in-band signal of how the work actually went, distinct from the OS-level
+    subprocess exit code (which can be non-zero even after a successful run
+    due to Claude Code CLI teardown quirks — see WOR-286).
+
+    Returns None when the file is missing or unreadable; callers should treat
+    that as "no in-band signal" rather than success.
+    """
+    result_path = repo_root / manifest.artifact_paths.result_json
+    try:
+        raw = result_path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    try:
+        data = json.loads(raw)
+    except (ValueError, json.JSONDecodeError):
+        return None
+    status = data.get("status") if isinstance(data, dict) else None
+    return status if isinstance(status, str) else None
 
 
 def _execute_finalization(
@@ -276,24 +328,46 @@ def _execute_finalization(
     ticket_id = worker.ticket_id
     linear_id = worker.linear_id
 
+    # WOR-286: Trust the worker's in-band success signal (result.json) over
+    # the subprocess exit code. Claude Code CLI sometimes exits non-zero
+    # during teardown after a fully successful run — that should not destroy
+    # the work. Only treat non-zero exit as failure when result.json is
+    # missing or also reports failure.
+    result_status = _read_result_status(repo_root, manifest)
     if returncode != 0:
-        logger.error("Worker %s exited non-zero (%d)", ticket_id, returncode)
-        escalated = bool(manifest.failure_policy.escalate_to_cloud)
-        if escalated:
-            logger.info("Escalating %s to cloud per failure policy", ticket_id)
-            safe_set_state(linear, linear_id, "In Progress", ticket_id)
-            _try_post_comment(
-                linear,
-                linear_id,
+        if result_status == "success":
+            logger.warning(
+                "Worker %s exited non-zero (%d) but result.json reports "
+                "status=success — trusting in-band signal and proceeding "
+                "with checks.",
                 ticket_id,
-                f"Local worker failed for `{ticket_id}` (non-zero exit). "
-                f"Escalating to cloud per failure policy.",
+                returncode,
             )
+            # Fall through to run_checks; treat as if returncode == 0.
         else:
-            safe_set_state(
-                linear, linear_id, manifest.ticket_state_map.failed, ticket_id
+            logger.error(
+                "Worker %s exited non-zero (%d); result.json status=%s — "
+                "routing to failure path",
+                ticket_id,
+                returncode,
+                result_status if result_status is not None else "missing",
             )
-        return "failure", escalated, False, None, []
+            escalated = bool(manifest.failure_policy.escalate_to_cloud)
+            if escalated:
+                logger.info("Escalating %s to cloud per failure policy", ticket_id)
+                safe_set_state(linear, linear_id, "In Progress", ticket_id)
+                _try_post_comment(
+                    linear,
+                    linear_id,
+                    ticket_id,
+                    f"Local worker failed for `{ticket_id}` (non-zero exit). "
+                    f"Escalating to cloud per failure policy.",
+                )
+            else:
+                safe_set_state(
+                    linear, linear_id, manifest.ticket_state_map.failed, ticket_id
+                )
+            return "failure", escalated, False, None, []
 
     checks_ok, failed_checks = run_checks(manifest, worker.worktree_path)
     if not checks_ok:

--- a/app/core/watcher/watcher_worktrees.py
+++ b/app/core/watcher/watcher_worktrees.py
@@ -12,6 +12,7 @@ import re
 import shutil
 import subprocess  # nosec B404
 from pathlib import Path
+from typing import Literal, NamedTuple
 
 from app.core.manifest import ExecutionManifest
 
@@ -22,6 +23,30 @@ from .watcher_types import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+class WipPreservationResult(NamedTuple):
+    """Outcome of attempting to preserve worker work-in-progress (WOR-288).
+
+    The caller (``finalize_worker``) uses the ``status`` field to decide
+    whether it is safe to remove the worktree:
+
+    * ``"clean"``    — tree was clean, no work to preserve. Safe to cleanup.
+    * ``"pushed"``   — commit + push succeeded; ``sha`` is the short SHA.
+                       Safe to cleanup.
+    * ``"backup"``   — commit or push failed, but the dirty worktree files
+                       were copied to ``backup_path``. Safe to cleanup.
+    * ``"failed"``   — neither pushed nor backed up. **Caller MUST NOT
+                       cleanup** the worktree — work would be lost.
+
+    ``error`` carries the first stderr/exception summary observed, for log
+    surfacing. ``backup_path`` is set only on ``"backup"``.
+    """
+
+    status: Literal["clean", "pushed", "backup", "failed"]
+    sha: str | None
+    backup_path: Path | None
+    error: str | None
 
 
 def create_worktree(repo_root: Path, manifest: ExecutionManifest) -> Path:
@@ -152,16 +177,70 @@ def write_worker_pytest_config(worktree_path: Path) -> None:
     (worktree_path / "pytest.ini").write_text("[pytest]\naddopts = --tb=short\n")
 
 
+def _save_dirty_worktree_to_backup(
+    worktree_path: Path,
+    ticket_id: str,
+    backup_root: Path,
+) -> Path | None:
+    """Copy a dirty worktree's contents to ``<backup_root>/<ticket_lower>/wip/``.
+
+    Used when ``commit_wip_state`` cannot push the WIP commit (network down,
+    branch protection, hook reject). Without this fallback, the unconditional
+    ``cleanup_worktree`` call in ``finalize_worker`` would destroy the work.
+
+    Returns the absolute backup path on success, or None on failure.
+    Skips ``.git/`` and ``__pycache__/`` to keep the backup small.
+    """
+    target = backup_root / ticket_id.lower().replace("-", "_") / "wip"
+    try:
+        if target.exists():
+            shutil.rmtree(target)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copytree(
+            worktree_path,
+            target,
+            ignore=shutil.ignore_patterns(".git", "__pycache__", "*.pyc"),
+        )
+    except OSError as exc:
+        logger.error(
+            "Failed to back up dirty worktree for %s to %s: %s",
+            ticket_id,
+            target,
+            exc,
+        )
+        return None
+    logger.warning(
+        "WIP push failed for %s — dirty worktree backed up to %s",
+        ticket_id,
+        target,
+    )
+    return target
+
+
 def commit_wip_state(
     worktree_path: Path,
     ticket_id: str,
     worker_branch: str,
-) -> str | None:
-    """Stage and commit all work-in-progress for post-failure retry.
+    *,
+    backup_root: Path | None = None,
+) -> WipPreservationResult:
+    """Preserve worker work-in-progress (WOR-258, WOR-288).
 
-    Returns the short commit SHA (12 chars) on success, or None if the tree
-    is clean or any git step fails. Never raises — logs warnings instead.
+    Tries to commit and push uncommitted worktree changes so a retry worker
+    can resume. If push fails and ``backup_root`` is provided, falls back to
+    copying the dirty worktree contents to
+    ``<backup_root>/<ticket_lower>/wip/`` so the work is not lost when
+    ``finalize_worker`` removes the worktree.
+
+    Returns a :class:`WipPreservationResult` whose ``status`` tells the
+    caller whether it is safe to call ``cleanup_worktree`` next:
+
+    * ``"clean"`` / ``"pushed"`` / ``"backup"`` → safe to cleanup
+    * ``"failed"`` → caller MUST leave the worktree in place
+
+    Never raises.
     """
+    error: str | None = None
     try:
         # Check if tree is clean
         status = subprocess.run(  # nosec B603 B607
@@ -170,19 +249,25 @@ def commit_wip_state(
             text=True,
             check=False,
         )
-        if status.returncode != 0 or not status.stdout.strip():
-            if status.returncode != 0:
-                logger.warning(
-                    "git status failed in %s for %s — skipping wip commit",
-                    worktree_path,
-                    ticket_id,
-                )
-            else:
-                logger.info(
-                    "No working tree changes for %s — no wip commit needed",
-                    ticket_id,
-                )
-            return None
+        if status.returncode != 0:
+            error = (status.stderr or status.stdout or "").strip()
+            logger.warning(
+                "git status failed in %s for %s — cannot determine WIP state: %s",
+                worktree_path,
+                ticket_id,
+                error,
+            )
+            return WipPreservationResult(
+                status="failed", sha=None, backup_path=None, error=error
+            )
+        if not status.stdout.strip():
+            logger.info(
+                "No working tree changes for %s — no wip commit needed",
+                ticket_id,
+            )
+            return WipPreservationResult(
+                status="clean", sha=None, backup_path=None, error=None
+            )
 
         # Stage all changes
         subprocess.run(  # nosec B603 B607
@@ -209,7 +294,7 @@ def commit_wip_state(
         )
 
         # Push the branch
-        push = subprocess.run(  # nosec B603 B607
+        subprocess.run(  # nosec B603 B607
             [
                 "git",
                 "-C",
@@ -223,13 +308,6 @@ def commit_wip_state(
             capture_output=True,
             text=True,
         )
-        if push.returncode != 0:
-            logger.warning(
-                "git push failed for %s — wip commit not pushed: %s",
-                ticket_id,
-                (push.stderr or push.stdout or "").strip(),
-            )
-            return None
 
         # Get short SHA
         rev = subprocess.run(  # nosec B603 B607
@@ -245,18 +323,32 @@ def commit_wip_state(
             ticket_id,
             worker_branch,
         )
-        return sha
+        return WipPreservationResult(
+            status="pushed", sha=sha, backup_path=None, error=None
+        )
 
     except subprocess.CalledProcessError as exc:
+        error = (exc.stderr or exc.stdout or str(exc)).strip()
         logger.warning(
-            "WIP commit failed for %s: %s",
+            "WIP commit/push failed for %s: %s",
             ticket_id,
-            (exc.stderr or exc.stdout or str(exc)).strip(),
+            error,
         )
-        return None
     except OSError as exc:
+        error = str(exc)
         logger.warning("WIP commit failed for %s (OSError): %s", ticket_id, exc)
-        return None
+
+    # Fall through: commit or push failed. Try the dirty-worktree backup so
+    # the work is not lost when finalize_worker removes the worktree.
+    if backup_root is not None:
+        backup = _save_dirty_worktree_to_backup(worktree_path, ticket_id, backup_root)
+        if backup is not None:
+            return WipPreservationResult(
+                status="backup", sha=None, backup_path=backup, error=error
+            )
+    return WipPreservationResult(
+        status="failed", sha=None, backup_path=None, error=error
+    )
 
 
 def squash_wip_commits(

--- a/tests/test_watcher_finalize.py
+++ b/tests/test_watcher_finalize.py
@@ -15,6 +15,7 @@ from app.core.linear_client import LinearError
 from app.core.manifest import FailurePolicy
 from app.core.watcher.watcher_finalize import _try_post_comment, finalize_worker
 from app.core.watcher.watcher_types import ActiveWorker
+from app.core.watcher.watcher_worktrees import WipPreservationResult
 from tests.conftest import make_manifest
 
 # ---------------------------------------------------------------------------
@@ -1069,7 +1070,9 @@ def test_attempt_pr_calls_commit_wip_state_on_failure(
     with (
         patch(
             "app.core.watcher.watcher_finalize.commit_wip_state",
-            return_value=None,
+            return_value=WipPreservationResult(
+                status="clean", sha=None, backup_path=None, error=None
+            ),
         ) as mock_commit,
         patch("app.core.watcher.watcher_finalize.create_pr", side_effect=exc),
     ):
@@ -1192,17 +1195,20 @@ def test_finalize_worker_calls_commit_wip_state_on_check_failure(
         patch("app.core.watcher.watcher_finalize.run_checks", return_value=(False, [])),
         patch(
             "app.core.watcher.watcher_finalize.commit_wip_state",
-            return_value="a1b2c3d4",
+            return_value=WipPreservationResult(
+                status="pushed", sha="a1b2c3d4", backup_path=None, error=None
+            ),
         ) as mock_commit,
         patch("app.core.watcher.watcher_finalize.cleanup_worktree"),
     ):
         _call_finalize(worker, metrics=metrics_mock)
 
-    mock_commit.assert_called_once_with(
-        tmp_path,
-        "WOR-10",
-        "wor-10-test-ticket",
-    )
+    # WOR-288: finalize_worker now passes a backup_root kwarg to commit_wip_state.
+    # Assert the positional args + keyword presence rather than exact call match.
+    mock_commit.assert_called_once()
+    args, kwargs = mock_commit.call_args
+    assert args == (tmp_path, "WOR-10", "wor-10-test-ticket")
+    assert "backup_root" in kwargs
 
 
 def test_finalize_worker_writes_last_failure_json_on_wip_commit(
@@ -1233,7 +1239,9 @@ def test_finalize_worker_writes_last_failure_json_on_wip_commit(
         patch("app.core.watcher.watcher_finalize.run_checks", return_value=(False, [])),
         patch(
             "app.core.watcher.watcher_finalize.commit_wip_state",
-            return_value="a1b2c3d4",
+            return_value=WipPreservationResult(
+                status="pushed", sha="a1b2c3d4", backup_path=None, error=None
+            ),
         ),
         patch("app.core.watcher.watcher_finalize.cleanup_worktree"),
     ):
@@ -1270,7 +1278,9 @@ def test_finalize_worker_last_failure_json_created_when_absent(
         patch("app.core.watcher.watcher_finalize.run_checks", return_value=(False, [])),
         patch(
             "app.core.watcher.watcher_finalize.commit_wip_state",
-            return_value="a1b2c3d4",
+            return_value=WipPreservationResult(
+                status="pushed", sha="a1b2c3d4", backup_path=None, error=None
+            ),
         ),
         patch("app.core.watcher.watcher_finalize.cleanup_worktree"),
     ):
@@ -1302,9 +1312,11 @@ def test_finalize_worker_skips_commit_wip_when_no_sha(tmp_path: Path) -> None:
         patch("app.core.watcher.watcher_finalize.run_checks", return_value=(False, [])),
         patch(
             "app.core.watcher.watcher_finalize.commit_wip_state",
-            return_value=None,
+            return_value=WipPreservationResult(
+                status="failed", sha=None, backup_path=None, error="boom"
+            ),
         ) as mock_commit,
-        patch("app.core.watcher.watcher_finalize.cleanup_worktree"),
+        patch("app.core.watcher.watcher_finalize.cleanup_worktree") as mock_cleanup,
     ):
         _call_finalize(worker, metrics=metrics_mock)
 
@@ -1313,6 +1325,8 @@ def test_finalize_worker_skips_commit_wip_when_no_sha(tmp_path: Path) -> None:
     artifact_dir = tmp_path / ".claude" / "artifacts" / "wor_10"
     failure_file = artifact_dir / "last_failure.json"
     assert not failure_file.exists()
+    # WOR-288: when WIP preservation fails, the worktree must NOT be removed.
+    mock_cleanup.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -1823,3 +1837,387 @@ def test_estimate_cloud_cost_none_tokens_returns_zero() -> None:
 
     assert _estimate_cloud_cost(None, 1000, "claude-opus-4-7") == 0.0
     assert _estimate_cloud_cost(1000, None, "claude-opus-4-7") == 0.0
+
+
+# ---------------------------------------------------------------------------
+# WOR-286 — trust result.json status when worker exit code disagrees
+# ---------------------------------------------------------------------------
+
+
+def _write_result_json(repo_root: Path, ticket_id: str, status: str) -> Path:
+    """Write a minimal worker result.json under repo_root's artifact dir."""
+    art = repo_root / ".claude" / "artifacts" / ticket_id.lower().replace("-", "_")
+    art.mkdir(parents=True, exist_ok=True)
+    f = art / "result.json"
+    f.write_text(
+        json.dumps({"ticket_id": ticket_id, "status": status, "summary": "x"}),
+        encoding="utf-8",
+    )
+    return f
+
+
+def test_finalize_worker_success_resultjson_overrides_nonzero_exit(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Worker exits non-zero but result.json says success — checks run, PR created."""
+    manifest = make_manifest(ticket_id="WOR-10", worker_branch="wor-10-test-ticket")
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    worktree = tmp_path / "worktree"
+    worktree.mkdir()
+    _write_result_json(repo_root, "WOR-10", "success")
+    metrics_mock = MagicMock()
+    linear_mock = MagicMock()
+    worker = ActiveWorker(
+        ticket_id="WOR-10",
+        linear_id="fake-linear-id",
+        manifest=manifest,
+        worktree_path=worktree,
+        process=MagicMock(spec=subprocess.Popen),
+    )
+
+    with (
+        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(True, [])),
+        patch(
+            "app.core.watcher.watcher_finalize.create_pr",
+            return_value="https://github.com/example/pr/1",
+        ) as mock_create_pr,
+        patch("app.core.watcher.watcher_finalize.cleanup_worktree"),
+        caplog.at_level(logging.WARNING, logger="app.core.watcher.watcher_finalize"),
+    ):
+        _call_finalize(
+            worker,
+            returncode=1,  # NON-ZERO exit — but result.json says success
+            linear=linear_mock,
+            metrics=metrics_mock,
+            repo_root=repo_root,
+        )
+
+    # PR was created despite the non-zero exit
+    mock_create_pr.assert_called_once()
+    # WARNING about exit-code disagreement was logged
+    assert any(
+        "exited non-zero" in r.message
+        and "result.json reports status=success" in r.message
+        for r in caplog.records
+    )
+    # Outcome recorded as success in metrics
+    m = metrics_mock.record.call_args[0][0]
+    assert m.outcome == "success"
+
+
+def test_finalize_worker_failure_resultjson_with_nonzero_exit_routes_failure(
+    tmp_path: Path,
+) -> None:
+    """Worker exits non-zero AND result.json says failure → existing failure path."""
+    manifest = make_manifest(ticket_id="WOR-10", worker_branch="wor-10-test-ticket")
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    worktree = tmp_path / "worktree"
+    worktree.mkdir()
+    _write_result_json(repo_root, "WOR-10", "failure")
+    metrics_mock = MagicMock()
+    linear_mock = MagicMock()
+    worker = ActiveWorker(
+        ticket_id="WOR-10",
+        linear_id="fake-linear-id",
+        manifest=manifest,
+        worktree_path=worktree,
+        process=MagicMock(spec=subprocess.Popen),
+    )
+
+    with (
+        patch(
+            "app.core.watcher.watcher_finalize.commit_wip_state",
+            return_value=WipPreservationResult(
+                status="clean", sha=None, backup_path=None, error=None
+            ),
+        ),
+        patch("app.core.watcher.watcher_finalize.cleanup_worktree"),
+    ):
+        _call_finalize(
+            worker,
+            returncode=1,
+            linear=linear_mock,
+            metrics=metrics_mock,
+            repo_root=repo_root,
+        )
+
+    # Linear set to failed-state ('Blocked' from the default ticket_state_map)
+    linear_mock.set_state.assert_called_with("fake-linear-id", "Blocked")
+    # Outcome recorded as failure
+    m = metrics_mock.record.call_args[0][0]
+    assert m.outcome == "failure"
+
+
+def test_finalize_worker_missing_resultjson_with_nonzero_exit_routes_failure(
+    tmp_path: Path,
+) -> None:
+    """Worker exits non-zero AND no result.json → failure path (no in-band signal)."""
+    manifest = make_manifest(ticket_id="WOR-10", worker_branch="wor-10-test-ticket")
+    # NB: no result.json written
+    metrics_mock = MagicMock()
+    linear_mock = MagicMock()
+    worker = ActiveWorker(
+        ticket_id="WOR-10",
+        linear_id="fake-linear-id",
+        manifest=manifest,
+        worktree_path=tmp_path,
+        process=MagicMock(spec=subprocess.Popen),
+    )
+
+    with (
+        patch(
+            "app.core.watcher.watcher_finalize.commit_wip_state",
+            return_value=WipPreservationResult(
+                status="clean", sha=None, backup_path=None, error=None
+            ),
+        ),
+        patch("app.core.watcher.watcher_finalize.cleanup_worktree"),
+    ):
+        _call_finalize(
+            worker,
+            returncode=1,
+            linear=linear_mock,
+            metrics=metrics_mock,
+            repo_root=tmp_path,
+        )
+
+    linear_mock.set_state.assert_called_with("fake-linear-id", "Blocked")
+    m = metrics_mock.record.call_args[0][0]
+    assert m.outcome == "failure"
+
+
+def test_finalize_worker_success_resultjson_but_checks_fail_routes_failure(
+    tmp_path: Path,
+) -> None:
+    """result.json says success but a required check fails → still routes to failure."""
+    manifest = make_manifest(
+        ticket_id="WOR-10",
+        worker_branch="wor-10-test-ticket",
+        failure_policy=FailurePolicy(on_check_failure="abort"),
+    )
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    worktree = tmp_path / "worktree"
+    worktree.mkdir()
+    _write_result_json(repo_root, "WOR-10", "success")
+    metrics_mock = MagicMock()
+    linear_mock = MagicMock()
+    worker = ActiveWorker(
+        ticket_id="WOR-10",
+        linear_id="fake-linear-id",
+        manifest=manifest,
+        worktree_path=worktree,
+        process=MagicMock(spec=subprocess.Popen),
+    )
+
+    with (
+        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(False, [])),
+        patch(
+            "app.core.watcher.watcher_finalize.commit_wip_state",
+            return_value=WipPreservationResult(
+                status="clean", sha=None, backup_path=None, error=None
+            ),
+        ),
+        patch("app.core.watcher.watcher_finalize.cleanup_worktree"),
+    ):
+        _call_finalize(
+            worker,
+            returncode=1,  # success result.json + non-zero exit — checks decide
+            linear=linear_mock,
+            metrics=metrics_mock,
+            repo_root=repo_root,
+        )
+
+    linear_mock.set_state.assert_called_with("fake-linear-id", "Blocked")
+    m = metrics_mock.record.call_args[0][0]
+    assert m.outcome == "failure"
+
+
+# ---------------------------------------------------------------------------
+# WOR-288 — cleanup_worktree gated on commit_wip_state result
+# ---------------------------------------------------------------------------
+
+
+def test_finalize_worker_failure_path_cleanup_skipped_when_wip_failed(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """commit_wip_state status='failed' → cleanup_worktree NOT called, ERROR logged."""
+    manifest = make_manifest(
+        ticket_id="WOR-10",
+        worker_branch="wor-10-test-ticket",
+        failure_policy=FailurePolicy(on_check_failure="abort"),
+    )
+    metrics_mock = MagicMock()
+    worker = ActiveWorker(
+        ticket_id="WOR-10",
+        linear_id="fake-linear-id",
+        manifest=manifest,
+        worktree_path=tmp_path,
+        process=MagicMock(spec=subprocess.Popen),
+    )
+
+    with (
+        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(False, [])),
+        patch(
+            "app.core.watcher.watcher_finalize.commit_wip_state",
+            return_value=WipPreservationResult(
+                status="failed",
+                sha=None,
+                backup_path=None,
+                error="pre-commit hook rejected commit",
+            ),
+        ),
+        patch("app.core.watcher.watcher_finalize.cleanup_worktree") as mock_cleanup,
+        caplog.at_level(logging.ERROR, logger="app.core.watcher.watcher_finalize"),
+    ):
+        _call_finalize(worker, metrics=metrics_mock, repo_root=tmp_path)
+
+    mock_cleanup.assert_not_called()
+    assert any(
+        "WIP preservation failed for WOR-10" in r.message
+        and "leaving worktree" in r.message
+        for r in caplog.records
+    )
+
+
+def test_finalize_worker_failure_path_cleanup_runs_when_wip_pushed(
+    tmp_path: Path,
+) -> None:
+    """commit_wip_state status='pushed' → cleanup_worktree IS called."""
+    manifest = make_manifest(
+        ticket_id="WOR-10",
+        worker_branch="wor-10-test-ticket",
+        failure_policy=FailurePolicy(on_check_failure="abort"),
+    )
+    metrics_mock = MagicMock()
+    worker = ActiveWorker(
+        ticket_id="WOR-10",
+        linear_id="fake-linear-id",
+        manifest=manifest,
+        worktree_path=tmp_path,
+        process=MagicMock(spec=subprocess.Popen),
+    )
+
+    with (
+        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(False, [])),
+        patch(
+            "app.core.watcher.watcher_finalize.commit_wip_state",
+            return_value=WipPreservationResult(
+                status="pushed", sha="a1b2c3d4", backup_path=None, error=None
+            ),
+        ),
+        patch("app.core.watcher.watcher_finalize.cleanup_worktree") as mock_cleanup,
+    ):
+        _call_finalize(worker, metrics=metrics_mock, repo_root=tmp_path)
+
+    mock_cleanup.assert_called_once()
+
+
+def test_finalize_worker_failure_path_cleanup_runs_when_wip_backup(
+    tmp_path: Path,
+) -> None:
+    """commit_wip_state status='backup' → cleanup IS called (work in backup)."""
+    manifest = make_manifest(
+        ticket_id="WOR-10",
+        worker_branch="wor-10-test-ticket",
+        failure_policy=FailurePolicy(on_check_failure="abort"),
+    )
+    metrics_mock = MagicMock()
+    worker = ActiveWorker(
+        ticket_id="WOR-10",
+        linear_id="fake-linear-id",
+        manifest=manifest,
+        worktree_path=tmp_path,
+        process=MagicMock(spec=subprocess.Popen),
+    )
+
+    with (
+        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(False, [])),
+        patch(
+            "app.core.watcher.watcher_finalize.commit_wip_state",
+            return_value=WipPreservationResult(
+                status="backup",
+                sha=None,
+                backup_path=tmp_path / "backup",
+                error="push rejected",
+            ),
+        ),
+        patch("app.core.watcher.watcher_finalize.cleanup_worktree") as mock_cleanup,
+    ):
+        _call_finalize(worker, metrics=metrics_mock, repo_root=tmp_path)
+
+    mock_cleanup.assert_called_once()
+
+
+def test_finalize_worker_failure_path_cleanup_runs_when_wip_clean(
+    tmp_path: Path,
+) -> None:
+    """commit_wip_state status='clean' (nothing to preserve) → cleanup IS called."""
+    manifest = make_manifest(
+        ticket_id="WOR-10",
+        worker_branch="wor-10-test-ticket",
+        failure_policy=FailurePolicy(on_check_failure="abort"),
+    )
+    metrics_mock = MagicMock()
+    worker = ActiveWorker(
+        ticket_id="WOR-10",
+        linear_id="fake-linear-id",
+        manifest=manifest,
+        worktree_path=tmp_path,
+        process=MagicMock(spec=subprocess.Popen),
+    )
+
+    with (
+        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(False, [])),
+        patch(
+            "app.core.watcher.watcher_finalize.commit_wip_state",
+            return_value=WipPreservationResult(
+                status="clean", sha=None, backup_path=None, error=None
+            ),
+        ),
+        patch("app.core.watcher.watcher_finalize.cleanup_worktree") as mock_cleanup,
+    ):
+        _call_finalize(worker, metrics=metrics_mock, repo_root=tmp_path)
+
+    mock_cleanup.assert_called_once()
+
+
+def test_finalize_worker_passes_backup_root_to_commit_wip_state(
+    tmp_path: Path,
+) -> None:
+    """finalize_worker passes backup_root=<repo>/.claude/artifacts to wip preserve."""
+    manifest = make_manifest(
+        ticket_id="WOR-10",
+        worker_branch="wor-10-test-ticket",
+        failure_policy=FailurePolicy(on_check_failure="abort"),
+    )
+    metrics_mock = MagicMock()
+    worker = ActiveWorker(
+        ticket_id="WOR-10",
+        linear_id="fake-linear-id",
+        manifest=manifest,
+        worktree_path=tmp_path / "worktree",
+        process=MagicMock(spec=subprocess.Popen),
+    )
+
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+
+    with (
+        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(False, [])),
+        patch(
+            "app.core.watcher.watcher_finalize.commit_wip_state",
+            return_value=WipPreservationResult(
+                status="clean", sha=None, backup_path=None, error=None
+            ),
+        ) as mock_commit,
+        patch("app.core.watcher.watcher_finalize.cleanup_worktree"),
+    ):
+        _call_finalize(worker, metrics=metrics_mock, repo_root=repo_root)
+
+    _, kwargs = mock_commit.call_args
+    assert kwargs.get("backup_root") == repo_root / ".claude" / "artifacts"

--- a/tests/test_watcher_worktrees.py
+++ b/tests/test_watcher_worktrees.py
@@ -553,7 +553,9 @@ def test_commit_wip_state_creates_and_pushes_on_dirty_tree(
     ):
         result = commit_wip_state(tmp_path, "WOR-10", "wor-10-test")
 
-    assert result == sha
+    assert result.status == "pushed"
+    assert result.sha == sha
+    assert result.backup_path is None
     assert call_count[0] == 5
     assert any("WIP commit" in r.message for r in caplog.records)
     assert any("a1b2c3d4" in r.message for r in caplog.records)
@@ -571,7 +573,9 @@ def test_commit_wip_state_no_op_on_clean_tree(
         )
         result = commit_wip_state(Path("/tmp"), "WOR-10", "wor-10-test")
 
-    assert result is None
+    assert result.status == "clean"
+    assert result.sha is None
+    assert result.backup_path is None
     assert any("no wip commit needed" in r.message for r in caplog.records)
 
 
@@ -607,29 +611,32 @@ def test_commit_wip_state_returns_none_on_git_error(
     ):
         result = commit_wip_state(tmp_path, "WOR-10", "wor-10-test")
 
-    assert result is None
-    assert any("WIP commit failed" in r.message for r in caplog.records)
+    # No backup_root passed → cannot fall back to backup → status is "failed"
+    assert result.status == "failed"
+    assert result.sha is None
+    assert any("WIP commit/push failed" in r.message for r in caplog.records)
 
 
 def test_commit_wip_state_returns_none_on_push_failure(
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    # status → dirty, add → ok, commit → ok, push → fail
-    mock_results = [
-        _completed_process(stdout="M test.txt\n"),  # status
-        _completed_process(),  # add
-        _completed_process(),  # commit
-        _completed_process(
-            returncode=1, stderr="remote: Authentication failed"
-        ),  # push
-    ]
+    # status → dirty, add → ok, commit → ok, push → raises CalledProcessError
+    # (real subprocess.run with check=True raises on non-zero; the mock must
+    # raise too for the path to behave correctly)
     call_count = [0]
 
     def _side_effect(*args: object, **kwargs: object) -> subprocess.CompletedProcess:
         idx = call_count[0]
         call_count[0] += 1
-        return mock_results[idx]
+        # 1: status (dirty), 2: add, 3: commit, 4: push raises
+        if idx == 0:
+            return _completed_process(stdout="M test.txt\n")
+        if idx == 3:
+            raise subprocess.CalledProcessError(
+                1, "git push", stderr="remote: Authentication failed"
+            )
+        return _completed_process()
 
     with (
         patch(
@@ -638,10 +645,13 @@ def test_commit_wip_state_returns_none_on_push_failure(
         ),
         caplog.at_level(logging.WARNING, logger="app.core.watcher.watcher_worktrees"),
     ):
+        # No backup_root → status == "failed"
         result = commit_wip_state(tmp_path, "WOR-10", "wor-10-test")
 
-    assert result is None
-    assert any("wip commit not pushed" in r.message for r in caplog.records)
+    assert result.status == "failed"
+    assert result.sha is None
+    assert "remote: Authentication failed" in (result.error or "")
+    assert any("WIP commit/push failed" in r.message for r in caplog.records)
 
 
 def test_commit_wip_state_skips_commit_when_staged_but_not_committed(
@@ -662,7 +672,8 @@ def test_commit_wip_state_skips_commit_when_staged_but_not_committed(
         )
         result = commit_wip_state(tmp_path, "WOR-10", "wor-10-test")
 
-    assert result is None
+    assert result.status == "clean"
+    assert result.sha is None
     assert any("no wip commit needed" in r.message for r in caplog.records)
 
 
@@ -670,7 +681,7 @@ def test_commit_wip_state_handles_status_error(
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    # git status fails (non-zero returncode) → log warning and return None
+    # git status fails (non-zero returncode) → log warning and return failed
     # status uses check=False so it returns a CompletedProcess, not a
     # CalledProcessError — the error is handled manually in the function.
     with (
@@ -687,8 +698,104 @@ def test_commit_wip_state_handles_status_error(
     ):
         result = commit_wip_state(tmp_path, "WOR-10", "wor-10-test")
 
-    assert result is None
+    assert result.status == "failed"
+    assert result.sha is None
+    assert "error: invalid option" in (result.error or "")
     assert any("git status failed" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# WOR-288 — backup_root fallback when commit/push fails
+# ---------------------------------------------------------------------------
+
+
+def test_commit_wip_state_falls_back_to_backup_when_push_fails(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Push failure + backup_root → dirty worktree contents copied to backup."""
+    # Set up a fake worktree with one file
+    worktree = tmp_path / "worktree"
+    worktree.mkdir()
+    (worktree / "test.txt").write_text("dirty content")
+    backup_root = tmp_path / "backup_root"
+
+    call_count = [0]
+
+    def _side_effect(*args: object, **kwargs: object) -> subprocess.CompletedProcess:
+        idx = call_count[0]
+        call_count[0] += 1
+        # 1: status (dirty), 2: add, 3: commit, 4: push raises
+        if idx == 0:
+            return _completed_process(stdout="M test.txt\n")
+        if idx == 3:
+            raise subprocess.CalledProcessError(
+                1, "git push", stderr="remote: Authentication failed"
+            )
+        return _completed_process()
+
+    with (
+        patch(
+            "app.core.watcher.watcher_worktrees.subprocess.run",
+            side_effect=_side_effect,
+        ),
+        caplog.at_level(logging.WARNING, logger="app.core.watcher.watcher_worktrees"),
+    ):
+        result = commit_wip_state(
+            worktree, "WOR-10", "wor-10-test", backup_root=backup_root
+        )
+
+    assert result.status == "backup"
+    assert result.sha is None
+    assert result.backup_path is not None
+    assert result.backup_path == backup_root / "wor_10" / "wip"
+    # Backed-up file is present
+    assert (result.backup_path / "test.txt").read_text() == "dirty content"
+    assert any("backed up to" in r.message for r in caplog.records)
+
+
+def test_commit_wip_state_clean_tree_with_backup_root_still_clean(
+    tmp_path: Path,
+) -> None:
+    """Clean tree + backup_root → status remains 'clean', no backup created."""
+    backup_root = tmp_path / "backup_root"
+    with patch("app.core.watcher.watcher_worktrees.subprocess.run") as mock_run:
+        mock_run.return_value = subprocess.CompletedProcess(
+            args="", returncode=0, stdout="", stderr=""
+        )
+        result = commit_wip_state(
+            Path("/tmp"), "WOR-10", "wor-10-test", backup_root=backup_root
+        )
+
+    assert result.status == "clean"
+    assert result.backup_path is None
+    assert not backup_root.exists()
+
+
+def test_save_dirty_worktree_to_backup_helper_returns_path(
+    tmp_path: Path,
+) -> None:
+    """Direct test of the backup helper used by commit_wip_state on push failure."""
+    from app.core.watcher.watcher_worktrees import _save_dirty_worktree_to_backup
+
+    worktree = tmp_path / "worktree"
+    worktree.mkdir()
+    (worktree / "a.py").write_text("print('a')")
+    (worktree / "b.py").write_text("print('b')")
+    # .git and __pycache__ should be ignored by the copytree filter
+    (worktree / ".git").mkdir()
+    (worktree / ".git" / "config").write_text("ignore me")
+    (worktree / "__pycache__").mkdir()
+    (worktree / "__pycache__" / "a.cpython-313.pyc").write_text("bytecode")
+
+    backup_root = tmp_path / "backup_root"
+    result = _save_dirty_worktree_to_backup(worktree, "WOR-10", backup_root)
+
+    assert result == backup_root / "wor_10" / "wip"
+    assert (result / "a.py").read_text() == "print('a')"
+    assert (result / "b.py").read_text() == "print('b')"
+    assert not (result / ".git").exists()
+    assert not (result / "__pycache__").exists()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Two related work-loss bugs hit on 2026-05-02 (WOR-270 nearly lost, WOR-271 actually lost — recovered manually). Closes both as a single coherent change since both live in `app/core/watcher/watcher_finalize.py` and together cover every observed work-loss failure mode.

### WOR-286 — outcome misclassification on non-zero exit

`_execute_finalization` classified any non-zero subprocess exit as failure, even when the worker had written `result.json` with `status=success` and the work was complete. Caused by treating the OS exit code as the primary success signal instead of the worker's in-band result.json.

**Fix:** read `result.json` first; if it reports `status=success` AND required checks pass, treat the run as success regardless of exit code. Log a WARNING noting the exit-code disagreement for visibility. When `result.json` is missing OR reports failure, route to existing failure path.

### WOR-288 — cleanup_worktree fired even when WIP commit silently failed

`commit_wip_state` swallowed every subprocess error and returned `None`. `finalize_worker` called `cleanup_worktree` unconditionally, destroying uncommitted worktree changes whenever pre-commit hooks rejected the commit, push was rate-limited, or auth expired. WOR-271 lost 17 file edits this way; recovery required replaying the worker's stream-json log.

**Fix:** introduce `WipPreservationResult` NamedTuple with explicit `status` field (`"clean"` / `"pushed"` / `"backup"` / `"failed"`). `commit_wip_state` now also accepts a `backup_root` kwarg — on commit/push failure, it copies the dirty worktree to `<backup_root>/<ticket>/wip/` as a last resort (excluding `.git/` and `__pycache__/`). `finalize_worker` only calls `cleanup_worktree` when the result indicates work is preserved (or there was nothing to lose); on `"failed"` it logs an ERROR and leaves the worktree in place for manual salvage.

## Test plan

- [x] 9 new tests covering: success-with-bad-exit, missing/failed result.json, success result + failed checks, all 4 wip-result paths in finalize_worker (clean/pushed/backup/failed), backup-on-push-failure, `.git`/`__pycache__` exclusion in the backup helper
- [x] 4 existing tests updated to use the new `WipPreservationResult` return type
- [x] `ruff check .` passes
- [x] `mypy app/` passes
- [x] `pytest -q` — **924 passed** (was 915)
- [x] pre-commit hooks pass

## Operational note

**The running watcher daemon must be restarted after this merges** — Python imports the loaded module at startup and does not hot-reload. The currently-running PID 368412 is using stale code that doesn't include either fix; without a restart, future failures will continue to silently destroy work.

Closes WOR-286
Closes WOR-288