### PR TITLE
docs: sync README watcher CLI flags with cli.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,10 @@ python -m app.cli watcher --worker-mode cloud    # force cloud (Anthropic API)
 python -m app.cli watcher --worker-mode local    # force local (LiteLLM proxy)
 python -m app.cli watcher --max-local-workers 8  # default 8; vLLM handles concurrency
 python -m app.cli watcher --max-cloud-workers 3  # default 3
-python -m app.cli watcher --verbose              # stream worker output live to stderr
+python -m app.cli watcher --verbose              # DEBUG level on the watcher's own logger
+python -m app.cli watcher --worker-verbose       # stream worker stdout+stderr live, prefixed [WOR-NN]
 python -m app.cli watcher --no-epic-shutdown     # keep daemon running past current epic
+python -m app.cli watcher --tui                  # live rich TUI: per-worker status, cost rollups, tracked PRs
 
 # Metrics
 python -m app.cli metrics browse   # open metrics DB in Datasette browser UI


### PR DESCRIPTION
## Summary

The watcher CLI flag list in `README.md` had drifted from `app/cli.py`:

- **Missing `--tui`** — added in WOR-272, render-snapshot tested in WOR-296
- **Missing `--worker-verbose`** — separate flag from `--verbose` since WOR-225's split between log level and worker output streaming
- **`--verbose` mislabeled** — README said "stream worker output live to stderr" (which is what `--worker-verbose` does); `--verbose` only sets DEBUG on the watcher's own logger

README-only change. Caught while running the daemon — user noticed `--tui` wasn't listed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)