### PR TITLE
WOR-347 Finalize: run commit_wip_state on success path too — fix work-loss bug from WOR-332 incident

### DIFF
--- a/app/core/watcher/watcher_finalize.py
+++ b/app/core/watcher/watcher_finalize.py
@@ -330,39 +330,46 @@ def finalize_worker(
     )
 
     restore_plan_files(worker.backed_up_plans)
-    if artifacts_preserved:
-        # Success path — artifacts already saved upstream; remove worktree.
-        cleanup_worktree(repo_root, worker.worktree_path)
-    else:
-        # Failure path — preserve WIP before considering teardown (WOR-258, WOR-288).
-        backup_root = repo_root / _CLAUDE_DIR / "artifacts"
-        wip_result = commit_wip_state(
-            worker.worktree_path,
-            worker.ticket_id,
-            worker.manifest.worker_branch,
-            backup_root=backup_root,
-        )
-        if wip_result.sha is not None:
-            _write_wip_sha_to_last_failure(worker, wip_result.sha)
+
+    # Always preserve any uncommitted WIP before deciding cleanup (WOR-347).
+    # Workers can exit rc=0 with all checks passing yet never have committed
+    # the work — the previous success path skipped commit_wip_state and
+    # destroyed uncommitted edits with the worktree. Running it on every path
+    # makes the worst case "an extra WIP commit on the worker branch" rather
+    # than "all work lost".
+    backup_root = repo_root / _CLAUDE_DIR / "artifacts"
+    wip_result = commit_wip_state(
+        worker.worktree_path,
+        worker.ticket_id,
+        worker.manifest.worker_branch,
+        backup_root=backup_root,
+    )
+    if wip_result.sha is not None:
+        _write_wip_sha_to_last_failure(worker, wip_result.sha)
+
+    if not artifacts_preserved:
+        # Failure path: also preserve full worker artifacts (logs, last_failure,
+        # etc.) for forensic analysis. Success path doesn't need this — the PR
+        # itself is the artifact.
         preserve_worker_artifacts(repo_root, worker)
 
-        if wip_result.status in ("clean", "pushed", "backup"):
-            cleanup_worktree(repo_root, worker.worktree_path)
-        else:
-            # WOR-288: WIP preservation failed (commit_wip_state could not push
-            # AND could not back up the dirty tree). Removing the worktree now
-            # would destroy uncommitted work — leave it in place for human
-            # salvage. The worktree path appears in the ERROR log so the
-            # operator can git status / commit / push manually.
-            logger.error(
-                "WIP preservation failed for %s — leaving worktree in place at %s "
-                "for manual recovery (error: %s). Run `git -C <path> status` to "
-                "inspect, then commit + push to %s manually.",
-                worker.ticket_id,
-                worker.worktree_path,
-                wip_result.error or "unknown",
-                worker.manifest.worker_branch,
-            )
+    if wip_result.status in ("clean", "pushed", "backup"):
+        cleanup_worktree(repo_root, worker.worktree_path)
+    else:
+        # WOR-288: WIP preservation failed (commit_wip_state could not push
+        # AND could not back up the dirty tree). Removing the worktree now
+        # would destroy uncommitted work — leave it in place for human
+        # salvage. The worktree path appears in the ERROR log so the
+        # operator can git status / commit / push manually.
+        logger.error(
+            "WIP preservation failed for %s — leaving worktree in place at %s "
+            "for manual recovery (error: %s). Run `git -C <path> status` to "
+            "inspect, then commit + push to %s manually.",
+            worker.ticket_id,
+            worker.worktree_path,
+            wip_result.error or "unknown",
+            worker.manifest.worker_branch,
+        )
     return outcome
 
 

