### PR TITLE
Hotfix v2: kill TUI flicker by disabling auto_refresh

### DIFF
--- a/app/core/watcher/watcher_tui.py
+++ b/app/core/watcher/watcher_tui.py
@@ -121,13 +121,12 @@ class WatcherDisplay:
             self._live = Live(
                 layout,
                 console=self._console,
-                refresh_per_second=2,
                 screen=True,
+                auto_refresh=False,
             )
-            self._live.start()
+            self._live.start(refresh=True)
             return
-        self._live.update(layout)
-        self._live.refresh()
+        self._live.update(layout, refresh=True)
 
     def _build_layout(self, state: TUIState) -> Layout:
         layout = Layout(name="root")


### PR DESCRIPTION
## Summary
PR #612 added `screen=True` (alt screen buffer) but flicker persisted on cmd.exe. Root cause is double-rendering: `auto_refresh=True` (default, 2 Hz) plus an explicit `self._live.refresh()` call after each `update()` triggers two redraws per state push. The alt screen buffer can't hide that flash on cmd.exe.

Switch to `auto_refresh=False` and use `update(layout, refresh=True)` for a single atomic render per state push. Watcher only pushes state on poll cycles (10s) and tick boundaries, so the 2 Hz background loop was pure overhead.

## Test plan
- [x] `python -m app.cli watcher --tui` no longer flickers on Windows cmd.exe at the 30s tick
- [x] State updates still appear (worker elapsed time advances, ticket changes propagate)
- [x] Ctrl-C exits cleanly, scrollback restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)