### PR TITLE
fix: watcher daemon UnboundLocalError + orphan-cleanup rmtree fallback

### DIFF
--- a/app/core/watcher/watcher.py
+++ b/app/core/watcher/watcher.py
@@ -608,6 +608,7 @@ class Watcher:
 
     def _reap_pool(self, workers: list[ActiveWorker]) -> tuple[list[ActiveWorker], str]:
         still_running: list[ActiveWorker] = []
+        outcome = ""
         for worker in workers:
             rc = worker.process.poll()
             if rc is None:

--- a/app/core/watcher/watcher_worktrees.py
+++ b/app/core/watcher/watcher_worktrees.py
@@ -554,7 +554,13 @@ def preserve_worker_artifacts(repo_root: Path, worker: ActiveWorker) -> None:
 
 
 def cleanup_worktree(repo_root: Path, worktree_path: Path) -> None:
-    """Remove a git worktree, logging a warning on failure."""
+    """Remove a git worktree, logging a warning on failure.
+
+    Falls back to ``shutil.rmtree`` when ``git worktree remove`` reports the
+    directory is not a registered worktree — that happens when a previous
+    cleanup failed mid-run, leaving a directory on disk that git no longer
+    tracks.
+    """
     try:
         subprocess.run(  # nosec B603 B607
             [
@@ -572,7 +578,29 @@ def cleanup_worktree(repo_root: Path, worktree_path: Path) -> None:
         )
         logger.info("Worktree removed: %s", worktree_path)
     except subprocess.CalledProcessError as exc:
-        logger.warning("Failed to remove worktree %s: %s", worktree_path, exc.stderr)
+        stderr = exc.stderr or ""
+        if "is not a working tree" in stderr and worktree_path.exists():
+            try:
+                shutil.rmtree(worktree_path)
+                logger.info(
+                    "Untracked worktree directory removed via rmtree: %s",
+                    worktree_path,
+                )
+                subprocess.run(  # nosec B603 B607
+                    ["git", "-C", str(repo_root), "worktree", "prune"],
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                )
+                return
+            except OSError as rmtree_exc:
+                logger.warning(
+                    "Failed to rmtree untracked worktree %s: %s",
+                    worktree_path,
+                    rmtree_exc,
+                )
+                return
+        logger.warning("Failed to remove worktree %s: %s", worktree_path, stderr)
 
 
 def cleanup_orphaned_worktrees(repo_root: Path) -> None:

--- a/tests/test_watcher_worktrees.py
+++ b/tests/test_watcher_worktrees.py
@@ -446,6 +446,43 @@ def test_cleanup_worktree_logs_warning_on_failure(
     assert any("Failed to remove" in r.message for r in caplog.records)
 
 
+def test_cleanup_worktree_rmtree_fallback_when_not_a_working_tree(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Untracked worktree directories on disk get rmtree'd as fallback."""
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    orphan = tmp_path / "worktrees" / "wor-99-orphan"
+    orphan.mkdir(parents=True)
+    (orphan / "leftover.txt").write_text("stale", encoding="utf-8")
+
+    call_count = {"n": 0}
+
+    def _side_effect(*args: object, **kwargs: object) -> MagicMock:
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            raise subprocess.CalledProcessError(
+                128,
+                "git",
+                stderr=f"fatal: '{orphan}' is not a working tree",
+            )
+        mock = MagicMock()
+        mock.returncode = 0
+        return mock
+
+    with (
+        caplog.at_level(logging.INFO, logger="app.core.watcher.watcher_worktrees"),
+        patch("subprocess.run", side_effect=_side_effect),
+    ):
+        cleanup_worktree(repo_root, orphan)
+
+    assert not orphan.exists(), "orphan directory should have been rmtree'd"
+    assert any(
+        "Untracked worktree directory removed via rmtree" in r.message
+        for r in caplog.records
+    )
+
+
 # ---------------------------------------------------------------------------
 # cleanup_orphaned_worktrees
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Two startup-blocking bugs surfaced after #601/#602 unblocked import.

### 1. `UnboundLocalError` in `Watcher._reap_pool`

`_reap_pool` returns `(still_running, outcome)`, but `outcome` was only assigned inside the worker-iteration body. With an empty pool — every poll cycle on startup before any worker has finished — the function raises:

```
UnboundLocalError: cannot access local variable 'outcome' where it is not associated with a value
```

Fix: initialise `outcome = ""` at the top of the function. (The caller discards the second value via tuple unpack, so the sentinel is harmless.)

### 2. Orphan-worktree cleanup never actually deletes untracked dirs

`cleanup_worktree` calls `git worktree remove --force`, which fails when the directory exists on disk but is no longer registered with git:

```
fatal: 'D:\Data\50_Code\worktrees\wor-216-...' is not a working tree
```

Today the watcher just logs a warning and the orphan survives every restart. Fix: detect that stderr fragment and fall back to `shutil.rmtree`, then `git worktree prune` to flush stale registry entries.

## Test plan

- [x] New test `test_cleanup_worktree_rmtree_fallback_when_not_a_working_tree` — orphan directory is actually deleted from disk after fallback fires
- [x] `pytest tests/test_watcher.py tests/test_watcher_worktrees.py` — 67 passed (was 66; +1 new)
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)