### PR TITLE
docs+scripts: WOR-313 retro + bulk-manifest generator

### DIFF
--- a/docs/retros/wor_313_2026-05-03.md
+++ b/docs/retros/wor_313_2026-05-03.md
@@ -1,0 +1,175 @@
+# WOR-313 mega overnight retro — 2026-05-03
+
+Forensic notes from the WOR-313 mega overnight hardening sweep. Captured while in-context so the knowledge survives log rotation and context loss. Will be transcribed into the `ticket_metrics.notes` column once WOR-332 ships.
+
+## Run summary
+
+- **Queued:** 27 children at 02:48 local (23:48 UTC) on 2026-05-02
+- **Daemon:** PID 322608, running on local mode with vLLM + Qwen3.6-35B-A3B-NVFP4
+- **As of 2026-05-03 ~05:15 UTC:** 10 MergedToEpic, 2 InProgressLocal, 7 Blocked, 8 ReadyForLocal (5 truly free, 3 conflict-blocked behind active workers)
+
+## Per-ticket forensic findings
+
+### WOR-329 — Sonar S4 (remove unused params)
+
+**DB row:** `outcome=success retry_count=0 wall=2905s tok=10.7M lines=43 files=5 recorded_at=2026-05-03 00:37:40`
+**Linear state at retro time:** stuck in `InProgressLocal` for ~5 hours despite worker actually succeeding
+**PR:** #642 (manually merged at 05:00 UTC after I resolved conflicts)
+
+**What happened:**
+- Worker finished at 00:37 UTC. result.json = success, all 3 checks passed (ruff/mypy/967 pytest), commit 914aacc pushed to remote worker branch
+- Daemon's `safe_set_state(linear, ..., "MergedToEpic")` apparently failed silently — Linear state was never updated past `InProgressLocal`
+- Auto-merge was never enabled on PR #642 — `autoMergeRequest: null` in GitHub API
+- Worker slot in daemon's in-memory `_local_active` was never freed (ghost slot held until daemon restart)
+- This blocked dispatch of WOR-277 + WOR-279 (which overlap on `watcher_finalize.py` / `post_setup.py`)
+
+**Manual rescue (2026-05-03 ~04:35 UTC):**
+- Set Linear state to `In Review` to match reality
+- Tried `gh pr merge 642 --auto` → failed with "Pull request Protected branch rules not configured for this branch"
+- Found PR #642 had merge conflicts (3 files) because sibling tickets WOR-322/323/326/327/330 had merged into epic in the meantime
+- Created temp worktree at `/tmp/wor329-fix`, did `git merge origin/epic/wor-313-...`, resolved 2 conflicts in `cli.py` + `watcher_finalize.py`:
+  - `cli.py` conflict: WOR-330 extracted `_run_github_create(config, args)` helper; WOR-329 had removed `prefs` param from `create_github_repo`. Resolution: take WOR-330's helper call, then update the helper internal to drop the `prefs=prefs` argument that no longer exists
+  - `watcher_finalize.py` conflict: WOR-327 introduced `_IN_PROGRESS_STATE` constant; WOR-329 had removed `linear_id`, `linear` from `_sonar_requires_escalation` signature. Resolution: combine both — `_sonar_requires_escalation(sonar_findings, ticket_id, escalation_policy)` + `safe_set_state(linear, linear_id, _IN_PROGRESS_STATE, ticket_id)`
+- All 995 tests passed locally; merge commit 3b87c3d pushed to worker branch
+- Linear auto-updated to `MergedToEpic` after PR merged (so GitHub→Linear automation works on manual merges; only the daemon's own state-update was broken)
+
+**Auto-tag candidate:** `success_outcome_state_mismatch` (Linear/daemon state diverged from result.json) AND `ghost_slot_held` (potentially a separate tag for the worker-slot bookkeeping issue)
+
+**Bug to file:** Watcher's `safe_set_state` failure during finalize doesn't get retried/escalated, leaving the slot ghost-held. Likely an exception during the Linear API call. Should be a follow-up under WOR-311/312 retry+finalize bucket.
+
+---
+
+### WOR-278 — GitHub flow E2E test
+### WOR-314 — Tests for dispatch.start_ticket
+
+**DB rows:**
+- WOR-278: `outcome=failure wall=4362s tok=0M lines=422 files=9 check_failures_json=null`
+- WOR-314: `outcome=failure wall=4460s tok=0M lines=422 files=9 check_failures_json=null`
+
+**The mystery:** Both ran for ~73 minutes wall time but consumed **0M tokens** and have identical `lines_changed=422 files=9 check_failures_json=null`. The identical line/file stats strongly suggest both never made any actual changes — those numbers reflect the rebase from epic, not the worker's work.
+
+**Hypotheses:**
+1. **vLLM connection failed silently** — worker started, worktree created, but `claude` subprocess couldn't reach vLLM via LiteLLM proxy. Worker spun without making LLM calls
+2. **Worktree setup or copy_manifest_to_worktree timed out** — worker process started but never got to invoke claude
+3. **`launch_worker` subprocess hung** — claude CLI started but never made it past initialization
+4. **The 73min wall time is from `process.poll()` returning None forever** — the daemon's `_reap_pool` only sees a finished worker when poll() returns non-None; if the subprocess hung indefinitely, `_reap_pool` never reaped it
+
+**Evidence to gather (when artifacts dir still exists):**
+- Check `.claude/artifacts/wor_278/worker_wor-278.log` size — if 0 bytes or only setup lines, confirms no LLM activity
+- Check daemon log for any vLLM connection errors around the 23:48-01:00 UTC window when these were dispatched
+- Check if these were dispatched before/after WOR-329 hung — if before, may be a precursor to the same vLLM issue
+
+**Auto-tag candidate:** `zero_tokens_high_wall_time` (covered by WOR-332's initial rule set)
+
+**Bug to file:** When `local_tokens < 100K AND wall_time > 1800s`, the daemon should treat the worker as suspect and possibly:
+- Force-kill the subprocess (currently relies on natural exit)
+- Investigate vLLM/proxy health before next dispatch
+- Mark the ticket with a special status (not just "failure") so the morning operator knows to investigate
+
+---
+
+### WOR-318 — EscalationPolicy.classify_* tests
+### WOR-319 — Manifest validators tests
+### WOR-320 — Docstrings: watcher_helpers.py
+### WOR-321 — Docstrings: watcher_subprocess.py
+### WOR-325 — ServiceManager probe tests
+
+**DB rows (all share the pattern):**
+- WOR-318: `outcome=failure wall=5216s tok=2M lines=340 files=9` + result.json `status=success`
+- WOR-319: `outcome=failure wall=5246s tok=0M lines=340 files=9` (no result.json — silent)
+- WOR-320: `outcome=failure wall=2501s tok=1M lines=340 files=9` + result.json `status=success`
+- WOR-321: `outcome=failure wall=4573s tok=3M lines=340 files=9` + result.json `status=failed`
+- WOR-325: `outcome=failure wall=914s tok=2M lines=326 files=8` + result.json `status=success`
+
+**The pattern — "no-op false-failures":**
+
+Every worker branch was created at the same time (off `epic/wor-313-...` HEAD on 2026-05-02 ~23:48 UTC). As sibling tickets merged into epic over the next few hours, the worker branches stayed at their original creation point. By the time these workers were dispatched (later in the night), the epic branch had advanced significantly.
+
+`git diff origin/epic/wor-313-... origin/wor-XXX-...` for these branches shows **deletions** (e.g. `-120 lines test_watcher_log_format.py, -77 lines test_user_prefs.py, -69 lines test_credentials.py` for WOR-320/318/321/325). The worker branches are *behind* the epic.
+
+When dispatched, `rebase_worktree_from_base` rebased the worktree onto the latest epic. The worker then found that the AC was already satisfied:
+- WOR-318: 29 escalation tests already exist, 100% coverage (likely from the original `test_escalation_policy.py` that predates this epic)
+- WOR-320: All public functions in `watcher_helpers.py` already have docstrings (likely from main, not this epic)
+- WOR-321: 5 sibling commits on the branch but `watcher_subprocess.py` not touched; functions already documented
+- WOR-325: 20 ServiceManager tests already pass; no changes needed
+
+Worker correctly reported "nothing to do." But:
+- `finalize_worker` doesn't have a "no-op" path
+- It tried to create a PR via `gh pr create` against the epic
+- Either gh refused (no diff) or created a PR that would *delete* sibling work
+- finalize marked outcome=failure → ticket Blocked
+
+**Auto-tag candidate:** `no_diff_against_base` (covered by WOR-332's initial rule set)
+
+**Bug to file:** `finalize_worker` should detect `git diff --stat <base>..HEAD` returning zero changes BEFORE attempting `gh pr create`. If empty, mark ticket as `Cancelled` (or a new `NoOp` state) and free the slot cleanly. This is the same gap-class as WOR-329 (finalize doesn't handle non-standard outcomes).
+
+**Process gap (planning):** Should have audited each "test coverage" ticket against existing tests before dispatching. `pytest --collect-only tests/test_escalation_policy.py | wc -l` would have shown WOR-318 was redundant in 1 second.
+
+---
+
+## Cross-ticket patterns and architectural observations
+
+### Pattern 1: "Finalize doesn't handle non-standard outcomes"
+
+Three distinct manifestations tonight:
+- WOR-329: success-but-state-update-failed → ghost slot
+- WOR-318/320/321/325: success-but-no-diff → false-failure on PR creation
+- WOR-278/314: zero-token-high-wall-time → daemon couldn't reap
+
+All three are the same shape: `_execute_finalization` assumes a normal worker lifecycle (success → checks → PR or failure → block). It has no path for "the worker did its job but the system around it is in an unexpected state." When that happens, the daemon either holds resources indefinitely or creates spurious failures.
+
+### Pattern 2: "Branches dispatched late are stale"
+
+When 27 tickets are queued at the same time but processed serially over hours, the late-dispatched ones see a much-evolved epic. The current `rebase_worktree_from_base` handles the code rebase, but doesn't handle the case where the rebased work is now redundant.
+
+### Pattern 3: "Test-only tickets have a higher false-failure rate than refactor tickets"
+
+Counter-intuitive but real. The 5 no-op false-failures are all test-coverage tickets. Refactor tickets (Sonar bundles, audits) have lower false-failure rates because their AC is "the code looks like X" — easier for the worker to verify it isn't already so. Test tickets with AC "≥ N tests for module Y" silently satisfy when the tests already exist.
+
+**Process improvement:** test-coverage tickets should have an AC like "ADD AT LEAST 5 NEW tests" with the worker required to record `tests_added` count, not just "≥ N tests cover X."
+
+---
+
+## SQL backfill (run after WOR-332 ships)
+
+```sql
+-- WOR-329: ghost slot
+UPDATE ticket_metrics SET notes = '2026-05-03 retro: succeeded but daemon ghost-slot bug — Linear state stuck InProgressLocal for 5h, worker slot held until restart. Manual rescue: resolved merge conflicts (combined WOR-330 helper + WOR-327 constant + WOR-329 removed params), pushed 3b87c3d, manually merged PR #642 at 05:00 UTC. See .claude/artifacts/wor_313_retro_2026-05-03.md for full incident.' WHERE ticket_id = 'WOR-329';
+
+-- WOR-278: 0M tokens × 73min mystery
+UPDATE ticket_metrics SET notes = '2026-05-03 retro: 73min wall × 0M tokens — worker process never invoked LLM successfully. Identical pattern to WOR-314. Suspected vLLM connection failure or claude subprocess hang. Investigation pending; check worker_wor-278.log if still on disk.' WHERE ticket_id = 'WOR-278';
+
+-- WOR-314: same mystery
+UPDATE ticket_metrics SET notes = '2026-05-03 retro: 73min wall × 0M tokens — same pattern as WOR-278. Identical lines_changed=422 files=9 suggests same early-crash failure mode. Investigation pending.' WHERE ticket_id = 'WOR-314';
+
+-- WOR-318: no-op
+UPDATE ticket_metrics SET notes = '2026-05-03 retro: no-op false-failure. Worker correctly identified that 29 escalation tests already exist with 100% coverage (predates this epic). Worker reported success but finalize tried gh pr create on empty diff. Ticket should have been Cancelled, not Blocked.' WHERE ticket_id = 'WOR-318';
+
+-- WOR-319: no-op (silent)
+UPDATE ticket_metrics SET notes = '2026-05-03 retro: no-op false-failure (no result.json — worker exited before writing artifact). DB row pattern matches sibling tickets (lines_changed=340 files=9). Likely same root cause: AC already satisfied by existing tests in main.' WHERE ticket_id = 'WOR-319';
+
+-- WOR-320: no-op
+UPDATE ticket_metrics SET notes = '2026-05-03 retro: no-op false-failure. Worker verified all public functions in watcher_helpers.py already have docstrings. Reported success; finalize failed on empty diff.' WHERE ticket_id = 'WOR-320';
+
+-- WOR-321: no-op (worker self-reported failed)
+UPDATE ticket_metrics SET notes = '2026-05-03 retro: no-op false-failure. Branch had 5 sibling commits but none touched watcher_subprocess.py. All 7 public functions already documented. Worker reported status=failed (only one of the 5 to do so), but underlying issue is the same no-op trap.' WHERE ticket_id = 'WOR-321';
+
+-- WOR-325: no-op
+UPDATE ticket_metrics SET notes = '2026-05-03 retro: no-op false-failure. Tests for ServiceManager already committed on the branch before /implement-session started. All 20 tests pass. Worker reported success; finalize failed on empty diff.' WHERE ticket_id = 'WOR-325';
+```
+
+After running, also `set_tags` (per WOR-332) for the auto-detected pattern:
+```sql
+UPDATE ticket_metrics SET tags = '["success_outcome_state_mismatch"]' WHERE ticket_id = 'WOR-329';
+UPDATE ticket_metrics SET tags = '["zero_tokens_high_wall_time"]' WHERE ticket_id IN ('WOR-278', 'WOR-314');
+UPDATE ticket_metrics SET tags = '["no_diff_against_base"]' WHERE ticket_id IN ('WOR-318', 'WOR-319', 'WOR-320', 'WOR-321', 'WOR-325');
+```
+
+## Follow-up tickets to file in the morning
+
+1. **Watcher: detect no-op workers (no diff vs base) and mark Cancelled** — fixes the WOR-318/319/320/321/325 false-failure class
+2. **Watcher: free `_local_active` slot on `safe_set_state` failure** — fixes the WOR-329 ghost slot class. Possibly also: retry the state update on transient failure
+3. **Watcher: investigate the WOR-278/WOR-314 zero-token early crash** — needs log forensics first (check daemon log + worker log files if still on disk) before filing a fix ticket
+4. **Process: planning skills should pre-check test existence** — `pytest --collect-only` against the target module before queueing test-coverage tickets
+
+These all overlap conceptually with WOR-311/312's "watcher retry+finalize" investigation. Could fold into that bucket or file as siblings.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,11 @@ line-length = 88
 [tool.ruff.lint]
 select = ["E", "F", "I"]
 
+[tool.ruff.lint.per-file-ignores]
+# Long string literals are intentional in batch-generation scripts that
+# define ticket manifest content as data — splitting them would hurt readability.
+"scripts/generate_overnight_manifests.py" = ["E501"]
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = "--cov=app --cov-report=term-missing --cov-fail-under=80"

--- a/scripts/generate_overnight_manifests.py
+++ b/scripts/generate_overnight_manifests.py
@@ -1,0 +1,967 @@
+"""Generate manifests for the WOR-313 mega overnight hardening epic.
+
+Writes 27 ExecutionManifest JSON files to .claude/artifacts/<id>/manifest.json,
+validates each via the ExecutionManifest model, and prints a summary.
+
+Run: python scripts/generate_overnight_manifests.py
+
+This is a one-off script; it is not imported by app code and is intentionally
+kept under scripts/ rather than app/.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from app.core.manifest import ExecutionManifest  # noqa: E402
+
+EPIC_BRANCH = "epic/wor-313-mega-overnight-hardening"
+
+COMMON_FORBIDDEN = [
+    ".env",
+    ".mcp.json",
+    ".claude/settings*",
+]
+
+# Each entry: ticket_id, branch, title, allowed_paths, forbidden_paths_extra,
+# related_files_hint, effort, change_type, reasoning_demand, scope_clarity,
+# constraint_density, ac_specificity, tech_stack, raw_extensions,
+# objective (1-paragraph), acceptance_criteria, implementation_constraints
+TICKETS: list[dict[str, Any]] = [
+    {
+        "ticket_id": "WOR-247",
+        "branch": "wor-247-bench-store-import-contract",
+        "title": "Import linter: add bench_store isolation contract",
+        "allowed_paths": [".importlinter"],
+        "related_files_hint": [".importlinter", "app/core/bench_store.py"],
+        "effort": "high",
+        "change_type": "additive",
+        "reasoning_demand": 2,
+        "scope_clarity": 5,
+        "constraint_density": 3,
+        "ac_specificity": 5,
+        "tech_stack": "python,importlinter,toml",
+        "raw_extensions": '[".importlinter"]',
+        "objective": "Add a `forbidden` contract to `.importlinter` blocking watcher modules from importing app.core.bench_store, then run `lint-imports` to confirm it passes.",
+        "acceptance_criteria": [
+            "New `[importlinter:contract:bench-store-not-in-watcher]` contract added to .importlinter",
+            "Contract is type=forbidden, source_modules lists all app.core.watcher.* modules, forbidden_modules=app.core.bench_store",
+            "`lint-imports` passes with the new contract",
+            "Contract has CONTRACT OWNER comment matching existing style",
+        ],
+        "implementation_constraints": [
+            "Use Edit tool to modify .importlinter, do not rewrite the whole file",
+            "Mirror the comment style of existing contracts (CONTRACT OWNER, type, name)",
+            "Add the contract block at the END of the file",
+        ],
+    },
+    {
+        "ticket_id": "WOR-250",
+        "branch": "wor-250-archive-bench-tomls",
+        "title": "Config: archive stale bench experiment TOML files",
+        "allowed_paths": ["config/**", "scripts/bench/**", "README.md"],
+        "related_files_hint": ["config/", "scripts/bench/run_bench.py", "README.md"],
+        "effort": "high",
+        "change_type": "removal",
+        "reasoning_demand": 2,
+        "scope_clarity": 4,
+        "constraint_density": 3,
+        "ac_specificity": 4,
+        "tech_stack": "toml,filesystem",
+        "raw_extensions": '[".toml",".md"]',
+        "objective": "Archive WOR-221/cliff bench experiment TOML files to config/archive/ keeping only the active configs (escalation_policy.toml + currently-referenced bench TOMLs).",
+        "acceptance_criteria": [
+            "config/ contains <= 5 files at the top level (the rest moved to config/archive/)",
+            "scripts/bench/run_bench.py still works with the kept configs (run --tier speed --dry-run if available)",
+            "Each remaining bench TOML has a one-line top comment describing its purpose",
+            "git mv used (not delete + create) so history is preserved",
+        ],
+        "implementation_constraints": [
+            "Use git mv not shutil.move",
+            "Do NOT delete escalation_policy.toml — that's production",
+            "Check scripts/bench/ source for which bench-*.toml files are actually loaded; keep those",
+        ],
+    },
+    {
+        "ticket_id": "WOR-251",
+        "branch": "wor-251-pin-sonarqube-mcp",
+        "title": "MCP: pin SonarQube MCP server to a specific version in .mcp.json",
+        "allowed_paths": [".mcp.json"],
+        "forbidden_paths_extra": [],  # .mcp.json IS the target — override the default forbid
+        "related_files_hint": [".mcp.json"],
+        "effort": "high",
+        "change_type": "modification",
+        "reasoning_demand": 1,
+        "scope_clarity": 5,
+        "constraint_density": 3,
+        "ac_specificity": 5,
+        "tech_stack": "json,npm",
+        "raw_extensions": '[".json"]',
+        "objective": "Pin sonarqube-mcp-server to a specific version in .mcp.json so it doesn't redownload+upgrade on every cold session.",
+        "acceptance_criteria": [
+            ".mcp.json args specify sonarqube-mcp-server@<version> not just sonarqube-mcp-server",
+            "Version comes from `npm show sonarqube-mcp-server version` or equivalent",
+            "Run `npm view sonarqube-mcp-server version` first to find current stable",
+            "JSON syntax remains valid",
+        ],
+        "implementation_constraints": [
+            "Use Edit tool — do not rewrite the whole .mcp.json",
+            "Override the default forbidden_paths protection on .mcp.json — this ticket explicitly targets it",
+            "Verify json.load still parses the file after the edit",
+        ],
+    },
+    {
+        "ticket_id": "WOR-252",
+        "branch": "wor-252-remove-type-ignore-metrics-mode",
+        "title": "Fix: remove type: ignore in _to_metrics_mode with proper cast",
+        "allowed_paths": ["app/core/watcher/watcher_types.py"],
+        "related_files_hint": [
+            "app/core/watcher/watcher_types.py",
+            "app/core/metrics.py",
+        ],
+        "effort": "high",
+        "change_type": "refactor",
+        "reasoning_demand": 2,
+        "scope_clarity": 5,
+        "constraint_density": 3,
+        "ac_specificity": 5,
+        "tech_stack": "python,mypy,typing",
+        "raw_extensions": '[".py"]',
+        "objective": "Replace the `# type: ignore[return-value]` on _to_metrics_mode with proper typing.cast() — preferably using get_args(ImplementationMode) so the valid values stay in sync with the type.",
+        "acceptance_criteria": [
+            "_to_metrics_mode no longer has any # type: ignore comment",
+            "mypy app/ passes",
+            "Function behavior unchanged: returns 'cloud' for unknown values, otherwise returns the input as ImplementationMode",
+            "Prefer the `get_args(ImplementationMode)` pattern (option A in ticket description)",
+        ],
+        "implementation_constraints": [
+            "Use Edit tool",
+            "Add `from typing import cast, get_args` if not already imported",
+            "Do not modify metrics.py or any other file",
+        ],
+    },
+    {
+        "ticket_id": "WOR-275",
+        "branch": "wor-275-file-reread-cap",
+        "title": "Worker file re-read suppression: cap at 2 reads/file with explicit instruction",
+        "allowed_paths": [
+            ".claude/commands/implement-ticket.md",
+            ".claude/commands/start-ticket.md",
+        ],
+        "forbidden_paths_extra": [
+            ".claude/commands/start-epic.md"
+        ],  # don't touch sibling skills
+        "related_files_hint": [
+            ".claude/commands/implement-ticket.md",
+            ".claude/commands/start-ticket.md",
+        ],
+        "effort": "high",
+        "change_type": "modification",
+        "reasoning_demand": 2,
+        "scope_clarity": 4,
+        "constraint_density": 3,
+        "ac_specificity": 4,
+        "tech_stack": "markdown",
+        "raw_extensions": '[".md"]',
+        "objective": "Add a 'Read each file at most 2 times per session' rule to implement-ticket.md and conditional risk_flags to start-ticket.md when context_snippets are populated. Skill-text-only change; no code.",
+        "acceptance_criteria": [
+            "implement-ticket.md has a per-file 2-read cap rule with the exact text from the ticket description",
+            "start-ticket.md adds a risk_flag when related_files_hint has > 5 files",
+            "start-ticket.md adds a risk_flag when context_snippets is populated",
+            "No code changes in app/ — pure skill text",
+        ],
+        "implementation_constraints": [
+            "Use Edit tool, do not rewrite whole skill files",
+            "Stretch goal in description (--disallowed-tools enforcement) is OUT OF SCOPE for this ticket",
+            "Do not touch start-epic.md or close-epic.md",
+        ],
+    },
+    {
+        "ticket_id": "WOR-277",
+        "branch": "wor-277-waste-score-column",
+        "title": "Watcher waste-score: per-session metric in ticket_metrics + warning log",
+        "allowed_paths": [
+            "app/core/watcher/worker_waste.py",
+            "app/core/watcher/watcher_finalize.py",
+            "app/core/metrics.py",
+            "app/cli.py",
+            "config/escalation_policy.toml",
+            "app/core/escalation_policy.py",
+            "tests/test_worker_waste.py",
+            "tests/test_metrics.py",
+            "tests/test_watcher_finalize.py",
+        ],
+        "related_files_hint": [
+            "app/core/watcher/watcher_helpers.py",
+            "app/core/watcher/watcher_finalize.py",
+            "app/core/metrics.py",
+            "app/core/escalation_policy.py",
+        ],
+        "effort": "max",
+        "change_type": "additive",
+        "reasoning_demand": 4,
+        "scope_clarity": 4,
+        "constraint_density": 4,
+        "ac_specificity": 5,
+        "tech_stack": "python,sqlite,pydantic,pytest",
+        "raw_extensions": '[".py",".toml"]',
+        "objective": "Add a 0-100 waste score per worker session, persist to metrics.db, log WARNING when score>threshold, and add a CLI command for ad-hoc scoring. Formula is pre-baked in the ticket description.",
+        "acceptance_criteria": [
+            "app/core/watcher/worker_waste.py exists with compute_waste_score(log_path) -> WasteReport",
+            "Tests cover each waste signal independently + composite score",
+            "ticket_metrics.waste_score and ticket_metrics.waste_breakdown_json columns added via _migrate",
+            "finalize_worker populates them after each session",
+            "Watcher emits WARNING when score > threshold (default 60)",
+            "config/escalation_policy.toml has [waste] warn_threshold (default 60)",
+            "python -m app.cli waste-score WOR-NNN works",
+            "ruff check . , mypy app/ , pytest pass",
+        ],
+        "implementation_constraints": [
+            "Use the formula EXACTLY as written in the ticket description — do not invent your own",
+            "worker_waste.py is a NEW file — read source signatures BEFORE writing, run mypy on it immediately after creation",
+            "test_worker_waste.py is NEW — read tests/test_watcher_helpers.py first for fixture pattern",
+            "DB migration must be idempotent (use ALTER TABLE IF NOT EXISTS pattern or check before adding column)",
+            "Do not block ticket completion based on waste score — observability only",
+        ],
+    },
+    {
+        "ticket_id": "WOR-278",
+        "branch": "wor-278-github-e2e-test",
+        "title": "GitHub flow: end-to-end integration test for generate --github-create + --git-push",
+        "allowed_paths": ["tests/test_cli.py", "tests/test_cli_github_flow.py"],
+        "related_files_hint": [
+            "app/cli.py",
+            "app/core/post_setup.py",
+            "tests/test_cli.py",
+        ],
+        "effort": "high",
+        "change_type": "additive",
+        "reasoning_demand": 3,
+        "scope_clarity": 5,
+        "constraint_density": 3,
+        "ac_specificity": 5,
+        "tech_stack": "python,pytest,unittest.mock",
+        "raw_extensions": '[".py"]',
+        "objective": "Add an end-to-end test for the generate --github-create + --git-push flow with all external calls mocked. Verifies clone URL flows correctly through create -> configure -> push.",
+        "acceptance_criteria": [
+            "At least one test that runs the full --github-create + --git-push chain end-to-end with all external calls mocked",
+            "Test verifies clone URL propagates create -> configure -> push correctly",
+            "Failure-path test for the configure -> push handoff",
+            "Existing tests still pass",
+        ],
+        "implementation_constraints": [
+            "Mock app.core.credentials.keyring, app.core.post_setup.urllib.request.urlopen, app.core.post_setup.subprocess.run at module boundaries",
+            "Do NOT make real GitHub API calls",
+            "Test-only ticket — no production code changes",
+            "Either extend tests/test_cli.py or create tests/test_cli_github_flow.py (your choice based on size)",
+        ],
+    },
+    {
+        "ticket_id": "WOR-279",
+        "branch": "wor-279-github-flow-rollback",
+        "title": "GitHub flow: rollback / cleanup on partial failure",
+        "allowed_paths": [
+            "app/core/post_setup.py",
+            "app/cli.py",
+            "tests/test_post_setup.py",
+            "tests/test_cli.py",
+        ],
+        "related_files_hint": [
+            "app/core/post_setup.py",
+            "app/cli.py",
+            "tests/test_post_setup.py",
+        ],
+        "effort": "xhigh",
+        "change_type": "additive",
+        "reasoning_demand": 3,
+        "scope_clarity": 4,
+        "constraint_density": 3,
+        "ac_specificity": 5,
+        "tech_stack": "python,urllib,subprocess",
+        "raw_extensions": '[".py"]',
+        "objective": "Add delete_github_repo() + wrap _run_generate's GitHub flow in try/except with optional --no-rollback-on-failure flag. When create succeeds but configure/push fails, delete the orphaned repo.",
+        "acceptance_criteria": [
+            "delete_github_repo function added with same security/error patterns as create_github_repo (nosec, timeout=10, format-validate first)",
+            "_run_generate rolls back the created repo when configure or push fails",
+            "--no-rollback-on-failure flag opts out of rollback",
+            "Tests cover success, configure-fail-rollback, push-fail-rollback, and opt-out paths",
+            "ruff + mypy + pytest pass",
+        ],
+        "implementation_constraints": [
+            "Mirror the security patterns of create_github_repo: nosec B310 on urlopen, timeout=10, format-validate repo_full_name before DELETE",
+            "delete_github_repo errors WARN to stderr but do not raise (best-effort cleanup)",
+            "Re-raise the original exception after rollback — don't swallow",
+            "Touches post_setup.py — may serialize with WOR-322 (docstrings) and WOR-323 (bare except audit)",
+        ],
+    },
+    {
+        "ticket_id": "WOR-280",
+        "branch": "wor-280-cli-set-token-getpass-test",
+        "title": "GitHub flow: cover interactive getpass path in cli_set_token",
+        "allowed_paths": ["app/core/credentials.py", "tests/test_credentials.py"],
+        "related_files_hint": ["app/core/credentials.py", "tests/test_credentials.py"],
+        "effort": "high",
+        "change_type": "modification",
+        "reasoning_demand": 2,
+        "scope_clarity": 5,
+        "constraint_density": 3,
+        "ac_specificity": 5,
+        "tech_stack": "python,pytest,getpass",
+        "raw_extensions": '[".py"]',
+        "objective": "Refactor cli_set_token to use top-level `from getpass import getpass` import (mock-friendly), then add 4 tests covering success, empty input, EOF, and keyring error paths.",
+        "acceptance_criteria": [
+            "cli_set_token refactored to use top-level getpass import (or otherwise made mock-friendly)",
+            "4 new tests: test_cli_set_token_success, test_cli_set_token_empty_input, test_cli_set_token_eof, test_cli_set_token_keyring_error",
+            "credentials.py coverage rises to >= 80%",
+            "No CLI behavior change (still prompts via getpass on real TTYs)",
+            "All existing tests still pass",
+        ],
+        "implementation_constraints": [
+            "Use patch('app.core.credentials.getpass') in the new tests",
+            "Touches tests/test_credentials.py — may serialize with WOR-316",
+            "Do NOT remove the env-var fallback for GITHUB_TOKEN; that's separately tested by WOR-316",
+        ],
+    },
+    {
+        "ticket_id": "WOR-304",
+        "branch": "wor-304-watcher-daemon-smoke-test-ci",
+        "title": "CI: smoke-start watcher daemon for 5s to catch startup-only bugs",
+        "allowed_paths": [
+            ".github/workflows/ci.yml",
+            ".github/workflows/*.yml",
+            "CLAUDE.md",
+            "Makefile",
+        ],
+        "related_files_hint": [".github/workflows/", "CLAUDE.md", "app/cli.py"],
+        "effort": "high",
+        "change_type": "additive",
+        "reasoning_demand": 2,
+        "scope_clarity": 5,
+        "constraint_density": 3,
+        "ac_specificity": 5,
+        "tech_stack": "yaml,bash,github-actions",
+        "raw_extensions": '[".yml",".md"]',
+        "objective": "Add a CI step that smoke-starts `python -m app.cli watcher` for 5 seconds and asserts it stays alive. Catches the class of startup-only daemon bugs (PRs #601-#604) that pytest/mypy don't catch.",
+        "acceptance_criteria": [
+            ".github/workflows/ci.yml gains a watcher-smoke job that fails the build when daemon exits within 5s",
+            "Job uses LINEAR_API_KEY=dummy + clean working dir",
+            "Job runs after pytest and on every PR targeting main or epic/*",
+            "Local one-liner equivalent documented in CLAUDE.md (e.g. make watcher-smoke or bash one-liner)",
+            "Cost: ~6 sec per CI run",
+        ],
+        "implementation_constraints": [
+            "Use `timeout 5 python -m app.cli watcher --no-epic-shutdown || ([ $? -eq 124 ] && echo OK) || (echo FAIL && exit 1)` pattern",
+            "Pre-flight: read .github/workflows/ to see the existing CI structure first",
+            "If a Makefile doesn't exist, you can create one with the smoke target — or document in CLAUDE.md as a bash one-liner",
+            "DO NOT run the smoke test locally to verify (requires vLLM); CI will validate",
+        ],
+    },
+    {
+        "ticket_id": "WOR-314",
+        "branch": "wor-314-tests-dispatch-start-ticket",
+        "title": "Tests: add tests/test_watcher_dispatch.py for dispatch.start_ticket flow",
+        "allowed_paths": ["tests/test_watcher_dispatch.py"],
+        "related_files_hint": [
+            "app/core/watcher/dispatch.py",
+            "tests/test_watcher.py",
+            "tests/test_watcher_dispatch.py",
+        ],
+        "effort": "high",
+        "change_type": "additive",
+        "reasoning_demand": 3,
+        "scope_clarity": 5,
+        "constraint_density": 4,
+        "ac_specificity": 5,
+        "tech_stack": "python,pytest,unittest.mock",
+        "raw_extensions": '[".py"]',
+        "objective": "Add 5+ direct unit tests for dispatch.start_ticket. The existing test file has watcher-level smoke tests that mock start_ticket; this ticket adds direct unit tests of the function itself.",
+        "acceptance_criteria": [
+            "5+ new tests covering: cloud pool full, vLLM not ready, vLLM ready dispatch, ActiveWorker creation, safe_set_state failure tolerance, copy_manifest_to_worktree failure propagation, backup_plan_files called",
+            "Coverage of app/core/watcher/dispatch.py rises to >= 70%",
+            "All existing tests still pass",
+            "ruff + mypy + pytest pass",
+        ],
+        "implementation_constraints": [
+            "Mock at app.core.watcher.dispatch.<name> not at the source module",
+            "Use MagicMock(spec=ServiceManager) for service mocks",
+            "Test-only ticket — no production code changes",
+            "WOR-328 (Sonar S3) may also touch tests/test_watcher_dispatch.py — watcher will serialize",
+        ],
+    },
+    {
+        "ticket_id": "WOR-315",
+        "branch": "wor-315-tests-color-formatter",
+        "title": "Tests: add tests/test_watcher_log_format.py for ColorFormatter",
+        "allowed_paths": ["tests/test_watcher_log_format.py"],
+        "related_files_hint": ["app/core/watcher/log_format.py"],
+        "effort": "high",
+        "change_type": "additive",
+        "reasoning_demand": 2,
+        "scope_clarity": 5,
+        "constraint_density": 3,
+        "ac_specificity": 5,
+        "tech_stack": "python,pytest,logging",
+        "raw_extensions": '[".py"]',
+        "objective": "Create a NEW test file tests/test_watcher_log_format.py with 6+ tests covering ColorFormatter ANSI prefixes for each log level + TTY detection guard.",
+        "acceptance_criteria": [
+            "tests/test_watcher_log_format.py exists with 6+ tests for DEBUG/INFO/WARNING/ERROR/CRITICAL color prefixes + TTY guard",
+            "Coverage of app/core/watcher/log_format.py >= 90%",
+            "ruff + mypy + pytest pass",
+        ],
+        "implementation_constraints": [
+            "NEW test file — read tests/test_watcher_helpers.py FIRST for fixture/import patterns",
+            "Run pytest tests/test_watcher_log_format.py -x IMMEDIATELY after creation to catch import errors",
+            "Construct LogRecord directly via logging.LogRecord(...) — do not use logging.getLogger() side effects",
+            "Test-only ticket",
+        ],
+    },
+    {
+        "ticket_id": "WOR-316",
+        "branch": "wor-316-tests-credentials-edge-cases",
+        "title": "Tests: add edge-case coverage for app/core/credentials.py",
+        "allowed_paths": ["tests/test_credentials.py"],
+        "related_files_hint": ["app/core/credentials.py", "tests/test_credentials.py"],
+        "effort": "high",
+        "change_type": "additive",
+        "reasoning_demand": 2,
+        "scope_clarity": 5,
+        "constraint_density": 3,
+        "ac_specificity": 5,
+        "tech_stack": "python,pytest,keyring",
+        "raw_extensions": '[".py"]',
+        "objective": "Add 6+ edge-case tests for save_token, get_token, delete_token + GITHUB_TOKEN env-var fallback. Complements WOR-280 (which covers cli_set_token specifically).",
+        "acceptance_criteria": [
+            "6+ new tests covering save_token success/error, get_token (keyring hit/miss/env fallback/error+env), delete_token (exists/missing)",
+            "credentials.py coverage rises (current ~51%, target >= 80%)",
+            "All existing tests still pass",
+            "Do not duplicate WOR-280's cli_set_token tests",
+        ],
+        "implementation_constraints": [
+            "Use unittest.mock.patch('app.core.credentials.keyring') for keyring mocks",
+            "Use monkeypatch.setenv / delenv for env-var manipulation",
+            "Touches tests/test_credentials.py — may serialize with WOR-280",
+            "Test-only ticket",
+        ],
+    },
+    {
+        "ticket_id": "WOR-317",
+        "branch": "wor-317-tests-user-prefs-edge-cases",
+        "title": "Tests: add edge-case coverage for app/core/user_prefs.py",
+        "allowed_paths": ["tests/test_user_prefs.py"],
+        "related_files_hint": ["app/core/user_prefs.py", "tests/test_user_prefs.py"],
+        "effort": "high",
+        "change_type": "additive",
+        "reasoning_demand": 2,
+        "scope_clarity": 5,
+        "constraint_density": 3,
+        "ac_specificity": 5,
+        "tech_stack": "python,pytest,pydantic",
+        "raw_extensions": '[".py"]',
+        "objective": "Add 5+ edge-case tests for PrefsStore (corrupt JSON, missing file/dir, atomic write, round-trip) and UserPreferences validation.",
+        "acceptance_criteria": [
+            "5+ new tests covering corrupt JSON, missing file, missing dir, atomic write, JSON round-trip, Pydantic validation rejection",
+            "All existing tests still pass",
+            "ruff + mypy + pytest pass",
+        ],
+        "implementation_constraints": [
+            "Test-only ticket",
+            "Use tmp_path fixture for filesystem isolation",
+            "Verify atomic write by checking that no .tmp partial file is left after a successful save (or after a simulated mid-write crash)",
+        ],
+    },
+    {
+        "ticket_id": "WOR-318",
+        "branch": "wor-318-tests-escalation-policy-classify",
+        "title": "Tests: cover EscalationPolicy.classify_* decision tables",
+        "allowed_paths": ["tests/test_escalation_policy.py"],
+        "related_files_hint": [
+            "app/core/escalation_policy.py",
+            "config/escalation_policy.toml",
+            "tests/test_escalation_policy.py",
+        ],
+        "effort": "high",
+        "change_type": "additive",
+        "reasoning_demand": 2,
+        "scope_clarity": 5,
+        "constraint_density": 3,
+        "ac_specificity": 5,
+        "tech_stack": "python,pytest,toml",
+        "raw_extensions": '[".py"]',
+        "objective": "Add 8+ tests locking the EscalationPolicy decision tables (4 result-flag classifiers, 5 sonar severity classifiers, 2 from_toml error paths).",
+        "acceptance_criteria": [
+            "8+ new tests covering classify_result for each flag, classify_sonar_finding for each severity, from_toml malformed/missing-section error paths",
+            "All existing tests still pass",
+            "app/core/escalation_policy.py coverage rises",
+        ],
+        "implementation_constraints": [
+            "Test-only ticket",
+            "Do NOT modify config/escalation_policy.toml — write test TOML to tmp_path",
+            "Use EscalationPolicy.from_toml(tmp_path / 'escalation_policy.toml') for setup",
+        ],
+    },
+    {
+        "ticket_id": "WOR-319",
+        "branch": "wor-319-tests-manifest-validators",
+        "title": "Tests: add validator tests for app/core/manifest.py (extra=forbid, paths, taxonomy ranges)",
+        "allowed_paths": ["tests/test_manifest.py"],
+        "related_files_hint": ["app/core/manifest.py", "tests/test_manifest.py"],
+        "effort": "high",
+        "change_type": "additive",
+        "reasoning_demand": 2,
+        "scope_clarity": 5,
+        "constraint_density": 3,
+        "ac_specificity": 5,
+        "tech_stack": "python,pytest,pydantic",
+        "raw_extensions": '[".py"]',
+        "objective": "Add 8+ validator tests for ExecutionManifest covering extra=forbid rejection, Literal/range constraints, ArtifactPaths normalization.",
+        "acceptance_criteria": [
+            "8+ new tests covering extra_forbidden, change_type Literal, reasoning_demand range, scope_clarity range, max_retries values, allowed_paths edge cases, ArtifactPaths.from_ticket_id normalization",
+            "Use pytest.raises(ValidationError) with match= for error message checks",
+            "All existing tests still pass",
+        ],
+        "implementation_constraints": [
+            "Test-only ticket",
+            "Read tests/test_manifest.py first for existing fixture patterns",
+            "Use ExecutionManifest constructor directly OR ExecutionManifest.model_validate(dict) for dict-based tests",
+        ],
+    },
+    {
+        "ticket_id": "WOR-320",
+        "branch": "wor-320-docstrings-watcher-helpers",
+        "title": "Docstrings: add to public functions in app/core/watcher/watcher_helpers.py",
+        "allowed_paths": ["app/core/watcher/watcher_helpers.py"],
+        "related_files_hint": ["app/core/watcher/watcher_helpers.py"],
+        "effort": "high",
+        "change_type": "docs",
+        "reasoning_demand": 1,
+        "scope_clarity": 5,
+        "constraint_density": 3,
+        "ac_specificity": 4,
+        "tech_stack": "python",
+        "raw_extensions": '[".py"]',
+        "objective": "Add concise Google-style docstrings to all public functions in watcher_helpers.py that lack them.",
+        "acceptance_criteria": [
+            "All public (non-_-prefixed) functions in watcher_helpers.py have at least a one-line docstring",
+            "Existing docstrings unchanged",
+            "ruff + mypy + pytest pass with no behavior change",
+        ],
+        "implementation_constraints": [
+            "Use Edit tool per function — do not rewrite the file",
+            "Match the style of existing well-documented functions like _parse_worker_usage",
+            "One-sentence summary sufficient; Args/Returns/Raises only when useful",
+            "Do NOT modify private (_-prefixed) functions",
+        ],
+    },
+    {
+        "ticket_id": "WOR-321",
+        "branch": "wor-321-docstrings-watcher-subprocess",
+        "title": "Docstrings: add to public functions in app/core/watcher/watcher_subprocess.py",
+        "allowed_paths": ["app/core/watcher/watcher_subprocess.py"],
+        "related_files_hint": ["app/core/watcher/watcher_subprocess.py"],
+        "effort": "high",
+        "change_type": "docs",
+        "reasoning_demand": 1,
+        "scope_clarity": 5,
+        "constraint_density": 3,
+        "ac_specificity": 4,
+        "tech_stack": "python",
+        "raw_extensions": '[".py"]',
+        "objective": "Add Google-style docstrings to public functions in watcher_subprocess.py (launch_worker, run_checks, fetch_sonar_findings, create_pr, parse_git_shortstat, etc.).",
+        "acceptance_criteria": [
+            "All public functions in watcher_subprocess.py have docstrings",
+            "ruff + mypy + pytest pass with no behavior change",
+        ],
+        "implementation_constraints": [
+            "Use Edit tool per function",
+            "For launch_worker: document the worker_verbose<->tee path relationship",
+            "Do NOT modify other watcher modules",
+        ],
+    },
+    {
+        "ticket_id": "WOR-322",
+        "branch": "wor-322-docstrings-post-setup",
+        "title": "Docstrings: add to public functions in app/core/post_setup.py",
+        "allowed_paths": ["app/core/post_setup.py"],
+        "related_files_hint": ["app/core/post_setup.py"],
+        "effort": "high",
+        "change_type": "docs",
+        "reasoning_demand": 1,
+        "scope_clarity": 5,
+        "constraint_density": 3,
+        "ac_specificity": 4,
+        "tech_stack": "python",
+        "raw_extensions": '[".py"]',
+        "objective": "Add Google-style docstrings to public functions in post_setup.py. For GitHub-API helpers, document the endpoint, auth model, and failure semantics.",
+        "acceptance_criteria": [
+            "All public functions in post_setup.py have docstrings",
+            "ruff + mypy + pytest pass with no behavior change",
+        ],
+        "implementation_constraints": [
+            "Use Edit tool per function",
+            "Touches post_setup.py — may serialize with WOR-279, WOR-323, WOR-329",
+            "Documentation-only — no test changes required",
+        ],
+    },
+    {
+        "ticket_id": "WOR-323",
+        "branch": "wor-323-audit-bare-except-post-setup",
+        "title": "Audit: replace bare except Exception in app/core/post_setup.py with specific exceptions",
+        "allowed_paths": ["app/core/post_setup.py", "tests/test_post_setup.py"],
+        "related_files_hint": ["app/core/post_setup.py", "tests/test_post_setup.py"],
+        "effort": "xhigh",
+        "change_type": "refactor",
+        "reasoning_demand": 3,
+        "scope_clarity": 4,
+        "constraint_density": 4,
+        "ac_specificity": 4,
+        "tech_stack": "python",
+        "raw_extensions": '[".py"]',
+        "objective": "Audit each `except Exception` in post_setup.py and replace with specific exception types where safe. Skip intentional broad catches with a comment explaining why.",
+        "acceptance_criteria": [
+            "At least 50% of bare `except Exception` in post_setup.py are replaced with specific types (or annotated as intentional)",
+            "All existing tests pass",
+            "ruff + mypy + pytest pass",
+        ],
+        "implementation_constraints": [
+            "Per occurrence: identify the specific exceptions raised in the try-block (URLError, HTTPError, CalledProcessError, JSONDecodeError, NoKeyringError, etc.)",
+            "Skip + comment if the catch is intentionally broad (e.g. cleanup/best-effort path)",
+            "Run pytest after each batch of changes",
+            "Touches post_setup.py — may serialize with WOR-279, WOR-322, WOR-329",
+        ],
+    },
+    {
+        "ticket_id": "WOR-324",
+        "branch": "wor-324-audit-noqa-watcher",
+        "title": "Audit: remove unused noqa/type:ignore comments in app/core/watcher/",
+        "allowed_paths": ["app/core/watcher/*.py"],
+        "forbidden_paths_extra": ["app/core/watcher/__init__.py"],
+        "related_files_hint": ["app/core/watcher/"],
+        "effort": "xhigh",
+        "change_type": "refactor",
+        "reasoning_demand": 3,
+        "scope_clarity": 4,
+        "constraint_density": 4,
+        "ac_specificity": 4,
+        "tech_stack": "python,ruff,mypy,bandit",
+        "raw_extensions": '[".py"]',
+        "objective": "Find and remove stale # noqa / # type: ignore suppressions in app/core/watcher/ where the underlying issue no longer exists. KEEP legitimate # nosec B603/B607 on subprocess calls.",
+        "acceptance_criteria": [
+            "At least 5 stale suppressions removed",
+            "No new ruff/mypy errors introduced",
+            "All tests pass",
+            "Suppressions kept have a comment explaining why",
+        ],
+        "implementation_constraints": [
+            "DO NOT remove # nosec B603 / B607 on subprocess.run calls — those are intentional",
+            "For each candidate: remove the suppression, run ruff/mypy, if passes keep removed; otherwise restore + comment",
+            "Touches multiple watcher files — may serialize with sibling tickets",
+            "Skip files actively touched by WOR-312 work (watcher_finalize.py, dispatch.py) if WOR-312 is in flight — but it's NOT in this overnight epic, so go ahead",
+        ],
+    },
+    {
+        "ticket_id": "WOR-325",
+        "branch": "wor-325-tests-watcher-services-probes",
+        "title": "Tests: add coverage for app/core/watcher/watcher_services.py::ServiceManager probes",
+        "allowed_paths": ["tests/test_watcher_services.py"],
+        "related_files_hint": [
+            "app/core/watcher/watcher_services.py",
+            "tests/test_watcher_services.py",
+        ],
+        "effort": "high",
+        "change_type": "additive",
+        "reasoning_demand": 2,
+        "scope_clarity": 5,
+        "constraint_density": 3,
+        "ac_specificity": 4,
+        "tech_stack": "python,pytest,subprocess,urllib",
+        "raw_extensions": '[".py"]',
+        "objective": "Add 5+ tests for ServiceManager.probe_vllm_health and process-management edge cases.",
+        "acceptance_criteria": [
+            "5+ new tests covering: probe_vllm_health (port not bound, 5xx, 200), ensure_litellm_running (already running, Popen failure), ensure_ollama_running fallback, shutdown_litellm",
+            "All existing tests still pass",
+            "ruff + mypy + pytest pass",
+        ],
+        "implementation_constraints": [
+            "Use patch('urllib.request.urlopen') for health probe mocks",
+            "Use patch('subprocess.Popen') for process launching mocks",
+            "Test-only ticket",
+        ],
+    },
+    {
+        "ticket_id": "WOR-326",
+        "branch": "wor-326-sonar-s1-quick-wins",
+        "title": "SonarCloud S1: quick-win cleanups (S1481, S5713, S1066) — 5 findings",
+        "allowed_paths": [
+            "app/core/watcher/watcher.py",
+            "app/core/watcher/watcher_finalize.py",
+            "app/core/watcher/dispatch.py",
+        ],
+        "related_files_hint": [
+            "app/core/watcher/watcher.py",
+            "app/core/watcher/watcher_finalize.py",
+            "app/core/watcher/dispatch.py",
+        ],
+        "effort": "high",
+        "change_type": "refactor",
+        "reasoning_demand": 2,
+        "scope_clarity": 5,
+        "constraint_density": 4,
+        "ac_specificity": 5,
+        "tech_stack": "python",
+        "raw_extensions": '[".py"]',
+        "objective": "Apply 5 mechanical Sonar fixes: 2x unused locals -> _, 2x duplicate exception class removal, 1x collapse nested if. Pure cleanup.",
+        "acceptance_criteria": [
+            "All 5 Sonar findings resolved (verify via mcp sonarqube issues query after merge)",
+            "ruff + mypy + pytest pass",
+            "No behavior change — same tests pass",
+        ],
+        "implementation_constraints": [
+            "Read ~10 lines of context around each finding before applying the fix",
+            "Use Edit tool, line-by-line",
+            "Touches 3 watcher files — may serialize with sibling Sonar tickets",
+        ],
+    },
+    {
+        "ticket_id": "WOR-327",
+        "branch": "wor-327-sonar-s2-string-literals",
+        "title": "SonarCloud S2: extract duplicated string literals (S1192) — 2 findings",
+        "allowed_paths": [
+            "app/core/watcher/watcher.py",
+            "app/core/watcher/watcher_finalize.py",
+            "app/core/watcher/watcher_types.py",
+        ],
+        "related_files_hint": [
+            "app/core/watcher/watcher.py",
+            "app/core/watcher/watcher_finalize.py",
+            "app/core/watcher/watcher_types.py",
+        ],
+        "effort": "high",
+        "change_type": "refactor",
+        "reasoning_demand": 2,
+        "scope_clarity": 5,
+        "constraint_density": 3,
+        "ac_specificity": 5,
+        "tech_stack": "python",
+        "raw_extensions": '[".py"]',
+        "objective": "Extract 2 duplicated string literals into module-level constants: */manifest.json (3x in watcher.py) and 'In Progress' (4x in watcher_finalize.py).",
+        "acceptance_criteria": [
+            "Both S1192 findings resolved",
+            "Constants are leading-underscore (module-private) following existing conventions",
+            "ruff + mypy + pytest pass",
+            "No behavior change",
+        ],
+        "implementation_constraints": [
+            "Check watcher_types.py for existing 'In Progress' constant before defining a new one",
+            "Use Edit tool with replace_all=True for the literal substitution",
+            "Touches multiple watcher files — may serialize with WOR-326",
+        ],
+    },
+    {
+        "ticket_id": "WOR-328",
+        "branch": "wor-328-sonar-s3-dispatch-signature",
+        "title": "SonarCloud S3: clean up dispatch.start_ticket signature (S107 + S1172) — remove dead params",
+        "allowed_paths": [
+            "app/core/watcher/dispatch.py",
+            "app/core/watcher/watcher.py",
+            "tests/test_watcher_dispatch.py",
+        ],
+        "related_files_hint": [
+            "app/core/watcher/dispatch.py",
+            "app/core/watcher/watcher.py",
+            "tests/test_watcher_dispatch.py",
+        ],
+        "effort": "high",
+        "change_type": "refactor",
+        "reasoning_demand": 2,
+        "scope_clarity": 5,
+        "constraint_density": 4,
+        "ac_specificity": 5,
+        "tech_stack": "python",
+        "raw_extensions": '[".py"]',
+        "objective": "Remove 3 dead params (project_id, retry_counters, max_local_workers) from dispatch.start_ticket. Auto-resolves S107 (16 -> 13 params) + 3x S1172. Confirms WOR-311's finding.",
+        "acceptance_criteria": [
+            "All 4 Sonar findings resolved (3x S1172 + 1x S107)",
+            "ruff + mypy + pytest pass",
+            "All existing tests still pass after removing dead-param mocks",
+        ],
+        "implementation_constraints": [
+            "Verify each param is genuinely unused inside start_ticket body before removing",
+            "Update the call site in app/core/watcher/watcher.py",
+            "Update test mocks in tests/test_watcher_dispatch.py — remove project_id=, retry_counters={}, max_local_workers= keyword args",
+            "DO NOT delete Watcher._retry_counters dict itself — that's WOR-312's territory",
+            "Touches dispatch.py + watcher.py — may serialize with WOR-326, WOR-327",
+        ],
+    },
+    {
+        "ticket_id": "WOR-329",
+        "branch": "wor-329-sonar-s4-unused-params",
+        "title": "SonarCloud S4: remove unused parameters in watcher_finalize.py + post_setup.py (S1172) — 3 findings",
+        "allowed_paths": [
+            "app/core/watcher/watcher_finalize.py",
+            "app/core/post_setup.py",
+            "tests/test_watcher_finalize.py",
+            "tests/test_post_setup.py",
+        ],
+        "related_files_hint": [
+            "app/core/watcher/watcher_finalize.py",
+            "app/core/post_setup.py",
+        ],
+        "effort": "high",
+        "change_type": "refactor",
+        "reasoning_demand": 2,
+        "scope_clarity": 5,
+        "constraint_density": 4,
+        "ac_specificity": 5,
+        "tech_stack": "python",
+        "raw_extensions": '[".py"]',
+        "objective": "Remove 3 unused params (linear_id, linear in watcher_finalize.py; prefs in post_setup.py). Verify they're truly unused first.",
+        "acceptance_criteria": [
+            "All 3 S1172 findings resolved (or renamed to _<name> with comment if removal isn't safe)",
+            "ruff + mypy + pytest pass",
+            "All call sites updated; no broken tests",
+        ],
+        "implementation_constraints": [
+            "Read each function body fully before removing — check for hidden uses",
+            "If used in string templates or kwargs spread, do NOT remove",
+            "If exists for protocol compliance, prefer rename to _<name>",
+            "Touches watcher_finalize.py + post_setup.py — may serialize with WOR-279, WOR-322, WOR-323, WOR-326, WOR-327",
+        ],
+    },
+    {
+        "ticket_id": "WOR-330",
+        "branch": "wor-330-sonar-s5-cli-complexity",
+        "title": "SonarCloud S5: reduce cognitive complexity in app/cli.py (S3776) — 3 functions",
+        "allowed_paths": ["app/cli.py", "tests/test_cli.py"],
+        "related_files_hint": ["app/cli.py", "tests/test_cli.py"],
+        "effort": "xhigh",
+        "change_type": "refactor",
+        "reasoning_demand": 4,
+        "scope_clarity": 4,
+        "constraint_density": 4,
+        "ac_specificity": 5,
+        "tech_stack": "python",
+        "raw_extensions": '[".py"]',
+        "objective": "Reduce cognitive complexity of 3 large functions in app/cli.py (currently 26, 23, +1 more) to <= 15 by extracting per-step helpers. Behavior must be preserved exactly.",
+        "acceptance_criteria": [
+            "All 3 S3776 cli.py findings resolved (cognitive complexity <= 15 each)",
+            "ruff + mypy + pytest pass",
+            "All 24+ existing test_cli.py tests still pass with no changes",
+        ],
+        "implementation_constraints": [
+            "These functions are tested via app.cli.main(...) so behavior MUST be preserved exactly",
+            "Functions at lines 272 and 335 are likely _run_generate and _run_config — split into per-step helpers",
+            "Helper names should be descriptive (e.g. _handle_github_create, _handle_post_setup)",
+            "Run pytest after each function refactor, not at the end",
+            "May touch tests/test_cli.py if helpers need direct test coverage — but ideally no test changes",
+        ],
+    },
+]
+
+
+def build_manifest(t: dict[str, Any]) -> dict[str, Any]:
+    ticket_id = t["ticket_id"]
+    artifact_id = ticket_id.lower().replace("-", "_")
+    # Compose forbidden list, then strip any path that's in allowed_paths
+    # (a ticket can intentionally target a normally-forbidden file like .mcp.json).
+    allowed_set = set(t["allowed_paths"])
+    forbidden_raw = list(COMMON_FORBIDDEN) + t.get("forbidden_paths_extra", [])
+    forbidden = [p for p in forbidden_raw if p not in allowed_set]
+    return {
+        "manifest_version": "1.0",
+        "ticket_id": ticket_id,
+        "epic_id": "WOR-313",
+        "title": t["title"],
+        "priority": 3,
+        "status": "ReadyForLocal",
+        "linear_id": None,
+        "blocked_by_tickets": [],
+        "parallel_safe": True,
+        "risk_level": "low",
+        "risk_flags": [],
+        "implementation_mode": "local",
+        "effort": t["effort"],
+        "review_mode": "auto",
+        "change_type": t["change_type"],
+        "reasoning_demand": t["reasoning_demand"],
+        "scope_clarity": t["scope_clarity"],
+        "constraint_density": t["constraint_density"],
+        "ac_specificity": t["ac_specificity"],
+        "tech_stack": t["tech_stack"],
+        "raw_extensions": t["raw_extensions"],
+        "base_branch": EPIC_BRANCH,
+        "worker_branch": t["branch"],
+        "worktree_name": None,
+        "objective": t["objective"],
+        "acceptance_criteria": t["acceptance_criteria"],
+        "implementation_constraints": t["implementation_constraints"],
+        "allowed_paths": t["allowed_paths"],
+        "forbidden_paths": forbidden,
+        "related_files_hint": t["related_files_hint"],
+        "required_checks": ["ruff check .", "mypy app/", "pytest"],
+        "optional_checks": [],
+        "done_definition": t["objective"][:200],
+        "failure_policy": {
+            "on_check_failure": "abort",
+            "max_retries": 0,
+            "escalate_to_cloud": False,
+        },
+        "ticket_state_map": {
+            "in_progress_local": "InProgressLocal",
+            "failed": "Blocked",
+        },
+        "context_snippets": [],
+        "artifact_paths": {
+            "result_json": f".claude/artifacts/{artifact_id}/result.json",
+            "manifest_copy": f".claude/artifacts/{artifact_id}/manifest.json",
+        },
+    }
+
+
+def main() -> int:
+    artifacts_root = REPO_ROOT / ".claude" / "artifacts"
+    failures: list[str] = []
+    successes: list[str] = []
+
+    for t in TICKETS:
+        ticket_id = t["ticket_id"]
+        artifact_id = ticket_id.lower().replace("-", "_")
+        artifact_dir = artifacts_root / artifact_id
+        artifact_dir.mkdir(parents=True, exist_ok=True)
+
+        manifest_dict = build_manifest(t)
+
+        # Validate before writing
+        try:
+            ExecutionManifest.model_validate(manifest_dict)
+        except Exception as exc:  # noqa: BLE001
+            failures.append(f"{ticket_id}: validation FAILED: {exc}")
+            continue
+
+        manifest_path = artifact_dir / "manifest.json"
+        manifest_path.write_text(json.dumps(manifest_dict, indent=2), encoding="utf-8")
+        successes.append(ticket_id)
+
+    print(f"Wrote {len(successes)} manifests successfully:")
+    for tid in successes:
+        print(f"  {tid}")
+
+    if failures:
+        print(f"\n{len(failures)} validation failures:")
+        for f in failures:
+            print(f"  {f}")
+        return 1
+
+    print(
+        f"\nTotal: {len(TICKETS)} tickets, {len(successes)} manifests written, 0 failures."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
Two artifacts from the 2026-05-03 overnight WOR-313 mega-epic sweep:

1. **`docs/retros/wor_313_2026-05-03.md`** — forensic notes for the 7 Blocked tickets + WOR-329 ghost-slot incident. Per-ticket findings, 3 cross-ticket architectural patterns, and a ready-to-run SQL backfill block (executes once WOR-332 adds the \`notes\`/\`tags\` columns).
2. **`scripts/generate_overnight_manifests.py`** — bulk-manifest generator that seeded the 27-child mega-epic. Defines tickets as a list of dicts, validates each via the \`ExecutionManifest\` model. Useful template for future batch dispatches.

Plus a ruff per-file-ignore for E501 on the script — long string literals in the ticket data are intentional.

## Why now
The retro captures knowledge that would rotate out of conversation context. WOR-332 references this file as the source for backfilling forensic notes into the metrics DB once that ticket ships.

## Test plan
- [x] ruff + mypy + pytest pass (no production code touched)
- [x] Pre-commit hooks pass on the new files

🤖 Generated with [Claude Code](https://claude.com/claude-code)