### PR TITLE
WOR-348 Persist effort to ticket_metrics

### DIFF
--- a/app/core/metrics.py
+++ b/app/core/metrics.py
@@ -89,6 +89,7 @@ CREATE TABLE IF NOT EXISTS ticket_metrics (
     waste_breakdown_json  TEXT,
     tags                  TEXT,
     notes                 TEXT,
+    effort                TEXT,
     recorded_at           TEXT NOT NULL DEFAULT (datetime('now')),
     PRIMARY KEY (ticket_id, project_id)
 )
@@ -185,6 +186,10 @@ class TicketMetrics(BaseModel):
     notes: str | None = Field(
         default=None,
         description="Free-form operator notes for morning retros",
+    )
+    effort: str | None = Field(
+        default=None,
+        description="Effort level from the manifest: low/medium/high/xhigh/max",
     )
 
 
@@ -367,6 +372,8 @@ class MetricsStore:
             conn.execute("ALTER TABLE ticket_metrics ADD COLUMN tags TEXT")
         if "notes" not in existing:
             conn.execute("ALTER TABLE ticket_metrics ADD COLUMN notes TEXT")
+        if "effort" not in existing:
+            conn.execute("ALTER TABLE ticket_metrics ADD COLUMN effort TEXT")
 
     @contextmanager
     def _connect(self) -> Generator[sqlite3.Connection, None, None]:
@@ -394,7 +401,7 @@ class MetricsStore:
                     sonar_findings_count, context_compactions,
                     change_type, reasoning_demand, scope_clarity,
                     constraint_density, ac_specificity, tech_stack, raw_extensions,
