### PR TITLE
WOR-363 Persist dispatch_concurrency — pool size at worker launch

### DIFF
--- a/app/core/metrics.py
+++ b/app/core/metrics.py
@@ -93,6 +93,7 @@ CREATE TABLE IF NOT EXISTS ticket_metrics (
     compact_duration_ms   INTEGER,
     api_retry_count       INTEGER,
     subagent_spawns       INTEGER,
+    dispatch_concurrency  INTEGER,
     recorded_at           TEXT NOT NULL DEFAULT (datetime('now')),
     PRIMARY KEY (ticket_id, project_id)
 )
@@ -221,6 +222,14 @@ class TicketMetrics(BaseModel):
         description=(
             "Count of Task-tool invocations (WOR-364). Each spawns a subagent "
             "with its own LLM stream — multiplies effective vLLM concurrency."
+        ),
+    )
+    dispatch_concurrency: int | None = Field(
+        default=None,
+        description=(
+            "Count of OTHER active workers (local + cloud) at the moment this "
+            "worker launched (WOR-363). 0 = solo dispatch. Empirical input for "
+            "throughput-vs-concurrency analysis."
         ),
     )
 
@@ -429,6 +438,10 @@ class MetricsStore:
             conn.execute(
                 "ALTER TABLE ticket_metrics ADD COLUMN subagent_spawns INTEGER"
             )
+        if "dispatch_concurrency" not in existing:
+            conn.execute(
+                "ALTER TABLE ticket_metrics ADD COLUMN dispatch_concurrency INTEGER"
+            )
 
     @contextmanager
     def _connect(self) -> Generator[sqlite3.Connection, None, None]:
@@ -457,7 +470,8 @@ class MetricsStore:
                     change_type, reasoning_demand, scope_clarity,
                     constraint_density, ac_specificity, tech_stack, raw_extensions,
                     waste_score, waste_breakdown_json, tags, notes, effort,
