### PR TITLE
WOR-357 Parse compact_boundary system events for context_compactions

### DIFF
--- a/app/core/watcher/watcher_helpers.py
+++ b/app/core/watcher/watcher_helpers.py
@@ -33,29 +33,37 @@ def _parse_worker_usage(
 ) -> tuple[int | None, int | None, int | None]:
     """Return cumulative (input_tokens, output_tokens) summed across all
     ``type=assistant`` events in the stream-json worker log, plus
-    *context_compactions* from the final ``type=result`` event.
+    *context_compactions* counted from ``type=system, subtype=compact_boundary``
+    events (WOR-357).
 
     Assistant-turn deltas are summed so that downstream metrics
     (``local_output_tokens``, ``local_output_tokens_per_second``) reflect the
-    true token volume of a session.  *context_compactions* is a scalar on the
-    result event only and is **not** accumulated.
+    true token volume of a session.
+
+    *context_compactions* is the count of ``compact_boundary`` system events
+    emitted by Claude Code when it auto-compacts the conversation. The
+    pre-WOR-357 implementation read ``obj["context_compactions"]`` from the
+    final ``type=result`` event, but that field is never populated by Claude
+    Code — every row written before this fix had ``context_compactions=NULL``.
+    The actual signal lives in events of the form::
+
+        {"type":"system","subtype":"compact_boundary",
+         "compact_metadata":{"trigger":"auto","pre_tokens":...,"post_tokens":...,
+                             "duration_ms":...}}
 
     When assistant events carry usage data, their cumulative sum is returned.
     When no assistant events have usage, the last ``type=result`` event's
-    snapshot is used as a fallback (preserving the pre-fix behaviour for logs
-    without assistant events).  Returns ``(None, None, None)`` only when
-    neither assistant events nor the result event carries usage data.
-
-    **Note:** Rows written before this fix under-counted tokens.  Forward
-    rows will be accurate; backward analytics must account for the pre-fix
-    rows being unreliable.
+    usage snapshot is used as a fallback for tokens. Returns
+    ``(None, None, None)`` when the log itself cannot be opened or parsed at
+    all; returns ``(in, out, 0)`` for parseable logs containing zero
+    compact_boundary events.
     """
     try:
         with log_path.open(encoding="utf-8") as f:
             total_input = 0
             total_output = 0
             has_assistant_usage = False
-            context_compactions: int | None = None
+            compact_count = 0
             last_input: int | None = None
             last_output: int | None = None
             for raw in f:
