### PR TITLE
WOR-361 Rename local_output_tokens_per_second → output_tokens_per_wall_second

### DIFF
--- a/app/core/metrics.py
+++ b/app/core/metrics.py
@@ -69,7 +69,7 @@ CREATE TABLE IF NOT EXISTS ticket_metrics (
     local_output_tokens   INTEGER,
     local_tokens          INTEGER,
     local_wall_time       REAL,
-    local_output_tokens_per_second REAL,
+    output_tokens_per_wall_second REAL,
     escalated_to_cloud    INTEGER NOT NULL DEFAULT 0,
     outcome               TEXT NOT NULL,
     retry_count           INTEGER NOT NULL DEFAULT 0,
@@ -114,8 +114,15 @@ class TicketMetrics(BaseModel):
     local_input_tokens: int | None = None
     local_output_tokens: int | None = None
     local_tokens: int | None = None
-    local_output_tokens_per_second: float | None = Field(
-        default=None, description="output_tokens / wall_time when both present"
+    output_tokens_per_wall_second: float | None = Field(
+        default=None,
+        description=(
+            "output_tokens / total local_wall_time. WOR-361: this is NOT decode "
+            "throughput — wall_time includes prefill, tool exec, hooks, and "
+            "compaction. For real decode rate, query vLLM /metrics directly. "
+            "Useful only for 'did this ticket take a long time relative to its "
+            "output' style questions."
+        ),
     )
     local_wall_time: float | None = Field(default=None, description="Seconds")
     escalated_to_cloud: bool = False
@@ -338,11 +345,22 @@ class MetricsStore:
             conn.execute(
                 "ALTER TABLE ticket_metrics ADD COLUMN local_output_tokens INTEGER"
             )
-        if "local_output_tokens_per_second" not in existing:
-            conn.execute(
-                "ALTER TABLE ticket_metrics "
-                "ADD COLUMN local_output_tokens_per_second REAL"
-            )
+        # WOR-361: rename misleading column. Idempotent across states:
+        # - fresh DB: CREATE TABLE already used the new name
+        # - already-migrated: new name exists, skip
+        # - pre-rename DB: rename old → new
+        # - very old DB without either: ADD COLUMN with new name
+        if "output_tokens_per_wall_second" not in existing:
+            if "local_output_tokens_per_second" in existing:
+                conn.execute(
+                    "ALTER TABLE ticket_metrics RENAME COLUMN "
+                    "local_output_tokens_per_second TO output_tokens_per_wall_second"
+                )
+            else:
+                conn.execute(
+                    "ALTER TABLE ticket_metrics "
+                    "ADD COLUMN output_tokens_per_wall_second REAL"
+                )
         # WOR-262 taxonomy columns
         if "change_type" not in existing:
             conn.execute("ALTER TABLE ticket_metrics ADD COLUMN change_type TEXT")
@@ -394,7 +412,7 @@ class MetricsStore:
                     ticket_id, project_id, epic_id, implementation_mode,
                     cloud_used, cloud_model, cloud_tokens, cloud_cost_estimate,
                     local_used, local_model, local_input_tokens, local_output_tokens,
-                    local_tokens, local_wall_time, local_output_tokens_per_second,
+                    local_tokens, local_wall_time, output_tokens_per_wall_second,
                     escalated_to_cloud, outcome,
                     retry_count, check_failures_json,
                     lines_changed, files_changed,
@@ -408,7 +426,7 @@ class MetricsStore:
                     :local_used, :local_model,
                     :local_input_tokens, :local_output_tokens,
                     :local_tokens, :local_wall_time,
-                    :local_output_tokens_per_second,
+                    :output_tokens_per_wall_second,
                     :escalated_to_cloud, :outcome,
                     :retry_count, :check_failures_json,
                     :lines_changed, :files_changed,

--- a/app/core/watcher/watcher_finalize.py
+++ b/app/core/watcher/watcher_finalize.py
@@ -242,7 +242,7 @@ def finalize_worker(
     local_tokens: int | None = None
     local_input_tokens: int | None = None
     local_output_tokens: int | None = None
-    local_output_tokens_per_second: float | None = None
+    output_tokens_per_wall_second: float | None = None
     local_model_str: str | None = None
     if eff == "local":
         local_tokens = (
@@ -254,7 +254,7 @@ def finalize_worker(
         local_output_tokens = output_tokens
         local_model_str = _LOCAL_MODEL
         if output_tokens is not None and wall_time and wall_time > 0:
-            local_output_tokens_per_second = output_tokens / wall_time
+            output_tokens_per_wall_second = output_tokens / wall_time
 
     # Compute waste score from the worker log (WOR-277).
     waste_report = compute_waste_score(log_path)
@@ -300,7 +300,7 @@ def finalize_worker(
             local_output_tokens=local_output_tokens,
             local_tokens=local_tokens,
             local_wall_time=wall_time,
-            local_output_tokens_per_second=local_output_tokens_per_second,
+            output_tokens_per_wall_second=output_tokens_per_wall_second,
             escalated_to_cloud=escalated,
             outcome=outcome,
             retry_count=worker.retry_count,
@@ -335,7 +335,7 @@ def finalize_worker(
             wall_time_s=wall_time,
             input_tokens=input_tokens,
             output_tokens=output_tokens,
-            output_tok_per_s=local_output_tokens_per_second,
+            output_tok_per_s=output_tokens_per_wall_second,
             context_compactions=context_compactions,
         )
     )

--- a/app/core/watcher/watcher_helpers.py
+++ b/app/core/watcher/watcher_helpers.py
@@ -37,7 +37,7 @@ def _parse_worker_usage(
     events (WOR-357).
 
     Assistant-turn deltas are summed so that downstream metrics
-    (``local_output_tokens``, ``local_output_tokens_per_second``) reflect the
+    (``local_output_tokens``, ``output_tokens_per_wall_second``) reflect the
     true token volume of a session.
 
     *context_compactions* is the count of ``compact_boundary`` system events

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -394,7 +394,7 @@ class TestCheckRunLog:
 class TestMigration:
     def test_migration_adds_new_columns(self, tmp_path):
         """Existing DB gets local_input_tokens, local_output_tokens,
-        local_output_tokens_per_second without error."""
+        output_tokens_per_wall_second without error."""
         store = MetricsStore(db_path=tmp_path / "app.db")
         # Write and read before _migrate runs to establish baseline
         store.record(_ticket())
@@ -413,14 +413,14 @@ class TestMigration:
             _ticket(
                 local_input_tokens=10000,
                 local_output_tokens=500,
-                local_output_tokens_per_second=4.17,
+                output_tokens_per_wall_second=4.17,
             )
         )
         result = store.get_by_ticket("WOR-1", "proj-a")
         assert result is not None
         assert result.local_input_tokens == 10000
         assert result.local_output_tokens == 500
-        assert result.local_output_tokens_per_second == pytest.approx(4.17)
+        assert result.output_tokens_per_wall_second == pytest.approx(4.17)
 
     def test_new_columns_none_default(self, tmp_path):
         """Fields default to None when not provided."""
@@ -429,7 +429,7 @@ class TestMigration:
         result = store.get_by_ticket("WOR-1", "proj-a")
         assert result.local_input_tokens is None
         assert result.local_output_tokens is None
-        assert result.local_output_tokens_per_second is None
+        assert result.output_tokens_per_wall_second is None
 
     def test_backward_compat_local_tokens_preserved(self, tmp_path):
         """local_tokens remains valid alongside new fields."""

--- a/tests/test_watcher_finalize.py
+++ b/tests/test_watcher_finalize.py
@@ -1195,7 +1195,7 @@ def test_finalize_worker_writes_separate_token_fields(tmp_path: Path) -> None:
     assert m.local_input_tokens == 15000
     assert m.local_output_tokens == 600
     assert m.local_tokens == 15600  # backward-compat sum
-    assert m.local_output_tokens_per_second == pytest.approx(60.0)  # 600/10
+    assert m.output_tokens_per_wall_second == pytest.approx(60.0)  # 600/10
 
 
 def test_finalize_worker_token_fields_none_when_no_log(
@@ -1227,7 +1227,7 @@ def test_finalize_worker_token_fields_none_when_no_log(
     assert m.local_input_tokens is None
     assert m.local_output_tokens is None
     assert m.local_tokens is None
-    assert m.local_output_tokens_per_second is None
+    assert m.output_tokens_per_wall_second is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_watcher_finalize_metrics.py
+++ b/tests/test_watcher_finalize_metrics.py
@@ -266,7 +266,7 @@ def test_finalize_worker_cloud_metrics_populated_for_cloud_run(
     assert m.local_output_tokens is None
     assert m.local_tokens is None
     assert m.local_model is None
-    assert m.local_output_tokens_per_second is None
+    assert m.output_tokens_per_wall_second is None
 
 
 def test_finalize_worker_cloud_model_from_env(
@@ -406,7 +406,7 @@ def test_finalize_worker_local_run_keeps_local_fields(
     assert m.local_input_tokens == 15000
     assert m.local_output_tokens == 600
     assert m.local_tokens == 15600
-    assert m.local_output_tokens_per_second == pytest.approx(60.0)
+    assert m.output_tokens_per_wall_second == pytest.approx(60.0)
     # Cloud fields must be None for local runs
     assert m.cloud_model is None
     assert m.cloud_tokens is None


### PR DESCRIPTION
## Summary

Hard rename of misleading column. The metric is `output_tokens / total_wall_time`, not decode throughput — wall_time includes prefill, hooks, compaction, etc. WOR-305 reported "39 tok/s" while actually hitting bench-level decode (~125 tok/s).

## Sub-ticket of WOR-365

This is the first of 5 PRs in the metrics-enrichment mini-epic. Targets the epic branch (auto-merge when CI passes); epic → main PR comes after all 5 land.

## Test plan

- [x] All 183 tests in metrics + finalize + helpers files pass
- [x] ruff + mypy clean
- [x] Migration idempotent across 4 states (fresh / already-migrated / pre-rename / very old)

Part of WOR-365