### PR TITLE
WOR-349 Fix waste-score detector — 3 parsing bugs (signal was always 0)

### DIFF
--- a/app/core/watcher/worker_waste.py
+++ b/app/core/watcher/worker_waste.py
@@ -97,8 +97,7 @@ def compute_waste_score(log_path: Path) -> WasteReport:
         except json.JSONDecodeError:
             continue
 
-        tool_use = _extract_tool_use(obj)
-        if tool_use is not None:
+        for tool_use in _extract_tool_uses(obj):
             name = tool_use.get("name", "")
             inp = tool_use.get("input", {})
             if isinstance(inp, str):
@@ -109,7 +108,14 @@ def compute_waste_score(log_path: Path) -> WasteReport:
 
             if name == "Read":
                 # Count reads per file path to detect redundant reads.
-                file_path = inp.get("path", "") or inp.get("file", "")
+                # Claude Code's Read tool uses `file_path` as the parameter
+                # name (WOR-349); legacy fallbacks kept defensively in case
+                # synthetic logs use other keys.
+                file_path = (
+                    inp.get("file_path", "")
+                    or inp.get("path", "")
+                    or inp.get("file", "")
+                )
                 if file_path:
                     read_counts[file_path] = read_counts.get(file_path, 0) + 1
 
@@ -149,10 +155,18 @@ def compute_waste_score(log_path: Path) -> WasteReport:
             if out_tok is not None:
                 total_output_tokens += int(out_tok)
 
-            # Thinking tokens come from the reasoning field in the message.
-            reasoning = msg.get("reasoning", "") or msg.get("content", "")
-            if isinstance(reasoning, str):
-                total_thinking_tokens += len(reasoning)
+            # Thinking tokens come from content blocks of type "thinking" on
+            # assistant messages (WOR-349). The previous code looked for a
+            # top-level `message.reasoning` field that does not exist in
+            # Claude Code's stream-json format, so total_thinking_tokens was
+            # always 0 for real logs.
+            content = msg.get("content", [])
+            if isinstance(content, list):
+                for block in content:
+                    if isinstance(block, dict) and block.get("type") == "thinking":
+                        text = block.get("thinking", "")
+                        if isinstance(text, str):
+                            total_thinking_tokens += len(text)
 
     # --- Compute signals ---
     redundant_reads = sum(max(0, c - 1) for c in read_counts.values() if c > 1)
@@ -212,19 +226,38 @@ def compute_waste_score(log_path: Path) -> WasteReport:
     )
 
 
-def _extract_tool_use(obj: dict[str, Any]) -> dict[str, Any] | None:
-    """Extract a tool_use block from a stream-json event.
+def _extract_tool_uses(obj: dict[str, Any]) -> list[dict[str, Any]]:
+    """Extract all tool_use blocks from a stream-json event.
 
