### PR TITLE
WOR-279 GitHub flow: rollback / cleanup on partial failure

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -14,8 +14,10 @@ from app.core.credentials import cli_delete_token, save_token
 from app.core.generator import generate
 from app.core.metrics import MetricsStore
 from app.core.post_setup import (
+    _parse_repo_full_name,
     configure_github_repo,
     create_github_repo,
+    delete_github_repo,
     fetch_skills,
     run_git_init,
     run_initial_push,
@@ -113,6 +115,15 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     gen.add_argument(
         "--git-push", action="store_true", help="Push initial commit to remote."
+    )
+    gen.add_argument(
+        "--no-rollback-on-failure",
+        action="store_true",
+        default=False,
+        help=(
+            "Skip rolling back a GitHub repo when configure or push fails. "
+            "Without this flag, an orphaned repo is deleted on failure."
+        ),
     )
     gen.add_argument(
         "--remote-url",
@@ -409,12 +420,6 @@ def _run_github_create(config: RepoConfig, args: argparse.Namespace) -> str | No
         private=github_private,
     )
     print(f"✓ Created GitHub repo: {clone_url}")
-    repo_full_name = clone_url.replace("https://github.com/", "").rstrip("/")
-    try:
-        configure_github_repo(repo_full_name, config.preset, config.include_ci)
-        print("✓ Configured GitHub repository settings")
-    except RuntimeError as exc:
-        print(f"Warning: {exc}", file=sys.stderr)
     return clone_url
 
 
@@ -457,6 +462,21 @@ def _run_generate(args: argparse.Namespace) -> int:
             print(f"Error: {exc}", file=sys.stderr)
             return 1
 
+    repo_full_name: str | None = None
+    if clone_url is not None:
+        repo_full_name = _parse_repo_full_name(clone_url)
+
+    rollback = not args.no_rollback_on_failure
+    if repo_full_name is not None and clone_url is not None:
+        try:
+            configure_github_repo(repo_full_name, config.preset, config.include_ci)
+            print("✓ Configured GitHub repository settings")
+        except RuntimeError as exc:
+            if rollback:
+                delete_github_repo(repo_full_name)
+            print(f"Error: {exc}", file=sys.stderr)
+            return 1
+
     if args.git_push:
         push_url: str | None = clone_url if clone_url is not None else args.remote_url
         if push_url is None:
@@ -465,6 +485,8 @@ def _run_generate(args: argparse.Namespace) -> int:
         try:
             _run_initial_push(args.output, push_url)
         except RuntimeError as exc:
+            if rollback and repo_full_name is not None:
+                delete_github_repo(repo_full_name)
             print(f"Error: {exc}", file=sys.stderr)
             return 1
 

--- a/app/core/post_setup.py
+++ b/app/core/post_setup.py
@@ -345,6 +345,73 @@ def create_github_repo(
     return clone_url
 
 
+def delete_github_repo(repo_full_name: str) -> None:
+    """Best-effort delete of a GitHub repository.
+
+    **Endpoint:** ``DELETE https://api.github.com/repos/{owner}/{repo}``
+
+    **Auth model:** Bearer token obtained from :func:`app.core.credentials.get_token`.
+
+    **Failure semantics:** Logs a warning to stderr on failure — this is a
+    best-effort cleanup function and never raises.
+
+    Args:
+        repo_full_name: Repository owner and name in ``owner/repo`` format.
+
+    Example:
+        >>> delete_github_repo("testuser/myrepo")  # doctest: +SKIP
+    """
+    # Validate full_name format
+    if "/" not in repo_full_name or repo_full_name.count("/") != 1:
+        print(
+            f"Warning: cannot delete repo {repo_full_name!r} — "
+            f"invalid format (expected owner/repo)",
+            file=sys.stderr,
+        )
+        return
+
+    owner, repo = repo_full_name.split("/")
+
+    token = get_token()
+    if token is None:
+        print(
+            f"Warning: cannot delete repo {repo_full_name!r} — "
+            "no GitHub token configured",
+            file=sys.stderr,
+        )
+        return
+
+    url = f"https://api.github.com/repos/{owner}/{repo}"
+    req = urllib.request.Request(  # nosec B310
+        url,
+        method="DELETE",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+        },
+    )
+
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:  # nosec B310  # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected
+            resp.read()
+    except urllib.error.HTTPError as exc:
+        err_body = ""
+        try:
+            err_body = json.loads(exc.read()).get("message", str(exc))
+        except (OSError, ValueError):  # noqa: BLE001
+            err_body = str(exc)
+        print(
+            f"Warning: could not delete repo {repo_full_name!r} ({exc.code}): "
+            f"{err_body}",
+            file=sys.stderr,
+        )
+    except OSError as exc:
+        print(
+            f"Warning: could not delete repo {repo_full_name!r}: {exc}",
+            file=sys.stderr,
+        )
+
+
 # ── Topic maps ─────────────────────────────────────────────────────────────────
 
 _TOPICS_BY_PRESET: dict[str, list[str]] = {

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,6 @@
+import urllib.error
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -347,3 +348,311 @@ def test_watcher_max_local_workers_default_is_8():
     assert rc == 0
     _, kwargs = MockWatcher.call_args
     assert kwargs.get("max_local_workers") == 8
+
+
+# ── GitHub rollback tests ──────────────────────────────────────────────────────
+
+
+def _make_github_response():
+    """Return a mock response that looks like a GitHub create-repo response."""
+    from unittest.mock import MagicMock
+
+    resp = MagicMock()
+    resp.__enter__ = lambda s: s
+    resp.__exit__ = MagicMock(return_value=False)
+    resp.read = MagicMock(
+        return_value=b'{"html_url": "https://github.com/testuser/myrepo"}'
+    )
+    return resp
+
+
+class TestGitHubRollback:
+    """Tests for delete_github_repo and rollback behavior."""
+
+    def test_delete_github_repo_sends_delete_request(self):
+        resp = MagicMock()
+        resp.__enter__ = lambda s: s
+        resp.__exit__ = MagicMock(return_value=False)
+        resp.read = MagicMock(return_value=b"")
+
+        with (
+            patch(
+                "app.core.post_setup.urllib.request.urlopen",
+                return_value=resp,
+            ) as mock_urlopen,
+            patch("app.core.post_setup.get_token", return_value="ghp_fake"),
+        ):
+            from app.core.post_setup import delete_github_repo
+
+            delete_github_repo("testuser/myrepo")
+
+        mock_urlopen.assert_called_once()
+        req = mock_urlopen.call_args[0][0]
+        assert req.method == "DELETE"
+        assert "testuser/myrepo" in req.full_url
+
+    def test_delete_github_repo_warns_on_http_error(self, capsys):
+        from unittest.mock import patch
+
+        fp = MagicMock()
+        fp.read = MagicMock(return_value=b"Not Found")
+        exc = urllib.error.HTTPError(
+            "https://api.github.com/repos/testuser/myrepo",
+            404,
+            "Not Found",
+            {},
+            fp,
+        )
+        with (
+            patch(
+                "app.core.post_setup.urllib.request.urlopen",
+                side_effect=exc,
+            ),
+            patch("app.core.post_setup.get_token", return_value="ghp_fake"),
+        ):
+            from app.core.post_setup import delete_github_repo
+
+            delete_github_repo("testuser/myrepo")
+
+        captured = capsys.readouterr()
+        assert "Warning" in captured.err
+        assert "404" in captured.err
+
+    def test_delete_github_repo_warns_on_oserror(self, capsys):
+        from unittest.mock import patch
+
+        with (
+            patch(
+                "app.core.post_setup.urllib.request.urlopen",
+                side_effect=OSError("network unreachable"),
+            ),
+            patch("app.core.post_setup.get_token", return_value="ghp_fake"),
+        ):
+            from app.core.post_setup import delete_github_repo
+
+            delete_github_repo("testuser/myrepo")
+
+        captured = capsys.readouterr()
+        assert "Warning" in captured.err
+        assert "network unreachable" in captured.err
+
+    def test_delete_github_repo_warns_when_no_token(self, capsys):
+        from unittest.mock import patch
+
+        with patch("app.core.post_setup.get_token", return_value=None):
+            from app.core.post_setup import delete_github_repo
+
+            delete_github_repo("testuser/myrepo")
+
+        captured = capsys.readouterr()
+        assert "Warning" in captured.err
+        assert "no GitHub token" in captured.err
+
+    def test_delete_github_repo_warns_on_invalid_format(self, capsys):
+        from unittest.mock import patch
+
+        with patch("app.core.post_setup.get_token", return_value="ghp_fake"):
+            from app.core.post_setup import delete_github_repo
+
+            delete_github_repo("badformat")
+
+        captured = capsys.readouterr()
+        assert "Warning" in captured.err
+        assert "invalid format" in captured.err
+
+    def test_delete_github_repo_does_not_raise(self):
+        """delete_github_repo is best-effort — never raises."""
+        from unittest.mock import patch
+
+        with (
+            patch(
+                "app.core.post_setup.urllib.request.urlopen",
+                side_effect=OSError("network unreachable"),
+            ),
+            patch("app.core.post_setup.get_token", return_value="ghp_fake"),
+        ):
+            from app.core.post_setup import delete_github_repo
+
+            delete_github_repo("testuser/myrepo")  # should not raise
+
+    def test_delete_github_repo_invalid_format_noop(self):
+        """Invalid format should not attempt any network call."""
+        from unittest.mock import patch
+
+        with (
+            patch("app.core.post_setup.get_token", return_value="ghp_fake") as mock_get,
+            patch("app.core.post_setup.urllib.request.urlopen") as mock_urlopen,
+        ):
+            from app.core.post_setup import delete_github_repo
+
+            delete_github_repo("badformat")
+
+        mock_get.assert_not_called()
+        mock_urlopen.assert_not_called()
+
+    def test_delete_github_repo_invalid_format_multiple_slashes_noop(self):
+        """Multiple slashes should not attempt any network call."""
+        from unittest.mock import patch
+
+        with (
+            patch("app.core.post_setup.get_token", return_value="ghp_fake") as mock_get,
+            patch("app.core.post_setup.urllib.request.urlopen") as mock_urlopen,
+        ):
+            from app.core.post_setup import delete_github_repo
+
+            delete_github_repo("test/user/myrepo")
+
+        mock_get.assert_not_called()
+        mock_urlopen.assert_not_called()
+
+
+class TestGitHubRollbackFlow:
+    """Integration tests for the rollback flow in _run_generate."""
+
+    def test_push_failure_triggers_rollback(self, output_dir, capsys):
+        """When push fails, the repo should be deleted."""
+        with (
+            patch(
+                "app.cli.create_github_repo",
+                return_value="https://github.com/testuser/myrepo",
+            ),
+            patch(
+                "app.cli.configure_github_repo",
+            ),
+            patch("app.core.post_setup.get_token", return_value="ghp_fake"),
+            patch(
+                "app.cli.run_initial_push",
+                side_effect=RuntimeError("failed to push"),
+            ) as mock_push,
+            patch("app.cli.run_git_init"),
+            patch("app.cli.run_precommit_install"),
+            patch(
+                "app.cli.delete_github_repo",
+            ) as mock_delete,
+        ):
+            rc = main(
+                [
+                    "generate",
+                    "--preset",
+                    "python_basic",
+                    "--repo-name",
+                    "myrepo",
+                    "--output",
+                    str(output_dir),
+                    "--github-create",
+                    "--git-push",
+                    "--remote-url",
+                    "https://github.com/testuser/myrepo",
+                ]
+            )
+
+        assert rc == 1
+        mock_push.assert_called_once()
+        mock_delete.assert_called_once_with("testuser/myrepo")
+        captured = capsys.readouterr()
+        assert "failed to push" in captured.err
+
+    def test_push_no_rollback_with_flag(self, output_dir, capsys):
+        """--no-rollback-on-failure should skip the delete call."""
+        with (
+            patch(
+                "app.cli.create_github_repo",
+                return_value="https://github.com/testuser/myrepo",
+            ),
+            patch(
+                "app.cli.configure_github_repo",
+            ),
+            patch("app.core.post_setup.get_token", return_value="ghp_fake"),
+            patch(
+                "app.cli.run_initial_push",
+                side_effect=RuntimeError("failed to push"),
+            ),
+            patch("app.cli.run_git_init"),
+            patch("app.cli.run_precommit_install"),
+            patch(
+                "app.cli.delete_github_repo",
+            ) as mock_delete,
+        ):
+            rc = main(
+                [
+                    "generate",
+                    "--preset",
+                    "python_basic",
+                    "--repo-name",
+                    "myrepo",
+                    "--output",
+                    str(output_dir),
+                    "--github-create",
+                    "--git-push",
+                    "--remote-url",
+                    "https://github.com/testuser/myrepo",
+                    "--no-rollback-on-failure",
+                ]
+            )
+
+        assert rc == 1
+        mock_delete.assert_not_called()
+
+    def test_configure_failure_triggers_rollback(self, output_dir, capsys):
+        """When configure fails, the repo should be deleted."""
+        with (
+            patch(
+                "app.cli.create_github_repo",
+                return_value="https://github.com/testuser/myrepo",
+            ),
+            patch("app.core.post_setup.get_token", return_value="ghp_fake"),
+            patch(
+                "app.cli.configure_github_repo",
+                side_effect=RuntimeError("forbidden"),
+            ),
+            patch("app.cli.run_git_init"),
+            patch("app.cli.run_precommit_install"),
+            patch(
+                "app.cli.delete_github_repo",
+            ) as mock_delete,
+        ):
+            rc = main(
+                [
+                    "generate",
+                    "--preset",
+                    "python_basic",
+                    "--repo-name",
+                    "myrepo",
+                    "--output",
+                    str(output_dir),
+                    "--github-create",
+                ]
+            )
+
+        assert rc == 1
+        mock_delete.assert_called_once_with("testuser/myrepo")
+        captured = capsys.readouterr()
+        assert "forbidden" in captured.err
+
+    def test_github_create_failure_no_rollback(self, output_dir, capsys):
+        """If create itself fails, there's nothing to rollback."""
+        with (
+            patch(
+                "app.cli.create_github_repo",
+                side_effect=RuntimeError("Repository already exists"),
+            ),
+            patch("app.core.post_setup.get_token", return_value="ghp_fake"),
+            patch("app.cli.run_git_init"),
+            patch("app.cli.run_precommit_install"),
+            patch("app.cli.delete_github_repo") as mock_delete,
+        ):
+            rc = main(
+                [
+                    "generate",
+                    "--preset",
+                    "python_basic",
+                    "--repo-name",
+                    "myrepo",
+                    "--output",
+                    str(output_dir),
+                    "--github-create",
+                ]
+            )
+
+        assert rc == 1
+        mock_delete.assert_not_called()

--- a/tests/test_post_setup.py
+++ b/tests/test_post_setup.py
@@ -9,6 +9,7 @@ import pytest
 from app.core.post_setup import (
     configure_github_repo,
     create_github_repo,
+    delete_github_repo,
     fetch_skills,
     run_git_init,
     run_initial_push,
@@ -650,3 +651,100 @@ class TestConfigureGithubRepo:
         topics_req = mock_urlopen.call_args_list[0][0][0]
         body = json.loads(topics_req.data)
         assert body == {"names": ["python"]}  # fallback
+
+
+class TestDeleteGithubRepo:
+    def _make_response(self, status: int = 200) -> MagicMock:
+        cm = MagicMock()
+        cm.__enter__ = lambda s: s
+        cm.__exit__ = MagicMock(return_value=False)
+        cm.read = MagicMock(return_value=b"")
+        type(cm).status = status
+        return cm
+
+    def _make_http_error(self, code: int, body: str) -> urllib.error.HTTPError:
+        fp = MagicMock()
+        fp.read = MagicMock(return_value=body.encode())
+        return urllib.error.HTTPError(
+            "https://api.github.com/repos/test/repo",
+            code,
+            "error",
+            {},
+            fp,
+        )
+
+    def test_deletes_repo_on_success(self, capsys):
+        resp = self._make_response(200)
+        with (
+            patch(
+                "app.core.post_setup.urllib.request.urlopen",
+                return_value=resp,
+            ) as mock_urlopen,
+            patch("app.core.post_setup.get_token", return_value="ghp_fake"),
+        ):
+            delete_github_repo("testuser/myrepo")
+
+        mock_urlopen.assert_called_once()
+        req = mock_urlopen.call_args[0][0]
+        assert req.method == "DELETE"
+        assert req.full_url == "https://api.github.com/repos/testuser/myrepo"
+        captured = capsys.readouterr()
+        assert captured.err == ""
+
+    def test_warns_on_http_error(self, capsys):
+        exc = self._make_http_error(404, "Not Found")
+        with (
+            patch(
+                "app.core.post_setup.urllib.request.urlopen",
+                side_effect=exc,
+            ),
+            patch("app.core.post_setup.get_token", return_value="ghp_fake"),
+        ):
+            delete_github_repo("testuser/myrepo")
+
+        captured = capsys.readouterr()
+        assert "Warning" in captured.err
+        assert "404" in captured.err
+        # Non-JSON body falls back to str(exc) — "HTTP Error 404: Not Found"
+        assert "404" in captured.err
+
+    def test_warns_on_oserror(self, capsys):
+        with (
+            patch(
+                "app.core.post_setup.urllib.request.urlopen",
+                side_effect=OSError("network unreachable"),
+            ),
+            patch("app.core.post_setup.get_token", return_value="ghp_fake"),
+        ):
+            delete_github_repo("testuser/myrepo")
+
+        captured = capsys.readouterr()
+        assert "Warning" in captured.err
+        assert "network unreachable" in captured.err
+
+    def test_warns_when_no_token(self, capsys):
+        with patch("app.core.post_setup.get_token", return_value=None):
+            delete_github_repo("testuser/myrepo")
+
+        captured = capsys.readouterr()
+        assert "Warning" in captured.err
+        assert "no GitHub token" in captured.err
+
+    def test_warns_on_invalid_format(self, capsys):
+        delete_github_repo("badformat")
+
+        captured = capsys.readouterr()
+        assert "Warning" in captured.err
+        assert "invalid format" in captured.err
+
+    def test_warns_on_invalid_format_multiple_slashes(self, capsys):
+        delete_github_repo("test/user/myrepo")
+
+        captured = capsys.readouterr()
+        assert "Warning" in captured.err
+
+    def test_noop_when_no_repo_name(self, capsys):
+        delete_github_repo("")
+
+        captured = capsys.readouterr()
+        assert "Warning" in captured.err


### PR DESCRIPTION
Closes WOR-279

Add delete_github_repo() + wrap _run_generate's GitHub flow in try/except with optional --no-rollback-on-failure flag. When create succeeds but configure/push fails, delete the orphaned repo.