--- a/tests/test_watcher_finalize_recovery.py
+++ b/tests/test_watcher_finalize_recovery.py
@@ -595,3 +595,111 @@ def test_finalize_worker_passes_backup_root_to_commit_wip_state(
 
     _, kwargs = mock_commit.call_args
     assert kwargs.get("backup_root") == repo_root / ".claude" / "artifacts"
+
+
+# ---------------------------------------------------------------------------
+# WOR-347 — success path must preserve uncommitted WIP
+# ---------------------------------------------------------------------------
+
+
+def test_finalize_worker_success_path_runs_commit_wip_state(
+    tmp_path: Path,
+) -> None:
+    """WOR-347 regression: even on the success path (result.json=success, checks
+    pass, PR created), commit_wip_state must run BEFORE cleanup_worktree so
+    any uncommitted edits the worker forgot to commit get preserved.
+
+    Before WOR-347 the success path skipped commit_wip_state entirely and
+    cleanup destroyed any uncommitted work — that destroyed WOR-332's entire
+    implementation on 2026-05-03 (worker passed all 96 tests but never ran
+    git commit).
+    """
+    manifest = make_manifest(ticket_id="WOR-10", worker_branch="wor-10-test-ticket")
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    worktree = tmp_path / "worktree"
+    worktree.mkdir()
+    _write_result_json(repo_root, "WOR-10", "success")
+    worker = ActiveWorker(
+        ticket_id="WOR-10",
+        linear_id="fake-linear-id",
+        manifest=manifest,
+        worktree_path=worktree,
+        process=MagicMock(spec=subprocess.Popen),
+    )
+
+    with (
+        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(True, [])),
+        patch(
+            "app.core.watcher.watcher_finalize.create_pr",
+            return_value="https://github.com/example/pr/1",
+        ),
+        patch(
+            "app.core.watcher.watcher_finalize.commit_wip_state",
+            return_value=WipPreservationResult(
+                status="pushed", sha="deadbeef", backup_path=None, error=None
+            ),
+        ) as mock_commit,
+        patch("app.core.watcher.watcher_finalize.cleanup_worktree") as mock_cleanup,
+    ):
+        _call_finalize(worker, returncode=0, repo_root=repo_root)
+
+    # commit_wip_state MUST be called even though everything succeeded
+    mock_commit.assert_called_once()
+    args, kwargs = mock_commit.call_args
+    assert args == (worktree, "WOR-10", "wor-10-test-ticket")
+    assert "backup_root" in kwargs
+
+    # Cleanup still runs because commit_wip_state returned "pushed"
+    mock_cleanup.assert_called_once()
+
+
+def test_finalize_worker_success_path_skips_cleanup_when_wip_preservation_fails(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """WOR-347 defense-in-depth: if commit_wip_state fails on the success path
+    (e.g. push refused, backup write failed), the worktree must NOT be cleaned
+    up — uncommitted work would be lost otherwise. Same gate as the failure
+    path (WOR-288).
+    """
+    manifest = make_manifest(ticket_id="WOR-10", worker_branch="wor-10-test-ticket")
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    worktree = tmp_path / "worktree"
+    worktree.mkdir()
+    _write_result_json(repo_root, "WOR-10", "success")
+    worker = ActiveWorker(
+        ticket_id="WOR-10",
+        linear_id="fake-linear-id",
+        manifest=manifest,
+        worktree_path=worktree,
+        process=MagicMock(spec=subprocess.Popen),
+    )
+
+    with (
+        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(True, [])),
+        patch(
+            "app.core.watcher.watcher_finalize.create_pr",
+            return_value="https://github.com/example/pr/1",
+        ),
+        patch(
+            "app.core.watcher.watcher_finalize.commit_wip_state",
+            return_value=WipPreservationResult(
+                status="failed",
+                sha=None,
+                backup_path=None,
+                error="git push rejected: branch protection",
+            ),
+        ),
+        patch("app.core.watcher.watcher_finalize.cleanup_worktree") as mock_cleanup,
+        caplog.at_level(logging.ERROR, logger="app.core.watcher.watcher_finalize"),
+    ):
+        _call_finalize(worker, returncode=0, repo_root=repo_root)
+
+    # Cleanup MUST be skipped — would destroy uncommitted work
+    mock_cleanup.assert_not_called()
+    # Operator-visible ERROR log was emitted
+    assert any(
+        "WIP preservation failed for WOR-10" in r.message for r in caplog.records
+    )


