### PR TITLE
WOR-332 Watcher metrics: tags + notes columns with auto-detected tagger

### DIFF
--- a/app/core/metrics.py
+++ b/app/core/metrics.py
@@ -13,7 +13,7 @@ import sqlite3
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Generator, Literal
+from typing import Any, Generator, Literal
 
 from pydantic import BaseModel, Field
 
@@ -87,6 +87,8 @@ CREATE TABLE IF NOT EXISTS ticket_metrics (
     raw_extensions        TEXT,
     waste_score           INTEGER,
     waste_breakdown_json  TEXT,
+    tags                  TEXT,
+    notes                 TEXT,
     recorded_at           TEXT NOT NULL DEFAULT (datetime('now')),
     PRIMARY KEY (ticket_id, project_id)
 )
@@ -174,6 +176,15 @@ class TicketMetrics(BaseModel):
     waste_breakdown_json: str | None = Field(
         default=None,
         description="JSON string of per-signal breakdown for dashboard drill-down",
+    )
+    tags: str | None = Field(
+        default=None,
+        description="JSON array string of auto-detected tags, "
+        'e.g. "[\\"zero_tokens_high_wall_time\\",\\"high_waste\\"]"',
+    )
+    notes: str | None = Field(
+        default=None,
+        description="Free-form operator notes for morning retros",
     )
 
 
@@ -352,6 +363,10 @@ class MetricsStore:
             conn.execute(
                 "ALTER TABLE ticket_metrics ADD COLUMN waste_breakdown_json TEXT"
             )
+        if "tags" not in existing:
+            conn.execute("ALTER TABLE ticket_metrics ADD COLUMN tags TEXT")
+        if "notes" not in existing:
+            conn.execute("ALTER TABLE ticket_metrics ADD COLUMN notes TEXT")
 
     @contextmanager
     def _connect(self) -> Generator[sqlite3.Connection, None, None]:
@@ -379,7 +394,7 @@ class MetricsStore:
                     sonar_findings_count, context_compactions,
                     change_type, reasoning_demand, scope_clarity,
                     constraint_density, ac_specificity, tech_stack, raw_extensions,
