### PR TITLE
WOR-358 Persist compact_duration_ms — total ms spent on context compaction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ scripts/bench/fixtures/
 
 # Benchmark results DB (local data, not committed)
 bench_results.db
+bench.db
 
 # Unified metrics + bench DB (local data, not committed)
 app.db

--- a/app/core/metrics.py
+++ b/app/core/metrics.py
@@ -90,6 +90,7 @@ CREATE TABLE IF NOT EXISTS ticket_metrics (
     tags                  TEXT,
     notes                 TEXT,
     effort                TEXT,
+    compact_duration_ms   INTEGER,
     recorded_at           TEXT NOT NULL DEFAULT (datetime('now')),
     PRIMARY KEY (ticket_id, project_id)
 )
@@ -197,6 +198,14 @@ class TicketMetrics(BaseModel):
     effort: str | None = Field(
         default=None,
         description="Effort level from the manifest: low/medium/high/xhigh/max",
+    )
+    compact_duration_ms: int | None = Field(
+        default=None,
+        description=(
+            "Cumulative ms spent on context compaction during the session "
+            "(WOR-358). Sum of compact_metadata.duration_ms across all "
+            "compact_boundary system events."
+        ),
     )
 
 
@@ -392,6 +401,10 @@ class MetricsStore:
             conn.execute("ALTER TABLE ticket_metrics ADD COLUMN notes TEXT")
         if "effort" not in existing:
             conn.execute("ALTER TABLE ticket_metrics ADD COLUMN effort TEXT")
+        if "compact_duration_ms" not in existing:
+            conn.execute(
+                "ALTER TABLE ticket_metrics ADD COLUMN compact_duration_ms INTEGER"
+            )
 
     @contextmanager
     def _connect(self) -> Generator[sqlite3.Connection, None, None]:
@@ -419,7 +432,8 @@ class MetricsStore:
                     sonar_findings_count, context_compactions,
                     change_type, reasoning_demand, scope_clarity,
                     constraint_density, ac_specificity, tech_stack, raw_extensions,