### PR DESCRIPTION
## Summary

Fixes the work-loss bug that destroyed WOR-332's implementation on 2026-05-03. The watcher was running \`commit_wip_state\` only on the failure path; if a worker exited \`rc=0\` with passing checks but never ran \`git commit\`, \`finalize_worker\` proceeded down the success path and called \`cleanup_worktree\` directly — destroying any uncommitted edits.

## Root cause (WOR-332 incident reproduction)

WOR-332's worker (2026-05-03 17:42 UTC):
- Made edits to 4 files (\`metrics.py\`, \`watcher_finalize.py\`, \`test_metrics.py\`, \`test_watcher_finalize.py\`)
- Ran 96 tests → all passed
- Ran ruff + mypy → clean
- Wrote summary message → exited cleanly with \`rc=0\`
- **Never ran \`git commit\`, \`git add\`, or \`git push\`** (verified via grep on the 1.6MB worker log — only one git command was ever executed: \`git status\`, no mutations)
- No \`result.json\` written

Watcher's finalize then:
1. \`rc=0\` + checks passing → success classification
2. Success path called \`cleanup_worktree\` directly
3. \`commit_wip_state\` was only called on the failure branch → skipped
4. Worktree deleted with all uncommitted work
5. Net result: ~80 min of compute + the entire auto-tagger implementation gone, no PR, no recovery

## Fix

Restructure \`finalize_worker\` to run \`commit_wip_state\` **before** the cleanup decision, regardless of success/failure. The cleanup gate (only proceed when \`wip_result.status in {clean, pushed, backup}\`) now applies to both paths.

\`preserve_worker_artifacts\` stays on the failure path only — the success path's PR is the artifact, no extra forensic preservation needed.

Worst case becomes \"an extra WIP commit on the worker branch with the worker's uncommitted work\" — vastly better than \"all work lost\".

### Before

\`\`\`python
if artifacts_preserved:
    cleanup_worktree(...)  # destroys uncommitted WIP
else:
    wip_result = commit_wip_state(...)  # only here
    if wip_result.status in {clean, pushed, backup}:
        cleanup_worktree(...)
    else:
        logger.error(...)
\`\`\`

### After

\`\`\`python
wip_result = commit_wip_state(...)  # always
if wip_result.sha is not None:
    _write_wip_sha_to_last_failure(worker, wip_result.sha)
if not artifacts_preserved:
    preserve_worker_artifacts(...)  # still failure-only
if wip_result.status in {clean, pushed, backup}:
    cleanup_worktree(...)
else:
    logger.error(...)  # leave worktree for human salvage
\`\`\`

## Tests added

- \`test_finalize_worker_success_path_runs_commit_wip_state\` — success scenario (result.json=success, run_checks pass, PR created) → assert \`commit_wip_state\` was called AND \`cleanup_worktree\` ran after
- \`test_finalize_worker_success_path_skips_cleanup_when_wip_preservation_fails\` — same scenario but \`commit_wip_state\` returns \`status=failed\` → assert cleanup did NOT run + ERROR log was emitted

## Out of scope (deferred)

The ticket also mentioned classifying \"no_diff_against_base\" as a failure outcome. That overlaps with WOR-332's \`compute_tags\` work — the \`no_diff_against_base\` tag will catch this case in metrics anyway. Defer the outcome reclassification until both ship and we see if it's still useful as a separate signal.

## Verification

- [x] \`ruff check .\` — clean
- [x] \`mypy app/\` — 29 source files, no issues
- [x] \`pytest --no-cov -q\` — **1069 passed** (1067 existing + 2 new), 0 failed
- [x] \`lint-imports\` — 5 contracts kept, 0 broken
- [x] All pre-commit hooks pass

## Coordination notes

- Daemon needs restart to pick up the fix; will be active alongside WOR-334 (ghost slot), WOR-339 (LiteLLM tabs), WOR-342 (finalize return cleanup) on the next restart.
- WOR-332 is reset to \`ReadyForLocal\`; once daemon restarts with this fix, it can re-dispatch safely.

Closes WOR-347