### PR TITLE
WOR-251 MCP: pin SonarQube MCP server to a specific version in .mcp.json

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -7,7 +7,7 @@
     "sonarqube": {
       "type": "stdio",
       "command": "cmd",
-      "args": ["/c", "npx", "-y", "sonarqube-mcp-server"],
+      "args": ["/c", "npx", "-y", "sonarqube-mcp-server@1.10.21"],
       "env": {
         "SONARQUBE_TOKEN": "${SONARCLOUD_TOKEN}",
         "SONARQUBE_URL": "https://sonarcloud.io",


### PR DESCRIPTION
Closes WOR-251

Pin sonarqube-mcp-server to a specific version in .mcp.json so it doesn't redownload+upgrade on every cold session.