### PR TITLE
chore: gitignore .claude/*.lock + docs/retros/*_logs/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,12 @@ litellm-local.yaml
 # Claude Code watcher logs
 .claude/*.log
 .claude/*.pid
+.claude/*.lock
+
+# Forensic log dumps under retros/ (raw worker logs + manifests captured during
+# post-mortem analysis). The retro markdown itself is committed; raw evidence
+# lives in private gists or Linear attachments instead.
+docs/retros/*_logs/
 
 # Benchmark fixtures (generated locally, not committed)
 scripts/bench/fixtures/


### PR DESCRIPTION
## Summary

- Gitignore `.claude/*.lock` — `ScheduleWakeup` writes `scheduled_tasks.lock` as runtime state (same category as `.claude/*.pid` which is already ignored)
- Gitignore `docs/retros/*_logs/` — forensic log dumps under retro folders (e.g. `docs/retros/wor_313_logs/`) captured during post-mortem analysis; raw evidence belongs in gists or Linear attachments, only the retro markdown itself is committed

## Why

After last night's WOR-313 overnight run, two untracked items appeared in the working tree:

1. `.claude/scheduled_tasks.lock` (1 KB) — runtime lockfile from ScheduleWakeup
2. `docs/retros/wor_313_logs/` (268 KB) — manifests + worker logs for WOR-278 / WOR-314 vLLM hangs, captured during morning forensic analysis

The forensic logs are now preserved as a private gist attached to WOR-313 ([gist link in the comment](https://linear.app/avirola/issue/WOR-313/epic-mega-overnight-hardening-sweep-tests-docstrings-audits-sonar)). This PR ensures both patterns stay out of the repo going forward.

## Test plan

- [x] Pre-commit hooks pass (no Python files touched)
- [x] No code changes; gitignore-only PR