### PR TITLE
fix: watcher daemon startup crash from invalid logging.basicConfig kwarg

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -215,11 +215,13 @@ def _run_watcher(args: argparse.Namespace) -> int:
     from app.core.watcher import Watcher
     from app.core.watcher.log_format import ColorFormatter
 
+    handler = logging.StreamHandler(sys.stderr)
+    handler.setFormatter(
+        ColorFormatter("%(asctime)s %(levelname)-8s %(name)s: %(message)s")
+    )
     logging.basicConfig(
         level=logging.DEBUG if args.verbose else logging.INFO,
-        format="%(asctime)s %(levelname)-8s %(name)s: %(message)s",
-        stream=sys.stderr,
-        cls=ColorFormatter,  # type: ignore[call-overload]
+        handlers=[handler],
     )
     mode = args.worker_mode or os.environ.get("WORKER_MODE", "default")
     max_local = args.max_local_workers


### PR DESCRIPTION
## Summary

`logging.basicConfig` does not accept a `cls` kwarg. The WOR-270 ColorFormatter wiring passed `cls=ColorFormatter` and silenced mypy with `# type: ignore[call-overload]`. On Python 3.13 the runtime raises `ValueError: Unrecognised argument(s): cls` at watcher startup and the daemon refuses to run.

## Fix

Install a `StreamHandler` with the `ColorFormatter` explicitly attached, then pass that handler to `basicConfig` — the documented way to use a custom formatter from `basicConfig`.

## Test plan

- [x] Smoke test: `python -c "...basicConfig with handlers=[handler]..."` emits INFO log via ColorFormatter without error
- [x] `python -m app.cli watcher --help` prints usage (no startup crash)
- [x] Pre-commit hooks pass: ruff/bandit/mypy/semgrep/detect-secrets/check-patch-paths

## Auto-merge

Targeting main directly (no Linear ticket — small bug fix unblocking daemon startup). Post-WOR-300 telemetry work is wasted until this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)