### PR TITLE
WOR-360 Persist api_retry_count for backend-stability monitoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ scripts/bench/fixtures/
 
 # Benchmark results DB (local data, not committed)
 bench_results.db
+bench.db
 
 # Unified metrics + bench DB (local data, not committed)
 app.db

--- a/app/core/metrics.py
+++ b/app/core/metrics.py
@@ -90,6 +90,7 @@ CREATE TABLE IF NOT EXISTS ticket_metrics (
     tags                  TEXT,
     notes                 TEXT,
     effort                TEXT,
+    compact_duration_ms   INTEGER,
     recorded_at           TEXT NOT NULL DEFAULT (datetime('now')),
     PRIMARY KEY (ticket_id, project_id)
 )
@@ -197,6 +198,14 @@ class TicketMetrics(BaseModel):
     effort: str | None = Field(
         default=None,
         description="Effort level from the manifest: low/medium/high/xhigh/max",
+    )
+    compact_duration_ms: int | None = Field(
+        default=None,
+        description=(
+            "Cumulative ms spent on context compaction during the session "
+            "(WOR-358). Sum of compact_metadata.duration_ms across all "
+            "compact_boundary system events."
+        ),
     )
 
 
@@ -392,6 +401,10 @@ class MetricsStore:
             conn.execute("ALTER TABLE ticket_metrics ADD COLUMN notes TEXT")
         if "effort" not in existing:
             conn.execute("ALTER TABLE ticket_metrics ADD COLUMN effort TEXT")
+        if "compact_duration_ms" not in existing:
+            conn.execute(
+                "ALTER TABLE ticket_metrics ADD COLUMN compact_duration_ms INTEGER"
+            )
 
     @contextmanager
     def _connect(self) -> Generator[sqlite3.Connection, None, None]:
@@ -419,7 +432,8 @@ class MetricsStore:
                     sonar_findings_count, context_compactions,
                     change_type, reasoning_demand, scope_clarity,
                     constraint_density, ac_specificity, tech_stack, raw_extensions,
