### PR TITLE
WOR-334 Fix _local_active ghost-slot leak when finalize_worker raises

### DIFF
--- a/app/core/watcher/watcher.py
+++ b/app/core/watcher/watcher.py
@@ -597,66 +597,101 @@ class Watcher:
     # Worker lifecycle
     # ------------------------------------------------------------------
 
-    def _reap_pool(self, workers: list[ActiveWorker]) -> tuple[list[ActiveWorker], str]:
-        still_running: list[ActiveWorker] = []
+    def _reap_pool(self, workers: list[ActiveWorker]) -> str:
+        """Poll each worker; finalize completed ones in-place.
+
+        Mutates ``workers`` directly — finished workers are removed from the
+        list even if their ``finalize_worker`` call raises. This prevents
+        ghost slots that would otherwise block future dispatch (WOR-334).
+
+        Returns the outcome of the last finalized worker (``""`` if none
+        finished, ``"failure"`` if the last one's finalize raised).
+        """
+        finished_indices: list[int] = []
         outcome = ""
-        for worker in workers:
+        for i, worker in enumerate(workers):
             rc = worker.process.poll()
             if rc is None:
-                still_running.append(worker)
                 continue
-            elapsed = time.monotonic() - worker.start_time
-            # Clear heartbeat state for the finished worker
-            self._heartbeat.pop(worker.ticket_id, None)
-            # Final heartbeat for finished worker
-            last_tick = self._heartbeat.get(worker.ticket_id, (0.0, 0))[1]
-            final_tick = int(elapsed / 30)
-            if final_tick > last_tick:
-                elapsed_str = format_elapsed(elapsed)
-                logger.info("[%s] %s", worker.ticket_id, elapsed_str)
-            # Build single-line finish summary with elapsed + token count
-            status = "success" if rc == 0 else "failed"
-            elapsed_str = format_elapsed(elapsed)
-            log_path = (
-                worker.worktree_path
-                / ".claude"
-                / "logs"
-                / f"{worker.ticket_id.replace('-', '_')}.jsonl"
-            )
-            token_str = format_worker_token_count(log_path)
-            logger.info(
-                "%s done (%s, %s, %s)",
-                worker.ticket_id,
-                status,
-                elapsed_str,
-                token_str,
-            )
-            outcome = finalize_worker(
-                worker,
-                returncode=rc,
-                wall_time=elapsed,
-                linear=self._linear,
-                metrics=self._metrics,
-                escalation_policy=self._escalation_policy,
-                repo_root=self._repo_root,
-                mode=self._mode,
-                project_id=self._project_id,
-                tracked_prs=self._tracked_prs,
-            )
-            self._processed_tickets.append(
-                _ProcessedTicket(
-                    ticket_id=worker.ticket_id,
-                    epic_id=worker.manifest.epic_id,
-                    worker_branch=worker.manifest.worker_branch,
-                    elapsed=elapsed,
-                    succeeded=(outcome == "success"),
+            # Worker finished — mark its slot for release BEFORE finalize so
+            # an exception inside finalize cannot leak the slot.
+            finished_indices.append(i)
+            try:
+                outcome = self._finalize_one_worker(worker, rc)
+            except Exception as exc:
+                logger.error(
+                    "finalize_worker raised for %s: %s. Worker slot freed; "
+                    "result.json / last_failure.json may be incomplete and "
+                    "Linear state may not have been advanced — investigate "
+                    "manually.",
+                    worker.ticket_id,
+                    exc,
+                    exc_info=True,
                 )
+                outcome = "failure"
+        # Remove in reverse so earlier indices stay valid.
+        for i in reversed(finished_indices):
+            del workers[i]
+        return outcome
+
+    def _finalize_one_worker(self, worker: ActiveWorker, rc: int) -> str:
+        """Run the per-worker finalize sequence (logging + finalize_worker call).
+
+        Separated from ``_reap_pool`` so the latter can wrap this in try/except
+        without entangling pool-management bookkeeping with finalize logic.
+        """
+        elapsed = time.monotonic() - worker.start_time
+        # Clear heartbeat state for the finished worker
+        self._heartbeat.pop(worker.ticket_id, None)
+        # Final heartbeat for finished worker
+        last_tick = self._heartbeat.get(worker.ticket_id, (0.0, 0))[1]
+        final_tick = int(elapsed / 30)
+        if final_tick > last_tick:
+            elapsed_str = format_elapsed(elapsed)
+            logger.info("[%s] %s", worker.ticket_id, elapsed_str)
+        # Build single-line finish summary with elapsed + token count
+        status = "success" if rc == 0 else "failed"
+        elapsed_str = format_elapsed(elapsed)
+        log_path = (
+            worker.worktree_path
+            / ".claude"
+            / "logs"
+            / f"{worker.ticket_id.replace('-', '_')}.jsonl"
+        )
+        token_str = format_worker_token_count(log_path)
+        logger.info(
+            "%s done (%s, %s, %s)",
+            worker.ticket_id,
+            status,
+            elapsed_str,
+            token_str,
+        )
+        outcome = finalize_worker(
+            worker,
+            returncode=rc,
+            wall_time=elapsed,
+            linear=self._linear,
+            metrics=self._metrics,
+            escalation_policy=self._escalation_policy,
+            repo_root=self._repo_root,
+            mode=self._mode,
+            project_id=self._project_id,
+            tracked_prs=self._tracked_prs,
+        )
+        self._processed_tickets.append(
+            _ProcessedTicket(
+                ticket_id=worker.ticket_id,
+                epic_id=worker.manifest.epic_id,
+                worker_branch=worker.manifest.worker_branch,
+                elapsed=elapsed,
+                succeeded=(outcome == "success"),
             )
-        return still_running, outcome
+        )
+        return outcome
 
     def _reap_finished_workers(self) -> None:
-        self._local_active, _ = self._reap_pool(self._local_active)
-        self._cloud_active, _ = self._reap_pool(self._cloud_active)
+        self._reap_pool(self._local_active)
+        self._reap_pool(self._cloud_active)
 
     # ------------------------------------------------------------------
     # Epic completion detection

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -993,3 +993,121 @@ def test_dispatch_proceeds_when_all_manifest_blockers_are_merged(
 
     assert len(w._local_active) == 1
     assert w._local_active[0].ticket_id == "WOR-10"
+
+
+# ---------------------------------------------------------------------------
+# _reap_pool — ghost-slot leak prevention (WOR-334)
+# ---------------------------------------------------------------------------
+
+
+def _finished_worker(ticket_id: str, returncode: int = 0) -> ActiveWorker:
+    """Build an ActiveWorker whose process.poll() returns returncode."""
+    worker = _make_active_worker(ticket_id=ticket_id)
+    worker.process.poll.return_value = returncode
+    return worker
+
+
+def _running_worker(ticket_id: str) -> ActiveWorker:
+    """Build an ActiveWorker whose process.poll() returns None (still alive)."""
+    worker = _make_active_worker(ticket_id=ticket_id)
+    worker.process.poll.return_value = None
+    return worker
+
+
+def test_reap_pool_frees_slot_when_finalize_raises(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """WOR-334 regression: an exception inside finalize_worker must not leave
+    the failing worker (or its siblings) in the pool."""
+    workers = [
+        _finished_worker("WOR-100"),
+        _finished_worker("WOR-101"),
+        _finished_worker("WOR-102"),
+    ]
+
+    watcher = Watcher(linear_client=MagicMock())
+
+    def finalize_side_effect(*args: Any, **kwargs: Any) -> str:
+        if args[0].ticket_id == "WOR-101":
+            raise RuntimeError("simulated Linear API blow-up")
+        return "success"
+
+    with (
+        patch(
+            "app.core.watcher.watcher.finalize_worker",
+            side_effect=finalize_side_effect,
+        ),
+        patch(
+            "app.core.watcher.watcher.format_worker_token_count",
+            return_value="0 tokens",
+        ),
+        caplog.at_level(logging.ERROR, logger="app.core.watcher.watcher"),
+    ):
+        watcher._reap_pool(workers)
+
+    assert workers == [], (
+        f"Expected pool to be empty after finalize raised; got "
+        f"{[w.ticket_id for w in workers]}"
+    )
+
+    error_records = [r for r in caplog.records if r.levelno == logging.ERROR]
+    matching = [r for r in error_records if "WOR-101" in r.getMessage()]
+    assert matching, "Expected an ERROR log mentioning WOR-101 when its finalize raised"
+    assert any(r.exc_info is not None for r in matching), (
+        "Expected exc_info to be attached to the ERROR log for forensic context"
+    )
+
+
+def test_reap_pool_eight_workers_one_raises_pool_empty() -> None:
+    """8 workers all finish, 1 raises during finalize -> pool ends empty.
+
+    This is the WOR-313 overnight scenario: a single finalize exception used
+    to freeze the pool at full size and block all further dispatch."""
+    workers = [_finished_worker(f"WOR-20{i}") for i in range(8)]
+    watcher = Watcher(linear_client=MagicMock())
+
+    def finalize_side_effect(*args: Any, **kwargs: Any) -> str:
+        if args[0].ticket_id == "WOR-204":
+            raise RuntimeError("simulated finalize blow-up")
+        return "success"
+
+    with (
+        patch(
+            "app.core.watcher.watcher.finalize_worker",
+            side_effect=finalize_side_effect,
+        ),
+        patch(
+            "app.core.watcher.watcher.format_worker_token_count",
+            return_value="0 tokens",
+        ),
+    ):
+        watcher._reap_pool(workers)
+
+    assert workers == [], (
+        f"Expected all 8 slots freed; remaining: {[w.ticket_id for w in workers]}"
+    )
+
+
+def test_reap_pool_keeps_still_running_workers() -> None:
+    """Sanity: workers whose poll() returns None must stay in the pool."""
+    running = _running_worker("WOR-300")
+    finished = _finished_worker("WOR-301")
+    workers = [running, finished]
+
+    watcher = Watcher(linear_client=MagicMock())
+
+    with (
+        patch(
+            "app.core.watcher.watcher.finalize_worker",
+            return_value="success",
+        ),
+        patch(
+            "app.core.watcher.watcher.format_worker_token_count",
+            return_value="0 tokens",
+        ),
+    ):
+        watcher._reap_pool(workers)
+
+    assert [w.ticket_id for w in workers] == ["WOR-300"], (
+        "Running worker should remain; finished worker should be removed"
+    )


### PR DESCRIPTION
## Summary

The watcher daemon was leaking dispatch slots whenever \`finalize_worker\` raised. Observed in the 2026-05-03 WOR-313 overnight run as **4+ hours of wasted dispatch capacity** (5 ReadyForLocal tickets sitting idle while the daemon thought its 8-slot pool was full). Single bounded fix in \`Watcher._reap_pool\`, defense-in-depth approach (Option C from the ticket).

## Root cause

\`Watcher._reap_pool\` previously built a fresh \`still_running\` list and returned it at function end. If \`finalize_worker\` raised mid-iteration:

- The function never returned
- The caller's \`self._local_active = self._reap_pool(...)\` assignment never ran
- All workers — including those already \"reaped\" earlier in the loop — stayed in the active list
- Next \`_dispatch_next_ticket\` cycle saw the pool as full → refused to dispatch

This compounded over time: every finalize exception added a permanent ghost slot until daemon restart.

## Fix (Option C — defense in depth)

| Change | Why |
|---|---|
| In-place mutation via \`finished_indices\` (removed in reverse) | Slot release happens regardless of finalize outcome (Option B from the ticket) |
| \`try/except\` around \`_finalize_one_worker\` inside \`_reap_pool\` | Exceptions get logged + slot freed instead of propagating (Option A) |
| Extracted \`_finalize_one_worker\` helper | Clean try/except boundary; separates pool-management from finalize logic |
| \`_reap_finished_workers\` drops destructuring | New \`_reap_pool\` signature is \`(workers) -> str\` (mutates in-place, returns last outcome) |
| ERROR log with full \`exc_info\` on exception | Previously silent — operator now sees forensic context |

## Tests added (3, all in \`tests/test_watcher.py\`)

- **\`test_reap_pool_frees_slot_when_finalize_raises\`** — 3 workers, middle one's finalize raises → all 3 removed, ERROR log with \`exc_info\` attached.
- **\`test_reap_pool_eight_workers_one_raises_pool_empty\`** — direct WOR-313 reproduction: 8 workers, 1 raises → pool ends empty.
- **\`test_reap_pool_keeps_still_running_workers\`** — sanity that workers with \`poll()==None\` stay in the pool.

Plus 2 small helpers: \`_finished_worker\` and \`_running_worker\` for fixture readability.

## Verification

- [x] \`ruff check .\` — clean
- [x] \`mypy app/\` — 29 source files, no issues
- [x] \`pytest --no-cov -q\` — **1064 passed** (1061 existing + 3 new), 0 failed
- [x] \`lint-imports\` — 5 contracts kept, 0 broken
- [x] All pre-commit hooks pass (trim/EOF/ruff/format/bandit/check-patch-paths/semgrep/mypy/detect-secrets)

## Coordination notes

- **WOR-312** (in-dispatch retry loop) restructures \`_execute_finalization\` heavily but does NOT touch \`_reap_pool\`. Should merge cleanly with this PR.
- **WOR-309** (commit_wip_state visibility) touches \`watcher_finalize.py\` only. No conflict.
- **WOR-333** (soft-stop) touches \`watcher.py\` but in a different area (signal handling + \`_dispatch_next_ticket\` skip). Should rebase cleanly.

Closes WOR-334