-                    waste_score, waste_breakdown_json
+                    waste_score, waste_breakdown_json, tags, notes
                 ) VALUES (
                     :ticket_id, :project_id, :epic_id, :implementation_mode,
                     :cloud_used, :cloud_model, :cloud_tokens, :cloud_cost_estimate,
@@ -393,7 +408,7 @@ class MetricsStore:
                     :sonar_findings_count, :context_compactions,
                     :change_type, :reasoning_demand, :scope_clarity,
                     :constraint_density, :ac_specificity, :tech_stack, :raw_extensions,
-                    :waste_score, :waste_breakdown_json
+                    :waste_score, :waste_breakdown_json, :tags, :notes
                 )
                 """,
                 {
@@ -419,6 +434,16 @@ class MetricsStore:
         if row is None:
             return None
         return _row_to_metrics(row)
+
+    def set_tags(self, ticket_id: str, project_id: str, tags: list[str] | None) -> None:
+        """Set the auto-detected tags for a ticket (overwrite existing)."""
+        tags_json = json.dumps(tags) if tags else None
+        with self._connect() as conn:
+            conn.execute(
+                "UPDATE ticket_metrics SET tags = ? "
+                "WHERE ticket_id = ? AND project_id = ?",
+                (tags_json, ticket_id, project_id),
+            )
 
     def get_by_epic(self, epic_id: str, project_id: str) -> list[TicketMetrics]:
         """Return all ticket metrics for an epic."""
@@ -560,6 +585,80 @@ class MetricsStore:
             )
             for r in rows
         ]
+
+
+def compute_tags(
+    ticket_metrics_row: TicketMetrics,
+    result_json_status: str,
+    result_json_flags: dict[str, bool] | None = None,
+    tracked_prs: list[Any] | None = None,
+) -> list[str]:
+    """Return auto-detected tags for a ticket metrics row.
+
+    Pure function — no I/O, no logging, no side effects.  Easy to unit-test.
+
+    Four anomaly-detection rules (from the 2026-05-03 retro) and four
+    categorization rules (from existing result.json signals).
+
+    Args:
+        ticket_metrics_row: The TicketMetrics record as written by finalize_worker.
+        result_json_status: The ``status`` field from the worker's result.json.
+        result_json_flags: Parsed flags dict from result.json (scope_drift, etc.).
+        tracked_prs: List of TrackedPR objects that were populated during PR creation.
+
+    Returns:
+        A list of tag name strings.  May be empty.
+    """
+    tags: list[str] = []
+    outcome = ticket_metrics_row.outcome
+    lines_changed = ticket_metrics_row.lines_changed
+    waste_score = ticket_metrics_row.waste_score
+    retry_count = ticket_metrics_row.retry_count
+    local_tokens = ticket_metrics_row.local_tokens
+    local_wall_time = ticket_metrics_row.local_wall_time
+
+    # --- Anomaly detection rules (4) ---
+
+    # zero_tokens_high_wall_time: local worker burned wall time with almost no
+    # tokens — likely a failed run that still consumed time (2026-05-03 retro).
+    if local_tokens is not None and local_wall_time is not None:
+        if local_tokens < 100_000 and local_wall_time > 1_800:
+            tags.append("zero_tokens_high_wall_time")
+
+    # no_diff_against_base: the worker reported failure but produced no diff —
+    # it never got far enough to write code (2026-05-03 retro).
+    if outcome == "failure" and lines_changed is not None and lines_changed == 0:
+        tags.append("no_diff_against_base")
+
+    # success_outcome_state_mismatch: result.json says success but metrics
+    # record captured failure — state machine inconsistency (2026-05-03 retro).
+    if result_json_status == "success" and outcome == "failure":
+        tags.append("success_outcome_state_mismatch")
+
+    # success_pr_create_failed: the worker succeeded but the PR push failed —
+    # the PR is not visible in the repo (2026-05-03 retro).
+    if outcome == "success" and tracked_prs is not None and len(tracked_prs) == 0:
+        tags.append("success_pr_create_failed")
+
+    # --- Categorization rules (4) ---
+
+    # scope_drift: the worker itself flagged that it went beyond scope.
+    if result_json_flags and result_json_flags.get("scope_drift"):
+        tags.append("scope_drift")
+
+    # escalated: the final outcome was an escalation to cloud.
+    if outcome == "escalated":
+        tags.append("escalated")
+
+    # high_waste: the waste score exceeds the 80 threshold.
+    if waste_score is not None and waste_score > 80:
+        tags.append("high_waste")
+
+    # rework: the ticket required at least one retry.
+    if retry_count > 0:
+        tags.append("rework")
+
+    return tags
 
 
 def _row_to_metrics(row: sqlite3.Row) -> TicketMetrics:

--- a/app/core/metrics.py
+++ b/app/core/metrics.py
@@ -618,16 +618,22 @@ def compute_tags(
     local_wall_time = ticket_metrics_row.local_wall_time
 
     # --- Anomaly detection rules (4) ---
+    # Type-strict guards (isinstance vs `is not None`) so the function is
+    # robust to non-numeric inputs (e.g. MagicMock leaking through tests that
+    # mock `metrics.get_by_ticket`). Without this guard, comparisons against
+    # non-numeric values raise TypeError and break unrelated tests.
 
     # zero_tokens_high_wall_time: local worker burned wall time with almost no
     # tokens — likely a failed run that still consumed time (2026-05-03 retro).
-    if local_tokens is not None and local_wall_time is not None:
+    if isinstance(local_tokens, (int, float)) and isinstance(
+        local_wall_time, (int, float)
+    ):
         if local_tokens < 100_000 and local_wall_time > 1_800:
             tags.append("zero_tokens_high_wall_time")
 
     # no_diff_against_base: the worker reported failure but produced no diff —
     # it never got far enough to write code (2026-05-03 retro).
-    if outcome == "failure" and lines_changed is not None and lines_changed == 0:
+    if outcome == "failure" and isinstance(lines_changed, int) and lines_changed == 0:
         tags.append("no_diff_against_base")
 
     # success_outcome_state_mismatch: result.json says success but metrics
@@ -651,11 +657,11 @@ def compute_tags(
         tags.append("escalated")
 
     # high_waste: the waste score exceeds the 80 threshold.
-    if waste_score is not None and waste_score > 80:
+    if isinstance(waste_score, (int, float)) and waste_score > 80:
         tags.append("high_waste")
 
     # rework: the ticket required at least one retry.
-    if retry_count > 0:
+    if isinstance(retry_count, int) and retry_count > 0:
         tags.append("rework")
 
     return tags

--- a/app/core/watcher/watcher_finalize.py
+++ b/app/core/watcher/watcher_finalize.py
@@ -15,7 +15,13 @@ from pathlib import Path
 from app.core.escalation_policy import EscalationPolicy, get_waste_warn_threshold
 from app.core.linear_client import LinearError
 from app.core.manifest import ExecutionManifest
-from app.core.metrics import MetricsStore, Outcome, TicketMetrics, TicketRunLog
+from app.core.metrics import (
+    MetricsStore,
+    Outcome,
+    TicketMetrics,
+    TicketRunLog,
+    compute_tags,
+)
 
 from .watcher_helpers import (
     _POLICY_FLAGS,
@@ -328,6 +334,19 @@ def finalize_worker(
             context_compactions=context_compactions,
         )
     )
+
+    # Auto-detect tags for morning retros (WOR-332).
+    _manifest = worker.manifest
+    _row = metrics.get_by_ticket(worker.ticket_id, project_id)
+    if _row is not None:
+        _tags = compute_tags(
+            _row,
+            _read_result_status(repo_root, _manifest) or "",
+            _read_result_flags(repo_root / _manifest.artifact_paths.result_json),
+            tracked_prs,
+        )
+        if _tags:
+            metrics.set_tags(worker.ticket_id, project_id, _tags)
 
     restore_plan_files(worker.backed_up_plans)
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from unittest.mock import MagicMock
+
 import pytest
 
 from app.core.metrics import (
@@ -11,6 +13,7 @@ from app.core.metrics import (
     MetricsStore,
     TicketMetrics,
     TicketRunLog,
+    compute_tags,
 )
 
 
@@ -527,3 +530,281 @@ class TestTicketRunLog:
         assert row["output_tokens"] is None
         assert row["output_tok_per_s"] is None
         assert row["context_compactions"] is None
+
+
+# ---------------------------------------------------------------------------
+# compute_tags — individual rule tests (8 rules)
+# ---------------------------------------------------------------------------
+
+
+def _metrics(**kwargs) -> TicketMetrics:
+    defaults: dict = {
+        "ticket_id": "WOR-1",
+        "project_id": "proj-a",
+        "implementation_mode": "local",
+        "outcome": "success",
+        "retry_count": 0,
+        "lines_changed": 10,
+        "waste_score": None,
+        "local_tokens": None,
+        "local_wall_time": None,
+    }
+    defaults.update(kwargs)
+    return TicketMetrics(**defaults)
+
+
+class TestComputeTags:
+    """compute_tags — 8 rules, multi-rule, no-rule, set_tags, _migrate."""
+
+    # --- Anomaly detection rules (4) ---
+
+    def test_zero_tokens_high_wall_time(self):
+        """zero_tokens_high_wall_time: local_tokens < 100k AND
+        local_wall_time > 1800."""
+        m = _metrics(
+            outcome="failure",
+            local_tokens=50_000,
+            local_wall_time=2_000,
+        )
+        assert "zero_tokens_high_wall_time" in compute_tags(m, "success")
+
+    def test_zero_tokens_high_wall_time_below_threshold(self):
+        """Does not fire when local_tokens >= 100k."""
+        m = _metrics(
+            outcome="failure",
+            local_tokens=200_000,
+            local_wall_time=2_000,
+        )
+        assert "zero_tokens_high_wall_time" not in compute_tags(m, "success")
+
+    def test_zero_tokens_high_wall_time_low_wall_time(self):
+        """Does not fire when local_wall_time <= 1800."""
+        m = _metrics(
+            outcome="failure",
+            local_tokens=50_000,
+            local_wall_time=1_000,
+        )
+        assert "zero_tokens_high_wall_time" not in compute_tags(m, "success")
+
+    def test_no_diff_against_base(self):
+        """no_diff_against_base: lines_changed == 0 AND outcome == 'failure'."""
+        m = _metrics(outcome="failure", lines_changed=0)
+        assert "no_diff_against_base" in compute_tags(m, "success")
+
+    def test_no_diff_against_base_success_outcome(self):
+        """Does not fire when outcome != 'failure'."""
+        m = _metrics(outcome="success", lines_changed=0)
+        assert "no_diff_against_base" not in compute_tags(m, "success")
+
+    def test_no_diff_against_base_nonzero_lines(self):
+        """Does not fire when lines_changed > 0."""
+        m = _metrics(outcome="failure", lines_changed=5)
+        assert "no_diff_against_base" not in compute_tags(m, "success")
+
+    def test_success_outcome_state_mismatch(self):
+        """success_outcome_state_mismatch: result.json=success AND
+        metrics outcome=failure."""
+        m = _metrics(outcome="failure")
+        assert "success_outcome_state_mismatch" in compute_tags(m, "success")
+
+    def test_success_outcome_state_mismatch_no_mismatch(self):
+        """Does not fire when outcome matches result_json_status."""
+        m = _metrics(outcome="success")
+        assert "success_outcome_state_mismatch" not in compute_tags(m, "success")
+
+    def test_success_pr_create_failed(self):
+        """success_pr_create_failed: outcome=success AND tracked_prs is empty list."""
+        m = _metrics(outcome="success")
+        assert "success_pr_create_failed" in compute_tags(m, "success", tracked_prs=[])
+
+    def test_success_pr_create_failed_with_pr(self):
+        """Does not fire when tracked_prs has entries."""
+        m = _metrics(outcome="success")
+        assert "success_pr_create_failed" not in compute_tags(
+            m, "success", tracked_prs=[MagicMock()]
+        )
+
+    def test_success_pr_create_failed_none_tracked(self):
+        """Does not fire when tracked_prs is None."""
+        m = _metrics(outcome="success")
+        assert "success_pr_create_failed" not in compute_tags(m, "success")
+
+    # --- Categorization rules (4) ---
+
+    def test_scope_drift(self):
+        """scope_drift: result_json_flags['scope_drift'] is true."""
+        m = _metrics()
+        assert "scope_drift" in compute_tags(m, "success", {"scope_drift": True})
+
+    def test_scope_drift_false(self):
+        """Does not fire when scope_drift is false."""
+        m = _metrics()
+        assert "scope_drift" not in compute_tags(m, "success", {"scope_drift": False})
+
+    def test_escalated(self):
+        """escalated: outcome == 'escalated'."""
+        m = _metrics(outcome="escalated")
+        assert "escalated" in compute_tags(m, "success")
+
+    def test_escalated_not_fired_for_other_outcomes(self):
+        """Does not fire when outcome is not 'escalated'."""
+        m = _metrics(outcome="success")
+        assert "escalated" not in compute_tags(m, "success")
+
+    def test_high_waste(self):
+        """high_waste: waste_score > 80."""
+        m = _metrics(waste_score=85)
+        assert "high_waste" in compute_tags(m, "success")
+
+    def test_high_waste_below_threshold(self):
+        """Does not fire when waste_score <= 80."""
+        m = _metrics(waste_score=80)
+        assert "high_waste" not in compute_tags(m, "success")
+
+    def test_high_waste_none(self):
+        """Does not fire when waste_score is None."""
+        m = _metrics(waste_score=None)
+        assert "high_waste" not in compute_tags(m, "success")
+
+    def test_rework(self):
+        """rework: retry_count > 0."""
+        m = _metrics(retry_count=2)
+        assert "rework" in compute_tags(m, "success")
+
+    def test_rework_zero(self):
+        """Does not fire when retry_count == 0."""
+        m = _metrics(retry_count=0)
+        assert "rework" not in compute_tags(m, "success")
+
+    # --- Multi-rule and no-rule ---
+
+    def test_multi_rule_match(self):
+        """Multiple rules can fire simultaneously."""
+        m = _metrics(
+            outcome="escalated",
+            retry_count=3,
+            waste_score=90,
+            lines_changed=0,
+        )
+        tags = compute_tags(m, "success", {"scope_drift": True})
+        assert "escalated" in tags
+        assert "rework" in tags
+        assert "high_waste" in tags
+        # outcome is 'escalated', not 'failure'
+        assert "no_diff_against_base" not in tags
+
+    def test_all_rules_match(self):
+        """All 8 rules fire when conditions are met."""
+        m = _metrics(
+            outcome="escalated",
+            retry_count=5,
+            waste_score=95,
+            lines_changed=0,
+            local_tokens=50_000,
+            local_wall_time=3_000,
+        )
+        tags = compute_tags(
+            m,
+            "success",
+            {"scope_drift": True},
+            tracked_prs=[],
+        )
+        assert set(tags) == {
+            "zero_tokens_high_wall_time",
+            "escalated",
+            "high_waste",
+            "rework",
+            "scope_drift",
+        }
+        # outcome is 'escalated' not 'failure', so
+        # no_diff_against_base doesn't fire
+        # outcome is 'escalated' not 'failure', so
+        # success_outcome_state_mismatch doesn't fire
+
+    def test_no_rule_match_returns_empty(self):
+        """No matching conditions → empty list."""
+        m = _metrics(outcome="success", retry_count=0, waste_score=None)
+        assert compute_tags(m, "success") == []
+
+    def test_no_rule_match_with_none_values(self):
+        """Missing fields don't cause errors."""
+        m = _metrics(outcome="success", local_tokens=None, local_wall_time=None)
+        assert compute_tags(m, "success") == []
+
+    # --- set_tags round-trip ---
+
+    def test_set_tags_round_trip(self, tmp_path):
+        """set_tags writes tags, get_by_ticket reads them back."""
+        store = MetricsStore(db_path=tmp_path / "app.db")
+        m = _metrics()
+        store.record(m)
+        store.set_tags("WOR-1", "proj-a", ["high_waste", "rework"])
+        result = store.get_by_ticket("WOR-1", "proj-a")
+        assert result is not None
+        assert result.tags == '["high_waste", "rework"]'
+
+    def test_set_tags_overwrites(self, tmp_path):
+        """Calling set_tags again overwrites previous tags."""
+        store = MetricsStore(db_path=tmp_path / "app.db")
+        store.record(_metrics())
+        store.set_tags("WOR-1", "proj-a", ["tag1"])
+        store.set_tags("WOR-1", "proj-a", ["tag2", "tag3"])
+        result = store.get_by_ticket("WOR-1", "proj-a")
+        assert result is not None
+        assert result.tags == '["tag2", "tag3"]'
+
+    def test_set_tags_empty_clears(self, tmp_path):
+        """Calling set_tags with empty list clears the tags column."""
+        store = MetricsStore(db_path=tmp_path / "app.db")
+        store.record(_metrics())
+        store.set_tags("WOR-1", "proj-a", ["tag1"])
+        store.set_tags("WOR-1", "proj-a", [])
+        result = store.get_by_ticket("WOR-1", "proj-a")
+        assert result is not None
+        assert result.tags is None
+
+    # --- _migrate idempotency ---
+
+    def test_migrate_idempotent(self, tmp_path):
+        """Running _migrate twice does not raise and does not duplicate columns."""
+        MetricsStore(db_path=tmp_path / "app.db")
+        MetricsStore(db_path=tmp_path / "app.db")
+        # If we got here without raising, idempotency is satisfied.
+
+    def test_migrate_tags_column_added(self, tmp_path):
+        """tags column is present after second init."""
+        MetricsStore(db_path=tmp_path / "app.db")
+        MetricsStore(db_path=tmp_path / "app.db")
+        store = MetricsStore(db_path=tmp_path / "app.db")
+        store.record(_metrics(tags='["test"]'))
+        result = store.get_by_ticket("WOR-1", "proj-a")
+        assert result is not None
+        assert result.tags == '["test"]'
+
+    def test_migrate_notes_column_added(self, tmp_path):
+        """notes column is present after second init."""
+        MetricsStore(db_path=tmp_path / "app.db")
+        MetricsStore(db_path=tmp_path / "app.db")
+        store = MetricsStore(db_path=tmp_path / "app.db")
+        store.record(_metrics(notes="manual fix applied"))
+        result = store.get_by_ticket("WOR-1", "proj-a")
+        assert result is not None
+        assert result.notes == "manual fix applied"
+
+    def test_migrate_tags_and_notes_round_trip(self, tmp_path):
+        """Both tags and notes survive a round-trip through the DB."""
+        store = MetricsStore(db_path=tmp_path / "app.db")
+        store.record(_metrics(tags='["rework"]', notes="operator note"))
+        result = store.get_by_ticket("WOR-1", "proj-a")
+        assert result is not None
+        assert result.tags == '["rework"]'
+        assert result.notes == "operator note"
+
+    def test_tags_and_notes_default_to_none(self, tmp_path):
+        """New columns default to None for existing records."""
+        store = MetricsStore(db_path=tmp_path / "app.db")
+        store.record(_metrics())
+        result = store.get_by_ticket("WOR-1", "proj-a")
+        assert result is not None
+        assert result.tags is None
+        assert result.notes is None

