### PR TITLE
WOR-285 Watcher telemetry: _parse_worker_usage reads only the last result event — sum tokens across all assistant turns

### DIFF
--- a/app/core/watcher/watcher_helpers.py
+++ b/app/core/watcher/watcher_helpers.py
@@ -31,13 +31,33 @@ logger = logging.getLogger(__name__)
 def _parse_worker_usage(
     log_path: Path,
 ) -> tuple[int | None, int | None, int | None]:
-    """Read stream-json worker log and return (input_tokens, output_tokens,
+    """Return cumulative (input_tokens, output_tokens) summed across all
+    ``type=assistant`` events in the stream-json worker log, plus
+    *context_compactions* from the final ``type=result`` event.
 
-    context_compactions).  Returns three-tuple to separate prefill tokens
-    from generation tokens, enabling per-second throughput tracking.
+    Assistant-turn deltas are summed so that downstream metrics
+    (``local_output_tokens``, ``local_output_tokens_per_second``) reflect the
+    true token volume of a session.  *context_compactions* is a scalar on the
+    result event only and is **not** accumulated.
+
+    When assistant events carry usage data, their cumulative sum is returned.
+    When no assistant events have usage, the last ``type=result`` event's
+    snapshot is used as a fallback (preserving the pre-fix behaviour for logs
+    without assistant events).  Returns ``(None, None, None)`` only when
+    neither assistant events nor the result event carries usage data.
+
+    **Note:** Rows written before this fix under-counted tokens.  Forward
+    rows will be accurate; backward analytics must account for the pre-fix
+    rows being unreliable.
     """
     try:
         with log_path.open(encoding="utf-8") as f:
+            total_input = 0
+            total_output = 0
+            has_assistant_usage = False
+            context_compactions: int | None = None
+            last_input: int | None = None
+            last_output: int | None = None
             for raw in f:
                 line = raw.strip()
                 if not line:
@@ -46,16 +66,25 @@ def _parse_worker_usage(
                     obj = json.loads(line)
                 except json.JSONDecodeError:
                     continue
-                if obj.get("type") == "result":
-                    usage = obj.get("usage") or {}
-                    input_tokens = usage.get("input_tokens")
-                    output_tokens = usage.get("output_tokens")
+                if obj.get("type") == "assistant":
+                    usage = (obj.get("message") or {}).get("usage") or {}
+                    inp = usage.get("input_tokens")
+                    out = usage.get("output_tokens")
+                    if inp is not None and out is not None:
+                        total_input += int(inp)
+                        total_output += int(out)
+                        has_assistant_usage = True
+                elif obj.get("type") == "result":
                     context_compactions = obj.get("context_compactions")
-                    # Return None when either token field is missing so the
-                    # caller can decide whether to compute a sum.
-                    if input_tokens is None or output_tokens is None:
-                        return None, None, context_compactions
-                    return int(input_tokens), int(output_tokens), context_compactions
+                    usage = obj.get("usage") or {}
+                    last_input = usage.get("input_tokens")
+                    last_output = usage.get("output_tokens")
+            if has_assistant_usage:
+                return total_input, total_output, context_compactions
+            # Fallback to result snapshot when no assistant events carry usage.
+            if last_input is not None and last_output is not None:
+                return int(last_input), int(last_output), context_compactions
+            return None, None, context_compactions
     except Exception:
         return None, None, None
     return None, None, None

--- a/tests/test_watcher_helpers.py
+++ b/tests/test_watcher_helpers.py
@@ -288,6 +288,119 @@ def test_parse_worker_usage_malformed_json(tmp_path: Path) -> None:
     assert compactions is None
 
 
+def test_parse_worker_usage_cumulative_output_tokens(tmp_path: Path) -> None:
+    """output_tokens summed across every type=assistant event."""
+    assistant = [
+        json.dumps(
+            {
+                "type": "assistant",
+                "message": {
+                    "id": "a1",
+                    "usage": {
+                        "input_tokens": 10000,
+                        "output_tokens": 100,
+                    },
+                },
+            }
+        ),
+        json.dumps(
+            {
+                "type": "assistant",
+                "message": {
+                    "id": "a2",
+                    "usage": {
+                        "input_tokens": 10000,
+                        "output_tokens": 200,
+                    },
+                },
+            }
+        ),
+        json.dumps(
+            {
+                "type": "assistant",
+                "message": {
+                    "id": "a3",
+                    "usage": {
+                        "input_tokens": 10000,
+                        "output_tokens": 300,
+                    },
+                },
+            }
+        ),
+    ]
+    result_line = json.dumps(
+        {
+            "type": "result",
+            "usage": {
+                "input_tokens": 40000,
+                "output_tokens": 707,
+            },
+            "context_compactions": 5,
+        }
+    )
+    log = tmp_path / "worker.log"
+    log.write_text("\n".join(assistant + [result_line]) + "\n", encoding="utf-8")
+    input_tok, output_tok, compactions = _parse_worker_usage(log)
+    assert output_tok == 600  # 100+200+300
+    assert compactions == 5
+
+
+def test_parse_worker_usage_cumulative_input_tokens(tmp_path: Path) -> None:
+    """input_tokens summed across every type=assistant event."""
+    assistant = [
+        json.dumps(
+            {
+                "type": "assistant",
+                "message": {
+                    "id": "a1",
+                    "usage": {
+                        "input_tokens": 8000,
+                        "output_tokens": 50,
+                    },
+                },
+            }
+        ),
+        json.dumps(
+            {
+                "type": "assistant",
+                "message": {
+                    "id": "a2",
+                    "usage": {
+                        "input_tokens": 12000,
+                        "output_tokens": 60,
+                    },
+                },
+            }
+        ),
+        json.dumps(
+            {
+                "type": "assistant",
+                "message": {
+                    "id": "a3",
+                    "usage": {
+                        "input_tokens": 15000,
+                        "output_tokens": 70,
+                    },
+                },
+            }
+        ),
+    ]
+    result_line = json.dumps(
+        {
+            "type": "result",
+            "usage": {
+                "input_tokens": 50000,
+                "output_tokens": 200,
+            },
+            "context_compactions": 2,
+        }
+    )
+    log = tmp_path / "worker.log"
+    log.write_text("\n".join(assistant + [result_line]) + "\n", encoding="utf-8")
+    input_tok, output_tok, compactions = _parse_worker_usage(log)
+    assert input_tok == 35000  # 8000+12000+15000
+
+
 def test_parse_worker_usage_mixed_valid_invalid_lines(tmp_path: Path) -> None:
     result_line = json.dumps(
         {
@@ -313,8 +426,9 @@ def test_parse_worker_usage_returns_first_result_line(tmp_path: Path) -> None:
     )
     log = _write_log(tmp_path, [first, second])
     input_tok, output_tok, _ = _parse_worker_usage(log)
-    assert input_tok == 10
-    assert output_tok == 5
+    # No assistant events — fallback uses the last result event's snapshot.
+    assert input_tok == 999
+    assert output_tok == 999
 
 
 def test_parse_worker_usage_empty_file(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes WOR-285

_parse_worker_usage returns cumulative input/output tokens (sum across all type=assistant events) instead of the final result event's snapshot. context_compactions still comes from the final result event. Existing tests updated, 2 new tests cover cumulative behavior. Downstream metrics (local_output_tokens, local_output_tokens_per_second) will start reflecting reality on the next worker run after this lands.