### PR TITLE
WOR-295 Watcher: _check_epic_completion spams Linear comment every poll cycle when --no-epic-shutdown is set

### DIFF
--- a/app/core/watcher/watcher.py
+++ b/app/core/watcher/watcher.py
@@ -103,6 +103,7 @@ class Watcher:
         self._retry_counters: dict[str, int] = {}
         self._escalation_policy = EscalationPolicy.from_toml()
         self._no_epic_shutdown = no_epic_shutdown
+        self._last_epic_complete_announced: dict[str, str] = {}
 
     # ------------------------------------------------------------------
     # Public entry point
@@ -457,7 +458,7 @@ class Watcher:
     # Worker lifecycle
     # ------------------------------------------------------------------
 
-    def _reap_pool(self, workers: list[ActiveWorker]) -> list[ActiveWorker]:
+    def _reap_pool(self, workers: list[ActiveWorker]) -> tuple[list[ActiveWorker], str]:
         still_running: list[ActiveWorker] = []
         for worker in workers:
             rc = worker.process.poll()
@@ -471,7 +472,7 @@ class Watcher:
                 rc,
                 elapsed,
             )
-            finalize_worker(
+            outcome, *_ = finalize_worker(
                 worker,
                 returncode=rc,
                 wall_time=elapsed,
@@ -488,14 +489,14 @@ class Watcher:
                     epic_id=worker.manifest.epic_id,
                     worker_branch=worker.manifest.worker_branch,
                     elapsed=elapsed,
-                    succeeded=rc == 0,
+                    succeeded=(outcome == "success"),
                 )
             )
-        return still_running
+        return still_running, outcome
 
     def _reap_finished_workers(self) -> None:
-        self._local_active = self._reap_pool(self._local_active)
-        self._cloud_active = self._reap_pool(self._cloud_active)
+        self._local_active, _ = self._reap_pool(self._local_active)
+        self._cloud_active, _ = self._reap_pool(self._cloud_active)
 
     # ------------------------------------------------------------------
     # Epic completion detection
@@ -554,11 +555,20 @@ class Watcher:
             return
 
         if self._processed_tickets:
-            failed = [t for t in self._processed_tickets if not t.succeeded]
-            succeeded = [t for t in self._processed_tickets if t.succeeded]
+            state_key = (
+                "|".join(sorted(t.ticket_id for t in self._processed_tickets))
+                + ":"
+                + str(any(not t.succeeded for t in self._processed_tickets))
+            )
             epic_id = next(
                 (t.epic_id for t in self._processed_tickets if t.epic_id), None
             )
+            if epic_id and self._last_epic_complete_announced.get(epic_id) == state_key:
+                return
+            if epic_id:
+                self._last_epic_complete_announced[epic_id] = state_key
+            failed = [t for t in self._processed_tickets if not t.succeeded]
+            succeeded = [t for t in self._processed_tickets if t.succeeded]
             if failed:
                 logger.warning(
                     "All tickets processed — %d failed, %d succeeded",

--- a/app/core/watcher/watcher_finalize.py
+++ b/app/core/watcher/watcher_finalize.py
@@ -151,7 +151,7 @@ def finalize_worker(
     repo_root: Path,
     mode: str,
     project_id: str,
-) -> None:
+) -> tuple[Outcome, bool, bool, list[str] | None, list[dict[str, int | str]]]:
     outcome, escalated, artifacts_preserved, sonar_findings, failed_checks = (
         _execute_finalization(worker, returncode, linear, escalation_policy, repo_root)
     )