-                    compact_duration_ms, api_retry_count, subagent_spawns
+                    compact_duration_ms, api_retry_count, subagent_spawns,
+                    dispatch_concurrency
                 ) VALUES (
                     :ticket_id, :project_id, :epic_id, :implementation_mode,
                     :cloud_used, :cloud_model, :cloud_tokens, :cloud_cost_estimate,
@@ -472,7 +486,8 @@ class MetricsStore:
                     :change_type, :reasoning_demand, :scope_clarity,
                     :constraint_density, :ac_specificity, :tech_stack, :raw_extensions,
                     :waste_score, :waste_breakdown_json, :tags, :notes, :effort,
-                    :compact_duration_ms, :api_retry_count, :subagent_spawns
+                    :compact_duration_ms, :api_retry_count, :subagent_spawns,
+                    :dispatch_concurrency
                 )
                 """,
                 {

--- a/app/core/metrics.py
+++ b/app/core/metrics.py
@@ -92,6 +92,7 @@ CREATE TABLE IF NOT EXISTS ticket_metrics (
     effort                TEXT,
     compact_duration_ms   INTEGER,
     api_retry_count       INTEGER,
+    subagent_spawns       INTEGER,
     recorded_at           TEXT NOT NULL DEFAULT (datetime('now')),
     PRIMARY KEY (ticket_id, project_id)
 )
@@ -213,6 +214,13 @@ class TicketMetrics(BaseModel):
         description=(
             "Count of system/api_retry events (WOR-360) — Claude Code's "
             "transient backend retries. Backend-stability proxy."
+        ),
+    )
+    subagent_spawns: int | None = Field(
+        default=None,
+        description=(
+            "Count of Task-tool invocations (WOR-364). Each spawns a subagent "
+            "with its own LLM stream — multiplies effective vLLM concurrency."
         ),
     )
 
@@ -417,6 +425,10 @@ class MetricsStore:
             conn.execute(
                 "ALTER TABLE ticket_metrics ADD COLUMN api_retry_count INTEGER"
             )
+        if "subagent_spawns" not in existing:
+            conn.execute(
+                "ALTER TABLE ticket_metrics ADD COLUMN subagent_spawns INTEGER"
+            )
 
     @contextmanager
     def _connect(self) -> Generator[sqlite3.Connection, None, None]:
@@ -445,7 +457,7 @@ class MetricsStore:
                     change_type, reasoning_demand, scope_clarity,
                     constraint_density, ac_specificity, tech_stack, raw_extensions,
                     waste_score, waste_breakdown_json, tags, notes, effort,
-                    compact_duration_ms, api_retry_count
+                    compact_duration_ms, api_retry_count, subagent_spawns
                 ) VALUES (
                     :ticket_id, :project_id, :epic_id, :implementation_mode,
                     :cloud_used, :cloud_model, :cloud_tokens, :cloud_cost_estimate,
@@ -460,7 +472,7 @@ class MetricsStore:
                     :change_type, :reasoning_demand, :scope_clarity,
                     :constraint_density, :ac_specificity, :tech_stack, :raw_extensions,
                     :waste_score, :waste_breakdown_json, :tags, :notes, :effort,
-                    :compact_duration_ms, :api_retry_count
+                    :compact_duration_ms, :api_retry_count, :subagent_spawns
                 )
                 """,
                 {

--- a/app/core/watcher/dispatch.py
+++ b/app/core/watcher/dispatch.py
@@ -83,6 +83,9 @@ def start_ticket(
     logger.info("Launching worker for %s (mode=%s)", ticket_id, effective_mode)
 
     backed_up_plans = backup_plan_files()
+    # WOR-363: capture pool size BEFORE launching this worker. Counts OTHER
+    # workers — does not include the one we're about to add.
+    dispatch_concurrency = len(_local_active) + len(_cloud_active)
     process = launch_worker(
         _repo_root, manifest, worktree_path, effective_mode, worker_verbose
     )
@@ -93,6 +96,7 @@ def start_ticket(
         worktree_path=worktree_path,
         process=process,
         backed_up_plans=backed_up_plans,
+        dispatch_concurrency=dispatch_concurrency,
     )
     if effective_mode == "local":
         _local_active.append(worker)

--- a/app/core/watcher/watcher_finalize.py
+++ b/app/core/watcher/watcher_finalize.py
@@ -335,6 +335,8 @@ def finalize_worker(
             api_retry_count=api_retry_count,
             # WOR-364: persist Task-tool subagent count
             subagent_spawns=subagent_spawns,
+            # WOR-363: persist dispatch-time worker pool size
+            dispatch_concurrency=worker.dispatch_concurrency,
         )
     )
     metrics.record_run(

--- a/app/core/watcher/watcher_finalize.py
+++ b/app/core/watcher/watcher_finalize.py
@@ -26,6 +26,7 @@ from app.core.metrics import (
 from .watcher_helpers import (
     _POLICY_FLAGS,
     _parse_worker_api_retries,
+    _parse_worker_subagent_spawns,
     _parse_worker_usage,
     _read_result_flags,
     resolve_effective_mode,
@@ -205,6 +206,7 @@ def finalize_worker(
         _parse_worker_usage(log_path)
     )
     api_retry_count = _parse_worker_api_retries(log_path)
+    subagent_spawns = _parse_worker_subagent_spawns(log_path)
     eff = resolve_effective_mode(mode, worker.manifest.implementation_mode)
 
     # Parse git diff --shortstat to populate lines_changed / files_changed.
@@ -331,6 +333,8 @@ def finalize_worker(
             compact_duration_ms=compact_duration_ms,
             # WOR-360: persist Claude Code's internal retry count
             api_retry_count=api_retry_count,
+            # WOR-364: persist Task-tool subagent count
+            subagent_spawns=subagent_spawns,
         )
     )
     metrics.record_run(

--- a/app/core/watcher/watcher_helpers.py
+++ b/app/core/watcher/watcher_helpers.py
@@ -108,6 +108,42 @@ def _parse_worker_usage(
     return None, None, None, None
 
 
+def _parse_worker_subagent_spawns(log_path: Path) -> int | None:
+    """Count Task-tool invocations in the worker log (WOR-364).
+
+    Each Task tool_use spawns a subagent (a separate Claude Code session
+    with its own LLM stream). High counts contribute to vLLM concurrency
+    even when the watcher's pool only shows one active worker.
+
+    Returns ``None`` if the log cannot be opened/parsed; ``0`` for
+    parseable logs with no Task tool_use events.
+    """
+    try:
+        with log_path.open(encoding="utf-8") as f:
+            count = 0
+            for raw in f:
+                line = raw.strip()
+                if not line:
+                    continue
+                try:
+                    obj = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if obj.get("type") != "assistant":
+                    continue
+                msg = obj.get("message", {}) or {}
+                for block in msg.get("content", []):
+                    if (
+                        isinstance(block, dict)
+                        and block.get("type") == "tool_use"
+                        and block.get("name") == "Task"
+                    ):
+                        count += 1
+            return count
+    except Exception:
+        return None
+
+
 def _parse_worker_api_retries(log_path: Path) -> int | None:
     """Count ``type=system, subtype=api_retry`` events in the worker log (WOR-360).
 

--- a/app/core/watcher/watcher_types.py
+++ b/app/core/watcher/watcher_types.py
@@ -66,6 +66,9 @@ class ActiveWorker:
     start_time: float = field(default_factory=time.monotonic)
     backed_up_plans: list[Path] = field(default_factory=list)
     retry_count: int = 0
+    # WOR-363: count of OTHER active workers at the moment this one launched.
+    # Captured by dispatch.start_ticket BEFORE adding self to the active pool.
+    dispatch_concurrency: int = 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -255,6 +255,38 @@ class TestApiRetryColumn:
             store._migrate(conn)
 
 
+class TestSubagentSpawnsColumn:
+    """WOR-364: persist Task-tool subagent count per session."""
+
+    def test_subagent_spawns_round_trip(self, tmp_path):
+        store = _store(tmp_path)
+        store.record(_ticket(subagent_spawns=4))
+        result = store.get_by_ticket("WOR-1", "proj-a")
+        assert result is not None
+        assert result.subagent_spawns == 4
+
+    def test_subagent_spawns_defaults_to_none(self, tmp_path):
+        store = _store(tmp_path)
+        store.record(_ticket())
+        result = store.get_by_ticket("WOR-1", "proj-a")
+        assert result is not None
+        assert result.subagent_spawns is None
+
+    def test_subagent_spawns_zero_distinct_from_none(self, tmp_path):
+        store = _store(tmp_path)
+        store.record(_ticket(subagent_spawns=0))
+        result = store.get_by_ticket("WOR-1", "proj-a")
+        assert result is not None
+        assert result.subagent_spawns == 0
+        assert result.subagent_spawns is not None
+
+    def test_subagent_spawns_migration_idempotent(self, tmp_path):
+        store = _store(tmp_path)
+        with store._connect() as conn:
+            store._migrate(conn)
+            store._migrate(conn)
+
+
 class TestAdditionalMetrics:
     def test_retry_and_diff_metrics_round_trip(self, tmp_path):
         store = _store(tmp_path)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -287,6 +287,39 @@ class TestSubagentSpawnsColumn:
             store._migrate(conn)
 
 
+class TestDispatchConcurrencyColumn:
+    """WOR-363: persist count of OTHER active workers at dispatch time."""
+
+    def test_dispatch_concurrency_round_trip(self, tmp_path):
+        store = _store(tmp_path)
+        store.record(_ticket(dispatch_concurrency=3))
+        result = store.get_by_ticket("WOR-1", "proj-a")
+        assert result is not None
+        assert result.dispatch_concurrency == 3
+
+    def test_dispatch_concurrency_solo_is_zero(self, tmp_path):
+        """Zero (solo dispatch) is a valid value, distinct from None."""
+        store = _store(tmp_path)
+        store.record(_ticket(dispatch_concurrency=0))
+        result = store.get_by_ticket("WOR-1", "proj-a")
+        assert result is not None
+        assert result.dispatch_concurrency == 0
+        assert result.dispatch_concurrency is not None
+
+    def test_dispatch_concurrency_defaults_to_none(self, tmp_path):
+        store = _store(tmp_path)
+        store.record(_ticket())
+        result = store.get_by_ticket("WOR-1", "proj-a")
+        assert result is not None
+        assert result.dispatch_concurrency is None
+
+    def test_dispatch_concurrency_migration_idempotent(self, tmp_path):
+        store = _store(tmp_path)
+        with store._connect() as conn:
+            store._migrate(conn)
+            store._migrate(conn)
+
+
 class TestAdditionalMetrics:
     def test_retry_and_diff_metrics_round_trip(self, tmp_path):
         store = _store(tmp_path)

--- a/tests/test_watcher_helpers.py
+++ b/tests/test_watcher_helpers.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from app.core.watcher.watcher_helpers import (
     _parse_ollama_model,
     _parse_worker_api_retries,
+    _parse_worker_subagent_spawns,
     _parse_worker_usage,
     build_worker_cmd,
     build_worker_env,
@@ -707,6 +708,78 @@ def test_parse_worker_api_retries_other_subtypes_ignored(tmp_path: Path) -> None
 def test_parse_worker_api_retries_missing_log(tmp_path: Path) -> None:
     """Missing log returns None (cannot read)."""
     assert _parse_worker_api_retries(tmp_path / "no_such_file.log") is None
+
+
+# ---------------------------------------------------------------------------
+# WOR-364 — _parse_worker_subagent_spawns
+# ---------------------------------------------------------------------------
+
+
+def _task_use(name: str = "Task") -> str:
+    return json.dumps(
+        {
+            "type": "assistant",
+            "message": {
+                "id": "a1",
+                "content": [{"type": "tool_use", "name": name, "input": {}}],
+            },
+        }
+    )
+
+
+def test_parse_worker_subagent_spawns_zero(tmp_path: Path) -> None:
+    """Log with no Task tool_use returns 0."""
+    log = _write_log(
+        tmp_path,
+        [
+            _task_use("Read"),
+            _task_use("Edit"),
+            _task_use("Bash"),
+            json.dumps(
+                {"type": "result", "usage": {"input_tokens": 100, "output_tokens": 5}}
+            ),
+        ],
+    )
+    assert _parse_worker_subagent_spawns(log) == 0
+
+
+def test_parse_worker_subagent_spawns_counts_3(tmp_path: Path) -> None:
+    """3 Task tool_use events returns 3."""
+    log = _write_log(
+        tmp_path,
+        [
+            _task_use("Task"),
+            _task_use("Read"),
+            _task_use("Task"),
+            _task_use("Bash"),
+            _task_use("Task"),
+            json.dumps(
+                {"type": "result", "usage": {"input_tokens": 100, "output_tokens": 5}}
+            ),
+        ],
+    )
+    assert _parse_worker_subagent_spawns(log) == 3
+
+
+def test_parse_worker_subagent_spawns_other_tools_ignored(tmp_path: Path) -> None:
+    """Read/Edit/Bash/Grep/Write/TodoWrite are not counted."""
+    log = _write_log(
+        tmp_path,
+        [
+            _task_use("Read"),
+            _task_use("Edit"),
+            _task_use("Bash"),
+            _task_use("Grep"),
+            _task_use("Write"),
+            _task_use("TodoWrite"),
+        ],
+    )
+    assert _parse_worker_subagent_spawns(log) == 0
+
+
+def test_parse_worker_subagent_spawns_missing_log(tmp_path: Path) -> None:
+    """Missing log returns None."""
+    assert _parse_worker_subagent_spawns(tmp_path / "no_such_file.log") is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Sub-ticket 5 of 5 in WOR-365. Captures len(_local_active) + len(_cloud_active) at the exact dispatch moment (BEFORE adding self), making concurrency analysis O(n) instead of O(n²) post-hoc.

Closes WOR-363
Part of WOR-365