-                    waste_score, waste_breakdown_json, tags, notes, effort
+                    waste_score, waste_breakdown_json, tags, notes, effort,
+                    compact_duration_ms
                 ) VALUES (
                     :ticket_id, :project_id, :epic_id, :implementation_mode,
                     :cloud_used, :cloud_model, :cloud_tokens, :cloud_cost_estimate,
@@ -433,7 +447,8 @@ class MetricsStore:
                     :sonar_findings_count, :context_compactions,
                     :change_type, :reasoning_demand, :scope_clarity,
                     :constraint_density, :ac_specificity, :tech_stack, :raw_extensions,
-                    :waste_score, :waste_breakdown_json, :tags, :notes, :effort
+                    :waste_score, :waste_breakdown_json, :tags, :notes, :effort,
+                    :compact_duration_ms
                 )
                 """,
                 {

--- a/app/core/metrics.py
+++ b/app/core/metrics.py
@@ -91,6 +91,7 @@ CREATE TABLE IF NOT EXISTS ticket_metrics (
     notes                 TEXT,
     effort                TEXT,
     compact_duration_ms   INTEGER,
+    api_retry_count       INTEGER,
     recorded_at           TEXT NOT NULL DEFAULT (datetime('now')),
     PRIMARY KEY (ticket_id, project_id)
 )
@@ -205,6 +206,13 @@ class TicketMetrics(BaseModel):
             "Cumulative ms spent on context compaction during the session "
             "(WOR-358). Sum of compact_metadata.duration_ms across all "
             "compact_boundary system events."
+        ),
+    )
+    api_retry_count: int | None = Field(
+        default=None,
+        description=(
+            "Count of system/api_retry events (WOR-360) — Claude Code's "
+            "transient backend retries. Backend-stability proxy."
         ),
     )
 
@@ -405,6 +413,10 @@ class MetricsStore:
             conn.execute(
                 "ALTER TABLE ticket_metrics ADD COLUMN compact_duration_ms INTEGER"
             )
+        if "api_retry_count" not in existing:
+            conn.execute(
+                "ALTER TABLE ticket_metrics ADD COLUMN api_retry_count INTEGER"
+            )
 
     @contextmanager
     def _connect(self) -> Generator[sqlite3.Connection, None, None]:
@@ -433,7 +445,7 @@ class MetricsStore:
                     change_type, reasoning_demand, scope_clarity,
                     constraint_density, ac_specificity, tech_stack, raw_extensions,
                     waste_score, waste_breakdown_json, tags, notes, effort,
-                    compact_duration_ms
+                    compact_duration_ms, api_retry_count
                 ) VALUES (
                     :ticket_id, :project_id, :epic_id, :implementation_mode,
                     :cloud_used, :cloud_model, :cloud_tokens, :cloud_cost_estimate,
@@ -448,7 +460,7 @@ class MetricsStore:
                     :change_type, :reasoning_demand, :scope_clarity,
                     :constraint_density, :ac_specificity, :tech_stack, :raw_extensions,
                     :waste_score, :waste_breakdown_json, :tags, :notes, :effort,
-                    :compact_duration_ms
+                    :compact_duration_ms, :api_retry_count
                 )
                 """,
                 {

--- a/app/core/watcher/watcher_finalize.py
+++ b/app/core/watcher/watcher_finalize.py
@@ -25,6 +25,7 @@ from app.core.metrics import (
 
 from .watcher_helpers import (
     _POLICY_FLAGS,
+    _parse_worker_api_retries,
     _parse_worker_usage,
     _read_result_flags,
     resolve_effective_mode,
@@ -203,6 +204,7 @@ def finalize_worker(
     input_tokens, output_tokens, context_compactions, compact_duration_ms = (
         _parse_worker_usage(log_path)
     )
+    api_retry_count = _parse_worker_api_retries(log_path)
     eff = resolve_effective_mode(mode, worker.manifest.implementation_mode)
 
     # Parse git diff --shortstat to populate lines_changed / files_changed.
@@ -327,6 +329,8 @@ def finalize_worker(
             effort=worker.manifest.effort,
             # WOR-358: persist total compaction time for throughput analysis
             compact_duration_ms=compact_duration_ms,
+            # WOR-360: persist Claude Code's internal retry count
+            api_retry_count=api_retry_count,
         )
     )
     metrics.record_run(

--- a/app/core/watcher/watcher_finalize.py
+++ b/app/core/watcher/watcher_finalize.py
@@ -200,7 +200,9 @@ def finalize_worker(
     )
 
     log_path = worker.worktree_path / f".claude/worker_{worker.ticket_id.lower()}.log"
-    input_tokens, output_tokens, context_compactions = _parse_worker_usage(log_path)
+    input_tokens, output_tokens, context_compactions, compact_duration_ms = (
+        _parse_worker_usage(log_path)
+    )
     eff = resolve_effective_mode(mode, worker.manifest.implementation_mode)
 
     # Parse git diff --shortstat to populate lines_changed / files_changed.
@@ -323,6 +325,8 @@ def finalize_worker(
             waste_breakdown_json=waste_breakdown_json,
             # WOR-348: persist manifest effort for retro analytics
             effort=worker.manifest.effort,
+            # WOR-358: persist total compaction time for throughput analysis
+            compact_duration_ms=compact_duration_ms,
         )
     )
     metrics.record_run(

--- a/app/core/watcher/watcher_helpers.py
+++ b/app/core/watcher/watcher_helpers.py
@@ -30,22 +30,20 @@ logger = logging.getLogger(__name__)
 
 def _parse_worker_usage(
     log_path: Path,
-) -> tuple[int | None, int | None, int | None]:
-    """Return cumulative (input_tokens, output_tokens) summed across all
-    ``type=assistant`` events in the stream-json worker log, plus
-    *context_compactions* counted from ``type=system, subtype=compact_boundary``
-    events (WOR-357).
+) -> tuple[int | None, int | None, int | None, int | None]:
+    """Return 4-tuple from the stream-json worker log:
+    ``(input_tokens, output_tokens, context_compactions, compact_duration_ms)``.
 
     Assistant-turn deltas are summed so that downstream metrics
     (``local_output_tokens``, ``output_tokens_per_wall_second``) reflect the
     true token volume of a session.
 
     *context_compactions* is the count of ``compact_boundary`` system events
-    emitted by Claude Code when it auto-compacts the conversation. The
-    pre-WOR-357 implementation read ``obj["context_compactions"]`` from the
-    final ``type=result`` event, but that field is never populated by Claude
-    Code — every row written before this fix had ``context_compactions=NULL``.
-    The actual signal lives in events of the form::
+    (WOR-357). *compact_duration_ms* (WOR-358) is the sum of
+    ``compact_metadata.duration_ms`` across those events — total wall time
+    spent on compaction during the session.
+
+    The actual compaction signal lives in events of the form::
 
         {"type":"system","subtype":"compact_boundary",
          "compact_metadata":{"trigger":"auto","pre_tokens":...,"post_tokens":...,
@@ -54,9 +52,9 @@ def _parse_worker_usage(
     When assistant events carry usage data, their cumulative sum is returned.
     When no assistant events have usage, the last ``type=result`` event's
     usage snapshot is used as a fallback for tokens. Returns
-    ``(None, None, None)`` when the log itself cannot be opened or parsed at
-    all; returns ``(in, out, 0)`` for parseable logs containing zero
-    compact_boundary events.
+    ``(None, None, None, None)`` when the log itself cannot be opened or
+    parsed at all; returns ``(in, out, 0, 0)`` for parseable logs containing
+    zero compact_boundary events.
     """
     try:
         with log_path.open(encoding="utf-8") as f:
@@ -64,6 +62,7 @@ def _parse_worker_usage(
             total_output = 0
             has_assistant_usage = False
             compact_count = 0
+            compact_duration_ms = 0
             last_input: int | None = None
             last_output: int | None = None
             for raw in f:
@@ -85,19 +84,28 @@ def _parse_worker_usage(
                         has_assistant_usage = True
                 elif obj_type == "system" and obj.get("subtype") == "compact_boundary":
                     compact_count += 1
+                    meta = obj.get("compact_metadata") or {}
+                    dur = meta.get("duration_ms")
+                    if isinstance(dur, (int, float)):
+                        compact_duration_ms += int(dur)
                 elif obj_type == "result":
                     usage = obj.get("usage") or {}
                     last_input = usage.get("input_tokens")
                     last_output = usage.get("output_tokens")
             if has_assistant_usage:
-                return total_input, total_output, compact_count
+                return total_input, total_output, compact_count, compact_duration_ms
             # Fallback to result snapshot when no assistant events carry usage.
             if last_input is not None and last_output is not None:
-                return int(last_input), int(last_output), compact_count
-            return None, None, compact_count
+                return (
+                    int(last_input),
+                    int(last_output),
+                    compact_count,
+                    compact_duration_ms,
+                )
+            return None, None, compact_count, compact_duration_ms
     except Exception:
-        return None, None, None
-    return None, None, None
+        return None, None, None, None
+    return None, None, None, None
 
 
 def format_token_count(total: int) -> str:
@@ -121,10 +129,10 @@ def format_worker_token_count(log_path: Path) -> str:
     """Return ``142k tokens`` for the worker log, ``? tokens`` if unknown.
 
     ``_parse_worker_usage`` already swallows its own errors and returns
-    ``(None, None, None)`` when the log is missing or malformed, so callers
-    do not need to wrap this in try/except.
+    ``(None, None, None, None)`` when the log is missing or malformed, so
+    callers do not need to wrap this in try/except.
     """
-    input_tok, output_tok, _ = _parse_worker_usage(log_path)
+    input_tok, output_tok, _, _ = _parse_worker_usage(log_path)
     if input_tok is None or output_tok is None:
         return "? tokens"
     return f"{format_token_count(input_tok + output_tok)} tokens"

--- a/app/core/watcher/watcher_helpers.py
+++ b/app/core/watcher/watcher_helpers.py
@@ -108,6 +108,34 @@ def _parse_worker_usage(
     return None, None, None, None
 
 
+def _parse_worker_api_retries(log_path: Path) -> int | None:
+    """Count ``type=system, subtype=api_retry`` events in the worker log (WOR-360).
+
+    Each event represents a transient API failure that Claude Code retried
+    internally. Useful as a backend-stability proxy — sessions with many
+    retries correlate with degraded vLLM/LiteLLM throughput.
+
+    Returns ``None`` if the log cannot be opened/parsed; ``0`` for
+    parseable logs with no retry events.
+    """
+    try:
+        with log_path.open(encoding="utf-8") as f:
+            count = 0
+            for raw in f:
+                line = raw.strip()
+                if not line:
+                    continue
+                try:
+                    obj = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if obj.get("type") == "system" and obj.get("subtype") == "api_retry":
+                    count += 1
+            return count
+    except Exception:
+        return None
+
+
 def format_token_count(total: int) -> str:
     """Format a token count for display: ``142k`` for >= 1000, raw integer below."""
     if total < 1000:

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -190,6 +190,39 @@ class TestEffortColumn:
             store._migrate(conn)
 
 
+class TestCompactDurationColumn:
+    """WOR-358: persist total compaction time per session."""
+
+    def test_compact_duration_round_trip(self, tmp_path):
+        store = _store(tmp_path)
+        store.record(_ticket(compact_duration_ms=88463))
+        result = store.get_by_ticket("WOR-1", "proj-a")
+        assert result is not None
+        assert result.compact_duration_ms == 88463
+
+    def test_compact_duration_defaults_to_none(self, tmp_path):
+        store = _store(tmp_path)
+        store.record(_ticket())
+        result = store.get_by_ticket("WOR-1", "proj-a")
+        assert result is not None
+        assert result.compact_duration_ms is None
+
+    def test_compact_duration_zero_distinct_from_none(self, tmp_path):
+        """Zero (no compactions) is a valid value, distinct from None (unknown)."""
+        store = _store(tmp_path)
+        store.record(_ticket(compact_duration_ms=0))
+        result = store.get_by_ticket("WOR-1", "proj-a")
+        assert result is not None
+        assert result.compact_duration_ms == 0
+        assert result.compact_duration_ms is not None
+
+    def test_compact_duration_migration_idempotent(self, tmp_path):
+        store = _store(tmp_path)
+        with store._connect() as conn:
+            store._migrate(conn)
+            store._migrate(conn)
+
+
 class TestAdditionalMetrics:
     def test_retry_and_diff_metrics_round_trip(self, tmp_path):
         store = _store(tmp_path)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -223,6 +223,38 @@ class TestCompactDurationColumn:
             store._migrate(conn)
 
 
+class TestApiRetryColumn:
+    """WOR-360: persist Claude Code's internal api_retry count per session."""
+
+    def test_api_retry_round_trip(self, tmp_path):
+        store = _store(tmp_path)
+        store.record(_ticket(api_retry_count=6))
+        result = store.get_by_ticket("WOR-1", "proj-a")
+        assert result is not None
+        assert result.api_retry_count == 6
+
+    def test_api_retry_defaults_to_none(self, tmp_path):
+        store = _store(tmp_path)
+        store.record(_ticket())
+        result = store.get_by_ticket("WOR-1", "proj-a")
+        assert result is not None
+        assert result.api_retry_count is None
+
+    def test_api_retry_zero_distinct_from_none(self, tmp_path):
+        store = _store(tmp_path)
+        store.record(_ticket(api_retry_count=0))
+        result = store.get_by_ticket("WOR-1", "proj-a")
+        assert result is not None
+        assert result.api_retry_count == 0
+        assert result.api_retry_count is not None
+
+    def test_api_retry_migration_idempotent(self, tmp_path):
+        store = _store(tmp_path)
+        with store._connect() as conn:
+            store._migrate(conn)
+            store._migrate(conn)
+
+
 class TestAdditionalMetrics:
     def test_retry_and_diff_metrics_round_trip(self, tmp_path):
         store = _store(tmp_path)

--- a/tests/test_watcher_helpers.py
+++ b/tests/test_watcher_helpers.py
@@ -247,7 +247,7 @@ def test_parse_worker_usage_success(tmp_path: Path) -> None:
         }
     )
     log = _write_log(tmp_path, ['{"type":"other","x":1}', result_line])
-    input_tok, output_tok, compactions = _parse_worker_usage(log)
+    input_tok, output_tok, compactions, _ = _parse_worker_usage(log)
     assert input_tok == 1000
     assert output_tok == 200
     assert compactions == 0  # was 3 under the old (broken) semantics
@@ -259,7 +259,7 @@ def test_parse_worker_usage_no_context_compactions(tmp_path: Path) -> None:
         {"type": "result", "usage": {"input_tokens": 500, "output_tokens": 50}}
     )
     log = _write_log(tmp_path, [result_line])
-    input_tok, output_tok, compactions = _parse_worker_usage(log)
+    input_tok, output_tok, compactions, _ = _parse_worker_usage(log)
     assert input_tok == 500
     assert output_tok == 50
     assert compactions == 0  # was None under the old semantics
@@ -268,7 +268,7 @@ def test_parse_worker_usage_no_context_compactions(tmp_path: Path) -> None:
 def test_parse_worker_usage_missing_log(tmp_path: Path) -> None:
     """Missing log returns None for all three fields (unchanged)."""
     log = tmp_path / "no_such_file.log"
-    input_tok, output_tok, compactions = _parse_worker_usage(log)
+    input_tok, output_tok, compactions, _ = _parse_worker_usage(log)
     assert input_tok is None
     assert output_tok is None
     assert compactions is None
@@ -283,7 +283,7 @@ def test_parse_worker_usage_no_result_line(tmp_path: Path) -> None:
             json.dumps({"type": "assistant", "content": "hello"}),
         ],
     )
-    input_tok, output_tok, compactions = _parse_worker_usage(log)
+    input_tok, output_tok, compactions, _ = _parse_worker_usage(log)
     assert input_tok is None
     assert output_tok is None
     assert compactions == 0  # log was parseable; just no compactions
@@ -293,7 +293,7 @@ def test_parse_worker_usage_malformed_json(tmp_path: Path) -> None:
     """Fully unparseable log returns None for all three fields (unchanged)."""
     log = tmp_path / "worker.log"
     log.write_text("not json at all\n{broken\n", encoding="utf-8")
-    input_tok, output_tok, compactions = _parse_worker_usage(log)
+    input_tok, output_tok, compactions, _ = _parse_worker_usage(log)
     assert input_tok is None
     assert output_tok is None
     # No JSON parseable at all → 0 events seen, but the file IS open-able,
@@ -331,7 +331,7 @@ def test_parse_worker_usage_one_compact_boundary(tmp_path: Path) -> None:
             ),
         ],
     )
