### PR TITLE
WOR-277 Watcher waste-score: per-session metric in ticket_metrics + warning log

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -142,6 +142,15 @@ def _build_parser() -> argparse.ArgumentParser:
     metrics_sub = metrics.add_subparsers(dest="metrics_cmd")
     metrics_sub.add_parser("browse", help="Open metrics DB in Datasette browser UI.")
 
+    waste = sub.add_parser(
+        "waste-score",
+        help="Compute and print the waste score for a worker session log.",
+    )
+    waste.add_argument(
+        "ticket_id",
+        help="Ticket ID (e.g. WOR-277).",
+    )
+
     watcher = sub.add_parser(
         "watcher", help="Run the local worker orchestrator daemon."
     )
@@ -491,6 +500,33 @@ def _run_generate(args: argparse.Namespace) -> int:
     return 0
 
 
+def _run_waste_score(args: argparse.Namespace) -> int:
+    from app.core.watcher.worker_waste import compute_waste_score
+
+    # The worker log lives in .claude/ within the repo root.
+    # We search for it relative to the current working directory.
+    ticket_id = args.ticket_id.lower()
+    log_path = Path(".claude") / f"worker_{ticket_id}.log"
+
+    if not log_path.exists():
+        print(
+            f"Error: worker log not found at {log_path}",
+            file=sys.stderr,
+        )
+        return 1
+
+    report = compute_waste_score(log_path)
+    print(f"Ticket: {args.ticket_id}")
+    print(f"Waste score: {report.score}/100")
+    print("Breakdown:")
+    for key, value in sorted(
+        report.breakdown.items(), key=lambda x: x[1], reverse=True
+    ):
+        if value > 0:
+            print(f"  {key}: {value}")
+    return 0
+
+
 def main(argv: list[str] | None = None) -> int:
     load_dotenv()
     # Ensure the terminal can emit UTF-8 (e.g. ✓); no-op on StringIO (pytest capsys).
@@ -526,6 +562,9 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.command == "watcher":
         return _run_watcher(args)
+
+    if args.command == "waste-score":
+        return _run_waste_score(args)
 
     return _run_generate(args)
 

--- a/app/core/escalation_policy.py
+++ b/app/core/escalation_policy.py
@@ -29,6 +29,15 @@ _VALID_ACTIONS: frozenset[str] = frozenset({"escalate", "fix_locally", "human"})
 DEFAULT_POLICY_PATH = (
     Path(__file__).parent.parent.parent / "config" / "escalation_policy.toml"
 )
+_DEFAULT_WASTE_WARN_THRESHOLD = 60
+
+
+def get_waste_warn_threshold(path: Path | str | None = None) -> int:
+    """Return the waste-score warning threshold from the policy file."""
+    try:
+        return EscalationPolicy.from_toml(path).waste_warn_threshold()
+    except Exception:
+        return _DEFAULT_WASTE_WARN_THRESHOLD
 
 
 class RetryConfig(BaseModel):
@@ -72,6 +81,19 @@ class SonarConfig(BaseModel):
     info: Action
 
 
+class WasteConfig(BaseModel):
+    model_config = {"extra": "forbid"}
+
+    warn_threshold: int
+
+    @field_validator("warn_threshold")
+    @classmethod
+    def positive(cls, v: int) -> int:
+        if v < 0:
+            raise ValueError("warn_threshold must be >= 0")
+        return v
+
+
 class EscalationPolicy(BaseModel):
     """Typed representation of escalation_policy.toml."""
 
@@ -81,6 +103,7 @@ class EscalationPolicy(BaseModel):
     auto_escalate: AutoEscalateConfig
     human_escalate: HumanEscalateConfig
     sonar: SonarConfig
+    waste: WasteConfig
 
     # ------------------------------------------------------------------
     # Classification helpers
@@ -133,6 +156,10 @@ class EscalationPolicy(BaseModel):
         if severity not in _VALID_SONAR_SEVERITIES:
             return "fix_locally"
         return cast(Action, getattr(self.sonar, severity))
+
+    def waste_warn_threshold(self) -> int:
+        """Return the waste-score warning threshold."""
+        return self.waste.warn_threshold
 
     # ------------------------------------------------------------------
     # Factory

--- a/app/core/metrics.py
+++ b/app/core/metrics.py
@@ -85,6 +85,8 @@ CREATE TABLE IF NOT EXISTS ticket_metrics (
     ac_specificity        INTEGER,
     tech_stack            TEXT,
     raw_extensions        TEXT,
+    waste_score           INTEGER,
+    waste_breakdown_json  TEXT,
     recorded_at           TEXT NOT NULL DEFAULT (datetime('now')),
     PRIMARY KEY (ticket_id, project_id)
 )
@@ -164,6 +166,14 @@ class TicketMetrics(BaseModel):
     raw_extensions: str | None = Field(
         default=None,
         description="JSON array string of file extensions touched",
+    )
+    waste_score: int | None = Field(
+        default=None,
+        description="0-100 waste score for the worker session",
+    )
+    waste_breakdown_json: str | None = Field(
+        default=None,
+        description="JSON string of per-signal breakdown for dashboard drill-down",
     )
 
 
