### PR TITLE
WOR-324 Audit: remove unused noqa/type:ignore comments in app/core/watcher/

### DIFF
--- a/app/core/watcher/log_format.py
+++ b/app/core/watcher/log_format.py
@@ -30,7 +30,7 @@ class ColorFormatter(logging.Formatter):
     Falls back to plain text for redirected/piped output (``isatty() == False``).
     """
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:  # noqa: ANN003, ANN002
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self._is_tty = sys.stderr.isatty()
 

--- a/app/core/watcher/watcher_services.py
+++ b/app/core/watcher/watcher_services.py
@@ -227,7 +227,7 @@ class ServiceManager:
         else:
             log_path = self._repo_root / ".claude" / "litellm.log"
             log_path.parent.mkdir(parents=True, exist_ok=True)
-            log_file = open(log_path, "wb")  # noqa: SIM115
+            log_file = open(log_path, "wb")
             logger.info("LiteLLM log: %s", log_path)
             self._litellm_proc = subprocess.Popen(  # nosec B603 B607
                 litellm_cmd,

--- a/app/core/watcher/watcher_subprocess.py
+++ b/app/core/watcher/watcher_subprocess.py
@@ -119,7 +119,7 @@ def launch_worker(
 
     log_path = worktree_path / f".claude/worker_{manifest.ticket_id.lower()}.log"
     log_path.parent.mkdir(parents=True, exist_ok=True)
-    log_file = open(log_path, "wb")  # noqa: SIM115
+    log_file = open(log_path, "wb")
 
     if worker_verbose:
         prefix = f"[{manifest.ticket_id}] ".encode()

--- a/app/core/watcher/watcher_types.py
+++ b/app/core/watcher/watcher_types.py
@@ -99,5 +99,5 @@ def is_watcher_running(pid_file: Path = _PID_FILE) -> bool:
 
 def _to_metrics_mode(mode: str) -> ImplementationMode:
     if mode in ("local", "cloud", "hybrid"):
-        return mode  # type: ignore[return-value]
+        return mode  # type: ignore[return-value]  # ImplementationMode is Literal["local","cloud","hybrid"]; str is compatible at runtime
     return "cloud"

--- a/app/core/watcher/watcher_worktrees.py
+++ b/app/core/watcher/watcher_worktrees.py
@@ -612,7 +612,7 @@ def _rmtree_force(path: Path) -> None:
 
     def _on_rm_error(func: object, p: str, _exc_info: object) -> None:
         os.chmod(p, stat.S_IWRITE)
-        func(p)  # type: ignore[operator]
+        func(p)  # type: ignore[operator]  # onexc callback: func is Callable[[str, BaseException], None] but typed as object for shutil compatibility
 
     shutil.rmtree(path, onexc=_on_rm_error)
 


### PR DESCRIPTION
Closes WOR-324

Find and remove stale # noqa / # type: ignore suppressions in app/core/watcher/ where the underlying issue no longer exists. KEEP legitimate # nosec B603/B607 on subprocess calls.