-                    waste_score, waste_breakdown_json, tags, notes
+                    waste_score, waste_breakdown_json, tags, notes, effort
                 ) VALUES (
                     :ticket_id, :project_id, :epic_id, :implementation_mode,
                     :cloud_used, :cloud_model, :cloud_tokens, :cloud_cost_estimate,
@@ -408,7 +415,7 @@ class MetricsStore:
                     :sonar_findings_count, :context_compactions,
                     :change_type, :reasoning_demand, :scope_clarity,
                     :constraint_density, :ac_specificity, :tech_stack, :raw_extensions,
-                    :waste_score, :waste_breakdown_json, :tags, :notes
+                    :waste_score, :waste_breakdown_json, :tags, :notes, :effort
                 )
                 """,
                 {

--- a/app/core/watcher/watcher_finalize.py
+++ b/app/core/watcher/watcher_finalize.py
@@ -321,6 +321,8 @@ def finalize_worker(
             raw_extensions=worker.manifest.raw_extensions,
             waste_score=waste_score,
             waste_breakdown_json=waste_breakdown_json,
+            # WOR-348: persist manifest effort for retro analytics
+            effort=worker.manifest.effort,
         )
     )
     metrics.record_run(

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -156,6 +156,40 @@ class TestTaxonomyColumns:
         assert result.raw_extensions is None
 
 
+class TestEffortColumn:
+    """WOR-348: persist effort (low/medium/high/xhigh/max) for retro analytics."""
+
+    def test_effort_round_trip(self, tmp_path):
+        store = _store(tmp_path)
+        store.record(_ticket(effort="xhigh"))
+        result = store.get_by_ticket("WOR-1", "proj-a")
+        assert result is not None
+        assert result.effort == "xhigh"
+
+    def test_effort_defaults_to_none(self, tmp_path):
+        store = _store(tmp_path)
+        store.record(_ticket())
+        result = store.get_by_ticket("WOR-1", "proj-a")
+        assert result is not None
+        assert result.effort is None
+
+    def test_effort_accepts_all_levels(self, tmp_path):
+        store = _store(tmp_path)
+        for level in ("low", "medium", "high", "xhigh", "max"):
+            store.record(_ticket(ticket_id=f"WOR-{level}", effort=level))
+            result = store.get_by_ticket(f"WOR-{level}", "proj-a")
+            assert result is not None
+            assert result.effort == level
+
+    def test_effort_migration_idempotent(self, tmp_path):
+        """Calling _migrate twice does not raise on the effort column."""
+        store = _store(tmp_path)
+        # First migration runs at __init__; call again to ensure idempotency.
+        with store._connect() as conn:
+            store._migrate(conn)
+            store._migrate(conn)
+
+
 class TestAdditionalMetrics:
     def test_retry_and_diff_metrics_round_trip(self, tmp_path):
         store = _store(tmp_path)

--- a/tests/test_watcher_finalize.py
+++ b/tests/test_watcher_finalize.py
@@ -376,6 +376,68 @@ def test_finalize_worker_taxonomy_none_when_manifest_lacks_them(tmp_path: Path) 
 
 
 # ---------------------------------------------------------------------------
+# WOR-348: effort propagates from manifest to ticket_metrics
+# ---------------------------------------------------------------------------
+
+
+def test_finalize_worker_copies_effort_to_metrics(tmp_path: Path) -> None:
+    manifest = make_manifest(
+        ticket_id="WOR-10",
+        worker_branch="wor-10-test-ticket",
+        effort="xhigh",
+    )
+    metrics_mock = MagicMock()
+
+    worker = ActiveWorker(
+        ticket_id="WOR-10",
+        linear_id="fake-linear-id",
+        manifest=manifest,
+        worktree_path=tmp_path,
+        process=MagicMock(spec=subprocess.Popen),
+    )
+
+    with (
+        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(True, [])),
+        patch(
+            "app.core.watcher.watcher_finalize.create_pr",
+            return_value="https://github.com/example/pr/1",
+        ),
+        patch("app.core.watcher.watcher_finalize.cleanup_worktree"),
+    ):
+        _call_finalize(worker, metrics=metrics_mock)
+
+    m = metrics_mock.record.call_args[0][0]
+    assert m.effort == "xhigh"
+
+
+def test_finalize_worker_effort_none_when_manifest_lacks_it(tmp_path: Path) -> None:
+    """Manifest with no effort field → metrics.effort is None (default)."""
+    manifest = make_manifest(ticket_id="WOR-10", worker_branch="wor-10-test-ticket")
+    metrics_mock = MagicMock()
+
+    worker = ActiveWorker(
+        ticket_id="WOR-10",
+        linear_id="fake-linear-id",
+        manifest=manifest,
+        worktree_path=tmp_path,
+        process=MagicMock(spec=subprocess.Popen),
+    )
+
+    with (
+        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(True, [])),
+        patch(
+            "app.core.watcher.watcher_finalize.create_pr",
+            return_value="https://github.com/example/pr/1",
+        ),
+        patch("app.core.watcher.watcher_finalize.cleanup_worktree"),
+    ):
+        _call_finalize(worker, metrics=metrics_mock)
+
+    m = metrics_mock.record.call_args[0][0]
+    assert m.effort is None
+
+
+# ---------------------------------------------------------------------------
 # sonar_findings_count wired to metrics
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Add the manifest's \`effort\` field to \`ticket_metrics\` so retros can answer effort-correlation questions with one SQL query instead of N filesystem reads.

## Problem

\`effort\` is set on every manifest at \`/start-ticket\` time, but it's never persisted. Surfaced 2026-05-03 during the first real metrics analysis — the table below required manually cross-referencing 31 manifest.json files:

| effort | n | success rate | avg tokens | avg wall (min) |
|---|---|---|---|---|
| high | 23 | 70% | 3.7M | 57 |
| xhigh | 6 | 83% | 13.9M | 96 |
| max | 2 | 50% | 25.9M | 96 |

That should be one SQL query. After this PR it is.

## Changes

- \`app/core/metrics.py\` — \`effort TEXT\` column + idempotent migration + Pydantic field
- \`app/core/watcher/watcher_finalize.py\` — \`effort=worker.manifest.effort\` plumbed through
- \`tests/test_metrics.py\` — \`TestEffortColumn\` class with 4 tests (round-trip, defaults, all 5 levels, idempotent migration)
- \`tests/test_watcher_finalize.py\` — 2 finalize-side tests (xhigh propagates, missing-effort stays None)

## Out of scope

- Backfilling existing 31 rows (manifest.json files are still on disk; one-shot script if needed)
- Auto-routing on effort (separate spike — depends on this data)
- Adding effort to TUI / dashboard (separate ticket if built)

## Test plan

- [x] \`pytest tests/test_metrics.py tests/test_watcher_finalize.py tests/test_watcher_finalize_metrics.py\` — 136 pass
- [x] Full \`pytest\` — 1119 pass (was 1117 + 6 new)
- [x] \`ruff check\` clean
- [x] \`mypy app/\` clean
- [ ] After merge: manual smoke-check that the next real worker run populates the column

## References

- WOR-214 — original effort field on ExecutionManifest
- WOR-262 — taxonomy column pattern
- WOR-284 — \`PRAGMA table_info\` migration pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)