### PR TITLE
WOR-280 GitHub flow: cover interactive getpass path in cli_set_token

### DIFF
--- a/app/core/credentials.py
+++ b/app/core/credentials.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from getpass import getpass
 
 import keyring
 from keyring.errors import KeyringError, NoKeyringError
@@ -39,10 +40,7 @@ def delete_token() -> None:
 def cli_set_token() -> int:
     """Prompt for a GitHub token via getpass and store it."""
     try:
-        token = __import__("getpass", fromlist=["getpass"]).getpass(
-            "GitHub token: ",
-            stream=sys.stderr,
-        )
+        token = getpass("GitHub token: ", stream=sys.stderr)
     except (EOFError, KeyboardInterrupt):
         print(file=sys.stderr)
         return 1

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -137,3 +137,35 @@ def test_get_token_empty_github_token_env():
         with patch.dict("os.environ", {"GITHUB_TOKEN": ""}):
             result = cred.get_token()
     assert result == ""
+
+
+def test_cli_set_token_success(capsys: pytest.CaptureFixture[str]) -> None:
+    with patch("app.core.credentials.getpass", return_value="ghp_live"):
+        with patch.object(cred, "save_token") as mock_save:
+            result = cred.cli_set_token()
+    assert result == 0
+    mock_save.assert_called_once_with("ghp_live")
+    assert "Done." in capsys.readouterr().err
+
+
+def test_cli_set_token_empty_input(capsys: pytest.CaptureFixture[str]) -> None:
+    with patch("app.core.credentials.getpass", return_value=""):
+        result = cred.cli_set_token()
+    assert result == 1
+    assert "empty token" in capsys.readouterr().err
+
+
+def test_cli_set_token_eof(capsys: pytest.CaptureFixture[str]) -> None:
+    with patch("app.core.credentials.getpass", side_effect=EOFError):
+        result = cred.cli_set_token()
+    assert result == 1
+
+
+def test_cli_set_token_keyring_error(capsys: pytest.CaptureFixture[str]) -> None:
+    with patch("app.core.credentials.getpass", return_value="ghp_live"):
+        with patch.object(
+            cred, "save_token", side_effect=KeyringError("keyring unavailable")
+        ):
+            result = cred.cli_set_token()
+    assert result == 1
+    assert "unable to store token" in capsys.readouterr().err


### PR DESCRIPTION
Closes WOR-280

Refactor cli_set_token to use top-level `from getpass import getpass` import (mock-friendly), then add 4 tests covering success, empty input, EOF, and keyring error paths.