### PR TITLE
Hotfix: --tui flag plumbing + cost rollup recorded_at column

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -235,6 +235,7 @@ def _run_watcher(args: argparse.Namespace) -> int:
         max_cloud_workers=max_cloud,
         worker_verbose=args.worker_verbose,
         no_epic_shutdown=args.no_epic_shutdown,
+        tui_mode=args.tui,
     )
     try:
         watcher.run()

--- a/app/core/metrics.py
+++ b/app/core/metrics.py
@@ -265,10 +265,10 @@ SELECT
 FROM ticket_metrics
 """
 _COST_ROLLUP_SQL_TODAY = (
-    _COST_ROLLUP_SQL_BASE + "WHERE started_at >= date('now', 'start of day')"
+    _COST_ROLLUP_SQL_BASE + "WHERE recorded_at >= date('now', 'start of day')"
 )
 _COST_ROLLUP_SQL_WEEK = (
-    _COST_ROLLUP_SQL_BASE + "WHERE started_at >= date('now', '-7 days')"
+    _COST_ROLLUP_SQL_BASE + "WHERE recorded_at >= date('now', '-7 days')"
 )
 _COST_ROLLUP_SQL_ALL = _COST_ROLLUP_SQL_BASE
 
@@ -450,8 +450,8 @@ class MetricsStore:
     def get_cost_rollup(self, period: Literal["today", "week", "all"]) -> CostRollup:
         """Return aggregated cost economics for *period*.
 
-        *today*   = rows where ``started_at >= date('now', 'start of day')``
-        *week*    = rows where ``started_at >= date('now', '-7 days')``
+        *today*   = rows where ``recorded_at >= date('now', 'start of day')``
+        *week*    = rows where ``recorded_at >= date('now', '-7 days')``
         *all*     = no filter
 
         cloud_spent  = SUM(cloud_cost_estimate) where cloud_used=1


### PR DESCRIPTION
## Summary
Two daemon-startup bugs surfaced by enabling `--tui` for the first time during WOR-244 end-to-end validation:

- `--tui` flag was defined in argparse but `_run_watcher` never threaded `args.tui` into `Watcher(tui_mode=...)`. The 4-panel rich layout existed but was unreachable. Fixed.
- `MetricsStore.get_cost_rollup` queried `WHERE started_at >= ...` but the `ticket_metrics` column is `recorded_at`. First call (from the TUI on the first poll) crashed the daemon with `sqlite3.OperationalError: no such column: started_at`. Fixed in both SQL constants + docstring.

Both bugs are part of the WOR-305 ("watcher correctness bugs surfaced by WOR-244 first-run validation") batch — keeping them as a separate hotfix PR so the daemon can run for the next validation pass while WOR-305 is groomed.

## Test plan
- [x] `python -c "MetricsStore().get_cost_rollup('today'/'week'/'all')"` returns CostRollup objects without error
- [x] `python -m app.cli watcher --tui` renders the 4-panel layout and stays up past the first poll
- [ ] Add a regression test for `get_cost_rollup` (zero coverage today) — tracked in WOR-305

🤖 Generated with [Claude Code](https://claude.com/claude-code)