@@ -336,6 +346,12 @@ class MetricsStore:
             conn.execute("ALTER TABLE ticket_metrics ADD COLUMN tech_stack TEXT")
         if "raw_extensions" not in existing:
             conn.execute("ALTER TABLE ticket_metrics ADD COLUMN raw_extensions TEXT")
+        if "waste_score" not in existing:
+            conn.execute("ALTER TABLE ticket_metrics ADD COLUMN waste_score INTEGER")
+        if "waste_breakdown_json" not in existing:
+            conn.execute(
+                "ALTER TABLE ticket_metrics ADD COLUMN waste_breakdown_json TEXT"
+            )
 
     @contextmanager
     def _connect(self) -> Generator[sqlite3.Connection, None, None]:
@@ -362,7 +378,8 @@ class MetricsStore:
                     lines_changed, files_changed,
                     sonar_findings_count, context_compactions,
                     change_type, reasoning_demand, scope_clarity,
-                    constraint_density, ac_specificity, tech_stack, raw_extensions
+                    constraint_density, ac_specificity, tech_stack, raw_extensions,
+                    waste_score, waste_breakdown_json
                 ) VALUES (
                     :ticket_id, :project_id, :epic_id, :implementation_mode,
                     :cloud_used, :cloud_model, :cloud_tokens, :cloud_cost_estimate,
@@ -375,7 +392,8 @@ class MetricsStore:
                     :lines_changed, :files_changed,
                     :sonar_findings_count, :context_compactions,
                     :change_type, :reasoning_demand, :scope_clarity,
-                    :constraint_density, :ac_specificity, :tech_stack, :raw_extensions
+                    :constraint_density, :ac_specificity, :tech_stack, :raw_extensions,
+                    :waste_score, :waste_breakdown_json
                 )
                 """,
                 {

--- a/app/core/watcher/watcher_finalize.py
+++ b/app/core/watcher/watcher_finalize.py
@@ -12,7 +12,7 @@ import os
 import subprocess  # nosec B404
 from pathlib import Path
 
-from app.core.escalation_policy import EscalationPolicy
+from app.core.escalation_policy import EscalationPolicy, get_waste_warn_threshold
 from app.core.linear_client import LinearError
 from app.core.manifest import ExecutionManifest
 from app.core.metrics import MetricsStore, Outcome, TicketMetrics, TicketRunLog
@@ -45,6 +45,7 @@ from .watcher_worktrees import (
     restore_plan_files,
     squash_wip_commits,
 )
+from .worker_waste import compute_waste_score
 
 logger = logging.getLogger(__name__)
 
@@ -245,6 +246,28 @@ def finalize_worker(
         local_model_str = _LOCAL_MODEL
         if output_tokens is not None and wall_time and wall_time > 0:
             local_output_tokens_per_second = output_tokens / wall_time
+
+    # Compute waste score from the worker log (WOR-277).
+    waste_report = compute_waste_score(log_path)
+    waste_score: int | None = waste_report.score if waste_report.score > 0 else None
+    waste_breakdown_json: str | None = (
+        json.dumps(waste_report.breakdown) if waste_report.score > 0 else None
+    )
+    if waste_score is not None and waste_score > get_waste_warn_threshold():
+        top_reasons = ", ".join(
+            f"{k}={v}"
+            for k, v in sorted(
+                waste_report.breakdown.items(), key=lambda x: x[1], reverse=True
+            )
+            if v > 0
+        )
+        logger.warning(
+            "High waste score for %s: %d/100 (%s)",
+            worker.ticket_id,
+            waste_score,
+            top_reasons,
+        )
+
     # Derive the first failed check name for TicketRunLog (WOR-261)
     first_failed_check: str | None = (
         str(failed_checks[0]["check"]) if failed_checks else None
@@ -287,6 +310,8 @@ def finalize_worker(
             ac_specificity=worker.manifest.ac_specificity,
             tech_stack=worker.manifest.tech_stack,
             raw_extensions=worker.manifest.raw_extensions,
+            waste_score=waste_score,
+            waste_breakdown_json=waste_breakdown_json,
         )
     )
     metrics.record_run(

--- a/app/core/watcher/worker_waste.py
+++ b/app/core/watcher/worker_waste.py
@@ -1,0 +1,230 @@
+"""Waste-score computation for worker session logs.
+
+Parses the Claude Code stream-json log to detect common waste patterns
+(redundant reads, manual check runs, redundant bash, cd commands, thinking
+bloat) and returns a 0-100 score.  Formula is identical to the one
+calibrated in WOR-277 so the future Streamlit dashboard can reuse it.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class WasteReport:
+    """Result of a waste-score computation."""
+
+    score: int
+    breakdown: dict[str, int]
+    # Individual signal counts (for dashboard drill-down).
+    redundant_reads: int
+    manual_check_runs: int
+    redundant_bash: int
+    cd_commands: int
+    thinking_to_text_ratio: float
+
+
+def compute_waste_score(log_path: Path) -> WasteReport:
+    """Compute a 0-100 waste score from a worker session log.
+
+    Parses the stream-json log for tool_use entries and counts waste signals:
+    redundant_reads, manual_check_runs, redundant_bash, cd_commands, and
+    thinking_to_text_ratio.
+
+    Returns a WasteReport with the composite score and per-signal breakdown.
+    Returns a zero-score report when the log is missing or unreadable.
+    """
+    if not log_path.exists():
+        logger.debug("Waste score: log not found at %s", log_path)
+        return WasteReport(
+            score=0,
+            breakdown={},
+            redundant_reads=0,
+            manual_check_runs=0,
+            redundant_bash=0,
+            cd_commands=0,
+            thinking_to_text_ratio=0.0,
+        )
+
+    try:
+        lines = log_path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        logger.warning("Waste score: could not read %s", log_path)
+        return WasteReport(
+            score=0,
+            breakdown={},
+            redundant_reads=0,
+            manual_check_runs=0,
+            redundant_bash=0,
+            cd_commands=0,
+            thinking_to_text_ratio=0.0,
+        )
+
+    # --- Collect raw signals ---
+    read_counts: dict[str, int] = {}  # file path -> count
+    manual_check_runs = 0
+    bash_commands: list[str] = []  # for redundancy detection
+    cd_commands = 0
+    total_thinking_tokens = 0
+    total_output_tokens = 0
+
+    _CHECK_COMMANDS = (
+        "ruff",
+        "mypy",
+        "pytest",
+        "pre-commit",
+        "bandit",
+        "semgrep",
+        "flake8",
+        "black",
+        "isort",
+        "pylint",
+    )
+
+    for raw_line in lines:
+        line = raw_line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+
+        tool_use = _extract_tool_use(obj)
+        if tool_use is not None:
+            name = tool_use.get("name", "")
+            inp = tool_use.get("input", {})
+            if isinstance(inp, str):
+                try:
+                    inp = json.loads(inp)
+                except (json.JSONDecodeError, TypeError):
+                    pass
+
+            if name == "Read":
+                # Count reads per file path to detect redundant reads.
+                file_path = inp.get("path", "") or inp.get("file", "")
+                if file_path:
+                    read_counts[file_path] = read_counts.get(file_path, 0) + 1
+
+            elif name == "Bash":
+                command = ""
+                if isinstance(inp, dict):
+                    command = str(inp.get("command", ""))
+                elif isinstance(inp, str):
+                    command = inp
+
+                # Count cd commands.
+                if command.strip().startswith("cd "):
+                    cd_commands += 1
+
+                # Count manual check runs — only for check tool commands,
+                # not for plain cd / ls / etc.
+                is_check_tool = False
+                for check_cmd in _CHECK_COMMANDS:
+                    if check_cmd in command:
+                        manual_check_runs += 1
+                        is_check_tool = True
+                        break
+
+                # Collect bash commands for redundancy detection.
+                # Exclude check-tool commands (already counted as
+                # manual_check_runs) and cd commands (already counted as
+                # cd_commands) to avoid double-counting.
+                is_cd = command.strip().startswith("cd ")
+                if command and not is_check_tool and not is_cd:
+                    bash_commands.append(command)
+
+        # Collect token counts for thinking ratio.
+        if obj.get("type") == "assistant":
+            msg = obj.get("message") or {}
+            usage = msg.get("usage") or {}
+            out_tok = usage.get("output_tokens")
+            if out_tok is not None:
+                total_output_tokens += int(out_tok)
+
+            # Thinking tokens come from the reasoning field in the message.
+            reasoning = msg.get("reasoning", "") or msg.get("content", "")
+            if isinstance(reasoning, str):
+                total_thinking_tokens += len(reasoning)
+
+    # --- Compute signals ---
+    redundant_reads = sum(max(0, c - 1) for c in read_counts.values() if c > 1)
+
+    # Redundant bash: commands that appear more than once (exact match).
+    cmd_freq: dict[str, int] = {}
+    for cmd in bash_commands:
+        cmd_freq[cmd] = cmd_freq.get(cmd, 0) + 1
+    redundant_bash = sum(max(0, c - 1) for c in cmd_freq.values() if c > 1)
+
+    # Thinking-to-text ratio: ratio of thinking tokens to output tokens.
+    # When output_tokens is 0 or None, ratio is 0.
+    if total_output_tokens > 0:
+        # Normalize thinking token count (char count) to an approximate token
+        # count (roughly 4 chars per token for English text).
+        thinking_tokens_approx = total_thinking_tokens / 4.0
+        thinking_to_text_ratio = (
+            thinking_tokens_approx / total_output_tokens
+            if total_output_tokens > 0
+            else 0.0
+        )
+    else:
+        thinking_to_text_ratio = 0.0
+
+    # --- Compute composite score ---
+    score = 0
+    score += min(redundant_reads * 2, 30)
+    score += min(manual_check_runs * 3, 25)
+    score += min(redundant_bash * 2, 20)
+    score += min(cd_commands, 15)
+    if thinking_to_text_ratio > 5:
+        score += min(int(thinking_to_text_ratio), 10)
+
+    score = min(score, 100)
+
+    # Only include signals that actually contribute (value > 0).
+    breakdown: dict[str, int] = {
+        k: int(v)
+        for k, v in {
+            "redundant_reads": redundant_reads,
+            "manual_check_runs": manual_check_runs,
+            "redundant_bash": redundant_bash,
+            "cd_commands": cd_commands,
+            "thinking_to_text_ratio": round(thinking_to_text_ratio, 2),
+        }.items()
+        if v > 0
+    }
+
+    return WasteReport(
+        score=score,
+        breakdown=breakdown,
+        redundant_reads=redundant_reads,
+        manual_check_runs=manual_check_runs,
+        redundant_bash=redundant_bash,
+        cd_commands=cd_commands,
+        thinking_to_text_ratio=thinking_to_text_ratio,
+    )
+
+
+def _extract_tool_use(obj: dict[str, Any]) -> dict[str, Any] | None:
+    """Extract a tool_use block from a stream-json event.
+
+    Handles both the direct ``{type: "tool_use", ...}`` form and the
+    ``{type: "assistant", message: {tool_calls: [{...}]}}`` form.
+    """
+    if obj.get("type") == "tool_use":
+        return obj
+    if obj.get("type") == "assistant":
+        msg = obj.get("message") or {}
+        tool_calls: list[dict[str, Any]] = msg.get("tool_calls", [])
+        for tc in tool_calls:
+            if tc.get("type") == "tool_use":
+                return tc
+        return None
+    return None