@@ -66,7 +74,8 @@ def _parse_worker_usage(
                     obj = json.loads(line)
                 except json.JSONDecodeError:
                     continue
-                if obj.get("type") == "assistant":
+                obj_type = obj.get("type")
+                if obj_type == "assistant":
                     usage = (obj.get("message") or {}).get("usage") or {}
                     inp = usage.get("input_tokens")
                     out = usage.get("output_tokens")
@@ -74,17 +83,18 @@ def _parse_worker_usage(
                         total_input += int(inp)
                         total_output += int(out)
                         has_assistant_usage = True
-                elif obj.get("type") == "result":
-                    context_compactions = obj.get("context_compactions")
+                elif obj_type == "system" and obj.get("subtype") == "compact_boundary":
+                    compact_count += 1
+                elif obj_type == "result":
                     usage = obj.get("usage") or {}
                     last_input = usage.get("input_tokens")
                     last_output = usage.get("output_tokens")
             if has_assistant_usage:
-                return total_input, total_output, context_compactions
+                return total_input, total_output, compact_count
             # Fallback to result snapshot when no assistant events carry usage.
             if last_input is not None and last_output is not None:
-                return int(last_input), int(last_output), context_compactions
-            return None, None, context_compactions
+                return int(last_input), int(last_output), compact_count
+            return None, None, compact_count
     except Exception:
         return None, None, None
     return None, None, None

--- a/tests/test_watcher_finalize.py
+++ b/tests/test_watcher_finalize.py
@@ -234,12 +234,16 @@ def test_finalize_worker_passes_usage_to_metrics(tmp_path: Path) -> None:
     log_dir = tmp_path / ".claude"
     log_dir.mkdir(parents=True)
     log_file = log_dir / "worker_wor-10.log"
+    # WOR-357: context_compactions is now counted from system/compact_boundary
+    # events, not from the result event's (always-NULL) field. Include 5
+    # such events so the assertion exercises the new counting path.
+    boundary = json.dumps({"type": "system", "subtype": "compact_boundary"}) + "\n"
     log_file.write_text(
-        json.dumps(
+        boundary * 5
+        + json.dumps(
             {
                 "type": "result",
                 "usage": {"input_tokens": 2000, "output_tokens": 400},
-                "context_compactions": 5,
             }
         )
         + "\n",

--- a/tests/test_watcher_helpers.py
+++ b/tests/test_watcher_helpers.py
@@ -227,6 +227,13 @@ def _write_log(tmp_path: Path, lines: list[str]) -> Path:
 
 
 def test_parse_worker_usage_success(tmp_path: Path) -> None:
+    """Result event provides token snapshot; no compact_boundary → 0 (WOR-357).
+
+    The pre-WOR-357 implementation read context_compactions from the result
+    event's top-level field — that field is never populated by Claude Code.
+    The test now reflects the new behaviour: compactions counted only from
+    type=system, subtype=compact_boundary events.
+    """
     result_line = json.dumps(
         {
             "type": "result",
@@ -236,17 +243,18 @@ def test_parse_worker_usage_success(tmp_path: Path) -> None:
                 "output_tokens": 200,
                 "cache_read_input_tokens": 0,
             },
-            "context_compactions": 3,
+            "context_compactions": 3,  # ignored under WOR-357 semantics
         }
     )
     log = _write_log(tmp_path, ['{"type":"other","x":1}', result_line])
     input_tok, output_tok, compactions = _parse_worker_usage(log)
     assert input_tok == 1000
     assert output_tok == 200
-    assert compactions == 3
+    assert compactions == 0  # was 3 under the old (broken) semantics
 
 
 def test_parse_worker_usage_no_context_compactions(tmp_path: Path) -> None:
+    """Parseable log with no compact_boundary events returns 0 (WOR-357)."""
     result_line = json.dumps(
         {"type": "result", "usage": {"input_tokens": 500, "output_tokens": 50}}
     )
@@ -254,10 +262,11 @@ def test_parse_worker_usage_no_context_compactions(tmp_path: Path) -> None:
     input_tok, output_tok, compactions = _parse_worker_usage(log)
     assert input_tok == 500
     assert output_tok == 50
-    assert compactions is None
+    assert compactions == 0  # was None under the old semantics
 
 
 def test_parse_worker_usage_missing_log(tmp_path: Path) -> None:
+    """Missing log returns None for all three fields (unchanged)."""
     log = tmp_path / "no_such_file.log"
     input_tok, output_tok, compactions = _parse_worker_usage(log)
     assert input_tok is None
@@ -266,6 +275,7 @@ def test_parse_worker_usage_missing_log(tmp_path: Path) -> None:
 
 
 def test_parse_worker_usage_no_result_line(tmp_path: Path) -> None:
+    """Parseable log without usable usage data returns 0 compactions (WOR-357)."""
     log = _write_log(
         tmp_path,
         [
@@ -276,16 +286,143 @@ def test_parse_worker_usage_no_result_line(tmp_path: Path) -> None:
     input_tok, output_tok, compactions = _parse_worker_usage(log)
     assert input_tok is None
     assert output_tok is None
-    assert compactions is None
+    assert compactions == 0  # log was parseable; just no compactions
 
 
 def test_parse_worker_usage_malformed_json(tmp_path: Path) -> None:
+    """Fully unparseable log returns None for all three fields (unchanged)."""
     log = tmp_path / "worker.log"
     log.write_text("not json at all\n{broken\n", encoding="utf-8")
     input_tok, output_tok, compactions = _parse_worker_usage(log)
     assert input_tok is None
     assert output_tok is None
-    assert compactions is None
+    # No JSON parseable at all → 0 events seen, but the file IS open-able,
+    # so we get the parseable-but-empty path.
+    assert compactions == 0
+
+
+# ---------------------------------------------------------------------------
+# WOR-357 — compact_boundary system event counting
+# ---------------------------------------------------------------------------
+
+
+def test_parse_worker_usage_one_compact_boundary(tmp_path: Path) -> None:
+    """A single compact_boundary system event yields context_compactions=1."""
+    log = _write_log(
+        tmp_path,
+        [
+            json.dumps(
+                {
+                    "type": "system",
+                    "subtype": "compact_boundary",
+                    "compact_metadata": {
+                        "trigger": "auto",
+                        "pre_tokens": 135486,
+                        "post_tokens": 3348,
+                        "duration_ms": 88463,
+                    },
+                }
+            ),
+            json.dumps(
+                {
+                    "type": "result",
+                    "usage": {"input_tokens": 100, "output_tokens": 50},
+                }
+            ),
+        ],
+    )
+    _, _, compactions = _parse_worker_usage(log)
+    assert compactions == 1
+
+
+def test_parse_worker_usage_multiple_compact_boundaries(tmp_path: Path) -> None:
+    """Three compact_boundary events sum to context_compactions=3."""
+    boundary = json.dumps(
+        {
+            "type": "system",
+            "subtype": "compact_boundary",
+            "compact_metadata": {"trigger": "auto"},
+        }
+    )
+    log = _write_log(
+        tmp_path,
+        [
+            boundary,
+            json.dumps({"type": "assistant", "message": {"id": "a1"}}),
+            boundary,
+            json.dumps({"type": "assistant", "message": {"id": "a2"}}),
+            boundary,
+            json.dumps(
+                {
+                    "type": "result",
+                    "usage": {"input_tokens": 100, "output_tokens": 10},
+                }
+            ),
+        ],
+    )
+    _, _, compactions = _parse_worker_usage(log)
+    assert compactions == 3
+
+
+def test_parse_worker_usage_other_system_subtypes_ignored(tmp_path: Path) -> None:
+    """system events with non-compact_boundary subtypes do not increment."""
+    log = _write_log(
+        tmp_path,
+        [
+            json.dumps({"type": "system", "subtype": "init"}),
+            json.dumps({"type": "system", "subtype": "task_started"}),
+            json.dumps({"type": "system", "subtype": "api_retry"}),
+            json.dumps({"type": "system", "subtype": "task_notification"}),
+            json.dumps(
+                {
+                    "type": "result",
+                    "usage": {"input_tokens": 100, "output_tokens": 5},
+                }
+            ),
+        ],
+    )
+    _, _, compactions = _parse_worker_usage(log)
+    assert compactions == 0
+
+
+def test_parse_worker_usage_compact_boundary_with_assistant_usage(
+    tmp_path: Path,
+) -> None:
+    """Cumulative assistant-token sum AND compaction count both reported."""
+    log = _write_log(
+        tmp_path,
+        [
+            json.dumps(
+                {
+                    "type": "assistant",
+                    "message": {
+                        "id": "a1",
+                        "usage": {"input_tokens": 1000, "output_tokens": 100},
+                    },
+                }
+            ),
+            json.dumps({"type": "system", "subtype": "compact_boundary"}),
+            json.dumps(
+                {
+                    "type": "assistant",
+                    "message": {
+                        "id": "a2",
+                        "usage": {"input_tokens": 500, "output_tokens": 50},
+                    },
+                }
+            ),
+            json.dumps(
+                {
+                    "type": "result",
+                    "usage": {"input_tokens": 1500, "output_tokens": 150},
+                }
+            ),
+        ],
+    )
+    input_tok, output_tok, compactions = _parse_worker_usage(log)
+    assert input_tok == 1500  # 1000 + 500 (sum across assistant events)
+    assert output_tok == 150  # 100 + 50
+    assert compactions == 1
 
 
 def test_parse_worker_usage_cumulative_output_tokens(tmp_path: Path) -> None:
@@ -342,7 +479,7 @@ def test_parse_worker_usage_cumulative_output_tokens(tmp_path: Path) -> None:
     log.write_text("\n".join(assistant + [result_line]) + "\n", encoding="utf-8")
     input_tok, output_tok, compactions = _parse_worker_usage(log)
     assert output_tok == 600  # 100+200+300
-    assert compactions == 5
+    assert compactions == 0  # WOR-357: result.context_compactions field is ignored
 
 
 def test_parse_worker_usage_cumulative_input_tokens(tmp_path: Path) -> None:
@@ -414,7 +551,7 @@ def test_parse_worker_usage_mixed_valid_invalid_lines(tmp_path: Path) -> None:
     input_tok, output_tok, compactions = _parse_worker_usage(log)
     assert input_tok == 300
     assert output_tok == 100
-    assert compactions == 1
+    assert compactions == 0  # WOR-357: result.context_compactions field is ignored
 
 
 def test_parse_worker_usage_returns_first_result_line(tmp_path: Path) -> None:
@@ -432,12 +569,13 @@ def test_parse_worker_usage_returns_first_result_line(tmp_path: Path) -> None:
 
 
 def test_parse_worker_usage_empty_file(tmp_path: Path) -> None:
+    """Empty file is open-able and parseable → (None, None, 0)."""
     log = tmp_path / "empty.log"
     log.write_text("", encoding="utf-8")
     input_tok, output_tok, compactions = _parse_worker_usage(log)
     assert input_tok is None
     assert output_tok is None
-    assert compactions is None
+    assert compactions == 0  # WOR-357: parseable path returns 0, not None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fix \`_parse_worker_usage\` in \`app/core/watcher/watcher_helpers.py\` to populate \`context_compactions\` correctly.

**Pre-WOR-357 bug:** the function read \`context_compactions\` from the result event's top-level field — but Claude Code never populates that field. Every \`ticket_metrics\` row had \`context_compactions=NULL\` (31/31 in current \`app.db\`).

**The actual signal** is in system events:

\`\`\`json
{"type":"system","subtype":"compact_boundary",
 "compact_metadata":{"trigger":"auto","pre_tokens":...,"post_tokens":...,
                     "duration_ms":...}}
\`\`\`

The fix counts those events instead.

## Verification against real logs

\`\`\`
WOR-322: input=3,121,325, output=16,590, compactions=0   ← matches monotonic 47K→67K growth
WOR-332: input=33,842,271, output=161,744, compactions=1 ← matches T70 input collapse 130K→50K
\`\`\`

## Test changes

- 4 new tests in \`test_watcher_helpers.py\` for compact_boundary counting (one event, multiple events, other system subtypes ignored, mixed with assistant events)
- 5 existing test assertions updated to reflect new semantics (parseable log + no compactions returns 0, not None)
- \`test_finalize_worker_passes_usage_to_metrics\` updated to write compact_boundary events instead of relying on the now-ignored result-event field

## Out of scope

- Backfilling \`context_compactions\` for existing rows from preserved logs (one-shot script if needed)
- Adding \`compact_duration_ms\` as a separate column
- Adding a \`mid_session_compaction\` rule to \`compute_tags\` (this PR unblocks it)

## Test plan

- [x] \`pytest tests/test_watcher_helpers.py tests/test_watcher_finalize.py\` — 90 pass
- [x] Full \`pytest\` — 1117 pass (was 1113 + 4 new)
- [x] \`ruff check\` clean
- [x] \`mypy app/\` clean
- [x] Verified against real preserved logs (WOR-322: 0, WOR-332: 1)

## References

- WOR-332 forensic — direct evidence of the compaction at T70
- WOR-121, WOR-284 — earlier "fixes" that wired up the wrong field
- \`app/core/watcher/watcher_helpers.py::_parse_worker_usage\` — site of the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)