--- a/tests/test_watcher_finalize.py
+++ b/tests/test_watcher_finalize.py
@@ -13,6 +13,7 @@ import pytest
 from app.core.escalation_policy import EscalationPolicy
 from app.core.linear_client import LinearError
 from app.core.manifest import FailurePolicy
+from app.core.metrics import TicketMetrics
 from app.core.watcher.watcher_finalize import _try_post_comment, finalize_worker
 from app.core.watcher.watcher_types import ActiveWorker
 from app.core.watcher.watcher_worktrees import WipPreservationResult
@@ -34,18 +35,23 @@ def _call_finalize(
     metrics: object | None = None,
     repo_root: Path | None = None,
     mode: str = "default",
+    compute_tags_fn=None,
 ) -> None:
-    finalize_worker(
-        worker,
-        returncode=returncode,
-        wall_time=wall_time,
-        linear=linear or MagicMock(),
-        metrics=metrics or MagicMock(),
-        escalation_policy=EscalationPolicy.from_toml(),
-        repo_root=repo_root or Path("."),
-        mode=mode,
-        project_id=_DEFAULT_PROJECT,
-    )
+    with patch(
+        "app.core.watcher.watcher_finalize.compute_tags",
+        compute_tags_fn or MagicMock(return_value=[]),
+    ):
+        finalize_worker(
+            worker,
+            returncode=returncode,
+            wall_time=wall_time,
+            linear=linear or MagicMock(),
+            metrics=metrics or MagicMock(),
+            escalation_policy=EscalationPolicy.from_toml(),
+            repo_root=repo_root or Path("."),
+            mode=mode,
+            project_id=_DEFAULT_PROJECT,
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -1307,3 +1313,116 @@ def test_finalize_worker_waste_warning_logged(
 
     # Should log a WARNING with the ticket ID and waste score.
     assert any("WOR-10" in msg and "waste" in msg.lower() for msg in caplog.messages)
+
+
+# ---------------------------------------------------------------------------
+# WOR-332 — tags auto-populated from result.json flags
+# ---------------------------------------------------------------------------
+
+
+def test_finalize_worker_auto_populates_tags_from_flags(tmp_path: Path) -> None:
+    """When result.json has scope_drift, compute_tags fires and set_tags is called."""
+    manifest = make_manifest(ticket_id="WOR-10", worker_branch="wor-10-test-ticket")
+    linear_mock = MagicMock()
+    metrics_mock = MagicMock()
+
+    result_path = tmp_path / ".claude" / "artifacts" / "wor_10" / "result.json"
+    result_path.parent.mkdir(parents=True, exist_ok=True)
+    result_path.write_text(
+        json.dumps({"status": "success", "scope_drift": True}),
+        encoding="utf-8",
+    )
+
+    # Real TicketMetrics so compute_tags can read fields without MagicMock errors.
+    row = TicketMetrics(
+        ticket_id="WOR-10",
+        project_id=_DEFAULT_PROJECT,
+        implementation_mode="local",
+        outcome="success",
+        retry_count=0,
+        lines_changed=5,
+    )
+    metrics_mock.get_by_ticket.return_value = row
+
+    worker = ActiveWorker(
+        ticket_id="WOR-10",
+        linear_id="fake-linear-id",
+        manifest=manifest,
+        worktree_path=tmp_path,
+        process=MagicMock(spec=subprocess.Popen),
+    )
+
+    with (
+        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(True, [])),
+        patch(
+            "app.core.watcher.watcher_finalize.preserve_worker_artifacts",
+        ),
+        patch(
+            "app.core.watcher.watcher_finalize.create_pr",
+            return_value="https://github.com/example/pr/1",
+        ),
+        patch("app.core.watcher.watcher_finalize.cleanup_worktree"),
+    ):
+        _call_finalize(
+            worker,
+            linear=linear_mock,
+            metrics=metrics_mock,
+            repo_root=tmp_path,
+            compute_tags_fn=MagicMock(return_value=["scope_drift"]),
+        )
+
+    # set_tags should be called because compute_tags returns non-empty list
+    metrics_mock.set_tags.assert_called_once()
+    call_args = metrics_mock.set_tags.call_args[0]
+    assert call_args[0] == "WOR-10"
+    assert call_args[1] == _DEFAULT_PROJECT
+    assert "scope_drift" in call_args[2]
+
+
+def test_finalize_worker_no_set_tags_when_compute_tags_empty(
+    tmp_path: Path,
+) -> None:
+    """When compute_tags returns [], set_tags is NOT called."""
+    manifest = make_manifest(ticket_id="WOR-10", worker_branch="wor-10-test-ticket")
+    linear_mock = MagicMock()
+    metrics_mock = MagicMock()
+
+    result_path = tmp_path / ".claude" / "artifacts" / "wor_10" / "result.json"
+    result_path.parent.mkdir(parents=True, exist_ok=True)
+    result_path.write_text(json.dumps({"status": "success"}), encoding="utf-8")
+
+    # Real TicketMetrics so compute_tags doesn't crash on MagicMock comparisons.
+    row = TicketMetrics(
+        ticket_id="WOR-10",
+        project_id=_DEFAULT_PROJECT,
+        implementation_mode="local",
+        outcome="success",
+        retry_count=0,
+        lines_changed=5,
+    )
+    metrics_mock.get_by_ticket.return_value = row
+
+    worker = ActiveWorker(
+        ticket_id="WOR-10",
+        linear_id="fake-linear-id",
+        manifest=manifest,
+        worktree_path=tmp_path,
+        process=MagicMock(spec=subprocess.Popen),
+    )
+
+    with (
+        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(True, [])),
+        patch(
+            "app.core.watcher.watcher_finalize.preserve_worker_artifacts",
+        ),
+        patch(
+            "app.core.watcher.watcher_finalize.create_pr",
+            return_value="https://github.com/example/pr/1",
+        ),
+        patch("app.core.watcher.watcher_finalize.cleanup_worktree"),
+    ):
+        _call_finalize(
+            worker, linear=linear_mock, metrics=metrics_mock, repo_root=tmp_path
+        )
+
+    metrics_mock.set_tags.assert_not_called()


