### PR TITLE
WOR-339 Fix LiteLLM orphan-tab race via TCP-probe vs HTTP-probe split

### DIFF
--- a/app/core/watcher/watcher_services.py
+++ b/app/core/watcher/watcher_services.py
@@ -184,8 +184,27 @@ class ServiceManager:
                 env=env,
             )
 
+    def _litellm_listening(self) -> bool:
+        """Return True if anything is bound to _LITELLM_PORT (fast TCP probe).
+
+        Used by ensure_litellm_running to decide whether to spawn. TCP
+        connect_ex completes in milliseconds and only returns success when a
+        socket is actually bound — it does not depend on the application
+        being responsive to HTTP requests, which avoids false negatives when
+        LiteLLM is busy serving an in-flight worker request (WOR-339).
+        """
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.settimeout(0.5)
+            return sock.connect_ex(("localhost", _LITELLM_PORT)) == 0
+
     def _litellm_serving(self) -> bool:
-        """Return True if LiteLLM is accepting HTTP requests on _LITELLM_PORT."""
+        """Return True if LiteLLM is responding to /health on _LITELLM_PORT.
+
+        Used by _wait_for_litellm_ready post-spawn to verify the proxy has
+        finished initializing and is actually serving requests, not just that
+        the port is bound. The 2s timeout is intentional — at startup time
+        nothing else is hitting the proxy, so /health responds promptly.
+        """
         try:
             conn = http.client.HTTPConnection("localhost", _LITELLM_PORT, timeout=2)
             conn.request("GET", "/health")
@@ -195,8 +214,15 @@ class ServiceManager:
             return False
 
     def ensure_litellm_running(self) -> None:
-        """Start the LiteLLM proxy if not already listening on _LITELLM_PORT."""
-        if self._litellm_serving():
+        """Start the LiteLLM proxy if no process is bound to _LITELLM_PORT.
+
+        Uses _litellm_listening (TCP probe) instead of _litellm_serving (HTTP
+        probe) for the spawn-or-not decision (WOR-339): the HTTP probe gave
+        false negatives when LiteLLM was busy serving an active worker, which
+        triggered redundant spawns that produced orphan tabs (port collisions
+        crash the new process but the cmd.exe tab persists with the error).
+        """
+        if self._litellm_listening():
             logger.debug("LiteLLM proxy already running on port %d", _LITELLM_PORT)
             return
 

--- a/tests/test_watcher_services.py
+++ b/tests/test_watcher_services.py
@@ -170,12 +170,54 @@ def test_litellm_serving_returns_false_on_connection_error(tmp_path: Path) -> No
     assert result is False
 
 
