### PR TITLE
WOR-342 Fix 3 SonarCloud findings (BLOCKER S3516 + MAJOR S5864 + MAJOR S3358)

### DIFF
--- a/app/core/watcher/watcher_finalize.py
+++ b/app/core/watcher/watcher_finalize.py
@@ -333,37 +333,36 @@ def finalize_worker(
     if artifacts_preserved:
         # Success path — artifacts already saved upstream; remove worktree.
         cleanup_worktree(repo_root, worker.worktree_path)
-        return outcome
-
-    # Failure path — preserve WIP before considering teardown (WOR-258, WOR-288).
-    backup_root = repo_root / _CLAUDE_DIR / "artifacts"
-    wip_result = commit_wip_state(
-        worker.worktree_path,
-        worker.ticket_id,
-        worker.manifest.worker_branch,
-        backup_root=backup_root,
-    )
-    if wip_result.sha is not None:
-        _write_wip_sha_to_last_failure(worker, wip_result.sha)
-    preserve_worker_artifacts(repo_root, worker)
-
-    if wip_result.status in ("clean", "pushed", "backup"):
-        cleanup_worktree(repo_root, worker.worktree_path)
     else:
-        # WOR-288: WIP preservation failed (commit_wip_state could not push
-        # AND could not back up the dirty tree). Removing the worktree now
-        # would destroy uncommitted work — leave it in place for human
-        # salvage. The worktree path appears in the ERROR log so the
-        # operator can git status / commit / push manually.
-        logger.error(
-            "WIP preservation failed for %s — leaving worktree in place at %s "
-            "for manual recovery (error: %s). Run `git -C <path> status` to "
-            "inspect, then commit + push to %s manually.",
-            worker.ticket_id,
+        # Failure path — preserve WIP before considering teardown (WOR-258, WOR-288).
+        backup_root = repo_root / _CLAUDE_DIR / "artifacts"
+        wip_result = commit_wip_state(
             worker.worktree_path,
-            wip_result.error or "unknown",
+            worker.ticket_id,
             worker.manifest.worker_branch,
+            backup_root=backup_root,
         )
+        if wip_result.sha is not None:
+            _write_wip_sha_to_last_failure(worker, wip_result.sha)
+        preserve_worker_artifacts(repo_root, worker)
+
+        if wip_result.status in ("clean", "pushed", "backup"):
+            cleanup_worktree(repo_root, worker.worktree_path)
+        else:
+            # WOR-288: WIP preservation failed (commit_wip_state could not push
+            # AND could not back up the dirty tree). Removing the worktree now
+            # would destroy uncommitted work — leave it in place for human
+            # salvage. The worktree path appears in the ERROR log so the
+            # operator can git status / commit / push manually.
+            logger.error(
+                "WIP preservation failed for %s — leaving worktree in place at %s "
+                "for manual recovery (error: %s). Run `git -C <path> status` to "
+                "inspect, then commit + push to %s manually.",
+                worker.ticket_id,
+                worker.worktree_path,
+                wip_result.error or "unknown",
+                worker.manifest.worker_branch,
+            )
     return outcome
 
 

--- a/app/core/watcher/watcher_helpers.py
+++ b/app/core/watcher/watcher_helpers.py
@@ -243,7 +243,10 @@ def build_worker_cmd(
         "--output-format",
         "stream-json",
     ]
-    _effort = effort if effort is not None else ("xhigh" if mode == "local" else "max")
+    if effort is not None:
+        _effort = effort
+    else:
+        _effort = "xhigh" if mode == "local" else "max"
     if mode == "local":
         # (CLI values: low|medium|high|xhigh|max — "normal" was removed)
         # When effort=None, fall back to xhigh for local, max for cloud.

--- a/app/core/watcher/watcher_worktrees.py
+++ b/app/core/watcher/watcher_worktrees.py
@@ -609,10 +609,11 @@ def _rmtree_force(path: Path) -> None:
     """
     import os
     import stat
+    from collections.abc import Callable
 
-    def _on_rm_error(func: object, p: str, _exc_info: object) -> None:
+    def _on_rm_error(func: Callable[..., object], p: str, _exc_info: object) -> None:
         os.chmod(p, stat.S_IWRITE)
-        func(p)  # type: ignore[operator]  # onexc callback: func is Callable[[str, BaseException], None] but typed as object for shutil compatibility
+        func(p)
 
     shutil.rmtree(path, onexc=_on_rm_error)
 


### PR DESCRIPTION
## Summary

3 SonarCloud findings in `app/core/watcher/`, all in one PR per the WOR-326 mechanical-bundle pattern. ~30 LOC net change, no behavior change.

## Fixes

| Rule | Sev | File | Fix |
|---|---|---|---|
| S3516 | BLOCKER | `watcher_finalize.py:332-367` | Collapse two `return outcome` paths (success line 336 + failure line 367) into a single trailing return after if/else |
| S5864 | MAJOR | `watcher_worktrees.py:613-615` | Type `_on_rm_error.func` as `Callable[..., object]` instead of `object`; remove `# type: ignore[operator]` |
| S3358 | MAJOR | `watcher_helpers.py:246` | Extract nested ternary `effort if effort is not None else ("xhigh" if mode == "local" else "max")` into a conventional `if/else` block |

## Verification

- [x] `ruff check .` — clean
- [x] `mypy app/` — clean (3 source files, no issues)
- [x] `pytest --no-cov -q` — **1061 passed**, 0 failed
- [x] `lint-imports` — 5 contracts kept, 0 broken

## Notes

- This was the only open Sonar BLOCKER; ships well ahead of WOR-312 (in-dispatch retry restructure of `_execute_finalization`) so it doesn't get re-flagged after that bigger refactor lands.
- No new tests added — the existing 118 tests across `tests/test_watcher_finalize.py`, `tests/test_watcher_worktrees.py`, `tests/test_watcher_helpers.py` cover both branches of the changed code paths.

## Test plan

- [x] Existing test suite passes (1061 tests)
- [x] Manual review: success path (artifacts_preserved=True) still cleans up worktree and returns outcome; failure path still preserves WIP, conditionally cleans up, returns outcome.

Closes WOR-342