-    _, _, compactions = _parse_worker_usage(log)
+    _, _, compactions, _ = _parse_worker_usage(log)
     assert compactions == 1
 
 
@@ -360,8 +360,80 @@ def test_parse_worker_usage_multiple_compact_boundaries(tmp_path: Path) -> None:
             ),
         ],
     )
-    _, _, compactions = _parse_worker_usage(log)
+    _, _, compactions, _ = _parse_worker_usage(log)
     assert compactions == 3
+
+
+def test_parse_worker_usage_compact_duration_summed(tmp_path: Path) -> None:
+    """WOR-358: 4th tuple element sums compact_metadata.duration_ms."""
+    log = _write_log(
+        tmp_path,
+        [
+            json.dumps(
+                {
+                    "type": "system",
+                    "subtype": "compact_boundary",
+                    "compact_metadata": {"duration_ms": 50000},
+                }
+            ),
+            json.dumps(
+                {
+                    "type": "system",
+                    "subtype": "compact_boundary",
+                    "compact_metadata": {"duration_ms": 38463},
+                }
+            ),
+            json.dumps(
+                {
+                    "type": "result",
+                    "usage": {"input_tokens": 100, "output_tokens": 5},
+                }
+            ),
+        ],
+    )
+    _, _, compactions, compact_dur = _parse_worker_usage(log)
+    assert compactions == 2
+    assert compact_dur == 88463
+
+
+def test_parse_worker_usage_compact_duration_zero_when_no_compactions(
+    tmp_path: Path,
+) -> None:
+    """No compact_boundary events → compact_duration_ms is 0, not None."""
+    log = _write_log(
+        tmp_path,
+        [
+            json.dumps(
+                {"type": "result", "usage": {"input_tokens": 100, "output_tokens": 5}}
+            ),
+        ],
+    )
+    _, _, compactions, compact_dur = _parse_worker_usage(log)
+    assert compactions == 0
+    assert compact_dur == 0
+
+
+def test_parse_worker_usage_compact_duration_missing_metadata(tmp_path: Path) -> None:
+    """compact_boundary event without duration_ms → counts as compaction but adds 0."""
+    log = _write_log(
+        tmp_path,
+        [
+            json.dumps({"type": "system", "subtype": "compact_boundary"}),
+            json.dumps(
+                {
+                    "type": "system",
+                    "subtype": "compact_boundary",
+                    "compact_metadata": {"trigger": "auto"},  # no duration_ms key
+                }
+            ),
+            json.dumps(
+                {"type": "result", "usage": {"input_tokens": 100, "output_tokens": 5}}
+            ),
+        ],
+    )
+    _, _, compactions, compact_dur = _parse_worker_usage(log)
+    assert compactions == 2
+    assert compact_dur == 0
 
 
 def test_parse_worker_usage_other_system_subtypes_ignored(tmp_path: Path) -> None:
