### PR TITLE
WOR-300 Epic: Watcher metrics correctness — DB telemetry + TUI render coverage

### DIFF
--- a/app/core/watcher/watcher_finalize.py
+++ b/app/core/watcher/watcher_finalize.py
@@ -26,6 +26,7 @@ from .watcher_helpers import (
 from .watcher_subprocess import (
     create_pr,
     fetch_sonar_findings,
+    parse_git_shortstat,
     run_checks,
 )
 from .watcher_tui import TrackedPR
@@ -185,12 +186,35 @@ def finalize_worker(
             escalation_policy,
             repo_root,
             tracked_prs=tracked_prs,
+            metrics=metrics,
+            project_id=project_id,
         )
     )
 
     log_path = worker.worktree_path / f".claude/worker_{worker.ticket_id.lower()}.log"
     input_tokens, output_tokens, context_compactions = _parse_worker_usage(log_path)
     eff = resolve_effective_mode(mode, worker.manifest.implementation_mode)
+
+    # Parse git diff --shortstat to populate lines_changed / files_changed.
+    # Must run before preserve_worker_artifacts tears down the worktree.
+    try:
+        diff_output = subprocess.run(  # nosec B603 B607
+            [
+                "git",
+                "-C",
+                str(worker.worktree_path),
+                "diff",
+                "--shortstat",
+                worker.manifest.base_branch,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        raw_shortstat = (diff_output.stdout or "") + (diff_output.stderr or "")
+        lines_changed, files_changed = parse_git_shortstat(raw_shortstat)
+    except (OSError, subprocess.TimeoutExpired, OSError):
+        lines_changed, files_changed = 0, 0
 
     # Cloud metrics — populated only when eff == "cloud"
     cloud_model: str | None = None
@@ -249,6 +273,8 @@ def finalize_worker(
             retry_count=worker.retry_count,
             context_compactions=context_compactions,
             check_failures=check_failures,
+            lines_changed=lines_changed,
+            files_changed=files_changed,
             sonar_findings_count=(
                 len(sonar_findings) if sonar_findings is not None else None
             ),
@@ -352,6 +378,8 @@ def _execute_finalization(
     escalation_policy: EscalationPolicy,
     repo_root: Path,
     tracked_prs: list[TrackedPR] | None = None,
+    metrics: MetricsStore | None = None,
+    project_id: str = "",
 ) -> tuple[
     Outcome, bool, bool, list[str] | None, list[dict[str, int | str]], str | None
 ]:
@@ -406,7 +434,13 @@ def _execute_finalization(
                 )
             return "failure", escalated, False, None, [], None
 
-    checks_ok, failed_checks = run_checks(manifest, worker.worktree_path)
+    checks_ok, failed_checks = run_checks(
+        manifest,
+        worker.worktree_path,
+        metrics=metrics,
+        ticket_id=ticket_id,
+        project_id=project_id,
+    )
     if not checks_ok:
         worker.retry_count += 1
     if not checks_ok and manifest.failure_policy.on_check_failure == "abort":

--- a/app/core/watcher/watcher_subprocess.py
+++ b/app/core/watcher/watcher_subprocess.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from typing import IO
 
 from app.core.manifest import ExecutionManifest
+from app.core.metrics import CheckRunEntry, MetricsStore
 
 from .watcher_helpers import (
     _tee_worker_output,
@@ -29,6 +30,14 @@ from .watcher_helpers import (
 from .watcher_types import _CLAUDE_DIR
 
 logger = logging.getLogger(__name__)
+
+# Regex for git diff --shortstat output like:
+#   "3 files changed, 45 insertions(+), 12 deletions(-)"
+_SHORTSTAT_RE = re.compile(
+    r"(\d+) files? changed"
+    r"(?:, (\d+) insertions?\(\+\))?"
+    r"(?:, (\d+) deletions?\(-\))?"
+)
 
 _SONAR_MAX_PAGES = 10
 _LINEAR_MCP = '{"mcpServers":{"linear-server":{"type":"http","url":"https://mcp.linear.app/mcp"}}}'
@@ -145,12 +154,20 @@ _LAST_FAILURE_FILENAME = "last_failure.json"
 
 
 def run_checks(
-    manifest: ExecutionManifest, worktree_path: Path
+    manifest: ExecutionManifest,
+    worktree_path: Path,
+    *,
+    metrics: MetricsStore | None = None,
+    ticket_id: str = "",
+    project_id: str = "",
 ) -> tuple[bool, list[dict[str, int | str]]]:
     """Run manifest.required_checks in the worktree.
 
     Returns (all_passed, failed_checks) where *failed_checks* is a list of
     ``{check: str, exit_code: int}`` for each check that returned non-zero.
+
+    When *metrics* is provided, each check execution is recorded to the
+    check_run_log table via ``MetricsStore.record_check_run``.
     """
     artifact_dir = worktree_path / Path(manifest.artifact_paths.result_json).parent
     failure_artifact = artifact_dir / _LAST_FAILURE_FILENAME
@@ -158,12 +175,24 @@ def run_checks(
     failed_checks: list[dict[str, int | str]] = []
     for check_cmd in manifest.required_checks:
         logger.info("Running check: %s", check_cmd)
+        start = datetime.now(timezone.utc).timestamp()
         result = subprocess.run(  # nosec B603
             shlex.split(check_cmd),
             cwd=str(worktree_path),
             capture_output=True,
             text=True,
         )
+        duration = datetime.now(timezone.utc).timestamp() - start
+        if metrics is not None and ticket_id:
+            metrics.record_check_run(
+                CheckRunEntry(
+                    ticket_id=ticket_id,
+                    project_id=project_id,
+                    check_cmd=check_cmd,
+                    outcome="passed" if result.returncode == 0 else "failed",
+                    duration_s=round(duration, 3),
+                )
+            )
         if result.returncode != 0:
             logger.error(
                 "Check failed: %s\n%s", check_cmd, result.stdout + result.stderr
@@ -351,3 +380,20 @@ def fetch_sonar_findings(branch: str) -> list[str] | None:
             break
 
     return all_severities
+
+
+def parse_git_shortstat(diff_output: str) -> tuple[int, int]:
+    """Parse ``git diff --shortstat`` output into (lines_changed, files_changed).
+
+    Returns ``(0, 0)`` when the diff output is empty or does not match the
+    expected pattern (e.g. no commits since base).
+    """
+    if not diff_output.strip():
+        return 0, 0
+    m = _SHORTSTAT_RE.search(diff_output)
+    if m is None:
+        return 0, 0
+    files = int(m.group(1))
+    ins = int(m.group(2)) if m.group(2) is not None else 0
+    dels = int(m.group(3)) if m.group(3) is not None else 0
+    return ins + dels, files

--- a/tests/test_watcher_finalize_metrics.py
+++ b/tests/test_watcher_finalize_metrics.py
@@ -124,6 +124,9 @@ def test_finalize_worker_check_failures_empty_on_success(
 
     m = metrics_mock.record.call_args[0][0]
     assert m.check_failures is None
+    # WOR-284 — git-diff fields are zero when worktree has no base branch
+    assert m.lines_changed == 0
+    assert m.files_changed == 0
 
 
 def test_finalize_worker_sonar_count_zero_on_empty_findings(

--- a/tests/test_watcher_subprocess.py
+++ b/tests/test_watcher_subprocess.py
@@ -18,6 +18,7 @@ from app.core.watcher.watcher_subprocess import (
     expand_skill,
     fetch_sonar_findings,
     launch_worker,
+    parse_git_shortstat,
     run_checks,
 )
 
@@ -507,6 +508,44 @@ def test_launch_worker_passes_linear_mcp_config_to_build_worker_cmd(
 
 
 # ---------------------------------------------------------------------------
+# parse_git_shortstat
+# ---------------------------------------------------------------------------
+
+
+def test_parse_git_shortstat_normal_output() -> None:
+    """Standard shortstat output is parsed correctly."""
+    line = "3 files changed, 45 insertions(+), 12 deletions(-)"
+    assert parse_git_shortstat(line) == (
+        57,
+        3,
+    )
+
+
+def test_parse_git_shortstat_no_insertions() -> None:
+    """Only deletions are handled when insertions are missing."""
+    assert parse_git_shortstat("2 files changed, 0 insertions(+), 30 deletions(-)") == (
+        30,
+        2,
+    )
+
+
+def test_parse_git_shortstat_no_deletions() -> None:
+    """Only insertions are handled when deletions are missing."""
+    assert parse_git_shortstat("1 file changed, 100 insertions(+)") == (100, 1)
+
+
+def test_parse_git_shortstat_empty_string() -> None:
+    """Empty or whitespace input returns zeros."""
+    assert parse_git_shortstat("") == (0, 0)
+    assert parse_git_shortstat("   \n  ") == (0, 0)
+
+
+def test_parse_git_shortstat_no_match() -> None:
+    """Unrecognised output returns zeros."""
+    assert parse_git_shortstat("nothing here") == (0, 0)
+
+
+# ---------------------------------------------------------------------------
 # run_checks
 # ---------------------------------------------------------------------------
 
@@ -670,6 +709,42 @@ def test_run_checks_last_failure_overwritten_by_last_failing_check(
     # Last failing check (mypy) should overwrite the first (ruff)
     assert data["check"] == "mypy app/"
     assert data["stdout"] == "output from check 2"
+
+
+def test_run_checks_records_check_run_per_check(tmp_path: Path) -> None:
+    """When metrics is provided, record_check_run is called once per check."""
+    manifest = _make_manifest(required_checks=["ruff check .", "mypy app/", "pytest"])
+    metrics_mock = MagicMock()
+
+    def fake_run(cmd: list[str], **kwargs: object) -> MagicMock:
+        result = MagicMock()
+        result.returncode = 0
+        result.stdout = ""
+        result.stderr = ""
+        return result
+
+    with patch(
+        "app.core.watcher.watcher_subprocess.subprocess.run", side_effect=fake_run
+    ):
+        run_checks(
+            manifest,
+            tmp_path,
+            metrics=metrics_mock,
+            ticket_id="WOR-10",
+            project_id="test-project",
+        )
+
+    assert metrics_mock.record_check_run.call_count == 3
+    called_calls = [
+        c.args[0].model_dump() for c in metrics_mock.record_check_run.call_args_list
+    ]
+    check_cmds = [c["check_cmd"] for c in called_calls]
+    assert check_cmds == ["ruff check .", "mypy app/", "pytest"]
+    for c in called_calls:
+        assert c["ticket_id"] == "WOR-10"
+        assert c["project_id"] == "test-project"
+        assert c["outcome"] == "passed"
+        assert c["duration_s"] is not None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_watcher_tui.py
+++ b/tests/test_watcher_tui.py
@@ -1,0 +1,475 @@
+"""Render-snapshot tests for WatcherDisplay (deferred from WOR-272).
+
+Covers WOR-296: snapshot the rich.Layout output of each code path in
+WatcherDisplay._build_layout and verify deterministic text representation.
+
+Tests MUST NOT instantiate ``rich.live.Live`` — only test _build_layout
+and _render_line sub-widgets directly.
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import MagicMock, patch
+
+from rich.console import Console
+from rich.live import Live
+
+from app.core.metrics import CostRollup
+from app.core.watcher.watcher_tui import (
+    TrackedPR,
+    TUIState,
+    WatcherDisplay,
+    WorkerState,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _tui_state(**kwargs) -> TUIState:
+    """Build a TUIState with explicit defaults."""
+    defaults: dict = {
+        "workers": [],
+        "cost_rollups": {
+            "today": CostRollup(),
+            "week": CostRollup(),
+            "all": CostRollup(),
+        },
+        "tracked_prs": [],
+    }
+    defaults.update(kwargs)
+    return TUIState(**defaults)
+
+
+def _take_snapshot(state: TUIState, width: int = 120) -> str:
+    """Render a WatcherDisplay layout to a text snapshot."""
+    display = WatcherDisplay()
+    console = Console(record=True, width=width, force_terminal=True)
+    console.print(display._build_layout(state))
+    return console.export_text()
+
+
+# ---------------------------------------------------------------------------
+# WOR-296 — scenario tests
+# ---------------------------------------------------------------------------
+
+
+def test_renders_idle_state_when_no_workers() -> None:
+    """Empty state: no active workers, no tracked PRs.
+
+    Asserts the worker table shows the "No active workers" fallback row.
+    """
+    state = _tui_state()
+    snapshot = _take_snapshot(state)
+
+    assert "No active workers" in snapshot
+    assert "—  —  No active workers" in snapshot or "No active workers" in snapshot
+    assert "No tracked PRs" in snapshot
+
+
+def test_renders_single_worker_with_elapsed_and_cost() -> None:
+    """Single local worker with elapsed time and local_saved amount."""
+    state = _tui_state(
+        workers=[
+            WorkerState(
+                ticket_id="WOR-50",
+                mode="local",
+                status="running",
+                elapsed_s=125.0,
+                local_saved=3.75,
+            ),
+        ],
+    )
+    snapshot = _take_snapshot(state)
+
+    assert "WOR-50" in snapshot
+    assert "local" in snapshot
+    assert "running" in snapshot
+    # 125s = 2m05s (int(125)//60=2, 125%60=5)
+    assert "2m05s" in snapshot
+    assert "$3.7500" in snapshot  # raw cost column format
+
+
+def test_renders_single_worker_cloud_cost() -> None:
+    """Single cloud worker shows cloud_cost in the cost column."""
+    state = _tui_state(
+        workers=[
+            WorkerState(
+                ticket_id="WOR-51",
+                mode="cloud",
+                status="running",
+                elapsed_s=45.0,
+                cloud_cost=0.85,
+            ),
+        ],
+    )
+    snapshot = _take_snapshot(state)
+
+    assert "WOR-51" in snapshot
+    assert "cloud" in snapshot
+    assert "45s" in snapshot
+    assert "$0.8500" in snapshot
+
+
+def test_renders_tracked_pr_with_status() -> None:
+    """PR auto-merge tracker table shows number, base branch, and status."""
+    state = _tui_state(
+        tracked_prs=[
+            TrackedPR(
+                number=42,
+                base="epic/wor-300",
+                last_status="PENDING",
+                last_poll=time.time() - 120.0,
+            ),
+            TrackedPR(
+                number=43,
+                base="main",
+                last_status="MERGED",
+                last_poll=time.time() - 60.0,
+            ),
+        ],
+    )
+    snapshot = _take_snapshot(state)
+
+    assert "42" in snapshot
+    assert "43" in snapshot
+    assert "epic/wor-300" in snapshot
+    assert "main" in snapshot
+    assert "PENDING" in snapshot
+    assert "MERGED" in snapshot
+
+
+def test_cost_rollup_status_bar() -> None:
+    """Top-left table shows Cost Economics with headers and dollar formatting.
+
+    Note: Rich layout clips data rows when the full layout is shown —
+    the section size=3 doesn't fit all three period rows. We assert on the
+    table headers (always visible) and verify _format_cost via unit tests.
+    """
+    state = _tui_state(
+        cost_rollups={
+            "today": CostRollup(
+                cloud_spent=66.0,
+                local_saved=2.22,
+                cloud_ticket_count=3,
+                local_ticket_count=5,
+            ),
+            "week": CostRollup(
+                cloud_spent=0.005,
+                local_saved=10.0,
+                cloud_ticket_count=1,
+                local_ticket_count=2,
+            ),
+            "all": CostRollup(
+                cloud_spent=500.0,
+                local_saved=25.0,
+                cloud_ticket_count=10,
+                local_ticket_count=20,
+            ),
+        },
+    )
+    snapshot = _take_snapshot(state)
+
+    assert "Cost Economics" in snapshot
+    assert "Period" in snapshot
+    assert "Cloud Spent" in snapshot
+    assert "Local Saved" in snapshot
+    assert "Cloud #" in snapshot
+    assert "Local #" in snapshot
+    # Session Totals (right side of top) is always rendered
+    assert "Session Totals" in snapshot
+    assert "Metric" in snapshot
+    assert "Value" in snapshot
+    # _format_cost correctness is verified separately in test_format_cost_*.
+
+
+def test_conflicting_pr_shows_in_red() -> None:
+    """CONFLICTING and BLOCKED PR statuses are styled with red.
+
+    Uses export_html() to assert on color class attributes rather than
+    plain-text output (rich colours are not visible in export_text()).
+    """
+    state = _tui_state(
+        tracked_prs=[
+            TrackedPR(
+                number=55,
+                base="epic/wor-300",
+                last_status="CONFLICTING",
+                last_poll=time.time() - 30.0,
+            ),
+            TrackedPR(
+                number=56,
+                base="main",
+                last_status="BLOCKED",
+                last_poll=time.time() - 60.0,
+            ),
+        ],
+    )
+    display = WatcherDisplay()
+    console = Console(record=True, width=120, force_terminal=True)
+    console.print(display._build_layout(state))
+    html = console.export_html()
+
+    assert "CONFLICTING" in html
+    assert "BLOCKED" in html
+    # Rich renders styled spans as <span class="r1"> where r1 maps to red
+    assert "r1" in html  # rich red style class
+
+
+def test_no_live_instantiated_in_snapshot_tests() -> None:
+    """Verifying that snapshot tests do not trigger Live creation.
+
+    _build_layout never creates a Live widget — only _render_live does,
+    and that is only called when _is_tty() is True and self._live is None.
+    Since we call _build_layout directly, Live.start() must never be called.
+    """
+    state = _tui_state()
+    with (
+        patch.object(Live, "start", wraps=Live.start) as mock_start,
+        patch.object(Live, "update", wraps=Live.update) as mock_update,
+        patch.object(Live, "refresh", wraps=Live.refresh) as mock_refresh,
+    ):
+        display = WatcherDisplay()
+        console = Console(record=True, width=120, force_terminal=True)
+        console.print(display._build_layout(state))
+
+    mock_start.assert_not_called()
+    mock_update.assert_not_called()
+    mock_refresh.assert_not_called()
+
+
+def test_pipe_fallback_no_live() -> None:
+    """When Console has no TTY (file=StringIO), _render_live delegates to _render_line
+    and never instantiates Live.
+
+    This covers the pipe fallback path in update_state → _render_live.
+    """
+    state = _tui_state(
+        workers=[
+            WorkerState(
+                ticket_id="WOR-50",
+                mode="local",
+                status="running",
+                elapsed_s=30.0,
+            ),
+        ],
+    )
+
+    display = WatcherDisplay()
+    # Piped console: no TTY → should NOT create Live widget
+    with patch.object(Live, "start") as mock_start:
+        # Calling update_state with a non-TTY console should route to _render_line
+        display.update_state(state)
+
+    # _is_tty() checks sys.stderr.isatty() which is False in tests,
+    # so update_state should call _render_line, not _render_live
+    mock_start.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Sub-widget unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_format_cost_small_values() -> None:
+    """Values < $0.01 use 4-decimal formatting."""
+    assert WatcherDisplay._format_cost(0.005) == "$0.0050"
+    assert WatcherDisplay._format_cost(0.0) == "$0.0000"
+    assert WatcherDisplay._format_cost(0.0099) == "$0.0099"
+
+
+def test_format_cost_regular_values() -> None:
+    """Values >= $0.01 use 2-decimal formatting."""
+    assert WatcherDisplay._format_cost(1.0) == "$1.00"
+    assert WatcherDisplay._format_cost(66.0) == "$66.00"
+    assert WatcherDisplay._format_cost(1000.5) == "$1000.50"
+
+
+def test_format_elapsed_seconds() -> None:
+    """Sub-60s elapsed displays as Xs."""
+    assert WatcherDisplay._format_elapsed(0) == "0s"
+    assert WatcherDisplay._format_elapsed(59) == "59s"
+    assert WatcherDisplay._format_elapsed(30) == "30s"
+
+
+def test_format_elapsed_minutes() -> None:
+    """60s+ elapsed displays as MmSSs."""
+    assert WatcherDisplay._format_elapsed(60) == "1m00s"
+    assert WatcherDisplay._format_elapsed(125) == "2m05s"
+    assert WatcherDisplay._format_elapsed(3661) == "61m01s"
+
+
+def test_format_elapsed_boundary() -> None:
+    """Exactly 60s boundary: 60s → 1m00s, 59s → 59s."""
+    assert WatcherDisplay._format_elapsed(59) == "59s"
+    assert WatcherDisplay._format_elapsed(60) == "1m00s"
+
+
+# ---------------------------------------------------------------------------
+# Worker/PR management
+# ---------------------------------------------------------------------------
+
+
+def test_add_and_remove_worker() -> None:
+    """add_worker appends, remove_worker filters by ticket_id."""
+    display = WatcherDisplay()
+    state = TUIState()
+    display._state = state
+
+    display.add_worker(WorkerState(ticket_id="WOR-1", mode="local", status="running"))
+    assert len(display._state.workers) == 1
+    assert display._state.workers[0].ticket_id == "WOR-1"
+
+    display.remove_worker("WOR-1")
+    assert len(display._state.workers) == 0
+
+
+def test_update_pr_registers_and_updates() -> None:
+    """First call appends, subsequent calls update existing entry."""
+    display = WatcherDisplay()
+    state = TUIState()
+    display._state = state
+
+    display.update_pr(42, "epic/wor-300", "PENDING", poll_time=1000.0)
+    assert len(display._state.tracked_prs) == 1
+    pr = display._state.tracked_prs[0]
+    assert pr.number == 42
+    assert pr.base == "epic/wor-300"
+    assert pr.last_status == "PENDING"
+    assert pr.last_poll == 1000.0
+
+    # Update existing
+    display.update_pr(42, "epic/wor-300", "MERGED", poll_time=2000.0)
+    assert len(display._state.tracked_prs) == 1
+    pr = display._state.tracked_prs[0]
+    assert pr.last_status == "MERGED"
+    assert pr.last_poll == 2000.0
+
+
+def test_poll_pr_status_returns_unknown_on_error() -> None:
+    """When gh CLI is unavailable or errors, return ('?','?')."""
+    with patch("subprocess.run", side_effect=FileNotFoundError("gh not found")):
+        result = WatcherDisplay.poll_pr_status(42)
+    assert result == ("?", "?")
+
+
+def test_poll_pr_status_returns_unknown_on_bad_json() -> None:
+    """Malformed JSON response returns ('?','?')."""
+    fake_response = MagicMock()
+    fake_response.returncode = 0
+    fake_response.stdout = "not json {{{"
+    with patch("subprocess.run", return_value=fake_response):
+        result = WatcherDisplay.poll_pr_status(42)
+    assert result == ("?", "?")
+
+
+def test_poll_pr_status_returns_unknown_on_nonzero_exit() -> None:
+    """Non-zero return code → ('?','?')."""
+    fake_response = MagicMock()
+    fake_response.returncode = 1
+    fake_response.stdout = ""
+    with patch("subprocess.run", return_value=fake_response):
+        result = WatcherDisplay.poll_pr_status(42)
+    assert result == ("?", "?")
+
+
+# ---------------------------------------------------------------------------
+# Line-based fallback
+# ---------------------------------------------------------------------------
+
+
+def test_render_line_logs_worker_lines() -> None:
+    """_render_line appends log lines for each worker."""
+    display = WatcherDisplay()
+    state = _tui_state(
+        workers=[
+            WorkerState(
+                ticket_id="WOR-1",
+                mode="local",
+                status="running",
+                elapsed_s=60.0,
+                local_saved=5.0,
+            ),
+        ],
+    )
+
+    with patch("app.core.watcher.watcher_tui.logger") as mock_logger:
+        display._render_line(state)
+
+    mock_logger.info.assert_called()
+    # Check the first call has the worker line
+    calls = [call[0][1] for call in mock_logger.info.call_args_list]
+    assert any("WOR-1" in msg for msg in calls)
+    assert any("local" in msg for msg in calls)
+    assert any("saved=$5.0000" in msg for msg in calls)
+
+
+def test_render_line_logs_cost_lines() -> None:
+    """_render_line appends cost rollup summary lines for each period."""
+    display = WatcherDisplay()
+    state = _tui_state(
+        cost_rollups={
+            "today": CostRollup(cloud_spent=10.0, local_saved=5.0),
+            "week": CostRollup(cloud_spent=20.0, local_saved=10.0),
+            "all": CostRollup(cloud_spent=100.0, local_saved=50.0),
+        },
+    )
+
+    with patch("app.core.watcher.watcher_tui.logger") as mock_logger:
+        display._render_line(state)
+
+    calls = [call[0][1] for call in mock_logger.info.call_args_list]
+    # Should have 3 cost lines + potentially worker lines
+    cost_lines = [c for c in calls if "COST" in c]
+    assert any("Today" in c for c in cost_lines)
+    assert any("Week" in c for c in cost_lines)
+    assert any("All" in c for c in cost_lines)
+
+
+# ---------------------------------------------------------------------------
+# TTY gating
+# ---------------------------------------------------------------------------
+
+
+def test_is_tty_returns_false_in_tests() -> None:
+    """In automated test environments, stderr is rarely a TTY."""
+    from app.core.watcher.watcher_tui import _is_tty
+
+    # In pytest, stderr is usually captured → not a TTY
+    # This test documents the expected behaviour, not a requirement
+    # Just verifies no crash — _is_tty() may be True/False depending on env
+    _is_tty()  # noqa: F841
+
+
+def test_stop_silently_handles_oserror() -> None:
+    """Live.stop() may raise OSError during shutdown — must be caught."""
+    display = WatcherDisplay()
+    fake_live = MagicMock()
+    fake_live.stop.side_effect = OSError("broken pipe")
+    display._live = fake_live
+
+    # Should not raise
+    display.stop()
+    assert display._live is None
+
+
+def test_stop_with_no_live_is_noop() -> None:
+    """When _live is None, stop() does nothing."""
+    display = WatcherDisplay()
+    display._live = None
+    # Should not raise
+    display.stop()
+
+
+def test_build_layout_has_correct_structure() -> None:
+    """_build_layout returns a Layout with root → top/middle/bottom."""
+    state = _tui_state()
+    display = WatcherDisplay()
+    layout = display._build_layout(state)
+
+    assert layout.name == "root"
+    assert layout["top"] is not None
+    assert layout["middle"] is not None
+    assert layout["bottom"] is not None


### PR DESCRIPTION
## Summary

Make `metrics.db` trustworthy and `WatcherDisplay` verifiable. Six previously-dead `ticket_metrics` columns and an empty `check_run_log` table now populate. `_parse_worker_usage` returns cumulative tokens summed across all assistant turns instead of the final-turn snapshot. `WatcherDisplay` is now covered by 24 render-snapshot tests that lift coverage on `watcher_tui.py` from 29% to 90%.

## Sub-tickets included

- **WOR-284** — Telemetry: populate `lines_changed`, `files_changed`, `sonar_findings_count`, `check_failures_json`, `context_compactions`, `check_run_log` (PR #598)
- **WOR-285** — Telemetry: `_parse_worker_usage` cumulative token sum (PR #591, merged directly to main earlier today; included via main → epic merge)
- **WOR-296** — TUI render-snapshot tests for `WatcherDisplay` (PR #597)

## Implementation highlights

- **`parse_git_shortstat` helper** in `watcher_subprocess.py` parses `git diff --shortstat <base>..HEAD` output and feeds `lines_changed` / `files_changed` into `TicketMetrics`. Runs before `preserve_worker_artifacts` and `cleanup_worktree` so the worktree still exists.
- **`run_checks` signature change** — adds `metrics: MetricsStore`, `ticket_id: str`, `project_id: str` parameters so each check execution can call `MetricsStore.record_check_run(CheckRunEntry(...))`. All call sites in `finalize_worker` updated.
- **24 TUI tests** — render-snapshot via `Console(record=True, force_terminal=True).export_text()`, no real-terminal dependency, no `Live` instantiation. One Rich layout quirk discovered (cost table data rows clip due to hard-coded `size=3`) — documented in WOR-254 improvement log for follow-up.
- **`_parse_worker_usage` cumulative sum** — sums `usage.output_tokens` across every `type=assistant` event; falls back to result-event snapshot when no assistant events have usage data. Sane throughput numbers (~92 tok/s output) now flow into `local_output_tokens_per_second`.

## Test plan

- [x] `pytest --cov=app` — **966 passed**, total coverage **85%** (up from 80% at WOR-225 close)
- [x] Security scan: **PASS** (`bandit -r app/ -q`; only stale-nosec warnings)
- [x] `ruff check .`, `mypy app/`, `deptry .`, `semgrep` — all pass
- [x] Coverage by module: `watcher_tui.py` 29% → 90%; `watcher_finalize.py` 94% (-1% from new edge-path lines, acceptable); `dispatch.py` 100%
- [x] UI / integration tests: none present (acknowledged)

## File-size advisories

`tests/test_watcher_subprocess.py` is 872 LOC (RECOMMEND tier ≥700). Consider splitting in a follow-up if it grows further. New file `tests/test_watcher_tui.py` is 475 LOC (under ADVISORY).

## Operational notes

- Forward-only telemetry fix — pre-WOR-284 rows in `metrics.db` keep their null values. Future analytics queries must filter by `recorded_at >= 2026-05-02T17:09:00Z` for trustworthy results.
- The watcher daemon must be restarted after merge so the new code (parse_git_shortstat, record_check_run wiring, cumulative `_parse_worker_usage`) is loaded.
- WOR-303 (route worker side-discoveries from result.json `notes` to WOR-254 improvement log) was filed during this work — pre-existing process gap, not a blocker.

**Milestone:** Watcher v3 — routing & cost economics

Closes WOR-300
Closes WOR-284
Closes WOR-285
Closes WOR-296