@@ -249,7 +249,7 @@ def finalize_worker(
     if artifacts_preserved:
         # Success path — artifacts already saved upstream; remove worktree.
         cleanup_worktree(repo_root, worker.worktree_path)
-        return
+        return outcome, escalated, artifacts_preserved, sonar_findings, failed_checks
 
     # Failure path — preserve WIP before considering teardown (WOR-258, WOR-288).
     backup_root = repo_root / _CLAUDE_DIR / "artifacts"
@@ -280,6 +280,7 @@ def finalize_worker(
             wip_result.error or "unknown",
             worker.manifest.worker_branch,
         )
+    return outcome, escalated, artifacts_preserved, sonar_findings, failed_checks
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -444,6 +444,105 @@ def test_check_epic_completion_empty_startup_keeps_polling(tmp_path: Path) -> No
 
 
 # ---------------------------------------------------------------------------
+# _check_epic_completion — memoization: duplicate suppression
+# ---------------------------------------------------------------------------
+
+
+def test_epic_completion_memoization_suppresses_duplicate(
+    tmp_path: Path,
+) -> None:
+    """Two consecutive _check_epic_completion calls with identical state must
+    post the Linear comment exactly once, not twice."""
+    linear_mock = MagicMock()
+    linear_mock.list_ready_for_local.return_value = []
+    w = Watcher(
+        linear_client=linear_mock,
+        repo_root=tmp_path,
+        no_epic_shutdown=True,
+    )
+    w._processed_tickets = [
+        _ProcessedTicket(
+            ticket_id="WOR-10",
+            epic_id="WOR-96",
+            worker_branch="wor-10-test-ticket",
+            elapsed=120.0,
+        )
+    ]
+
+    with patch.object(w, "_has_waiting_deps", return_value=False):
+        w._check_epic_completion()
+        w._check_epic_completion()
+
+    linear_mock.post_comment.assert_called_once()
+
+
+def test_epic_completion_re_emit_on_state_change(
+    tmp_path: Path,
+) -> None:
+    """When the processed-ticket state changes between calls (e.g. a new ticket
+    is added), a fresh comment IS posted."""
+    linear_mock = MagicMock()
+    linear_mock.list_ready_for_local.return_value = []
+    w = Watcher(
+        linear_client=linear_mock,
+        repo_root=tmp_path,
+        no_epic_shutdown=True,
+    )
+    w._processed_tickets = [
+        _ProcessedTicket(
+            ticket_id="WOR-10",
+            epic_id="WOR-96",
+            worker_branch="wor-10-test-ticket",
+            elapsed=120.0,
+        )
+    ]
+
+    with patch.object(w, "_has_waiting_deps", return_value=False):
+        w._check_epic_completion()
+        # State changed — add a second ticket
+        w._processed_tickets.append(
+            _ProcessedTicket(
+                ticket_id="WOR-11",
+                epic_id="WOR-96",
+                worker_branch="wor-11-test-ticket",
+                elapsed=60.0,
+            )
+        )
+        w._check_epic_completion()
+
+    assert linear_mock.post_comment.call_count == 2
+
+
+def test_epic_completion_failed_ticket_blocks_comment(
+    tmp_path: Path,
+) -> None:
+    """A _ProcessedTicket with succeeded=False must still block the comment
+    and NOT trigger re-posts through memoization."""
+    linear_mock = MagicMock()
+    linear_mock.list_ready_for_local.return_value = []
+    w = Watcher(
+        linear_client=linear_mock,
+        repo_root=tmp_path,
+        no_epic_shutdown=True,
+    )
+    w._processed_tickets = [
+        _ProcessedTicket(
+            ticket_id="WOR-10",
+            epic_id="WOR-96",
+            worker_branch="wor-10-test-ticket",
+            elapsed=120.0,
+            succeeded=False,
+        )
+    ]
+
+    with patch.object(w, "_has_waiting_deps", return_value=False):
+        w._check_epic_completion()
+        w._check_epic_completion()
+
+    linear_mock.post_comment.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
 # _handle_signal — SIGTERM triggers LiteLLM proxy cleanup and sets _running=False
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes WOR-295

Watcher daemon running with --no-epic-shutdown after a sub-ticket completes posts the epic-complete Linear comment exactly once per state transition, not once per poll cycle. Failed sub-tickets are correctly identified as failed in the processed_tickets table and prevent the `merged` comment from being posted.