@@ -381,7 +453,7 @@ def test_parse_worker_usage_other_system_subtypes_ignored(tmp_path: Path) -> Non
             ),
         ],
     )
-    _, _, compactions = _parse_worker_usage(log)
+    _, _, compactions, _ = _parse_worker_usage(log)
     assert compactions == 0
 
 
@@ -419,7 +491,7 @@ def test_parse_worker_usage_compact_boundary_with_assistant_usage(
             ),
         ],
     )
-    input_tok, output_tok, compactions = _parse_worker_usage(log)
+    input_tok, output_tok, compactions, _ = _parse_worker_usage(log)
     assert input_tok == 1500  # 1000 + 500 (sum across assistant events)
     assert output_tok == 150  # 100 + 50
     assert compactions == 1
@@ -477,7 +549,7 @@ def test_parse_worker_usage_cumulative_output_tokens(tmp_path: Path) -> None:
     )
     log = tmp_path / "worker.log"
     log.write_text("\n".join(assistant + [result_line]) + "\n", encoding="utf-8")
-    input_tok, output_tok, compactions = _parse_worker_usage(log)
+    input_tok, output_tok, compactions, _ = _parse_worker_usage(log)
     assert output_tok == 600  # 100+200+300
     assert compactions == 0  # WOR-357: result.context_compactions field is ignored
 
