### PR TITLE
WOR-353 Worker scope: auto-glob test allowed_paths + mandate unscoped pytest

### DIFF
--- a/.claude/commands/implement-ticket.md
+++ b/.claude/commands/implement-ticket.md
@@ -150,13 +150,43 @@ the PR is created, giving fine-grained retry resume.
 
 ### 4. Run required checks
 
-After implementation, run each command in `required_checks` in order:
+After implementation, run each command in `required_checks` in order. Run them
+**verbatim** as written in the manifest — do NOT scope them down to specific
+files for "speed", because the watcher will run them at the manifest's full
+scope and any regression you missed will fail the ticket (WOR-353).
 
 ```bash
 <check command 1>
 <check command 2>
 ...
 ```
+
+**Pytest scope rule (WOR-353):** When `required_checks` contains `pytest`
+without arguments, run the **full** test suite — not just the test files
+listed in `allowed_paths`. Sibling test files (e.g. `tests/test_X_metrics.py`,
+`tests/test_X_recovery.py`) often import the same module you modified and
+fail when their fixtures don't anticipate your changes.
+
+If you want a fast iteration loop while implementing, you may run
+`pytest <subset>` early — but **always run the unscoped `pytest` from
+`required_checks` once before declaring success**. If it fails, you still
+have the session context to fix it; if you skip it, the watcher catches
+the failure after your session ends and the ticket is marked Blocked.
+
+To proactively widen iteration scope without running the full suite, grep
+for tests importing each modified source module:
+
+```bash
+# Find test files that import any module you modified
+git diff --name-only $BASE_BRANCH...HEAD -- 'app/**/*.py' | while read f; do
+  module="${f%.py}"
+  module_path=$(echo "$module" | sed 's|/|.|g')
+  grep -l "from $module_path" tests/*.py 2>/dev/null
+done | sort -u
+```
+
+Pass that list (plus your scoped tests) to pytest during iteration. The
+final unscoped `pytest` from `required_checks` is still mandatory.
 
 If any required check fails:
 - Record the failure in the result artifact (step 5)

