### PR TITLE
fix: stale watcher_types import path + matching test logger name

### DIFF
--- a/app/core/watcher/watcher.py
+++ b/app/core/watcher/watcher.py
@@ -869,7 +869,7 @@ class Watcher:
             pass
 
     def _cleanup_orphaned_worktrees(self) -> None:
-        from app.core.watcher_types import _WORKTREE_BASE
+        from app.core.watcher.watcher_types import _WORKTREE_BASE
 
         base = self._repo_root.parent / _WORKTREE_BASE
         if not base.exists():

--- a/tests/test_watcher_services.py
+++ b/tests/test_watcher_services.py
@@ -96,7 +96,7 @@ def test_probe_vllm_health_logs_short_message_on_repeat_failure(
     with (
         patch("http.client.HTTPConnection") as mock_conn_cls,
         patch("sys.platform", "linux"),
-        caplog.at_level(logging.WARNING, logger="app.core.watcher_services"),
+        caplog.at_level(logging.WARNING, logger="app.core.watcher.watcher_services"),
     ):
         mock_conn_cls.return_value.request.side_effect = OSError("connection refused")
         mgr.probe_vllm_health()  # first call — logs full command


### PR DESCRIPTION
## Summary

Two leftovers from the package reorganisation that flattened `app.core.watcher_*` into `app.core.watcher.watcher_*`:

1. **Runtime crash on daemon startup** — `app/core/watcher/watcher.py:872` had `from app.core.watcher_types import _WORKTREE_BASE` inside `_cleanup_orphaned_worktrees`. Lazy import doesn't fire until first poll, so it slipped past `mypy app/`. Daemon now crashes with `ModuleNotFoundError: No module named 'app.core.watcher_types'` on every startup after #600.
2. **Silent test bug** — `tests/test_watcher_services.py:99` had `caplog.at_level(logger="app.core.watcher_services")`. Real logger name is `app.core.watcher.watcher_services`, so caplog captured nothing from the module under test. Test passed only because the assertion checked absence.

Found by hunting for `from app.core.watcher_(types|helpers|subprocess|worktrees|services|finalize|dispatch|tui)` across the codebase after PR #601 unblocked startup but the daemon still wouldn't run.

## Test plan

- [x] `python -c "from app.core.watcher import Watcher"` — imports cleanly
- [x] `_WORKTREE_BASE` resolves from `app.core.watcher.watcher_types`
- [x] `pytest tests/test_watcher_services.py` — 20/20 pass
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)