### PR TITLE
WOR-252 Fix: remove type: ignore in _to_metrics_mode with proper cast

### DIFF
--- a/app/core/watcher/watcher_types.py
+++ b/app/core/watcher/watcher_types.py
@@ -11,7 +11,7 @@ import sys
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Protocol
+from typing import Any, Protocol, cast, get_args
 
 from app.core.manifest import ExecutionManifest
 from app.core.metrics import ImplementationMode
@@ -98,6 +98,6 @@ def is_watcher_running(pid_file: Path = _PID_FILE) -> bool:
 
 
 def _to_metrics_mode(mode: str) -> ImplementationMode:
-    if mode in ("local", "cloud", "hybrid"):
-        return mode  # type: ignore[return-value]  # ImplementationMode is Literal["local","cloud","hybrid"]; str is compatible at runtime
+    if mode in get_args(ImplementationMode):
+        return cast(ImplementationMode, mode)
     return "cloud"


### PR DESCRIPTION
Closes WOR-252

Replace the `# type: ignore[return-value]` on _to_metrics_mode with proper typing.cast() — preferably using get_args(ImplementationMode) so the valid values stay in sync with the type.