-def test_ensure_litellm_running_skips_start_when_already_serving(
+def test_litellm_listening_returns_true_when_port_bound(tmp_path: Path) -> None:
+    """TCP probe must report True when something is bound to _LITELLM_PORT."""
+    mgr = ServiceManager(tmp_path)
+    mock_sock = MagicMock()
+    mock_sock.connect_ex.return_value = 0  # 0 = connection succeeded
+    with patch("socket.socket") as mock_socket_cls:
+        mock_socket_cls.return_value.__enter__.return_value = mock_sock
+        result = mgr._litellm_listening()
+    assert result is True
+
+
+def test_litellm_listening_returns_false_when_port_not_bound(tmp_path: Path) -> None:
+    """TCP probe must report False when nothing is bound to _LITELLM_PORT."""
+    mgr = ServiceManager(tmp_path)
+    mock_sock = MagicMock()
+    mock_sock.connect_ex.return_value = 111  # non-zero = connection refused
+    with patch("socket.socket") as mock_socket_cls:
+        mock_socket_cls.return_value.__enter__.return_value = mock_sock
+        result = mgr._litellm_listening()
+    assert result is False
+
+
+def test_ensure_litellm_running_skips_start_when_port_bound(
     tmp_path: Path,
 ) -> None:
+    """ensure_litellm_running uses TCP probe (not HTTP) for the early-return
+    decision, so a busy LiteLLM (port bound, /health slow) does not trigger
+    a redundant spawn (WOR-339 root cause)."""
     mgr = ServiceManager(tmp_path)
     with (
-        patch.object(mgr, "_litellm_serving", return_value=True),
+        patch.object(mgr, "_litellm_listening", return_value=True),
+        patch("subprocess.Popen") as mock_popen,
+    ):
+        mgr.ensure_litellm_running()
+    mock_popen.assert_not_called()
+
+
+def test_ensure_litellm_running_does_not_spawn_when_http_probe_would_fail(
+    tmp_path: Path,
+) -> None:
+    """WOR-339 regression: the OLD bug was ensure_litellm_running falling back
+    to spawning a new tab when /health was slow to respond. With the TCP-probe
+    check, even an unresponsive HTTP layer doesn't trigger a spawn as long as
+    something is bound to the port."""
+    mgr = ServiceManager(tmp_path)
+    with (
+        patch.object(mgr, "_litellm_listening", return_value=True),
+        patch.object(mgr, "_litellm_serving", return_value=False),  # HTTP slow / busy
         patch("subprocess.Popen") as mock_popen,
     ):
         mgr.ensure_litellm_running()


### PR DESCRIPTION
## Summary

Stops the watcher from spawning redundant LiteLLM proxy tabs when the existing proxy is busy serving in-flight workers. Observed in the 2026-05-03 WOR-313 overnight run as **10+ cmd.exe tabs**, all running broken litellm processes (port collision crashes the new process but the cmd.exe tab persists with the error message visible).

## Root cause

\`ensure_litellm_running\` used \`_litellm_serving\` (HTTP \`/health\` probe with 2s timeout) for the spawn-or-not decision. When LiteLLM was busy serving a worker's LLM call, \`/health\` didn't respond within 2s → probe returned False → redundant tab spawned. The new \`litellm\` process then failed to bind port 8082 (already taken), crashed, but the \`cmd.exe\` tab persisted with the error message. Repeat across the night → 10+ orphan tabs.

The race is **not** between concurrent dispatches (the daemon dispatches at most one per poll cycle). It's between sequential dispatches happening faster than the existing LiteLLM can free up its HTTP layer to respond to a probe.

## Fix

Split the two probes by purpose:

| Method | Mechanism | Used by | Why |
|---|---|---|---|
| **\`_litellm_listening\`** (NEW) | TCP \`connect_ex\` (~100ms, 0.5s timeout) | \`ensure_litellm_running\` early-return | Doesn't depend on application responsiveness; only checks if anything is bound to the port |
| **\`_litellm_serving\`** (unchanged) | HTTP \`GET /health\` (2s timeout) | \`_wait_for_litellm_ready\` post-spawn | Verifies the freshly-spawned proxy has finished initializing (no contention at startup) |

This eliminates the false-negative bug entirely without restructuring control flow. No new dependencies, no architectural changes, no removed call sites — just a more reliable port check.

## Tests

- **\`test_litellm_listening_returns_true_when_port_bound\`** — TCP probe success path (mock socket \`connect_ex\` returns 0)
- **\`test_litellm_listening_returns_false_when_port_not_bound\`** — TCP probe failure path (mock returns non-zero)
- **\`test_ensure_litellm_running_skips_start_when_port_bound\`** — replaces the old \`_litellm_serving\`-based skip test, which was silently passing for the wrong reason in environments where a real daemon happened to bind port 8082 (would have failed in CI)
- **\`test_ensure_litellm_running_does_not_spawn_when_http_probe_would_fail\`** — the WOR-339 regression test: \`_litellm_listening=True\` + \`_litellm_serving=False\` (busy LiteLLM scenario) → asserts NO spawn

## Verification

- [x] \`ruff check .\` — clean
- [x] \`mypy app/\` — 29 source files, no issues
- [x] \`pytest --no-cov -q\` — **1067 passed** (1064 existing + 3 new), 0 failed
- [x] \`lint-imports\` — 5 contracts kept, 0 broken
- [x] All pre-commit hooks pass

## Coordination notes

- No file conflict with WOR-332 (currently in flight) — touches \`watcher_services.py\` only
- Daemon needs restart to pick up the fix; will be active after the next restart along with WOR-334's ghost-slot fix

## Out of scope

- Replacing LiteLLM with a direct vLLM client — separate decision
- Cleaning up orphan tabs from prior runs — operator can use \`taskkill /F /IM cmd.exe /FI \"WINDOWTITLE eq litellm*\"\`
- Tracking individual tabs by PID (Windows-specific complexity)

Closes WOR-339