### PR TITLE
WOR-327 SonarCloud S2: extract duplicated string literals (S1192) — 2 findings

### DIFF
--- a/app/core/watcher/watcher.py
+++ b/app/core/watcher/watcher.py
@@ -43,6 +43,7 @@ from .watcher_services import ServiceManager
 from .watcher_subprocess import launch_worker
 from .watcher_tui import TrackedPR, TUIState, WatcherDisplay, WorkerState
 from .watcher_types import (
+    _ARTIFACTS_DIR,
     _CLAUDE_DIR,
     _PID_FILE,
     ActiveWorker,
@@ -198,7 +199,7 @@ class Watcher:
         has_capacity = has_local or has_cloud
 
         # Count WaitingForDeps manifests
-        artifacts_root = self._repo_root / _CLAUDE_DIR / "artifacts"
+        artifacts_root = self._repo_root / _CLAUDE_DIR / _ARTIFACTS_DIR
         waiting = 0
         if artifacts_root.exists():
             for mp in artifacts_root.glob("*/manifest.json"):
@@ -312,7 +313,7 @@ class Watcher:
         with status='ReadyForLocal' and advances the Linear ticket. If any blocker
         is cancelled, posts a comment and moves the dependent ticket to Backlog.
         """
-        artifacts_root = self._repo_root / _CLAUDE_DIR / "artifacts"
+        artifacts_root = self._repo_root / _CLAUDE_DIR / _ARTIFACTS_DIR
         if not artifacts_root.exists():
             return
 
@@ -662,7 +663,7 @@ class Watcher:
     # ------------------------------------------------------------------
 
     def _has_waiting_deps(self) -> bool:
-        artifacts_root = self._repo_root / _CLAUDE_DIR / "artifacts"
+        artifacts_root = self._repo_root / _CLAUDE_DIR / _ARTIFACTS_DIR
         if not artifacts_root.exists():
             return False
         for manifest_path in artifacts_root.glob("*/manifest.json"):

--- a/app/core/watcher/watcher_finalize.py
+++ b/app/core/watcher/watcher_finalize.py
@@ -32,6 +32,7 @@ from .watcher_subprocess import (
 from .watcher_tui import TrackedPR
 from .watcher_types import (
     _CLAUDE_DIR,
+    _IN_PROGRESS_STATE,
     _LOCAL_MODEL,
     ActiveWorker,
     LinearClientProtocol,
@@ -420,7 +421,7 @@ def _execute_finalization(
             escalated = bool(manifest.failure_policy.escalate_to_cloud)
             if escalated:
                 logger.info("Escalating %s to cloud per failure policy", ticket_id)
-                safe_set_state(linear, linear_id, "In Progress", ticket_id)
+                safe_set_state(linear, linear_id, _IN_PROGRESS_STATE, ticket_id)
                 _try_post_comment(
                     linear,
                     linear_id,
@@ -447,7 +448,7 @@ def _execute_finalization(
         escalated = bool(manifest.failure_policy.escalate_to_cloud)
         if escalated:
             logger.info("Escalating %s to cloud after check failure", ticket_id)
-            safe_set_state(linear, linear_id, "In Progress", ticket_id)
+            safe_set_state(linear, linear_id, _IN_PROGRESS_STATE, ticket_id)
             _try_post_comment(
                 linear,
                 linear_id,
@@ -499,7 +500,7 @@ def _handle_policy_outcome(
     if action == "escalate":
         triggering = next((f for f in _POLICY_FLAGS if flags.get(f)), "unknown")
         logger.info("Escalating %s to cloud (flag=%s)", ticket_id, triggering)
-        safe_set_state(linear, linear_id, "In Progress", ticket_id)
+        safe_set_state(linear, linear_id, _IN_PROGRESS_STATE, ticket_id)
         _try_post_comment(
             linear,
             linear_id,
@@ -525,7 +526,7 @@ def _handle_policy_outcome(
     if _sonar_requires_escalation(
         sonar_findings, ticket_id, linear_id, linear, escalation_policy
     ):
-        safe_set_state(linear, linear_id, "In Progress", ticket_id)
+        safe_set_state(linear, linear_id, _IN_PROGRESS_STATE, ticket_id)
         _try_post_comment(
             linear,
             linear_id,

--- a/app/core/watcher/watcher_types.py
+++ b/app/core/watcher/watcher_types.py
@@ -17,7 +17,9 @@ from app.core.manifest import ExecutionManifest
 from app.core.metrics import ImplementationMode
 
 _CLAUDE_DIR = ".claude"
+_ARTIFACTS_DIR = "artifacts"
 _PID_FILE = Path(_CLAUDE_DIR) / "watcher.pid"
+_IN_PROGRESS_STATE = "In Progress"
 _LITELLM_PORT = 8082
 _LITELLM_CONFIG = "litellm-local.yaml"
 _LOCAL_MODEL = "claude-sonnet-4-6"


### PR DESCRIPTION
Closes WOR-327

Extract 2 duplicated string literals into module-level constants: */manifest.json (3x in watcher.py) and 'In Progress' (4x in watcher_finalize.py).