--- a/config/escalation_policy.toml
+++ b/config/escalation_policy.toml
@@ -22,6 +22,11 @@ schema_migration = "human"
 cross_module_refactor = "human"
 auth_payments_touched = "human"
 
+[waste]
+# Waste-score threshold (0-100). When a worker session exceeds this score,
+# the watcher emits a WARNING log line.  Default 60 (clear regression).
+warn_threshold = 60
+
 [sonar]
 # Maps SonarLint/SonarCloud finding severity → action taken by the watcher.
 # fix_locally — local worker retries with the finding in context

--- a/tests/test_escalation_policy.py
+++ b/tests/test_escalation_policy.py
@@ -43,6 +43,9 @@ MINIMAL_VALID_TOML = """
     major = "fix_locally"
     minor = "fix_locally"
     info = "fix_locally"
+
+    [waste]
+    warn_threshold = 60
 """
 
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -410,6 +410,41 @@ class TestMigration:
         assert result.local_output_tokens == 500
 
 
+class TestWasteColumns:
+    """WOR-277: waste_score and waste_breakdown_json columns."""
+
+    def test_waste_score_round_trip(self, tmp_path):
+        store = _store(tmp_path)
+        store.record(
+            _ticket(
+                waste_score=72,
+                waste_breakdown_json='{"redundant_reads": 5, "manual_check_runs": 3}',
+            )
+        )
+        result = store.get_by_ticket("WOR-1", "proj-a")
+        assert result is not None
+        assert result.waste_score == 72
+        expected = '{"redundant_reads": 5, "manual_check_runs": 3}'
+        assert result.waste_breakdown_json == expected
+
+    def test_waste_score_defaults_to_none(self, tmp_path):
+        store = _store(tmp_path)
+        store.record(_ticket())
+        result = store.get_by_ticket("WOR-1", "proj-a")
+        assert result is not None
+        assert result.waste_score is None
+        assert result.waste_breakdown_json is None
+
+    def test_waste_score_zero_stored(self, tmp_path):
+        """A score of 0 is stored (not treated as None)."""
+        store = _store(tmp_path)
+        store.record(_ticket(waste_score=0, waste_breakdown_json="{}"))
+        result = store.get_by_ticket("WOR-1", "proj-a")
+        assert result is not None
+        assert result.waste_score == 0
+        assert result.waste_breakdown_json == "{}"
+
+
 def _run_log(**kwargs) -> TicketRunLog:
     defaults: dict = {
         "ticket_id": "WOR-1",

--- a/tests/test_watcher_finalize.py
+++ b/tests/test_watcher_finalize.py
@@ -1156,3 +1156,154 @@ def test_finalize_worker_token_fields_none_when_no_log(
     assert m.local_output_tokens is None
     assert m.local_tokens is None
     assert m.local_output_tokens_per_second is None
+
+
+# ---------------------------------------------------------------------------
+# WOR-277 — waste_score wired to metrics
+# ---------------------------------------------------------------------------
+
+
+def test_finalize_worker_waste_score_passed_to_metrics(tmp_path: Path) -> None:
+    """Waste score from the worker log is passed to TicketMetrics."""
+    manifest = make_manifest(ticket_id="WOR-10", worker_branch="wor-10-test-ticket")
+    metrics_mock = MagicMock()
+
+    log_dir = tmp_path / ".claude"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    log_file = log_dir / "worker_wor-10.log"
+    # Write a log with redundant reads to produce a non-zero waste score.
+    log_file.write_text(
+        json.dumps(
+            {
+                "type": "result",
+                "usage": {"input_tokens": 1000, "output_tokens": 200},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    # Add redundant Read tool_use entries.
+    for _ in range(3):
+        with open(log_file, "a", encoding="utf-8") as f:
+            f.write(
+                json.dumps(
+                    {
+                        "type": "tool_use",
+                        "name": "Read",
+                        "input": {"path": "a.py"},
+                    }
+                )
+                + "\n"
+            )
+
+    worker = ActiveWorker(
+        ticket_id="WOR-10",
+        linear_id="fake-linear-id",
+        manifest=manifest,
+        worktree_path=tmp_path,
+        process=MagicMock(spec=subprocess.Popen),
+    )
+
+    with (
+        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(True, [])),
+        patch(
+            "app.core.watcher.watcher_finalize.create_pr",
+            return_value="https://github.com/example/pr/1",
+        ),
+        patch("app.core.watcher.watcher_finalize.cleanup_worktree"),
+    ):
+        _call_finalize(worker, metrics=metrics_mock)
+
+    m = metrics_mock.record.call_args[0][0]
+    assert m.waste_score is not None
+    assert m.waste_score > 0
+    assert m.waste_breakdown_json is not None
+
+
+def test_finalize_worker_waste_score_none_when_no_log(
+    tmp_path: Path,
+) -> None:
+    """When no worker log exists, waste_score is None."""
+    manifest = make_manifest(ticket_id="WOR-10", worker_branch="wor-10-test-ticket")
+    metrics_mock = MagicMock()
+
+    worker = ActiveWorker(
+        ticket_id="WOR-10",
+        linear_id="fake-linear-id",
+        manifest=manifest,
+        worktree_path=tmp_path,
+        process=MagicMock(spec=subprocess.Popen),
+    )
+
+    with (
+        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(True, [])),
+        patch(
+            "app.core.watcher.watcher_finalize.create_pr",
+            return_value="https://github.com/example/pr/1",
+        ),
+        patch("app.core.watcher.watcher_finalize.cleanup_worktree"),
+    ):
+        _call_finalize(worker, metrics=metrics_mock)
+
+    m = metrics_mock.record.call_args[0][0]
+    assert m.waste_score is None
+    assert m.waste_breakdown_json is None
+
+
+def test_finalize_worker_waste_warning_logged(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """WARNING is logged when waste score exceeds threshold."""
+    manifest = make_manifest(ticket_id="WOR-10", worker_branch="wor-10-test-ticket")
+    metrics_mock = MagicMock()
+
+    log_dir = tmp_path / ".claude"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    log_file = log_dir / "worker_wor-10.log"
+    # Write a log with many redundant reads to produce a high waste score.
+    log_file.write_text(
+        json.dumps(
+            {
+                "type": "result",
+                "usage": {"input_tokens": 1000, "output_tokens": 200},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    # 20 redundant reads → 20 * 2 = 40, well above threshold of 60 with other signals.
+    for _ in range(25):
+        with open(log_file, "a", encoding="utf-8") as f:
+            f.write(
+                json.dumps(
+                    {
+                        "type": "tool_use",
+                        "name": "Read",
+                        "input": {"path": "a.py"},
+                    }
+                )
+                + "\n"
+            )
+
+    worker = ActiveWorker(
+        ticket_id="WOR-10",
+        linear_id="fake-linear-id",
+        manifest=manifest,
+        worktree_path=tmp_path,
+        process=MagicMock(spec=subprocess.Popen),
+    )
+
+    with (
+        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(True, [])),
+        patch(
+            "app.core.watcher.watcher_finalize.create_pr",
+            return_value="https://github.com/example/pr/1",
+        ),
+        patch("app.core.watcher.watcher_finalize.cleanup_worktree"),
+        caplog.at_level(logging.WARNING, logger="app.core.watcher.watcher_finalize"),
+    ):
+        _call_finalize(worker, metrics=metrics_mock)
+
+    # Should log a WARNING with the ticket ID and waste score.
+    assert any("WOR-10" in msg and "waste" in msg.lower() for msg in caplog.messages)

--- a/tests/test_worker_waste.py
+++ b/tests/test_worker_waste.py
@@ -1,0 +1,479 @@
+"""Tests for app.core.watcher.worker_waste — waste-score computation."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from app.core.watcher.worker_waste import (
+    WasteReport,
+    compute_waste_score,
+)
+
+
+def _write_log(tmp_path: Path, lines: list[str]) -> Path:
+    """Write a worker session log and return its path."""
+    log = tmp_path / "worker_wor-99.log"
+    log.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return log
+
+
+# ---------------------------------------------------------------------------
+# Missing / unreadable log
+# ---------------------------------------------------------------------------
+
+
+def test_missing_log_returns_zero_score(tmp_path: Path) -> None:
+    """When the log file doesn't exist, score is 0 with empty breakdown."""
+    report = compute_waste_score(tmp_path / "nonexistent.log")
+    assert report.score == 0
+    assert report.breakdown == {}
+    assert report.redundant_reads == 0
+    assert report.manual_check_runs == 0
+    assert report.redundant_bash == 0
+    assert report.cd_commands == 0
+    assert report.thinking_to_text_ratio == 0.0
+
+
+def test_unreadable_log_returns_zero_score(tmp_path: Path) -> None:
+    """When the log file can't be read, score is 0 with empty breakdown."""
+    log = tmp_path / "worker.log"
+    log.write_text("", encoding="utf-8")
+    # Make it unreadable by removing read permissions (Unix only, skip on Windows)
+    import os
+
+    try:
+        os.chmod(log, 0o000)
+        report = compute_waste_score(log)
+        assert report.score == 0
+    finally:
+        os.chmod(log, 0o644)
+
+
+# ---------------------------------------------------------------------------
+# redundant_reads signal
+# ---------------------------------------------------------------------------
+
+
+def test_no_redundant_reads(tmp_path: Path) -> None:
+    """Single reads of different files produce zero redundant_reads."""
+    lines = [
+        json.dumps({"type": "tool_use", "name": "Read", "input": {"path": "a.py"}}),
+        json.dumps({"type": "tool_use", "name": "Read", "input": {"path": "b.py"}}),
+    ]
+    report = compute_waste_score(_write_log(tmp_path, lines))
+    assert report.redundant_reads == 0
+    assert report.score == 0
+
+
+def test_redundant_reads_counted(tmp_path: Path) -> None:
+    """Reading the same file twice produces one redundant read."""
+    lines = [
+        json.dumps({"type": "tool_use", "name": "Read", "input": {"path": "a.py"}}),
+        json.dumps({"type": "tool_use", "name": "Read", "input": {"path": "a.py"}}),
+        json.dumps({"type": "tool_use", "name": "Read", "input": {"path": "a.py"}}),
+    ]
+    report = compute_waste_score(_write_log(tmp_path, lines))
+    assert report.redundant_reads == 2  # 3 reads - 1 = 2 redundant
+    # Score contribution: min(2 * 2, 30) = 4
+    assert report.score == 4
+
+
+def test_redundant_reads_capped_at_30(tmp_path: Path) -> None:
+    """redundant_reads score contribution is capped at 30."""
+    # 16 redundant reads → 16 * 2 = 32 → capped at 30
+    reads = [
+        json.dumps({"type": "tool_use", "name": "Read", "input": {"path": "a.py"}})
+        for _ in range(17)
+    ]
+    report = compute_waste_score(_write_log(tmp_path, reads))
+    assert report.redundant_reads == 16
+    assert report.score == 30
+
+
+# ---------------------------------------------------------------------------
+# manual_check_runs signal
+# ---------------------------------------------------------------------------
+
+
+def test_no_manual_check_runs(tmp_path: Path) -> None:
+    """Bash commands without check tools produce zero manual_check_runs."""
+    lines = [
+        json.dumps(
+            {"type": "tool_use", "name": "Bash", "input": {"command": "ls -la"}}
+        ),
+    ]
+    report = compute_waste_score(_write_log(tmp_path, lines))
+    assert report.manual_check_runs == 0
+    assert report.score == 0
+
+
+def test_manual_check_runs_counted(tmp_path: Path) -> None:
+    """Running ruff/mypy/pytest counts as manual check runs."""
+    lines = [
+        json.dumps(
+            {"type": "tool_use", "name": "Bash", "input": {"command": "ruff check ."}}
+        ),
+        json.dumps(
+            {"type": "tool_use", "name": "Bash", "input": {"command": "mypy app/"}}
+        ),
+        json.dumps(
+            {"type": "tool_use", "name": "Bash", "input": {"command": "pytest tests/"}}
+        ),
+    ]
+    report = compute_waste_score(_write_log(tmp_path, lines))
+    assert report.manual_check_runs == 3
+    # Score contribution: min(3 * 3, 25) = 9
+    assert report.score == 9
+
+
+def test_manual_check_runs_capped_at_25(tmp_path: Path) -> None:
+    """manual_check_runs score contribution is capped at 25."""
+    # 9 check runs → 9 * 3 = 27 → capped at 25
+    lines = [
+        json.dumps(
+            {"type": "tool_use", "name": "Bash", "input": {"command": "ruff check ."}}
+        )
+        for _ in range(9)
+    ]
+    report = compute_waste_score(_write_log(tmp_path, lines))
+    assert report.manual_check_runs == 9
+    assert report.score == 25
+
+
+# ---------------------------------------------------------------------------
+# redundant_bash signal
+# ---------------------------------------------------------------------------
+
+
+def test_no_redundant_bash(tmp_path: Path) -> None:
+    """Unique bash commands produce zero redundant_bash."""
+    lines = [
+        json.dumps({"type": "tool_use", "name": "Bash", "input": {"command": "ls"}}),
+        json.dumps({"type": "tool_use", "name": "Bash", "input": {"command": "pwd"}}),
+    ]
+    report = compute_waste_score(_write_log(tmp_path, lines))
+    assert report.redundant_bash == 0
+    assert report.score == 0
+
+
+def test_redundant_bash_counted(tmp_path: Path) -> None:
+    """Duplicate bash commands count as redundant."""
+    lines = [
+        json.dumps(
+            {"type": "tool_use", "name": "Bash", "input": {"command": "echo hi"}}
+        ),
+        json.dumps(
+            {"type": "tool_use", "name": "Bash", "input": {"command": "echo hi"}}
+        ),
+        json.dumps(
+            {"type": "tool_use", "name": "Bash", "input": {"command": "echo hi"}}
+        ),
+    ]
+    report = compute_waste_score(_write_log(tmp_path, lines))
+    assert report.redundant_bash == 2  # 3 - 1 = 2
+    # Score: min(2 * 2, 20) = 4
+    assert report.score == 4
+
+
+def test_redundant_bash_capped_at_20(tmp_path: Path) -> None:
+    """redundant_bash score contribution is capped at 20."""
+    # 11 duplicates → 11 * 2 = 22 → capped at 20
+    lines = [
+        json.dumps(
+            {"type": "tool_use", "name": "Bash", "input": {"command": "echo hi"}}
+        )
+        for _ in range(12)
+    ]
+    report = compute_waste_score(_write_log(tmp_path, lines))
+    assert report.redundant_bash == 11
+    assert report.score == 20
+
+
+# ---------------------------------------------------------------------------
+# cd_commands signal
+# ---------------------------------------------------------------------------
+
+
+def test_cd_commands_counted(tmp_path: Path) -> None:
+    """cd commands are counted."""
+    lines = [
+        json.dumps(
+            {"type": "tool_use", "name": "Bash", "input": {"command": "cd src"}}
+        ),
+        json.dumps({"type": "tool_use", "name": "Bash", "input": {"command": "cd .."}}),
+    ]
+    report = compute_waste_score(_write_log(tmp_path, lines))
+    assert report.cd_commands == 2
+    # Score contribution: min(2, 15) = 2
+    assert report.score == 2
+
+
+def test_cd_commands_capped_at_15(tmp_path: Path) -> None:
+    """cd_commands score contribution is capped at 15."""
+    lines = [
+        json.dumps({"type": "tool_use", "name": "Bash", "input": {"command": "cd src"}})
+        for _ in range(20)
+    ]
+    report = compute_waste_score(_write_log(tmp_path, lines))
+    assert report.cd_commands == 20
+    assert report.score == 15
+
+
+# ---------------------------------------------------------------------------
+# thinking_to_text_ratio signal
+# ---------------------------------------------------------------------------
+
+
+def test_thinking_to_text_ratio_high(tmp_path: Path) -> None:
+    """High thinking-to-text ratio adds to score."""
+    # 20000 chars of thinking (~5000 tokens) / 1000 output tokens = 5.0
+    # But we need > 5, so let's use 24000 chars / 1000 tokens = 6.0
+    lines = [
+        json.dumps(
+            {
+                "type": "assistant",
+                "message": {
+                    "reasoning": "x" * 24000,
+                    "usage": {"output_tokens": 1000},
+                },
+            }
+        ),
+    ]
+    report = compute_waste_score(_write_log(tmp_path, lines))
+    assert report.thinking_to_text_ratio > 5
+    # Score contribution: min(int(6.0), 10) = 6
+    assert report.score == 6
+
+
+def test_thinking_to_text_ratio_below_threshold(tmp_path: Path) -> None:
+    """Ratio <= 5 does not add to score."""
+    lines = [
+        json.dumps(
+            {
+                "type": "assistant",
+                "message": {
+                    "reasoning": "x" * 20000,  # ~5000 tokens / 1000 output = 5.0
+                    "usage": {"output_tokens": 1000},
+                },
+            }
+        ),
+    ]
+    report = compute_waste_score(_write_log(tmp_path, lines))
+    assert report.thinking_to_text_ratio == pytest.approx(5.0, rel=0.01)
+    # At exactly 5.0, the condition > 5 is False, so no addition.
+    assert report.score == 0
+
+
+def test_thinking_to_text_ratio_zero_on_no_output(tmp_path: Path) -> None:
+    """When output tokens are zero, ratio is 0."""
+    lines = [
+        json.dumps(
+            {
+                "type": "assistant",
+                "message": {
+                    "reasoning": "x" * 1000,
+                    "usage": {"output_tokens": 0},
+                },
+            }
+        ),
+    ]
+    report = compute_waste_score(_write_log(tmp_path, lines))
+    assert report.thinking_to_text_ratio == 0.0
+    assert report.score == 0
+
+
+# ---------------------------------------------------------------------------
+# Composite score
+# ---------------------------------------------------------------------------
+
+
+def test_composite_score_capped_at_100(tmp_path: Path) -> None:
+    """Composite score never exceeds 100."""
+    lines = (
+        # 10 redundant reads → 10 * 2 = 20
+        [
+            json.dumps({"type": "tool_use", "name": "Read", "input": {"path": "a.py"}})
+            for _ in range(11)
+        ]
+        +
+        # 10 check runs → 10 * 3 = 30
+        [
+            json.dumps(
+                {
+                    "type": "tool_use",
+                    "name": "Bash",
+                    "input": {"command": "ruff check ."},
+                }
+            )
+            for _ in range(10)
+        ]
+        +
+        # 10 cd commands → 10
+        [
+            json.dumps(
+                {"type": "tool_use", "name": "Bash", "input": {"command": "cd src"}}
+            )
+            for _ in range(10)
+        ]
+        +
+        # High thinking ratio → 10
+        [
+            json.dumps(
+                {
+                    "type": "assistant",
+                    "message": {
+                        "reasoning": "x" * 30000,
+                        "usage": {"output_tokens": 1000},
+                    },
+                }
+            )
+        ]
+    )
+    report = compute_waste_score(_write_log(tmp_path, lines))
+    # Raw: 20 + 30 + 10 + 10 = 70 (not yet over 100)
+    # But with enough signals it would cap at 100
+    assert report.score <= 100
+
+
+def test_all_signals_contribute(tmp_path: Path) -> None:
+    """All four signals contribute to the composite score."""
+    lines = (
+        # 2 redundant reads → 4
+        [
+            json.dumps({"type": "tool_use", "name": "Read", "input": {"path": "a.py"}})
+            for _ in range(3)
+        ]
+        +
+        # 2 check runs → 6
+        [
+            json.dumps(
+                {
+                    "type": "tool_use",
+                    "name": "Bash",
+                    "input": {"command": "ruff check ."},
+                }
+            )
+            for _ in range(2)
+        ]
+        +
+        # 2 cd commands → 2
+        [
+            json.dumps(
+                {"type": "tool_use", "name": "Bash", "input": {"command": "cd src"}}
+            )
+            for _ in range(2)
+        ]
+    )
+    report = compute_waste_score(_write_log(tmp_path, lines))
+    assert report.redundant_reads == 2
+    assert report.manual_check_runs == 2
+    assert report.cd_commands == 2
+    assert report.score == 4 + 6 + 2  # 12
+
+
+def test_empty_log_returns_zero(tmp_path: Path) -> None:
+    """An empty log file produces a zero score."""
+    log = tmp_path / "worker.log"
+    log.write_text("", encoding="utf-8")
+    report = compute_waste_score(log)
+    assert report.score == 0
+    assert report.breakdown == {}
+
+
+def test_malformed_json_lines_ignored(tmp_path: Path) -> None:
+    """Malformed JSON lines are silently skipped."""
+    lines = [
+        "not json at all",
+        "{broken json",
+        json.dumps({"type": "tool_use", "name": "Read", "input": {"path": "a.py"}}),
+    ]
+    report = compute_waste_score(_write_log(tmp_path, lines))
+    assert report.redundant_reads == 0
+    assert report.score == 0
+
+
+# ---------------------------------------------------------------------------
+# WasteReport structure
+# ---------------------------------------------------------------------------
+
+
+def test_waste_report_has_all_fields() -> None:
+    """WasteReport has all expected fields."""
+    report = WasteReport(
+        score=42,
+        breakdown={"redundant_reads": 5},
+        redundant_reads=5,
+        manual_check_runs=0,
+        redundant_bash=0,
+        cd_commands=0,
+        thinking_to_text_ratio=0.0,
+    )
+    assert report.score == 42
+    assert report.breakdown == {"redundant_reads": 5}
+    assert report.redundant_reads == 5
+    assert report.manual_check_runs == 0
+    assert report.redundant_bash == 0
+    assert report.cd_commands == 0
+    assert report.thinking_to_text_ratio == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Edge cases — tool_use input formats
+# ---------------------------------------------------------------------------
+
+
+def test_tool_use_with_string_input(tmp_path: Path) -> None:
+    """Handles tool_use where input is a JSON string instead of dict."""
+    lines = [
+        json.dumps(
+            {
+                "type": "tool_use",
+                "name": "Bash",
+                "input": '{"command": "ruff check ."}',
+            }
+        ),
+    ]
+    report = compute_waste_score(_write_log(tmp_path, lines))
+    assert report.manual_check_runs == 1
+
+
+def test_tool_use_with_dict_input(tmp_path: Path) -> None:
+    """Handles tool_use where input is already a dict."""
+    lines = [
+        json.dumps(
+            {
+                "type": "tool_use",
+                "name": "Bash",
+                "input": {"command": "ruff check ."},
+            }
+        ),
+    ]
+    report = compute_waste_score(_write_log(tmp_path, lines))
+    assert report.manual_check_runs == 1
+
+
+def test_assistant_with_tool_calls(tmp_path: Path) -> None:
+    """Handles assistant messages with tool_calls array."""
+    lines = [
+        json.dumps(
+            {
+                "type": "assistant",
+                "message": {
+                    "tool_calls": [
+                        {
+                            "type": "tool_use",
+                            "name": "Read",
+                            "input": {"path": "a.py"},
+                        }
+                    ],
+                    "usage": {"output_tokens": 100},
+                },
+            }
+        ),
+    ]
+    report = compute_waste_score(_write_log(tmp_path, lines))
+    assert report.redundant_reads == 0  # single read
+    assert report.score == 0


### PR DESCRIPTION
Closes WOR-277

Add a 0-100 waste score per worker session, persist to metrics.db, log WARNING when score>threshold, and add a CLI command for ad-hoc scoring. Formula is pre-baked in the ticket description.