### PR TITLE
fix: stop per-poll orphan-cleanup spam + rmtree handles read-only files

### DIFF
--- a/app/core/watcher/watcher.py
+++ b/app/core/watcher/watcher.py
@@ -253,16 +253,6 @@ class Watcher:
 
             elapsed_str = format_elapsed(elapsed)
             logger.info("[%s] %s", worker.ticket_id, elapsed_str)
-        from .watcher_types import _WORKTREE_BASE
-
-        base = self._repo_root.parent / _WORKTREE_BASE
-        if not base.exists():
-            return
-        for worktree_dir in base.iterdir():
-            if not worktree_dir.is_dir():
-                continue
-            logger.warning("Orphaned worktree detected: %s — removing", worktree_dir)
-            cleanup_worktree(self._repo_root, worktree_dir)
 
     # ------------------------------------------------------------------
     # TUI state

--- a/app/core/watcher/watcher_worktrees.py
+++ b/app/core/watcher/watcher_worktrees.py
@@ -581,7 +581,7 @@ def cleanup_worktree(repo_root: Path, worktree_path: Path) -> None:
         stderr = exc.stderr or ""
         if "is not a working tree" in stderr and worktree_path.exists():
             try:
-                shutil.rmtree(worktree_path)
+                _rmtree_force(worktree_path)
                 logger.info(
                     "Untracked worktree directory removed via rmtree: %s",
                     worktree_path,
@@ -601,6 +601,20 @@ def cleanup_worktree(repo_root: Path, worktree_path: Path) -> None:
                 )
                 return
         logger.warning("Failed to remove worktree %s: %s", worktree_path, stderr)
+
+
+def _rmtree_force(path: Path) -> None:
+    """``shutil.rmtree`` that handles Windows read-only files (e.g. ``.git`` entries
+    inside a git worktree directory).
+    """
+    import os
+    import stat
+
+    def _on_rm_error(func: object, p: str, _exc_info: object) -> None:
+        os.chmod(p, stat.S_IWRITE)
+        func(p)  # type: ignore[operator]
+
+    shutil.rmtree(path, onexc=_on_rm_error)
 
 
 def cleanup_orphaned_worktrees(repo_root: Path) -> None:


### PR DESCRIPTION
## Summary

Two daemon-startup bugs surfaced after PR #603 unblocked the rmtree fallback path.

### 1. Per-poll orphan-cleanup spam

`_emit_heartbeat` had a stray copy-paste of the orphan-cleanup loop appended after the per-worker heartbeat block. Since `_emit_heartbeat` runs every poll cycle, the watcher tried to remove the same orphan on every iteration and emitted two WARNING log lines per cycle:

```
20:59:15 WARNING Orphaned worktree detected: ... — removing
20:59:15 WARNING Failed to rmtree untracked worktree ...
20:59:28 WARNING Orphaned worktree detected: ... — removing  ← every poll
20:59:28 WARNING Failed to rmtree untracked worktree ...
20:59:40 WARNING Orphaned worktree detected: ... — removing
...
```

The startup-only call in `run()` → `_cleanup_orphaned_worktrees` is already wired correctly. Fix: delete the duplicate block from `_emit_heartbeat`.

### 2. Windows read-only files break `shutil.rmtree`

PR #603's rmtree fallback dies on Windows with `WinError 145 / WinError 5` because git worktrees ship with read-only metadata under `.git/`. Fix: extract `_rmtree_force(path)` helper that uses `shutil.rmtree(onexc=...)` to flip the read-only bit on each entry before retrying.

Verified manually with a tmp directory containing a `chmod 0444` file — plain `rmtree` raises `PermissionError`, `_rmtree_force` succeeds.

## Test plan

- [x] Manual: read-only file in tmp dir → plain `rmtree` fails, `_rmtree_force` succeeds
- [x] `pytest tests/test_watcher.py tests/test_watcher_worktrees.py` — 67 passed
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)