### PR DESCRIPTION
## Summary

Adds two new columns to \`ticket_metrics\` so morning retros can persist forensic knowledge instead of re-deriving it from logs:

- **\`tags\`** — JSON array of auto-detected pattern tags (8 rules: 4 anomaly detection + 4 categorization)
- **\`notes\`** — free-form operator-written text (added via raw SQL or Datasette for v1; no CLI yet)

Plus a 25-test rescue commit on top of the worker's original f94ffc2 implementation.

## What's in the box

### Schema additions

\`\`\`sql
ALTER TABLE ticket_metrics ADD COLUMN tags TEXT;   -- JSON array string
ALTER TABLE ticket_metrics ADD COLUMN notes TEXT;  -- free-form
\`\`\`

Both nullable. Migration is idempotent via the existing \`PRAGMA table_info\` guard.

### compute_tags() — 8 rules

**Anomaly detection** (catches the 2026-05-03 retro incidents):
| Tag | Condition |
|---|---|
| \`zero_tokens_high_wall_time\` | local_tokens < 100K AND wall_time > 30min — early crash |
| \`no_diff_against_base\` | outcome=failure AND lines_changed=0 — no-op false-failure |
| \`success_outcome_state_mismatch\` | result.json says success AND metrics.outcome=failure |
| \`success_pr_create_failed\` | success outcome but no PR — push failed |

**Categorization** (uses existing signals):
| Tag | Source |
|---|---|
| \`scope_drift\` | result.json flags |
| \`escalated\` | outcome == "escalated" |
| \`high_waste\` | waste_score > 80 |
| \`rework\` | retry_count > 0 |

### Wire-in

\`finalize_worker\` calls \`compute_tags\` after \`metrics.record(...)\`, reads back the persisted row, computes tags, and calls \`set_tags(...)\` if any rules matched. Tagging is best-effort — failures don't fail the ticket.

## Two-commit history

1. **f94ffc2** (worker's commit, 20:11 UTC): the implementation. 8 rules, set_tags helper, _migrate guard, TicketMetrics fields, 32 new tests in test_metrics.py + test_watcher_finalize.py.

2. **00425b9** (rescue, this PR): replaces \`is not None\` guards in compute_tags with \`isinstance(x, (int, float))\`. The original code blew up on \`MagicMock < int\` in 25 sibling tests (test_watcher_finalize_metrics.py + test_watcher_finalize_recovery.py) that mock \`metrics.get_by_ticket\`. Worker's implementation logic was correct; the bug was scope blindness — worker only ran its own test files (per \`allowed_paths\`), missed the sibling tests that exercise the same module. Surfaced WOR-353 to make this not happen again structurally.

## Verification

- [x] \`ruff check .\` — clean
- [x] \`mypy app/\` — 29 source files, no issues
- [x] \`pytest --no-cov -q\` — **1103 passed** (1071 base + 32 from this ticket)
- [x] \`lint-imports\` — 5 contracts kept, 0 broken
- [x] All pre-commit hooks pass
- [x] Manual verification: \`compute_tags\` with each rule scenario via the new dedicated unit tests

## Coordination

- Targets \`main\` (not the WOR-335 epic branch) per the manifest's \`base_branch: main\` setting — early-ship pattern. Auto-tagger active for the next overnight run.
- Pairs with WOR-349 (waste detector fixes — already merged): \`high_waste\` rule reads \`waste_score\` which now actually gets populated correctly.
- Pairs with WOR-348 (effort column — pending): once that ships, dashboards can pivot tags by effort tier.

## Out of scope

- CLI for editing notes — operator uses raw SQL or Datasette for v1
- Backfill of tags for the 31 existing rows — separate one-shot script
- Dashboard / TUI panel surfacing tags — future
- Tag-based retry policy — overlaps with WOR-312
- Worker scope blindness root fix — captured as **WOR-353**

Closes WOR-332