### PR TITLE
Hotfix: kill TUI flicker on cmd.exe with alt-screen buffer

### DIFF
--- a/app/core/watcher/watcher_tui.py
+++ b/app/core/watcher/watcher_tui.py
@@ -118,7 +118,12 @@ class WatcherDisplay:
             return
         layout = self._build_layout(self._state)
         if self._live is None:
-            self._live = Live(layout, console=self._console, refresh_per_second=2)
+            self._live = Live(
+                layout,
+                console=self._console,
+                refresh_per_second=2,
+                screen=True,
+            )
             self._live.start()
             return
         self._live.update(layout)


### PR DESCRIPTION
## Summary
One-line `screen=True` on `rich.live.Live` to use the alternate screen buffer. Eliminates the per-tick flicker visible on Windows cmd.exe (and cmd.exe hosted inside Windows Terminal).

Carve-out from WOR-306; the other 4 items in that ticket (live tokens/cost, last-action column, vLLM panel, queue panel) are larger changes worth landing separately.

## Test plan
- [x] `python -m app.cli watcher --tui` no longer flickers at the 30s refresh tick on Windows cmd.exe
- [x] Terminal scrollback restored cleanly on Ctrl-C
- [ ] WOR-306 description should be updated to drop bullet 5 once this merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)