### PR TITLE
WOR-304 CI: smoke-start watcher daemon for 5s to catch startup-only bugs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,3 +69,28 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
+  watcher-smoke:
+    runs-on: ubuntu-latest
+    needs: lint-and-test
+    if: github.event_name == 'pull_request' && (github.base_ref == 'main' || startsWith(github.base_ref, 'epic/'))
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: 'pip'
+          cache-dependency-path: 'requirements-dev.txt'
+
+      - name: Install dependencies
+        run: pip install -r requirements-dev.txt
+
+      - name: Watcher smoke test (5s)
+        run: |
+          timeout 5 python -m app.cli watcher --no-epic-shutdown || \
+            ([ $? -eq 124 ] && echo "OK: watcher stayed alive for 5s" || (echo "FAIL: watcher exited early" && exit 1))
+        env:
+          LINEAR_API_KEY: dummy  # pragma: allowlist secret

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,8 @@ python -m app.cli watcher --max-cloud-workers 3  # default 3; parallelisable
 python -m app.cli watcher --max-workers 2        # backward-compat alias: sets both to 2
 python -m app.cli watcher --verbose              # stream worker stdout/stderr live, prefixed with [WOR-NN]
 python -m app.cli watcher --no-epic-shutdown     # keep daemon running after current epic completes
+# Smoke test (5s): LINEAR_API_KEY=dummy python -m app.cli watcher --no-epic-shutdown
+#   (timeout 5 python -m app.cli watcher --no-epic-shutdown; exit 0 if killed by timeout)
 
 # Benchmark runner (do not run without explicit instruction)
 python scripts/bench/run_bench.py --tier speed


### PR DESCRIPTION
Closes WOR-304

Add a CI step that smoke-starts `python -m app.cli watcher` for 5 seconds and asserts it stays alive. Catches the class of startup-only daemon bugs (PRs #601-#604) that pytest/mypy don't catch.