--- a/.claude/commands/start-ticket.md
+++ b/.claude/commands/start-ticket.md
@@ -238,6 +238,33 @@ If `related_files_hint` is empty, leave `context_snippets` as null (omit it from
 Write the populated `context_snippets` object into the manifest at `context_snippets` key
 (see step 4.6 for the full manifest structure).
 
+### 2.6. Expand test allowed_paths to capture sibling test files (WOR-353)
+
+Before writing the manifest, glob-expand every `tests/test_<stem>.py` entry in
+`allowed_paths` to `tests/test_<stem>*.py` so the worker has explicit permission
+to run sibling test files that import the same source module.
+
+**Why:** Sibling test files (e.g. `tests/test_watcher_finalize_metrics.py`,
+`tests/test_watcher_finalize_recovery.py`) import the same module the worker
+modifies, but pytest fails on them aren't visible until the watcher runs the
+full suite as part of `required_checks`. Without this expansion, the worker
+self-reports success while the watcher rejects — operator must rescue.
+
+**Mechanical rule:** for each entry in `allowed_paths` matching the pattern
+`tests/test_<stem>.py`, replace it with `tests/test_<stem>*.py`. Examples:
+
+| Architect wrote | Becomes |
+|---|---|
+| `tests/test_metrics.py` | `tests/test_metrics*.py` |
+| `tests/test_watcher_finalize.py` | `tests/test_watcher_finalize*.py` |
+| `tests/test_X.py` (single ticket) | `tests/test_X*.py` |
+
+Already-globbed entries (e.g. `tests/test_*.py`, `tests/foo/*.py`) are left
+unchanged. Non-test paths (e.g. `app/core/metrics.py`) are left unchanged.
+
+The architect does NOT need to enumerate sibling tests manually — this step
+handles it mechanically before the manifest is written.
+
 ### 4.6. After human approves the plan — generate the execution manifest
 
 Once the human says to proceed, generate and write an `ExecutionManifest` JSON to disk. This is the handoff artifact the local worker reads — it must not require re-reading Linear or re-planning.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -372,6 +372,10 @@ and convert every match to `patch("new.module.path.function_name")`.
 
 **Use `replace_all=True` for bulk patch string migrations.** When updating `unittest.mock.patch()` strings after a module rename, use `Edit(old_string="app.core.old_module", new_string="app.core.new.module", replace_all=True)` rather than replacing each occurrence individually. One Edit call per (file, module-name) pair covers the entire migration in a single round-trip.
 
+**Run the unscoped `pytest` from `required_checks` before declaring success.** When the manifest's `required_checks` contains plain `pytest` (no args), the worker MUST run the full suite once before writing the success result artifact — not just the test files in `allowed_paths`. Sibling test files (e.g. `tests/test_X_metrics.py`, `tests/test_X_recovery.py`) often import the same source module the worker modified and fail when their fixtures don't anticipate the change. Skipping the unscoped run causes the watcher's `required_checks` step to catch the regression after the session has ended, marking the ticket Blocked even though the worker reported success. Targeted pytest is fine for fast iteration; the unscoped final run is mandatory. (See WOR-353.)
+
+**Test allowed_paths are auto-globbed at `/start-ticket` time.** When the architect lists `tests/test_X.py` in `allowed_paths`, the manifest writer expands it to `tests/test_X*.py` so sibling test files are explicitly in scope. Architects do NOT need to enumerate sibling tests manually. Already-globbed entries (e.g. `tests/test_*.py`) are left unchanged.
+
 ---
 
 ## Escalation policy


### PR DESCRIPTION
## Summary

Two skill-text fixes for the worker scope-blindness pattern that caused WOR-332's manual rescue.

**Problem:** When a worker modifies \`app/core/X.py\`, it runs pytest only on the test files listed in \`allowed_paths\` (typically just \`tests/test_X.py\`). Sibling test files (\`tests/test_X_metrics.py\`, \`tests/test_X_recovery.py\`) that import the same module are missed. Worker self-reports success; watcher's required-checks pytest catches the regression after the session ends; ticket is marked Blocked despite good code.

**WOR-332 evidence:** worker ran \`pytest tests/test_metrics.py tests/test_watcher_finalize.py\` 4 times, never the full suite. Watcher's \`pytest\` (no args) then found 25 failures in two sibling files. Manual rescue cost ~1 hour.

## Fixes

### Fix 1 — \`/start-ticket\` skill (manifest construction)

New step 2.6: glob-expand every \`tests/test_<stem>.py\` allowed_paths entry to \`tests/test_<stem>*.py\`. Mechanical, before manifest is written.

### Fix 2 — \`/implement-ticket\` skill (worker behavior)

Section 4 now mandates: when \`required_checks\` contains \`pytest\` (no args), the worker MUST run the unscoped suite once before declaring success. Targeted pytest is fine for fast iteration; the final unscoped run is mandatory. Includes a grep snippet for proactively finding importers of modified source modules.

### Documentation

\`CLAUDE.md\` "Worker efficiency" section gets two new rules so the discipline is visible where workers load canonical context.

## Why P2 High

Same severity as WOR-347 (the WIP-loss bug). Both cause silent worker-success / watcher-failure mismatches that require manual rescue. WOR-332's 5-hour total wall time was largely caused by this pattern (1st attempt failed, 2nd attempt failed for the same scope reason).

## Test plan

- [x] No production code changes — all skill text + CLAUDE.md only
- [x] Pre-commit hooks (ruff, mypy, bandit, semgrep, secrets) clean by virtue of no Python changes
- [ ] Real verification: next worker session that modifies a heavily-imported module should not fail at the watcher's required_checks step
- [ ] Spot-check: open a manifest written before this change and confirm the same allowed_paths produces the expanded glob at the next \`/start-ticket\` run

## References

- WOR-332 — the incident
- WOR-347 — companion (preserves WIP when rescue IS needed)
- WOR-275 — earlier worker scope discipline
- \`.claude/artifacts/wor_332/worker_wor-332.log\` — preserved evidence

🤖 Generated with [Claude Code](https://claude.com/claude-code)