### PR TITLE
WOR-356 Drop redundant manifest-copy step in /implement-ticket

### DIFF
--- a/.claude/commands/implement-ticket.md
+++ b/.claude/commands/implement-ticket.md
@@ -239,7 +239,14 @@ Write a JSON result file to `artifact_paths.result_json`. Create parent dirs as 
 }
 ```
 
-Also copy the manifest to `artifact_paths.manifest_copy` for audit purposes.
+**Do NOT copy the manifest anywhere.** `artifact_paths.manifest_copy` already
+points at the path where `/start-ticket` wrote the manifest (the same one you
+loaded in step 0). The watcher's `copy_manifest_to_worktree` step also placed
+it there before launching this session. There is nothing to copy — the manifest
+is already at its documented audit path. (Earlier skill text instructed a
+"copy manifest" step; that was a no-op that wasted 2-3 turns per session as
+the model attempted to `cp` a file onto itself before realizing the
+redundancy. WOR-322 paid ~12 minutes of wall time to this. WOR-356.)
 
 ### 6. Linear updates (comments only — state is owned by the watcher)
 


### PR DESCRIPTION
## Summary

Single-line skill-text fix. \`/implement-ticket\` step 5 instructed the worker to copy the manifest to \`artifact_paths.manifest_copy\` — but that path is the SAME one the worker already loaded the manifest from in step 0. The "copy" was a no-op that consistently confused the model.

## Evidence: WOR-322

```
T14  Bash(mkdir -p ".claude/artifacts/wor_322")    ← dir already existed
T15  Write(result.json)                            ← productive
T16  Bash(cp ".claude/artifacts/wor_322/manifest.json" "...same path...")
T17  (text only) "The manifest is already at the correct path. No copy needed."
```

3 turns × ~4 min/turn = ~12 minutes wasted on every session that follows the skill literally.

## Fix

Replaced the misleading "Also copy the manifest..." line with an explicit "Do NOT copy the manifest anywhere" directive that documents why and cites the WOR-322 evidence so the model has the failure mode in context if it ever sees a similar pattern.

## Test plan

- [x] No production code changes — single skill-text edit
- [x] Pre-commit hooks clean (no Python files)
- [ ] Real verification: next worker session should not attempt mkdir/cp/realize-redundancy turns at the end

## References

- WOR-322 forensic — direct evidence
- \`app/core/manifest.py::ArtifactPaths.from_ticket_id\` — confirms path resolution
- \`app/core/watcher/watcher_worktrees.py::copy_manifest_to_worktree\` — confirms manifest is in worktree before worker starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)