@@ -534,7 +606,7 @@ def test_parse_worker_usage_cumulative_input_tokens(tmp_path: Path) -> None:
     )
     log = tmp_path / "worker.log"
     log.write_text("\n".join(assistant + [result_line]) + "\n", encoding="utf-8")
-    input_tok, output_tok, compactions = _parse_worker_usage(log)
+    input_tok, output_tok, compactions, _ = _parse_worker_usage(log)
     assert input_tok == 35000  # 8000+12000+15000
 
 
@@ -548,7 +620,7 @@ def test_parse_worker_usage_mixed_valid_invalid_lines(tmp_path: Path) -> None:
     )
     log = tmp_path / "worker.log"
     log.write_text("garbage line\n" + result_line + "\n", encoding="utf-8")
-    input_tok, output_tok, compactions = _parse_worker_usage(log)
+    input_tok, output_tok, compactions, _ = _parse_worker_usage(log)
     assert input_tok == 300
     assert output_tok == 100
     assert compactions == 0  # WOR-357: result.context_compactions field is ignored
@@ -562,7 +634,7 @@ def test_parse_worker_usage_returns_first_result_line(tmp_path: Path) -> None:
         {"type": "result", "usage": {"input_tokens": 999, "output_tokens": 999}}
     )
     log = _write_log(tmp_path, [first, second])