-    Handles both the direct ``{type: "tool_use", ...}`` form and the
-    ``{type: "assistant", message: {tool_calls: [{...}]}}`` form.
+    Claude Code's stream-json format puts tool_use blocks in
+    ``message.content[]`` with ``type == "tool_use"``. A single assistant
+    turn can emit multiple tool_use blocks. Returns all of them in order
+    (empty list if none).
+
+    Also handles legacy/synthetic forms:
+    - direct ``{type: "tool_use", ...}`` event
+    - ``{type: "assistant", message: {tool_calls: [{...}]}}`` (legacy field)
     """
     if obj.get("type") == "tool_use":
-        return obj
-    if obj.get("type") == "assistant":
-        msg = obj.get("message") or {}
-        tool_calls: list[dict[str, Any]] = msg.get("tool_calls", [])
+        return [obj]
+    if obj.get("type") != "assistant":
+        return []
+
+    msg = obj.get("message") or {}
+    found: list[dict[str, Any]] = []
+
+    # Primary path: content blocks (Claude Code stream-json format).
+    content = msg.get("content", [])
+    if isinstance(content, list):
+        for block in content:
+            if isinstance(block, dict) and block.get("type") == "tool_use":
+                found.append(block)
+
+    # Legacy fallback: tool_calls list (kept for any synthetic logs).
+    tool_calls = msg.get("tool_calls", [])
+    if isinstance(tool_calls, list):
         for tc in tool_calls:
-            if tc.get("type") == "tool_use":
-                return tc
-        return None
-    return None
+            if isinstance(tc, dict) and tc.get("type") == "tool_use":
+                found.append(tc)
+
+    return found

--- a/tests/test_worker_waste.py
+++ b/tests/test_worker_waste.py
@@ -229,14 +229,17 @@ def test_cd_commands_capped_at_15(tmp_path: Path) -> None:
 
 def test_thinking_to_text_ratio_high(tmp_path: Path) -> None:
     """High thinking-to-text ratio adds to score."""
-    # 20000 chars of thinking (~5000 tokens) / 1000 output tokens = 5.0
-    # But we need > 5, so let's use 24000 chars / 1000 tokens = 6.0
+    # 24000 chars of thinking (~6000 tokens) / 1000 output tokens = 6.0
+    # WOR-349: thinking comes from content blocks of type "thinking", not from
+    # a top-level message.reasoning field.
     lines = [
         json.dumps(
             {
                 "type": "assistant",
                 "message": {
-                    "reasoning": "x" * 24000,
+                    "content": [
+                        {"type": "thinking", "thinking": "x" * 24000},
+                    ],
                     "usage": {"output_tokens": 1000},
                 },
             }
@@ -255,7 +258,9 @@ def test_thinking_to_text_ratio_below_threshold(tmp_path: Path) -> None:
             {
                 "type": "assistant",
                 "message": {
-                    "reasoning": "x" * 20000,  # ~5000 tokens / 1000 output = 5.0
+                    "content": [
+                        {"type": "thinking", "thinking": "x" * 20000},
+                    ],  # ~5000 tokens / 1000 output = 5.0
                     "usage": {"output_tokens": 1000},
                 },
             }
@@ -274,7 +279,9 @@ def test_thinking_to_text_ratio_zero_on_no_output(tmp_path: Path) -> None:
             {
                 "type": "assistant",
                 "message": {
-                    "reasoning": "x" * 1000,
+                    "content": [
+                        {"type": "thinking", "thinking": "x" * 1000},
+                    ],
                     "usage": {"output_tokens": 0},
                 },
             }
@@ -325,7 +332,9 @@ def test_composite_score_capped_at_100(tmp_path: Path) -> None:
                 {
                     "type": "assistant",
                     "message": {
-                        "reasoning": "x" * 30000,
+                        "content": [
+                            {"type": "thinking", "thinking": "x" * 30000},
+                        ],
                         "usage": {"output_tokens": 1000},
                     },
                 }
@@ -477,3 +486,61 @@ def test_assistant_with_tool_calls(tmp_path: Path) -> None:
     report = compute_waste_score(_write_log(tmp_path, lines))
     assert report.redundant_reads == 0  # single read
     assert report.score == 0
+
+
+# ---------------------------------------------------------------------------
+# WOR-349 — content-block parsing (Read tool input + thinking blocks)
+# ---------------------------------------------------------------------------
+
+
+def test_read_tool_uses_file_path_key_in_content_blocks(tmp_path: Path) -> None:
+    """WOR-349 regression: Claude Code's Read tool uses `file_path` (not
+    `path`/`file`), and tool_use blocks live in `message.content[]` (not in
+    `message.tool_calls[]`). Two reads of the same file_path should register
+    as 1 redundant_read."""
+    line = json.dumps(
+        {
+            "type": "assistant",
+            "message": {
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "name": "Read",
+                        "input": {"file_path": "/repo/app/core/foo.py"},
+                    },
+                    {
+                        "type": "tool_use",
+                        "name": "Read",
+                        "input": {"file_path": "/repo/app/core/foo.py"},
+                    },
+                ],
+                "usage": {"output_tokens": 50},
+            },
+        }
+    )
+    report = compute_waste_score(_write_log(tmp_path, [line]))
+    assert report.redundant_reads == 1
+    assert "redundant_reads" in report.breakdown
+
+
+def test_thinking_blocks_extracted_from_content_array(tmp_path: Path) -> None:
+    """WOR-349 regression: thinking text comes from content blocks of
+    type=='thinking' (with text under the `thinking` key), not from a
+    top-level `message.reasoning` field."""
+    line = json.dumps(
+        {
+            "type": "assistant",
+            "message": {
+                "content": [
+                    {"type": "thinking", "thinking": "x" * 8000},
+                    {"type": "text", "text": "Here is my answer."},
+                ],
+                "usage": {"output_tokens": 100},
+            },
+        }
+    )
+    report = compute_waste_score(_write_log(tmp_path, [line]))
+    # 8000 chars / 4 = 2000 thinking tokens; 2000 / 100 = ratio 20
+    assert report.thinking_to_text_ratio > 5
+    # Sanity: thinking signal contributes to score (capped at 10)
+    assert report.score >= 1


### PR DESCRIPTION
## Summary

\`compute_waste_score\` was producing \`score=0, breakdown={}\` for every real worker log. 0 of 31 metric rows had non-NULL \`waste_score\` — the column was decorative because **3 parsing bugs** in the detector silently nulled all signals.

## Root cause: 3 bugs

### Bug 1 (the master bug) — \`_extract_tool_use\` looked at the wrong field

```python
# Old: looked at message.tool_calls[]
tool_calls = msg.get(\"tool_calls\", [])
```

Claude Code's stream-json puts tool_use blocks in **\`message.content[]\` with \`type==\"tool_use\"\`**, not in a separate \`tool_calls\` list. Result: the detector saw zero tool_use entries in real logs → all signals stayed at 0.

Also: a single assistant turn often emits **multiple** tool_use blocks (e.g. parallel Bash + Read calls). The old function returned only the first match. Renamed \`_extract_tool_uses\` (plural) → returns the full list, caller iterates.

### Bug 2 — Read tool input key

```python
# Old:
file_path = inp.get(\"path\", \"\") or inp.get(\"file\", \"\")
```

Claude Code's Read tool uses **\`file_path\`**. Fix: prefer \`file_path\`, keep \`path\`/\`file\` as legacy fallback for synthetic test logs.

### Bug 3 — Thinking-token extraction

```python
# Old:
reasoning = msg.get(\"reasoning\", \"\") or msg.get(\"content\", \"\")
if isinstance(reasoning, str):  # always False — content is a list of dicts
    total_thinking_tokens += len(reasoning)
```

No \`message.reasoning\` field exists in stream-json. Thinking lives in **content blocks of \`type==\"thinking\"\`** with text under the \`thinking\` key. The fallback to \`message.content\` happened to be a list of dicts (not a string), so \`isinstance(reasoning, str)\` was False and the counter never incremented anyway.

Fix: iterate content blocks, extract \`thinking\` field from \`type==\"thinking\"\` blocks.

## Verification (the 3 reference logs)

Before:

\`\`\`
WOR-332 -> score=0  breakdown={}
WOR-277 -> score=0  breakdown={}
WOR-338 -> score=0  breakdown={}
\`\`\`

After:

\`\`\`
WOR-332 -> score=53  (11 redundant_reads, 15 manual_check_runs, 6 cd_commands)
WOR-277 -> score=57  (18 redundant_reads, 16 manual_check_runs, 1 redundant_bash)
WOR-338 -> score=80  (10 redundant_reads, 13 manual_check_runs, 10 redundant_bash, 19 cd_commands)
\`\`\`

The detector now produces useful signal. **WOR-338 had 19 \`cd\` commands** (worker fighting with directory navigation) and **all three workers ran 13-16 \`manual_check_runs\`** even though the post-tool-use hooks already run ruff/mypy automatically — concrete waste patterns surfaced.

\`thinking_to_text_ratio\` stays 0 because Qwen3 via the LiteLLM proxy doesn't emit thinking content blocks the same way Claude does. The signal will work correctly for Claude logs (test coverage proves it). Separate concern.

## Tests

**3 existing thinking-ratio tests updated** — they were synthesizing logs with the old \`message.reasoning\` shape, i.e. they were testing the bug. Updated to content-block format.

**2 new regression tests:**

- \`test_read_tool_uses_file_path_key_in_content_blocks\` — 2 reads of same \`file_path\` in \`message.content[]\` → \`redundant_reads >= 1\`
- \`test_thinking_blocks_extracted_from_content_array\` — assistant message with \`{type: thinking, thinking: \"x\"*8000}\` content block → \`thinking_to_text_ratio > 5\`

Total: **1071 tests pass** (1069 existing + 2 new). All checks green.

## Out of scope

- **WOR-351** — \`finalize_worker:252\` nulls valid \`waste_score=0\`. Split out as its own 1-line PR to keep this scope focused on detector correctness.
- Adding new signals (e.g. \`no_commit_before_exit\` for the WOR-332 failure mode).
- Threshold tuning — defer until we have non-zero data flowing through real dispatches.
- Backfilling \`waste_score\` for the 31 existing rows — could replay logs through the fixed detector but defer.

## Verification checklist

- [x] \`ruff check .\` — clean
- [x] \`mypy app/\` — 29 source files, no issues
- [x] \`pytest --no-cov -q\` — **1071 passed**, 0 failed
- [x] \`lint-imports\` — 5 contracts kept, 0 broken
- [x] All pre-commit hooks pass

## Coordination notes

- No file conflict with WOR-332 (currently re-dispatched and running in background) — touches \`worker_waste.py\` + its tests only.
- Daemon needs restart to pick up the fix (workers running pre-fix code still produce 0-score rows).

Closes WOR-349