### PR TITLE
WOR-354 Three-dot diff for lines_changed: invariant under base drift

### DIFF
--- a/app/core/watcher/watcher_finalize.py
+++ b/app/core/watcher/watcher_finalize.py
@@ -204,6 +204,9 @@ def finalize_worker(
     eff = resolve_effective_mode(mode, worker.manifest.implementation_mode)
 
     # Parse git diff --shortstat to populate lines_changed / files_changed.
+    # Three-dot diff against the merge-base — invariant under base_branch
+    # advancing during the worker's lifetime (WOR-354). Two-dot would attribute
+    # sibling-merge upstream commits to this worker.
     # Must run before preserve_worker_artifacts tears down the worktree.
     try:
         diff_output = subprocess.run(  # nosec B603 B607
@@ -213,7 +216,7 @@ def finalize_worker(
                 str(worker.worktree_path),
                 "diff",
                 "--shortstat",
-                worker.manifest.base_branch,
+                f"{worker.manifest.base_branch}...HEAD",
             ],
             capture_output=True,
             text=True,

--- a/tests/test_watcher_finalize_metrics.py
+++ b/tests/test_watcher_finalize_metrics.py
@@ -561,3 +561,123 @@ def test_estimate_cloud_cost_none_tokens_returns_zero() -> None:
 
     assert _estimate_cloud_cost(None, 1000, "claude-opus-4-7") == 0.0
     assert _estimate_cloud_cost(1000, None, "claude-opus-4-7") == 0.0
+
+
+# ---------------------------------------------------------------------------
+# WOR-354 — three-dot diff against merge-base, invariant under base drift
+# ---------------------------------------------------------------------------
+
+
+def _git(repo: Path, *args: str) -> str:
+    """Run a git command in repo and return stdout (utf-8, stripped)."""
+    return subprocess.run(  # nosec B603 B607
+        ["git", "-C", str(repo), *args],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+
+
+def _setup_repo_with_drift(
+    tmp_path: Path,
+    *,
+    worker_loc: int,
+    drift_loc: int,
+) -> Path:
+    """Build a real git repo simulating a worker branch off an epic branch
+    that subsequently drifted by ``drift_loc`` insertions on the base.
+
+    Layout:
+      main (initial)
+        └── epic (base_branch)
+              ├── worker_HEAD (adds worker_loc lines in worker.py)
+              └── (epic advances by drift_loc lines in sibling.py)
+
+    The returned worktree directory is checked out at worker_HEAD.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q", "-b", "main")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Test")
+    (repo / "README.md").write_text("init\n")
+    _git(repo, "add", "README.md")
+    _git(repo, "commit", "-q", "-m", "init")
+
+    _git(repo, "checkout", "-q", "-b", "epic")
+    (repo / "epic_seed.py").write_text("# epic seed\n")
+    _git(repo, "add", "epic_seed.py")
+    _git(repo, "commit", "-q", "-m", "epic base")
+
+    _git(repo, "checkout", "-q", "-b", "worker")
+    if worker_loc > 0:
+        worker_body = "\n".join("x" for _ in range(worker_loc)) + "\n"
+        (repo / "worker.py").write_text(worker_body)
+        _git(repo, "add", "worker.py")
+        _git(repo, "commit", "-q", "-m", "worker change")
+
+    _git(repo, "checkout", "-q", "epic")
+    sibling_body = "\n".join("y" for _ in range(drift_loc)) + "\n"
+    (repo / "sibling.py").write_text(sibling_body)
+    _git(repo, "add", "sibling.py")
+    _git(repo, "commit", "-q", "-m", "sibling merged into epic during worker run")
+
+    _git(repo, "checkout", "-q", "worker")
+    return repo
+
+
+def _finalize_with_real_diff(repo: Path, ticket_id: str = "WOR-354") -> object:
+    """Run finalize_worker against a real git repo with all other steps mocked."""
+    manifest = make_manifest(
+        ticket_id=ticket_id,
+        worker_branch="worker",
+        base_branch="epic",
+    )
+    metrics_mock = MagicMock()
+    worker = ActiveWorker(
+        ticket_id=ticket_id,
+        linear_id="fake-linear-id",
+        manifest=manifest,
+        worktree_path=repo,
+        process=MagicMock(spec=subprocess.Popen),
+    )
+    with (
+        patch(
+            "app.core.watcher.watcher_finalize.run_checks",
+            return_value=(True, []),
+        ),
+        patch(
+            "app.core.watcher.watcher_finalize.create_pr",
+            return_value="https://github.com/example/pr/1",
+        ),
+        patch("app.core.watcher.watcher_finalize.cleanup_worktree"),
+        patch(
+            "app.core.watcher.watcher_finalize.fetch_sonar_findings",
+            return_value=[],
+        ),
+    ):
+        _call_finalize(worker, metrics=metrics_mock)
+    return metrics_mock.record.call_args[0][0]
+
+
+def test_lines_changed_excludes_base_drift(tmp_path: Path) -> None:
+    """Three-dot diff: worker contributes 5 LOC; base advances 100 LOC during
+    the run; lines_changed must reflect only the worker's 5 LOC."""
+    repo = _setup_repo_with_drift(tmp_path, worker_loc=5, drift_loc=100)
+
+    m = _finalize_with_real_diff(repo)
+
+    # Three-dot semantics: only the worker's commits relative to the merge-base.
+    assert m.lines_changed == 5
+    assert m.files_changed == 1
+
+
+def test_lines_changed_zero_when_worker_no_op_under_drift(tmp_path: Path) -> None:
+    """Worker makes zero commits but base advances 100 LOC: lines_changed=0
+    (regression for the WOR-318/319/320/321 byte-identical-footprint pattern)."""
+    repo = _setup_repo_with_drift(tmp_path, worker_loc=0, drift_loc=100)
+
+    m = _finalize_with_real_diff(repo)
+
+    assert m.lines_changed == 0
+    assert m.files_changed == 0


### PR DESCRIPTION
## Summary

Switch `git diff --shortstat` from two-dot to three-dot in `watcher_finalize.py` so `lines_changed`/`files_changed` are invariant under base-branch advancement during a worker's lifetime.

## Why

During WOR-332 forensic backfill (2026-05-03), four sibling failures from the WOR-313 overnight epic showed byte-identical diff stats:

| Ticket | lines_changed | files_changed |
|--------|---------------|---------------|
| WOR-318 | 340 | 9 |
| WOR-319 | 340 | 9 |
| WOR-320 | 340 | 9 |
| WOR-321 | 340 | 9 |

Different workers, different scopes, identical footprint. The "diff" was measuring base drift (sibling merges that happened during their concurrent runs), not worker contribution.

Three-dot `<base>...HEAD` compares HEAD to the merge-base — fixed at worktree creation, invariant under base advancement.

## Test plan

- [x] `pytest tests/test_watcher_finalize_metrics.py` — 19 pass (17 existing + 2 new)
- [x] `pytest` — full suite 1113 pass
- [x] `ruff check .` clean
- [x] `mypy app/` clean
- [x] New `test_lines_changed_excludes_base_drift` — worker contributes 5 LOC, base advances 100 LOC, asserts `lines_changed=5` (not 105)
- [x] New `test_lines_changed_zero_when_worker_no_op_under_drift` — regression for the WOR-318/319/320/321 footprint pattern

## Out of scope

- Backfilling existing rows — historical data is unrecoverable
- Aggregate metrics (cost-per-LOC etc.) don't exist yet so nothing to recompute

🤖 Generated with [Claude Code](https://claude.com/claude-code)