-    input_tok, output_tok, _ = _parse_worker_usage(log)
+    input_tok, output_tok, _, _ = _parse_worker_usage(log)
     # No assistant events — fallback uses the last result event's snapshot.
     assert input_tok == 999
     assert output_tok == 999
@@ -572,7 +644,7 @@ def test_parse_worker_usage_empty_file(tmp_path: Path) -> None:
     """Empty file is open-able and parseable → (None, None, 0)."""
     log = tmp_path / "empty.log"
     log.write_text("", encoding="utf-8")
-    input_tok, output_tok, compactions = _parse_worker_usage(log)
+    input_tok, output_tok, compactions, _ = _parse_worker_usage(log)
     assert input_tok is None
     assert output_tok is None
     assert compactions == 0  # WOR-357: parseable path returns 0, not None
@@ -625,7 +697,7 @@ def test_parse_worker_usage_returns_separate_tokens(tmp_path: Path) -> None:
         }
     )
     log = _write_log(tmp_path, [result_line])
-    input_tok, output_tok, _ = _parse_worker_usage(log)
+    input_tok, output_tok, _, _ = _parse_worker_usage(log)
     assert input_tok == 12000
     assert output_tok == 800
 
@@ -636,7 +708,7 @@ def test_parse_worker_usage_missing_input_token_returns_none(
     """When input_tokens is absent, all tokens are None."""
     result_line = json.dumps({"type": "result", "usage": {"output_tokens": 500}})
     log = _write_log(tmp_path, [result_line])
-    input_tok, output_tok, _ = _parse_worker_usage(log)
+    input_tok, output_tok, _, _ = _parse_worker_usage(log)
     assert input_tok is None
     assert output_tok is None
 
@@ -647,6 +719,6 @@ def test_parse_worker_usage_missing_output_token_returns_none(
     """When output_tokens is absent, all tokens are None."""
     result_line = json.dumps({"type": "result", "usage": {"input_tokens": 3000}})
     log = _write_log(tmp_path, [result_line])
-    input_tok, output_tok, _ = _parse_worker_usage(log)
+    input_tok, output_tok, _, _ = _parse_worker_usage(log)
     assert input_tok is None
     assert output_tok is None

--- a/tests/test_watcher_helpers.py
+++ b/tests/test_watcher_helpers.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from app.core.watcher.watcher_helpers import (
     _parse_ollama_model,
+    _parse_worker_api_retries,
     _parse_worker_usage,
     build_worker_cmd,
     build_worker_env,
@@ -648,6 +649,64 @@ def test_parse_worker_usage_empty_file(tmp_path: Path) -> None:
     assert input_tok is None
     assert output_tok is None
     assert compactions == 0  # WOR-357: parseable path returns 0, not None
+
+
+# ---------------------------------------------------------------------------
+# WOR-360 — _parse_worker_api_retries
+# ---------------------------------------------------------------------------
+
+
+def test_parse_worker_api_retries_zero(tmp_path: Path) -> None:
+    """Log with no api_retry events returns 0."""
+    log = _write_log(
+        tmp_path,
+        [
+            json.dumps({"type": "system", "subtype": "init"}),
+            json.dumps(
+                {"type": "result", "usage": {"input_tokens": 100, "output_tokens": 5}}
+            ),
+        ],
+    )
+    assert _parse_worker_api_retries(log) == 0
+
+
+def test_parse_worker_api_retries_counts_5(tmp_path: Path) -> None:
+    """5 api_retry events returns 5."""
+    retry = json.dumps({"type": "system", "subtype": "api_retry"})
+    log = _write_log(
+        tmp_path,
+        [
+            retry,
+            retry,
+            retry,
+            retry,
+            retry,
+            json.dumps(
+                {"type": "result", "usage": {"input_tokens": 100, "output_tokens": 5}}
+            ),
+        ],
+    )
+    assert _parse_worker_api_retries(log) == 5
+
+
+def test_parse_worker_api_retries_other_subtypes_ignored(tmp_path: Path) -> None:
+    """Other system subtypes (init, compact_boundary, task_started) ignored."""
+    log = _write_log(
+        tmp_path,
+        [
+            json.dumps({"type": "system", "subtype": "init"}),
+            json.dumps({"type": "system", "subtype": "compact_boundary"}),
+            json.dumps({"type": "system", "subtype": "task_started"}),
+            json.dumps({"type": "system", "subtype": "task_notification"}),
+            json.dumps({"type": "system", "subtype": "api_retry"}),
+        ],
+    )
+    assert _parse_worker_api_retries(log) == 1
+
+
+def test_parse_worker_api_retries_missing_log(tmp_path: Path) -> None:
+    """Missing log returns None (cannot read)."""
+    assert _parse_worker_api_retries(tmp_path / "no_such_file.log") is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Sub-ticket 3 of 5 in WOR-365. Counts Claude Code's transient api_retry events per session (WOR-332 had 5, WOR-277 had 6). Sibling helper rather than growing the _parse_worker_usage tuple.

Closes WOR-360
Part of WOR-365