-                    waste_score, waste_breakdown_json, tags, notes, effort
+                    waste_score, waste_breakdown_json, tags, notes, effort,
+                    compact_duration_ms
                 ) VALUES (
                     :ticket_id, :project_id, :epic_id, :implementation_mode,
                     :cloud_used, :cloud_model, :cloud_tokens, :cloud_cost_estimate,
@@ -433,7 +447,8 @@ class MetricsStore:
                     :sonar_findings_count, :context_compactions,
                     :change_type, :reasoning_demand, :scope_clarity,
                     :constraint_density, :ac_specificity, :tech_stack, :raw_extensions,
-                    :waste_score, :waste_breakdown_json, :tags, :notes, :effort
+                    :waste_score, :waste_breakdown_json, :tags, :notes, :effort,
+                    :compact_duration_ms
                 )
                 """,
                 {

--- a/app/core/metrics.py
+++ b/app/core/metrics.py
@@ -69,7 +69,7 @@ CREATE TABLE IF NOT EXISTS ticket_metrics (
     local_output_tokens   INTEGER,
     local_tokens          INTEGER,
     local_wall_time       REAL,
-    local_output_tokens_per_second REAL,
+    output_tokens_per_wall_second REAL,
     escalated_to_cloud    INTEGER NOT NULL DEFAULT 0,
     outcome               TEXT NOT NULL,
     retry_count           INTEGER NOT NULL DEFAULT 0,
@@ -114,8 +114,15 @@ class TicketMetrics(BaseModel):
     local_input_tokens: int | None = None
     local_output_tokens: int | None = None
     local_tokens: int | None = None
-    local_output_tokens_per_second: float | None = Field(
-        default=None, description="output_tokens / wall_time when both present"
+    output_tokens_per_wall_second: float | None = Field(
+        default=None,
+        description=(
+            "output_tokens / total local_wall_time. WOR-361: this is NOT decode "
+            "throughput — wall_time includes prefill, tool exec, hooks, and "
+            "compaction. For real decode rate, query vLLM /metrics directly. "
+            "Useful only for 'did this ticket take a long time relative to its "
+            "output' style questions."
+        ),
     )
     local_wall_time: float | None = Field(default=None, description="Seconds")
     escalated_to_cloud: bool = False
@@ -338,11 +345,22 @@ class MetricsStore:
             conn.execute(
                 "ALTER TABLE ticket_metrics ADD COLUMN local_output_tokens INTEGER"
             )
-        if "local_output_tokens_per_second" not in existing:
-            conn.execute(
-                "ALTER TABLE ticket_metrics "
-                "ADD COLUMN local_output_tokens_per_second REAL"
-            )
+        # WOR-361: rename misleading column. Idempotent across states:
+        # - fresh DB: CREATE TABLE already used the new name
+        # - already-migrated: new name exists, skip
+        # - pre-rename DB: rename old → new
+        # - very old DB without either: ADD COLUMN with new name
+        if "output_tokens_per_wall_second" not in existing:
+            if "local_output_tokens_per_second" in existing:
+                conn.execute(
+                    "ALTER TABLE ticket_metrics RENAME COLUMN "
+                    "local_output_tokens_per_second TO output_tokens_per_wall_second"
+                )
+            else:
+                conn.execute(
+                    "ALTER TABLE ticket_metrics "
+                    "ADD COLUMN output_tokens_per_wall_second REAL"
+                )
         # WOR-262 taxonomy columns
         if "change_type" not in existing:
             conn.execute("ALTER TABLE ticket_metrics ADD COLUMN change_type TEXT")
@@ -394,7 +412,7 @@ class MetricsStore:
                     ticket_id, project_id, epic_id, implementation_mode,
                     cloud_used, cloud_model, cloud_tokens, cloud_cost_estimate,
                     local_used, local_model, local_input_tokens, local_output_tokens,
-                    local_tokens, local_wall_time, local_output_tokens_per_second,
+                    local_tokens, local_wall_time, output_tokens_per_wall_second,
                     escalated_to_cloud, outcome,
                     retry_count, check_failures_json,
                     lines_changed, files_changed,
@@ -408,7 +426,7 @@ class MetricsStore:
                     :local_used, :local_model,
                     :local_input_tokens, :local_output_tokens,
                     :local_tokens, :local_wall_time,
-                    :local_output_tokens_per_second,
+                    :output_tokens_per_wall_second,
                     :escalated_to_cloud, :outcome,
                     :retry_count, :check_failures_json,
                     :lines_changed, :files_changed,

--- a/app/core/watcher/watcher_finalize.py
+++ b/app/core/watcher/watcher_finalize.py
@@ -242,7 +242,7 @@ def finalize_worker(
     local_tokens: int | None = None
     local_input_tokens: int | None = None
     local_output_tokens: int | None = None
-    local_output_tokens_per_second: float | None = None
+    output_tokens_per_wall_second: float | None = None
     local_model_str: str | None = None
     if eff == "local":
         local_tokens = (
@@ -254,7 +254,7 @@ def finalize_worker(
         local_output_tokens = output_tokens
         local_model_str = _LOCAL_MODEL
         if output_tokens is not None and wall_time and wall_time > 0:
-            local_output_tokens_per_second = output_tokens / wall_time
+            output_tokens_per_wall_second = output_tokens / wall_time
 
     # Compute waste score from the worker log (WOR-277).
     waste_report = compute_waste_score(log_path)
@@ -300,7 +300,7 @@ def finalize_worker(
             local_output_tokens=local_output_tokens,
             local_tokens=local_tokens,
             local_wall_time=wall_time,
-            local_output_tokens_per_second=local_output_tokens_per_second,
+            output_tokens_per_wall_second=output_tokens_per_wall_second,
             escalated_to_cloud=escalated,
             outcome=outcome,
             retry_count=worker.retry_count,
@@ -335,7 +335,7 @@ def finalize_worker(
             wall_time_s=wall_time,
             input_tokens=input_tokens,
             output_tokens=output_tokens,
-            output_tok_per_s=local_output_tokens_per_second,
+            output_tok_per_s=output_tokens_per_wall_second,
             context_compactions=context_compactions,
         )
     )

--- a/app/core/watcher/watcher_finalize.py
+++ b/app/core/watcher/watcher_finalize.py
@@ -200,7 +200,9 @@ def finalize_worker(
     )
 
     log_path = worker.worktree_path / f".claude/worker_{worker.ticket_id.lower()}.log"
-    input_tokens, output_tokens, context_compactions = _parse_worker_usage(log_path)
+    input_tokens, output_tokens, context_compactions, compact_duration_ms = (
+        _parse_worker_usage(log_path)
+    )
     eff = resolve_effective_mode(mode, worker.manifest.implementation_mode)
 
     # Parse git diff --shortstat to populate lines_changed / files_changed.
@@ -323,6 +325,8 @@ def finalize_worker(
             waste_breakdown_json=waste_breakdown_json,
             # WOR-348: persist manifest effort for retro analytics
             effort=worker.manifest.effort,
+            # WOR-358: persist total compaction time for throughput analysis
+            compact_duration_ms=compact_duration_ms,
         )
     )
     metrics.record_run(

--- a/app/core/watcher/watcher_helpers.py
+++ b/app/core/watcher/watcher_helpers.py
@@ -30,22 +30,20 @@ logger = logging.getLogger(__name__)
 
 def _parse_worker_usage(
     log_path: Path,
-) -> tuple[int | None, int | None, int | None]:
-    """Return cumulative (input_tokens, output_tokens) summed across all
-    ``type=assistant`` events in the stream-json worker log, plus
-    *context_compactions* counted from ``type=system, subtype=compact_boundary``
-    events (WOR-357).
+) -> tuple[int | None, int | None, int | None, int | None]:
+    """Return 4-tuple from the stream-json worker log:
+    ``(input_tokens, output_tokens, context_compactions, compact_duration_ms)``.
 
     Assistant-turn deltas are summed so that downstream metrics
     (``local_output_tokens``, ``output_tokens_per_wall_second``) reflect the
     true token volume of a session.
 
     *context_compactions* is the count of ``compact_boundary`` system events
-    emitted by Claude Code when it auto-compacts the conversation. The
-    pre-WOR-357 implementation read ``obj["context_compactions"]`` from the
-    final ``type=result`` event, but that field is never populated by Claude
-    Code — every row written before this fix had ``context_compactions=NULL``.
-    The actual signal lives in events of the form::
+    (WOR-357). *compact_duration_ms* (WOR-358) is the sum of
+    ``compact_metadata.duration_ms`` across those events — total wall time
+    spent on compaction during the session.
+
+    The actual compaction signal lives in events of the form::
 
         {"type":"system","subtype":"compact_boundary",
          "compact_metadata":{"trigger":"auto","pre_tokens":...,"post_tokens":...,
@@ -54,9 +52,9 @@ def _parse_worker_usage(
     When assistant events carry usage data, their cumulative sum is returned.
     When no assistant events have usage, the last ``type=result`` event's
     usage snapshot is used as a fallback for tokens. Returns
-    ``(None, None, None)`` when the log itself cannot be opened or parsed at
-    all; returns ``(in, out, 0)`` for parseable logs containing zero
-    compact_boundary events.
+    ``(None, None, None, None)`` when the log itself cannot be opened or
+    parsed at all; returns ``(in, out, 0, 0)`` for parseable logs containing
+    zero compact_boundary events.
     """
     try:
         with log_path.open(encoding="utf-8") as f:
@@ -64,6 +62,7 @@ def _parse_worker_usage(
             total_output = 0
             has_assistant_usage = False
             compact_count = 0
+            compact_duration_ms = 0
             last_input: int | None = None
             last_output: int | None = None
             for raw in f:
@@ -85,19 +84,28 @@ def _parse_worker_usage(
                         has_assistant_usage = True
                 elif obj_type == "system" and obj.get("subtype") == "compact_boundary":
                     compact_count += 1
+                    meta = obj.get("compact_metadata") or {}
+                    dur = meta.get("duration_ms")
+                    if isinstance(dur, (int, float)):
+                        compact_duration_ms += int(dur)
                 elif obj_type == "result":
                     usage = obj.get("usage") or {}
                     last_input = usage.get("input_tokens")
                     last_output = usage.get("output_tokens")
             if has_assistant_usage:
-                return total_input, total_output, compact_count
+                return total_input, total_output, compact_count, compact_duration_ms
             # Fallback to result snapshot when no assistant events carry usage.
             if last_input is not None and last_output is not None:
-                return int(last_input), int(last_output), compact_count
-            return None, None, compact_count
+                return (
+                    int(last_input),
+                    int(last_output),
+                    compact_count,
+                    compact_duration_ms,
+                )
+            return None, None, compact_count, compact_duration_ms
     except Exception:
-        return None, None, None
-    return None, None, None
+        return None, None, None, None
+    return None, None, None, None
 
 
 def format_token_count(total: int) -> str:
@@ -121,10 +129,10 @@ def format_worker_token_count(log_path: Path) -> str:
     """Return ``142k tokens`` for the worker log, ``? tokens`` if unknown.
 
     ``_parse_worker_usage`` already swallows its own errors and returns
-    ``(None, None, None)`` when the log is missing or malformed, so callers
-    do not need to wrap this in try/except.
+    ``(None, None, None, None)`` when the log is missing or malformed, so
+    callers do not need to wrap this in try/except.
     """
-    input_tok, output_tok, _ = _parse_worker_usage(log_path)
+    input_tok, output_tok, _, _ = _parse_worker_usage(log_path)
     if input_tok is None or output_tok is None:
         return "? tokens"
     return f"{format_token_count(input_tok + output_tok)} tokens"

--- a/app/core/watcher/watcher_helpers.py
+++ b/app/core/watcher/watcher_helpers.py
@@ -37,7 +37,7 @@ def _parse_worker_usage(
     events (WOR-357).
 
     Assistant-turn deltas are summed so that downstream metrics
-    (``local_output_tokens``, ``local_output_tokens_per_second``) reflect the
+    (``local_output_tokens``, ``output_tokens_per_wall_second``) reflect the
     true token volume of a session.
 
     *context_compactions* is the count of ``compact_boundary`` system events

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -394,7 +394,7 @@ class TestCheckRunLog:
 class TestMigration:
     def test_migration_adds_new_columns(self, tmp_path):
         """Existing DB gets local_input_tokens, local_output_tokens,
-        local_output_tokens_per_second without error."""
+        output_tokens_per_wall_second without error."""
         store = MetricsStore(db_path=tmp_path / "app.db")
         # Write and read before _migrate runs to establish baseline
         store.record(_ticket())
@@ -413,14 +413,14 @@ class TestMigration:
             _ticket(
                 local_input_tokens=10000,
                 local_output_tokens=500,
-                local_output_tokens_per_second=4.17,
+                output_tokens_per_wall_second=4.17,
             )
         )
         result = store.get_by_ticket("WOR-1", "proj-a")
         assert result is not None
         assert result.local_input_tokens == 10000
         assert result.local_output_tokens == 500
-        assert result.local_output_tokens_per_second == pytest.approx(4.17)
+        assert result.output_tokens_per_wall_second == pytest.approx(4.17)
 
     def test_new_columns_none_default(self, tmp_path):
         """Fields default to None when not provided."""
@@ -429,7 +429,7 @@ class TestMigration:
         result = store.get_by_ticket("WOR-1", "proj-a")
         assert result.local_input_tokens is None
         assert result.local_output_tokens is None
-        assert result.local_output_tokens_per_second is None
+        assert result.output_tokens_per_wall_second is None
 
     def test_backward_compat_local_tokens_preserved(self, tmp_path):
         """local_tokens remains valid alongside new fields."""

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -190,6 +190,39 @@ class TestEffortColumn:
             store._migrate(conn)
 
 
+class TestCompactDurationColumn:
+    """WOR-358: persist total compaction time per session."""
+
+    def test_compact_duration_round_trip(self, tmp_path):
+        store = _store(tmp_path)
+        store.record(_ticket(compact_duration_ms=88463))
+        result = store.get_by_ticket("WOR-1", "proj-a")
+        assert result is not None
+        assert result.compact_duration_ms == 88463
+
+    def test_compact_duration_defaults_to_none(self, tmp_path):
+        store = _store(tmp_path)
+        store.record(_ticket())
+        result = store.get_by_ticket("WOR-1", "proj-a")
+        assert result is not None
+        assert result.compact_duration_ms is None
+
+    def test_compact_duration_zero_distinct_from_none(self, tmp_path):
+        """Zero (no compactions) is a valid value, distinct from None (unknown)."""
+        store = _store(tmp_path)
+        store.record(_ticket(compact_duration_ms=0))
+        result = store.get_by_ticket("WOR-1", "proj-a")
+        assert result is not None
+        assert result.compact_duration_ms == 0
+        assert result.compact_duration_ms is not None
+
+    def test_compact_duration_migration_idempotent(self, tmp_path):
+        store = _store(tmp_path)
+        with store._connect() as conn:
+            store._migrate(conn)
+            store._migrate(conn)
+
+
 class TestAdditionalMetrics:
     def test_retry_and_diff_metrics_round_trip(self, tmp_path):
         store = _store(tmp_path)

--- a/tests/test_watcher_finalize.py
+++ b/tests/test_watcher_finalize.py
@@ -1195,7 +1195,7 @@ def test_finalize_worker_writes_separate_token_fields(tmp_path: Path) -> None:
     assert m.local_input_tokens == 15000
     assert m.local_output_tokens == 600
     assert m.local_tokens == 15600  # backward-compat sum
-    assert m.local_output_tokens_per_second == pytest.approx(60.0)  # 600/10
+    assert m.output_tokens_per_wall_second == pytest.approx(60.0)  # 600/10
 
 
 def test_finalize_worker_token_fields_none_when_no_log(
@@ -1227,7 +1227,7 @@ def test_finalize_worker_token_fields_none_when_no_log(
     assert m.local_input_tokens is None
     assert m.local_output_tokens is None
     assert m.local_tokens is None
-    assert m.local_output_tokens_per_second is None
+    assert m.output_tokens_per_wall_second is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_watcher_finalize_metrics.py
+++ b/tests/test_watcher_finalize_metrics.py
@@ -266,7 +266,7 @@ def test_finalize_worker_cloud_metrics_populated_for_cloud_run(
     assert m.local_output_tokens is None
     assert m.local_tokens is None
     assert m.local_model is None
-    assert m.local_output_tokens_per_second is None
+    assert m.output_tokens_per_wall_second is None
 
 
 def test_finalize_worker_cloud_model_from_env(
@@ -406,7 +406,7 @@ def test_finalize_worker_local_run_keeps_local_fields(
     assert m.local_input_tokens == 15000
     assert m.local_output_tokens == 600
     assert m.local_tokens == 15600
-    assert m.local_output_tokens_per_second == pytest.approx(60.0)
+    assert m.output_tokens_per_wall_second == pytest.approx(60.0)
     # Cloud fields must be None for local runs
     assert m.cloud_model is None
     assert m.cloud_tokens is None

--- a/tests/test_watcher_helpers.py
+++ b/tests/test_watcher_helpers.py
@@ -247,7 +247,7 @@ def test_parse_worker_usage_success(tmp_path: Path) -> None:
         }
     )
     log = _write_log(tmp_path, ['{"type":"other","x":1}', result_line])
-    input_tok, output_tok, compactions = _parse_worker_usage(log)
+    input_tok, output_tok, compactions, _ = _parse_worker_usage(log)
     assert input_tok == 1000
     assert output_tok == 200
     assert compactions == 0  # was 3 under the old (broken) semantics
@@ -259,7 +259,7 @@ def test_parse_worker_usage_no_context_compactions(tmp_path: Path) -> None:
         {"type": "result", "usage": {"input_tokens": 500, "output_tokens": 50}}
     )
     log = _write_log(tmp_path, [result_line])
-    input_tok, output_tok, compactions = _parse_worker_usage(log)
+    input_tok, output_tok, compactions, _ = _parse_worker_usage(log)
     assert input_tok == 500
     assert output_tok == 50
     assert compactions == 0  # was None under the old semantics
@@ -268,7 +268,7 @@ def test_parse_worker_usage_no_context_compactions(tmp_path: Path) -> None:
 def test_parse_worker_usage_missing_log(tmp_path: Path) -> None:
     """Missing log returns None for all three fields (unchanged)."""
     log = tmp_path / "no_such_file.log"
-    input_tok, output_tok, compactions = _parse_worker_usage(log)
+    input_tok, output_tok, compactions, _ = _parse_worker_usage(log)
     assert input_tok is None
     assert output_tok is None
     assert compactions is None
@@ -283,7 +283,7 @@ def test_parse_worker_usage_no_result_line(tmp_path: Path) -> None:
             json.dumps({"type": "assistant", "content": "hello"}),
         ],
     )
-    input_tok, output_tok, compactions = _parse_worker_usage(log)
+    input_tok, output_tok, compactions, _ = _parse_worker_usage(log)
     assert input_tok is None
     assert output_tok is None
     assert compactions == 0  # log was parseable; just no compactions
@@ -293,7 +293,7 @@ def test_parse_worker_usage_malformed_json(tmp_path: Path) -> None:
     """Fully unparseable log returns None for all three fields (unchanged)."""
     log = tmp_path / "worker.log"
     log.write_text("not json at all\n{broken\n", encoding="utf-8")
-    input_tok, output_tok, compactions = _parse_worker_usage(log)
+    input_tok, output_tok, compactions, _ = _parse_worker_usage(log)
     assert input_tok is None
     assert output_tok is None
     # No JSON parseable at all → 0 events seen, but the file IS open-able,
@@ -331,7 +331,7 @@ def test_parse_worker_usage_one_compact_boundary(tmp_path: Path) -> None:
             ),
         ],
     )
-    _, _, compactions = _parse_worker_usage(log)
+    _, _, compactions, _ = _parse_worker_usage(log)
     assert compactions == 1
 
 
@@ -360,8 +360,80 @@ def test_parse_worker_usage_multiple_compact_boundaries(tmp_path: Path) -> None:
             ),
         ],
     )
-    _, _, compactions = _parse_worker_usage(log)
+    _, _, compactions, _ = _parse_worker_usage(log)
     assert compactions == 3
+
+
+def test_parse_worker_usage_compact_duration_summed(tmp_path: Path) -> None:
+    """WOR-358: 4th tuple element sums compact_metadata.duration_ms."""
+    log = _write_log(
+        tmp_path,
+        [
+            json.dumps(
+                {
+                    "type": "system",
+                    "subtype": "compact_boundary",
+                    "compact_metadata": {"duration_ms": 50000},
+                }
+            ),
+            json.dumps(
+                {
+                    "type": "system",
+                    "subtype": "compact_boundary",
+                    "compact_metadata": {"duration_ms": 38463},
+                }
+            ),
+            json.dumps(
+                {
+                    "type": "result",
+                    "usage": {"input_tokens": 100, "output_tokens": 5},
+                }
+            ),
+        ],
+    )
+    _, _, compactions, compact_dur = _parse_worker_usage(log)
+    assert compactions == 2
+    assert compact_dur == 88463
+
+
+def test_parse_worker_usage_compact_duration_zero_when_no_compactions(
+    tmp_path: Path,
+) -> None:
+    """No compact_boundary events → compact_duration_ms is 0, not None."""
+    log = _write_log(
+        tmp_path,
+        [
+            json.dumps(
+                {"type": "result", "usage": {"input_tokens": 100, "output_tokens": 5}}
+            ),
+        ],
+    )
+    _, _, compactions, compact_dur = _parse_worker_usage(log)
+    assert compactions == 0
+    assert compact_dur == 0
+
+
+def test_parse_worker_usage_compact_duration_missing_metadata(tmp_path: Path) -> None:
+    """compact_boundary event without duration_ms → counts as compaction but adds 0."""
+    log = _write_log(
+        tmp_path,
+        [
+            json.dumps({"type": "system", "subtype": "compact_boundary"}),
+            json.dumps(
+                {
+                    "type": "system",
+                    "subtype": "compact_boundary",
+                    "compact_metadata": {"trigger": "auto"},  # no duration_ms key
+                }
+            ),
+            json.dumps(
+                {"type": "result", "usage": {"input_tokens": 100, "output_tokens": 5}}
+            ),
+        ],
+    )
+    _, _, compactions, compact_dur = _parse_worker_usage(log)
+    assert compactions == 2
+    assert compact_dur == 0
 
 
 def test_parse_worker_usage_other_system_subtypes_ignored(tmp_path: Path) -> None:
@@ -381,7 +453,7 @@ def test_parse_worker_usage_other_system_subtypes_ignored(tmp_path: Path) -> Non
             ),
         ],
     )
-    _, _, compactions = _parse_worker_usage(log)
+    _, _, compactions, _ = _parse_worker_usage(log)
     assert compactions == 0
 
 
@@ -419,7 +491,7 @@ def test_parse_worker_usage_compact_boundary_with_assistant_usage(
             ),
         ],
     )
-    input_tok, output_tok, compactions = _parse_worker_usage(log)
+    input_tok, output_tok, compactions, _ = _parse_worker_usage(log)
     assert input_tok == 1500  # 1000 + 500 (sum across assistant events)
     assert output_tok == 150  # 100 + 50
     assert compactions == 1
@@ -477,7 +549,7 @@ def test_parse_worker_usage_cumulative_output_tokens(tmp_path: Path) -> None:
     )
     log = tmp_path / "worker.log"
     log.write_text("\n".join(assistant + [result_line]) + "\n", encoding="utf-8")
-    input_tok, output_tok, compactions = _parse_worker_usage(log)
+    input_tok, output_tok, compactions, _ = _parse_worker_usage(log)
     assert output_tok == 600  # 100+200+300
     assert compactions == 0  # WOR-357: result.context_compactions field is ignored
 
@@ -534,7 +606,7 @@ def test_parse_worker_usage_cumulative_input_tokens(tmp_path: Path) -> None:
     )
     log = tmp_path / "worker.log"
     log.write_text("\n".join(assistant + [result_line]) + "\n", encoding="utf-8")
-    input_tok, output_tok, compactions = _parse_worker_usage(log)
+    input_tok, output_tok, compactions, _ = _parse_worker_usage(log)
     assert input_tok == 35000  # 8000+12000+15000
 
 
@@ -548,7 +620,7 @@ def test_parse_worker_usage_mixed_valid_invalid_lines(tmp_path: Path) -> None:
     )
     log = tmp_path / "worker.log"
     log.write_text("garbage line\n" + result_line + "\n", encoding="utf-8")
-    input_tok, output_tok, compactions = _parse_worker_usage(log)
+    input_tok, output_tok, compactions, _ = _parse_worker_usage(log)
     assert input_tok == 300
     assert output_tok == 100
     assert compactions == 0  # WOR-357: result.context_compactions field is ignored
@@ -562,7 +634,7 @@ def test_parse_worker_usage_returns_first_result_line(tmp_path: Path) -> None:
         {"type": "result", "usage": {"input_tokens": 999, "output_tokens": 999}}
     )
     log = _write_log(tmp_path, [first, second])
-    input_tok, output_tok, _ = _parse_worker_usage(log)
+    input_tok, output_tok, _, _ = _parse_worker_usage(log)
     # No assistant events — fallback uses the last result event's snapshot.
     assert input_tok == 999
     assert output_tok == 999
@@ -572,7 +644,7 @@ def test_parse_worker_usage_empty_file(tmp_path: Path) -> None:
     """Empty file is open-able and parseable → (None, None, 0)."""
     log = tmp_path / "empty.log"
     log.write_text("", encoding="utf-8")
-    input_tok, output_tok, compactions = _parse_worker_usage(log)
+    input_tok, output_tok, compactions, _ = _parse_worker_usage(log)
     assert input_tok is None
     assert output_tok is None
     assert compactions == 0  # WOR-357: parseable path returns 0, not None
@@ -625,7 +697,7 @@ def test_parse_worker_usage_returns_separate_tokens(tmp_path: Path) -> None:
         }
     )
     log = _write_log(tmp_path, [result_line])
-    input_tok, output_tok, _ = _parse_worker_usage(log)
+    input_tok, output_tok, _, _ = _parse_worker_usage(log)
     assert input_tok == 12000
     assert output_tok == 800
 
@@ -636,7 +708,7 @@ def test_parse_worker_usage_missing_input_token_returns_none(
     """When input_tokens is absent, all tokens are None."""
     result_line = json.dumps({"type": "result", "usage": {"output_tokens": 500}})
     log = _write_log(tmp_path, [result_line])
-    input_tok, output_tok, _ = _parse_worker_usage(log)
+    input_tok, output_tok, _, _ = _parse_worker_usage(log)
     assert input_tok is None
     assert output_tok is None
 
@@ -647,6 +719,6 @@ def test_parse_worker_usage_missing_output_token_returns_none(
     """When output_tokens is absent, all tokens are None."""
     result_line = json.dumps({"type": "result", "usage": {"input_tokens": 3000}})
     log = _write_log(tmp_path, [result_line])
-    input_tok, output_tok, _ = _parse_worker_usage(log)
+    input_tok, output_tok, _, _ = _parse_worker_usage(log)
     assert input_tok is None
     assert output_tok is None


### PR DESCRIPTION
Sub-ticket 2 of 5 in WOR-365. Extends _parse_worker_usage to 4-tuple (adds compact_duration_ms), wires through to TicketMetrics. WOR-332's compaction was 88s — invisible until now.

Closes WOR-358
Part of WOR-365