### PR TITLE
WOR-365 Metrics Enrichment Wave 2 — 4 new columns + 1 rename

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ scripts/bench/fixtures/
 
 # Benchmark results DB (local data, not committed)
 bench_results.db
+bench.db
 
 # Unified metrics + bench DB (local data, not committed)
 app.db

--- a/app/core/metrics.py
+++ b/app/core/metrics.py
@@ -90,6 +90,7 @@ CREATE TABLE IF NOT EXISTS ticket_metrics (
     tags                  TEXT,
     notes                 TEXT,
     effort                TEXT,
+    compact_duration_ms   INTEGER,
     recorded_at           TEXT NOT NULL DEFAULT (datetime('now')),
     PRIMARY KEY (ticket_id, project_id)
 )
@@ -197,6 +198,14 @@ class TicketMetrics(BaseModel):
     effort: str | None = Field(
         default=None,
         description="Effort level from the manifest: low/medium/high/xhigh/max",
+    )
+    compact_duration_ms: int | None = Field(
+        default=None,
+        description=(
+            "Cumulative ms spent on context compaction during the session "
+            "(WOR-358). Sum of compact_metadata.duration_ms across all "
+            "compact_boundary system events."
+        ),
     )
 
 
@@ -392,6 +401,10 @@ class MetricsStore:
             conn.execute("ALTER TABLE ticket_metrics ADD COLUMN notes TEXT")
         if "effort" not in existing:
             conn.execute("ALTER TABLE ticket_metrics ADD COLUMN effort TEXT")
+        if "compact_duration_ms" not in existing:
+            conn.execute(
+                "ALTER TABLE ticket_metrics ADD COLUMN compact_duration_ms INTEGER"
+            )
 
     @contextmanager
     def _connect(self) -> Generator[sqlite3.Connection, None, None]:
@@ -419,7 +432,8 @@ class MetricsStore:
                     sonar_findings_count, context_compactions,
                     change_type, reasoning_demand, scope_clarity,
                     constraint_density, ac_specificity, tech_stack, raw_extensions,
-                    waste_score, waste_breakdown_json, tags, notes, effort
+                    waste_score, waste_breakdown_json, tags, notes, effort,
+                    compact_duration_ms
                 ) VALUES (
                     :ticket_id, :project_id, :epic_id, :implementation_mode,
                     :cloud_used, :cloud_model, :cloud_tokens, :cloud_cost_estimate,
@@ -433,7 +447,8 @@ class MetricsStore:
                     :sonar_findings_count, :context_compactions,
                     :change_type, :reasoning_demand, :scope_clarity,
                     :constraint_density, :ac_specificity, :tech_stack, :raw_extensions,
-                    :waste_score, :waste_breakdown_json, :tags, :notes, :effort
+                    :waste_score, :waste_breakdown_json, :tags, :notes, :effort,
+                    :compact_duration_ms
                 )
                 """,
                 {

--- a/app/core/metrics.py
+++ b/app/core/metrics.py
@@ -69,7 +69,7 @@ CREATE TABLE IF NOT EXISTS ticket_metrics (
     local_output_tokens   INTEGER,
     local_tokens          INTEGER,
     local_wall_time       REAL,
-    local_output_tokens_per_second REAL,
+    output_tokens_per_wall_second REAL,
     escalated_to_cloud    INTEGER NOT NULL DEFAULT 0,
     outcome               TEXT NOT NULL,
     retry_count           INTEGER NOT NULL DEFAULT 0,
@@ -114,8 +114,15 @@ class TicketMetrics(BaseModel):
     local_input_tokens: int | None = None
     local_output_tokens: int | None = None
     local_tokens: int | None = None
-    local_output_tokens_per_second: float | None = Field(
-        default=None, description="output_tokens / wall_time when both present"
+    output_tokens_per_wall_second: float | None = Field(
+        default=None,
+        description=(
+            "output_tokens / total local_wall_time. WOR-361: this is NOT decode "
+            "throughput — wall_time includes prefill, tool exec, hooks, and "
+            "compaction. For real decode rate, query vLLM /metrics directly. "
+            "Useful only for 'did this ticket take a long time relative to its "
+            "output' style questions."
+        ),
     )
     local_wall_time: float | None = Field(default=None, description="Seconds")
     escalated_to_cloud: bool = False
@@ -338,11 +345,22 @@ class MetricsStore:
             conn.execute(
                 "ALTER TABLE ticket_metrics ADD COLUMN local_output_tokens INTEGER"
             )
-        if "local_output_tokens_per_second" not in existing:
-            conn.execute(
-                "ALTER TABLE ticket_metrics "
-                "ADD COLUMN local_output_tokens_per_second REAL"
-            )
+        # WOR-361: rename misleading column. Idempotent across states:
+        # - fresh DB: CREATE TABLE already used the new name
+        # - already-migrated: new name exists, skip
+        # - pre-rename DB: rename old → new
+        # - very old DB without either: ADD COLUMN with new name
+        if "output_tokens_per_wall_second" not in existing:
+            if "local_output_tokens_per_second" in existing:
+                conn.execute(
+                    "ALTER TABLE ticket_metrics RENAME COLUMN "
+                    "local_output_tokens_per_second TO output_tokens_per_wall_second"
+                )
+            else:
+                conn.execute(
+                    "ALTER TABLE ticket_metrics "
+                    "ADD COLUMN output_tokens_per_wall_second REAL"
+                )
         # WOR-262 taxonomy columns
         if "change_type" not in existing:
             conn.execute("ALTER TABLE ticket_metrics ADD COLUMN change_type TEXT")
@@ -394,7 +412,7 @@ class MetricsStore:
                     ticket_id, project_id, epic_id, implementation_mode,
                     cloud_used, cloud_model, cloud_tokens, cloud_cost_estimate,
                     local_used, local_model, local_input_tokens, local_output_tokens,
-                    local_tokens, local_wall_time, local_output_tokens_per_second,
+                    local_tokens, local_wall_time, output_tokens_per_wall_second,
                     escalated_to_cloud, outcome,
                     retry_count, check_failures_json,
                     lines_changed, files_changed,
@@ -408,7 +426,7 @@ class MetricsStore:
                     :local_used, :local_model,
                     :local_input_tokens, :local_output_tokens,
                     :local_tokens, :local_wall_time,
-                    :local_output_tokens_per_second,
+                    :output_tokens_per_wall_second,
                     :escalated_to_cloud, :outcome,
                     :retry_count, :check_failures_json,
                     :lines_changed, :files_changed,

--- a/app/core/metrics.py
+++ b/app/core/metrics.py
@@ -91,6 +91,7 @@ CREATE TABLE IF NOT EXISTS ticket_metrics (
     notes                 TEXT,
     effort                TEXT,
     compact_duration_ms   INTEGER,
+    api_retry_count       INTEGER,
     recorded_at           TEXT NOT NULL DEFAULT (datetime('now')),
     PRIMARY KEY (ticket_id, project_id)
 )
@@ -205,6 +206,13 @@ class TicketMetrics(BaseModel):
             "Cumulative ms spent on context compaction during the session "
             "(WOR-358). Sum of compact_metadata.duration_ms across all "
             "compact_boundary system events."
+        ),
+    )
+    api_retry_count: int | None = Field(
+        default=None,
+        description=(
+            "Count of system/api_retry events (WOR-360) — Claude Code's "
+            "transient backend retries. Backend-stability proxy."
         ),
     )
 
@@ -405,6 +413,10 @@ class MetricsStore:
             conn.execute(
                 "ALTER TABLE ticket_metrics ADD COLUMN compact_duration_ms INTEGER"
             )
+        if "api_retry_count" not in existing:
+            conn.execute(
+                "ALTER TABLE ticket_metrics ADD COLUMN api_retry_count INTEGER"
+            )
 
     @contextmanager
     def _connect(self) -> Generator[sqlite3.Connection, None, None]:
@@ -433,7 +445,7 @@ class MetricsStore:
                     change_type, reasoning_demand, scope_clarity,
                     constraint_density, ac_specificity, tech_stack, raw_extensions,
                     waste_score, waste_breakdown_json, tags, notes, effort,
-                    compact_duration_ms
+                    compact_duration_ms, api_retry_count
                 ) VALUES (
                     :ticket_id, :project_id, :epic_id, :implementation_mode,
                     :cloud_used, :cloud_model, :cloud_tokens, :cloud_cost_estimate,
@@ -448,7 +460,7 @@ class MetricsStore:
                     :change_type, :reasoning_demand, :scope_clarity,
                     :constraint_density, :ac_specificity, :tech_stack, :raw_extensions,
                     :waste_score, :waste_breakdown_json, :tags, :notes, :effort,
-                    :compact_duration_ms
+                    :compact_duration_ms, :api_retry_count
                 )
                 """,
                 {

--- a/app/core/metrics.py
+++ b/app/core/metrics.py
@@ -93,6 +93,7 @@ CREATE TABLE IF NOT EXISTS ticket_metrics (
     compact_duration_ms   INTEGER,
     api_retry_count       INTEGER,
     subagent_spawns       INTEGER,
+    dispatch_concurrency  INTEGER,
     recorded_at           TEXT NOT NULL DEFAULT (datetime('now')),
     PRIMARY KEY (ticket_id, project_id)
 )
@@ -221,6 +222,14 @@ class TicketMetrics(BaseModel):
         description=(
             "Count of Task-tool invocations (WOR-364). Each spawns a subagent "
             "with its own LLM stream — multiplies effective vLLM concurrency."
+        ),
+    )
+    dispatch_concurrency: int | None = Field(
+        default=None,
+        description=(
+            "Count of OTHER active workers (local + cloud) at the moment this "
+            "worker launched (WOR-363). 0 = solo dispatch. Empirical input for "
+            "throughput-vs-concurrency analysis."
         ),
     )
 
@@ -429,6 +438,10 @@ class MetricsStore:
             conn.execute(
                 "ALTER TABLE ticket_metrics ADD COLUMN subagent_spawns INTEGER"
             )
+        if "dispatch_concurrency" not in existing:
+            conn.execute(
+                "ALTER TABLE ticket_metrics ADD COLUMN dispatch_concurrency INTEGER"
+            )
 
     @contextmanager
     def _connect(self) -> Generator[sqlite3.Connection, None, None]:
@@ -457,7 +470,8 @@ class MetricsStore:
                     change_type, reasoning_demand, scope_clarity,
                     constraint_density, ac_specificity, tech_stack, raw_extensions,
                     waste_score, waste_breakdown_json, tags, notes, effort,
-                    compact_duration_ms, api_retry_count, subagent_spawns
+                    compact_duration_ms, api_retry_count, subagent_spawns,
+                    dispatch_concurrency
                 ) VALUES (
                     :ticket_id, :project_id, :epic_id, :implementation_mode,
                     :cloud_used, :cloud_model, :cloud_tokens, :cloud_cost_estimate,
@@ -472,7 +486,8 @@ class MetricsStore:
                     :change_type, :reasoning_demand, :scope_clarity,
                     :constraint_density, :ac_specificity, :tech_stack, :raw_extensions,
                     :waste_score, :waste_breakdown_json, :tags, :notes, :effort,
-                    :compact_duration_ms, :api_retry_count, :subagent_spawns
+                    :compact_duration_ms, :api_retry_count, :subagent_spawns,
+                    :dispatch_concurrency
                 )
                 """,
                 {

--- a/app/core/metrics.py
+++ b/app/core/metrics.py
@@ -92,6 +92,7 @@ CREATE TABLE IF NOT EXISTS ticket_metrics (
     effort                TEXT,
     compact_duration_ms   INTEGER,
     api_retry_count       INTEGER,
+    subagent_spawns       INTEGER,
     recorded_at           TEXT NOT NULL DEFAULT (datetime('now')),
     PRIMARY KEY (ticket_id, project_id)
 )
@@ -213,6 +214,13 @@ class TicketMetrics(BaseModel):
         description=(
             "Count of system/api_retry events (WOR-360) — Claude Code's "
             "transient backend retries. Backend-stability proxy."
+        ),
+    )
+    subagent_spawns: int | None = Field(
+        default=None,
+        description=(
+            "Count of Task-tool invocations (WOR-364). Each spawns a subagent "
+            "with its own LLM stream — multiplies effective vLLM concurrency."
         ),
     )
 
@@ -417,6 +425,10 @@ class MetricsStore:
             conn.execute(
                 "ALTER TABLE ticket_metrics ADD COLUMN api_retry_count INTEGER"
             )
+        if "subagent_spawns" not in existing:
+            conn.execute(
+                "ALTER TABLE ticket_metrics ADD COLUMN subagent_spawns INTEGER"
+            )
 
     @contextmanager
     def _connect(self) -> Generator[sqlite3.Connection, None, None]:
@@ -445,7 +457,7 @@ class MetricsStore:
                     change_type, reasoning_demand, scope_clarity,
                     constraint_density, ac_specificity, tech_stack, raw_extensions,
                     waste_score, waste_breakdown_json, tags, notes, effort,
-                    compact_duration_ms, api_retry_count
+                    compact_duration_ms, api_retry_count, subagent_spawns
                 ) VALUES (
                     :ticket_id, :project_id, :epic_id, :implementation_mode,
                     :cloud_used, :cloud_model, :cloud_tokens, :cloud_cost_estimate,
@@ -460,7 +472,7 @@ class MetricsStore:
                     :change_type, :reasoning_demand, :scope_clarity,
                     :constraint_density, :ac_specificity, :tech_stack, :raw_extensions,
                     :waste_score, :waste_breakdown_json, :tags, :notes, :effort,
-                    :compact_duration_ms, :api_retry_count
+                    :compact_duration_ms, :api_retry_count, :subagent_spawns
                 )
                 """,
                 {

--- a/app/core/watcher/dispatch.py
+++ b/app/core/watcher/dispatch.py
@@ -83,6 +83,9 @@ def start_ticket(
     logger.info("Launching worker for %s (mode=%s)", ticket_id, effective_mode)
 
     backed_up_plans = backup_plan_files()
+    # WOR-363: capture pool size BEFORE launching this worker. Counts OTHER
+    # workers — does not include the one we're about to add.
+    dispatch_concurrency = len(_local_active) + len(_cloud_active)
     process = launch_worker(
         _repo_root, manifest, worktree_path, effective_mode, worker_verbose
     )
@@ -93,6 +96,7 @@ def start_ticket(
         worktree_path=worktree_path,
         process=process,
         backed_up_plans=backed_up_plans,
+        dispatch_concurrency=dispatch_concurrency,
     )
     if effective_mode == "local":
         _local_active.append(worker)

--- a/app/core/watcher/watcher_finalize.py
+++ b/app/core/watcher/watcher_finalize.py
@@ -25,6 +25,7 @@ from app.core.metrics import (
 
 from .watcher_helpers import (
     _POLICY_FLAGS,
+    _parse_worker_api_retries,
     _parse_worker_usage,
     _read_result_flags,
     resolve_effective_mode,
@@ -203,6 +204,7 @@ def finalize_worker(
     input_tokens, output_tokens, context_compactions, compact_duration_ms = (
         _parse_worker_usage(log_path)
     )
+    api_retry_count = _parse_worker_api_retries(log_path)
     eff = resolve_effective_mode(mode, worker.manifest.implementation_mode)
 
     # Parse git diff --shortstat to populate lines_changed / files_changed.
@@ -327,6 +329,8 @@ def finalize_worker(
             effort=worker.manifest.effort,
             # WOR-358: persist total compaction time for throughput analysis
             compact_duration_ms=compact_duration_ms,
+            # WOR-360: persist Claude Code's internal retry count
+            api_retry_count=api_retry_count,
         )
     )
     metrics.record_run(

--- a/app/core/watcher/watcher_finalize.py
+++ b/app/core/watcher/watcher_finalize.py
@@ -242,7 +242,7 @@ def finalize_worker(
     local_tokens: int | None = None
     local_input_tokens: int | None = None
     local_output_tokens: int | None = None
-    local_output_tokens_per_second: float | None = None
+    output_tokens_per_wall_second: float | None = None
     local_model_str: str | None = None
     if eff == "local":
         local_tokens = (
@@ -254,7 +254,7 @@ def finalize_worker(
         local_output_tokens = output_tokens
         local_model_str = _LOCAL_MODEL
         if output_tokens is not None and wall_time and wall_time > 0:
-            local_output_tokens_per_second = output_tokens / wall_time
+            output_tokens_per_wall_second = output_tokens / wall_time
 
     # Compute waste score from the worker log (WOR-277).
     waste_report = compute_waste_score(log_path)
@@ -300,7 +300,7 @@ def finalize_worker(
             local_output_tokens=local_output_tokens,
             local_tokens=local_tokens,
             local_wall_time=wall_time,
-            local_output_tokens_per_second=local_output_tokens_per_second,
+            output_tokens_per_wall_second=output_tokens_per_wall_second,
             escalated_to_cloud=escalated,
             outcome=outcome,
             retry_count=worker.retry_count,
@@ -335,7 +335,7 @@ def finalize_worker(
             wall_time_s=wall_time,
             input_tokens=input_tokens,
             output_tokens=output_tokens,
-            output_tok_per_s=local_output_tokens_per_second,
+            output_tok_per_s=output_tokens_per_wall_second,
             context_compactions=context_compactions,
         )
     )

--- a/app/core/watcher/watcher_finalize.py
+++ b/app/core/watcher/watcher_finalize.py
@@ -335,6 +335,8 @@ def finalize_worker(
             api_retry_count=api_retry_count,
             # WOR-364: persist Task-tool subagent count
             subagent_spawns=subagent_spawns,
+            # WOR-363: persist dispatch-time worker pool size
+            dispatch_concurrency=worker.dispatch_concurrency,
         )
     )
     metrics.record_run(

--- a/app/core/watcher/watcher_finalize.py
+++ b/app/core/watcher/watcher_finalize.py
@@ -26,6 +26,7 @@ from app.core.metrics import (
 from .watcher_helpers import (
     _POLICY_FLAGS,
     _parse_worker_api_retries,
+    _parse_worker_subagent_spawns,
     _parse_worker_usage,
     _read_result_flags,
     resolve_effective_mode,
@@ -205,6 +206,7 @@ def finalize_worker(
         _parse_worker_usage(log_path)
     )
     api_retry_count = _parse_worker_api_retries(log_path)
+    subagent_spawns = _parse_worker_subagent_spawns(log_path)
     eff = resolve_effective_mode(mode, worker.manifest.implementation_mode)
 
     # Parse git diff --shortstat to populate lines_changed / files_changed.
@@ -331,6 +333,8 @@ def finalize_worker(
             compact_duration_ms=compact_duration_ms,
             # WOR-360: persist Claude Code's internal retry count
             api_retry_count=api_retry_count,
+            # WOR-364: persist Task-tool subagent count
+            subagent_spawns=subagent_spawns,
         )
     )
     metrics.record_run(

--- a/app/core/watcher/watcher_finalize.py
+++ b/app/core/watcher/watcher_finalize.py
@@ -200,7 +200,9 @@ def finalize_worker(
     )
 
     log_path = worker.worktree_path / f".claude/worker_{worker.ticket_id.lower()}.log"
-    input_tokens, output_tokens, context_compactions = _parse_worker_usage(log_path)
+    input_tokens, output_tokens, context_compactions, compact_duration_ms = (
+        _parse_worker_usage(log_path)
+    )
     eff = resolve_effective_mode(mode, worker.manifest.implementation_mode)
 
     # Parse git diff --shortstat to populate lines_changed / files_changed.
@@ -323,6 +325,8 @@ def finalize_worker(
             waste_breakdown_json=waste_breakdown_json,
             # WOR-348: persist manifest effort for retro analytics
             effort=worker.manifest.effort,
+            # WOR-358: persist total compaction time for throughput analysis
+            compact_duration_ms=compact_duration_ms,
         )
     )
     metrics.record_run(

--- a/app/core/watcher/watcher_helpers.py
+++ b/app/core/watcher/watcher_helpers.py
@@ -30,22 +30,20 @@ logger = logging.getLogger(__name__)
 
 def _parse_worker_usage(
     log_path: Path,
-) -> tuple[int | None, int | None, int | None]:
-    """Return cumulative (input_tokens, output_tokens) summed across all
-    ``type=assistant`` events in the stream-json worker log, plus
-    *context_compactions* counted from ``type=system, subtype=compact_boundary``
-    events (WOR-357).
+) -> tuple[int | None, int | None, int | None, int | None]:
+    """Return 4-tuple from the stream-json worker log:
+    ``(input_tokens, output_tokens, context_compactions, compact_duration_ms)``.
 
     Assistant-turn deltas are summed so that downstream metrics
     (``local_output_tokens``, ``output_tokens_per_wall_second``) reflect the
     true token volume of a session.
 
     *context_compactions* is the count of ``compact_boundary`` system events
-    emitted by Claude Code when it auto-compacts the conversation. The
-    pre-WOR-357 implementation read ``obj["context_compactions"]`` from the
-    final ``type=result`` event, but that field is never populated by Claude
-    Code — every row written before this fix had ``context_compactions=NULL``.
-    The actual signal lives in events of the form::
+    (WOR-357). *compact_duration_ms* (WOR-358) is the sum of
+    ``compact_metadata.duration_ms`` across those events — total wall time
+    spent on compaction during the session.
+
+    The actual compaction signal lives in events of the form::
 
         {"type":"system","subtype":"compact_boundary",
          "compact_metadata":{"trigger":"auto","pre_tokens":...,"post_tokens":...,
@@ -54,9 +52,9 @@ def _parse_worker_usage(
     When assistant events carry usage data, their cumulative sum is returned.
     When no assistant events have usage, the last ``type=result`` event's
     usage snapshot is used as a fallback for tokens. Returns
-    ``(None, None, None)`` when the log itself cannot be opened or parsed at
-    all; returns ``(in, out, 0)`` for parseable logs containing zero
-    compact_boundary events.
+    ``(None, None, None, None)`` when the log itself cannot be opened or
+    parsed at all; returns ``(in, out, 0, 0)`` for parseable logs containing
+    zero compact_boundary events.
     """
     try:
         with log_path.open(encoding="utf-8") as f:
@@ -64,6 +62,7 @@ def _parse_worker_usage(
             total_output = 0
             has_assistant_usage = False
             compact_count = 0
+            compact_duration_ms = 0
             last_input: int | None = None
             last_output: int | None = None
             for raw in f:
@@ -85,19 +84,28 @@ def _parse_worker_usage(
                         has_assistant_usage = True
                 elif obj_type == "system" and obj.get("subtype") == "compact_boundary":
                     compact_count += 1
+                    meta = obj.get("compact_metadata") or {}
+                    dur = meta.get("duration_ms")
+                    if isinstance(dur, (int, float)):
+                        compact_duration_ms += int(dur)
                 elif obj_type == "result":
                     usage = obj.get("usage") or {}
                     last_input = usage.get("input_tokens")
                     last_output = usage.get("output_tokens")
             if has_assistant_usage:
-                return total_input, total_output, compact_count
+                return total_input, total_output, compact_count, compact_duration_ms
             # Fallback to result snapshot when no assistant events carry usage.
             if last_input is not None and last_output is not None:
-                return int(last_input), int(last_output), compact_count
-            return None, None, compact_count
+                return (
+                    int(last_input),
+                    int(last_output),
+                    compact_count,
+                    compact_duration_ms,
+                )
+            return None, None, compact_count, compact_duration_ms
     except Exception:
-        return None, None, None
-    return None, None, None
+        return None, None, None, None
+    return None, None, None, None
 
 
 def format_token_count(total: int) -> str:
@@ -121,10 +129,10 @@ def format_worker_token_count(log_path: Path) -> str:
     """Return ``142k tokens`` for the worker log, ``? tokens`` if unknown.
 
     ``_parse_worker_usage`` already swallows its own errors and returns
-    ``(None, None, None)`` when the log is missing or malformed, so callers
-    do not need to wrap this in try/except.
+    ``(None, None, None, None)`` when the log is missing or malformed, so
+    callers do not need to wrap this in try/except.
     """
-    input_tok, output_tok, _ = _parse_worker_usage(log_path)
+    input_tok, output_tok, _, _ = _parse_worker_usage(log_path)
     if input_tok is None or output_tok is None:
         return "? tokens"
     return f"{format_token_count(input_tok + output_tok)} tokens"

--- a/app/core/watcher/watcher_helpers.py
+++ b/app/core/watcher/watcher_helpers.py
@@ -108,6 +108,34 @@ def _parse_worker_usage(
     return None, None, None, None
 
 
+def _parse_worker_api_retries(log_path: Path) -> int | None:
+    """Count ``type=system, subtype=api_retry`` events in the worker log (WOR-360).
+
+    Each event represents a transient API failure that Claude Code retried
+    internally. Useful as a backend-stability proxy — sessions with many
+    retries correlate with degraded vLLM/LiteLLM throughput.
+
+    Returns ``None`` if the log cannot be opened/parsed; ``0`` for
+    parseable logs with no retry events.
+    """
+    try:
+        with log_path.open(encoding="utf-8") as f:
+            count = 0
+            for raw in f:
+                line = raw.strip()
+                if not line:
+                    continue
+                try:
+                    obj = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if obj.get("type") == "system" and obj.get("subtype") == "api_retry":
+                    count += 1
+            return count
+    except Exception:
+        return None
+
+
 def format_token_count(total: int) -> str:
     """Format a token count for display: ``142k`` for >= 1000, raw integer below."""
     if total < 1000:

--- a/app/core/watcher/watcher_helpers.py
+++ b/app/core/watcher/watcher_helpers.py
@@ -108,6 +108,42 @@ def _parse_worker_usage(
     return None, None, None, None
 
 
+def _parse_worker_subagent_spawns(log_path: Path) -> int | None:
+    """Count Task-tool invocations in the worker log (WOR-364).
+
+    Each Task tool_use spawns a subagent (a separate Claude Code session
+    with its own LLM stream). High counts contribute to vLLM concurrency
+    even when the watcher's pool only shows one active worker.
+
+    Returns ``None`` if the log cannot be opened/parsed; ``0`` for
+    parseable logs with no Task tool_use events.
+    """
+    try:
+        with log_path.open(encoding="utf-8") as f:
+            count = 0
+            for raw in f:
+                line = raw.strip()
+                if not line:
+                    continue
+                try:
+                    obj = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if obj.get("type") != "assistant":
+                    continue
+                msg = obj.get("message", {}) or {}
+                for block in msg.get("content", []):
+                    if (
+                        isinstance(block, dict)
+                        and block.get("type") == "tool_use"
+                        and block.get("name") == "Task"
+                    ):
+                        count += 1
+            return count
+    except Exception:
+        return None
+
+
 def _parse_worker_api_retries(log_path: Path) -> int | None:
     """Count ``type=system, subtype=api_retry`` events in the worker log (WOR-360).
 

--- a/app/core/watcher/watcher_helpers.py
+++ b/app/core/watcher/watcher_helpers.py
@@ -37,7 +37,7 @@ def _parse_worker_usage(
     events (WOR-357).
 
     Assistant-turn deltas are summed so that downstream metrics
-    (``local_output_tokens``, ``local_output_tokens_per_second``) reflect the
+    (``local_output_tokens``, ``output_tokens_per_wall_second``) reflect the
     true token volume of a session.
 
     *context_compactions* is the count of ``compact_boundary`` system events

--- a/app/core/watcher/watcher_types.py
+++ b/app/core/watcher/watcher_types.py
@@ -66,6 +66,9 @@ class ActiveWorker:
     start_time: float = field(default_factory=time.monotonic)
     backed_up_plans: list[Path] = field(default_factory=list)
     retry_count: int = 0
+    # WOR-363: count of OTHER active workers at the moment this one launched.
+    # Captured by dispatch.start_ticket BEFORE adding self to the active pool.
+    dispatch_concurrency: int = 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -394,7 +394,7 @@ class TestCheckRunLog:
 class TestMigration:
     def test_migration_adds_new_columns(self, tmp_path):
         """Existing DB gets local_input_tokens, local_output_tokens,
-        local_output_tokens_per_second without error."""
+        output_tokens_per_wall_second without error."""
         store = MetricsStore(db_path=tmp_path / "app.db")
         # Write and read before _migrate runs to establish baseline
         store.record(_ticket())
@@ -413,14 +413,14 @@ class TestMigration:
             _ticket(
                 local_input_tokens=10000,
                 local_output_tokens=500,
-                local_output_tokens_per_second=4.17,
+                output_tokens_per_wall_second=4.17,
             )
         )
         result = store.get_by_ticket("WOR-1", "proj-a")
         assert result is not None
         assert result.local_input_tokens == 10000
         assert result.local_output_tokens == 500
-        assert result.local_output_tokens_per_second == pytest.approx(4.17)
+        assert result.output_tokens_per_wall_second == pytest.approx(4.17)
 
     def test_new_columns_none_default(self, tmp_path):
         """Fields default to None when not provided."""
@@ -429,7 +429,7 @@ class TestMigration:
         result = store.get_by_ticket("WOR-1", "proj-a")
         assert result.local_input_tokens is None
         assert result.local_output_tokens is None
-        assert result.local_output_tokens_per_second is None
+        assert result.output_tokens_per_wall_second is None
 
     def test_backward_compat_local_tokens_preserved(self, tmp_path):
         """local_tokens remains valid alongside new fields."""

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -190,6 +190,39 @@ class TestEffortColumn:
             store._migrate(conn)
 
 
+class TestCompactDurationColumn:
+    """WOR-358: persist total compaction time per session."""
+
+    def test_compact_duration_round_trip(self, tmp_path):
+        store = _store(tmp_path)
+        store.record(_ticket(compact_duration_ms=88463))
+        result = store.get_by_ticket("WOR-1", "proj-a")
+        assert result is not None
+        assert result.compact_duration_ms == 88463
+
+    def test_compact_duration_defaults_to_none(self, tmp_path):
+        store = _store(tmp_path)
+        store.record(_ticket())
+        result = store.get_by_ticket("WOR-1", "proj-a")
+        assert result is not None
+        assert result.compact_duration_ms is None
+
+    def test_compact_duration_zero_distinct_from_none(self, tmp_path):
+        """Zero (no compactions) is a valid value, distinct from None (unknown)."""
+        store = _store(tmp_path)
+        store.record(_ticket(compact_duration_ms=0))
+        result = store.get_by_ticket("WOR-1", "proj-a")
+        assert result is not None
+        assert result.compact_duration_ms == 0
+        assert result.compact_duration_ms is not None
+
+    def test_compact_duration_migration_idempotent(self, tmp_path):
+        store = _store(tmp_path)
+        with store._connect() as conn:
+            store._migrate(conn)
+            store._migrate(conn)
+
+
 class TestAdditionalMetrics:
     def test_retry_and_diff_metrics_round_trip(self, tmp_path):
         store = _store(tmp_path)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -223,6 +223,38 @@ class TestCompactDurationColumn:
             store._migrate(conn)
 
 
+class TestApiRetryColumn:
+    """WOR-360: persist Claude Code's internal api_retry count per session."""
+
+    def test_api_retry_round_trip(self, tmp_path):
+        store = _store(tmp_path)
+        store.record(_ticket(api_retry_count=6))
+        result = store.get_by_ticket("WOR-1", "proj-a")
+        assert result is not None
+        assert result.api_retry_count == 6
+
+    def test_api_retry_defaults_to_none(self, tmp_path):
+        store = _store(tmp_path)
+        store.record(_ticket())
+        result = store.get_by_ticket("WOR-1", "proj-a")
+        assert result is not None
+        assert result.api_retry_count is None
+
+    def test_api_retry_zero_distinct_from_none(self, tmp_path):
+        store = _store(tmp_path)
+        store.record(_ticket(api_retry_count=0))
+        result = store.get_by_ticket("WOR-1", "proj-a")
+        assert result is not None
+        assert result.api_retry_count == 0
+        assert result.api_retry_count is not None
+
+    def test_api_retry_migration_idempotent(self, tmp_path):
+        store = _store(tmp_path)
+        with store._connect() as conn:
+            store._migrate(conn)
+            store._migrate(conn)
+
+
 class TestAdditionalMetrics:
     def test_retry_and_diff_metrics_round_trip(self, tmp_path):
         store = _store(tmp_path)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -255,6 +255,38 @@ class TestApiRetryColumn:
             store._migrate(conn)
 
 
+class TestSubagentSpawnsColumn:
+    """WOR-364: persist Task-tool subagent count per session."""
+
+    def test_subagent_spawns_round_trip(self, tmp_path):
+        store = _store(tmp_path)
+        store.record(_ticket(subagent_spawns=4))
+        result = store.get_by_ticket("WOR-1", "proj-a")
+        assert result is not None
+        assert result.subagent_spawns == 4
+
+    def test_subagent_spawns_defaults_to_none(self, tmp_path):
+        store = _store(tmp_path)
+        store.record(_ticket())
+        result = store.get_by_ticket("WOR-1", "proj-a")
+        assert result is not None
+        assert result.subagent_spawns is None
+
+    def test_subagent_spawns_zero_distinct_from_none(self, tmp_path):
+        store = _store(tmp_path)
+        store.record(_ticket(subagent_spawns=0))
+        result = store.get_by_ticket("WOR-1", "proj-a")
+        assert result is not None
+        assert result.subagent_spawns == 0
+        assert result.subagent_spawns is not None
+
+    def test_subagent_spawns_migration_idempotent(self, tmp_path):
+        store = _store(tmp_path)
+        with store._connect() as conn:
+            store._migrate(conn)
+            store._migrate(conn)
+
+
 class TestAdditionalMetrics:
     def test_retry_and_diff_metrics_round_trip(self, tmp_path):
         store = _store(tmp_path)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -287,6 +287,39 @@ class TestSubagentSpawnsColumn:
             store._migrate(conn)
 
 
+class TestDispatchConcurrencyColumn:
+    """WOR-363: persist count of OTHER active workers at dispatch time."""
+
+    def test_dispatch_concurrency_round_trip(self, tmp_path):
+        store = _store(tmp_path)
+        store.record(_ticket(dispatch_concurrency=3))
+        result = store.get_by_ticket("WOR-1", "proj-a")
+        assert result is not None
+        assert result.dispatch_concurrency == 3
+
+    def test_dispatch_concurrency_solo_is_zero(self, tmp_path):
+        """Zero (solo dispatch) is a valid value, distinct from None."""
+        store = _store(tmp_path)
+        store.record(_ticket(dispatch_concurrency=0))
+        result = store.get_by_ticket("WOR-1", "proj-a")
+        assert result is not None
+        assert result.dispatch_concurrency == 0
+        assert result.dispatch_concurrency is not None
+
+    def test_dispatch_concurrency_defaults_to_none(self, tmp_path):
+        store = _store(tmp_path)
+        store.record(_ticket())
+        result = store.get_by_ticket("WOR-1", "proj-a")
+        assert result is not None
+        assert result.dispatch_concurrency is None
+
+    def test_dispatch_concurrency_migration_idempotent(self, tmp_path):
+        store = _store(tmp_path)
+        with store._connect() as conn:
+            store._migrate(conn)
+            store._migrate(conn)
+
+
 class TestAdditionalMetrics:
     def test_retry_and_diff_metrics_round_trip(self, tmp_path):
         store = _store(tmp_path)

--- a/tests/test_watcher_finalize.py
+++ b/tests/test_watcher_finalize.py
@@ -1195,7 +1195,7 @@ def test_finalize_worker_writes_separate_token_fields(tmp_path: Path) -> None:
     assert m.local_input_tokens == 15000
     assert m.local_output_tokens == 600
     assert m.local_tokens == 15600  # backward-compat sum
-    assert m.local_output_tokens_per_second == pytest.approx(60.0)  # 600/10
+    assert m.output_tokens_per_wall_second == pytest.approx(60.0)  # 600/10
 
 
 def test_finalize_worker_token_fields_none_when_no_log(
@@ -1227,7 +1227,7 @@ def test_finalize_worker_token_fields_none_when_no_log(
     assert m.local_input_tokens is None
     assert m.local_output_tokens is None
     assert m.local_tokens is None
-    assert m.local_output_tokens_per_second is None
+    assert m.output_tokens_per_wall_second is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_watcher_finalize_metrics.py
+++ b/tests/test_watcher_finalize_metrics.py
@@ -266,7 +266,7 @@ def test_finalize_worker_cloud_metrics_populated_for_cloud_run(
     assert m.local_output_tokens is None
     assert m.local_tokens is None
     assert m.local_model is None
-    assert m.local_output_tokens_per_second is None
+    assert m.output_tokens_per_wall_second is None
 
 
 def test_finalize_worker_cloud_model_from_env(
@@ -406,7 +406,7 @@ def test_finalize_worker_local_run_keeps_local_fields(
     assert m.local_input_tokens == 15000
     assert m.local_output_tokens == 600
     assert m.local_tokens == 15600
-    assert m.local_output_tokens_per_second == pytest.approx(60.0)
+    assert m.output_tokens_per_wall_second == pytest.approx(60.0)
     # Cloud fields must be None for local runs
     assert m.cloud_model is None
     assert m.cloud_tokens is None

--- a/tests/test_watcher_helpers.py
+++ b/tests/test_watcher_helpers.py
@@ -247,7 +247,7 @@ def test_parse_worker_usage_success(tmp_path: Path) -> None:
         }
     )
     log = _write_log(tmp_path, ['{"type":"other","x":1}', result_line])
-    input_tok, output_tok, compactions = _parse_worker_usage(log)
+    input_tok, output_tok, compactions, _ = _parse_worker_usage(log)
     assert input_tok == 1000
     assert output_tok == 200
     assert compactions == 0  # was 3 under the old (broken) semantics
@@ -259,7 +259,7 @@ def test_parse_worker_usage_no_context_compactions(tmp_path: Path) -> None:
         {"type": "result", "usage": {"input_tokens": 500, "output_tokens": 50}}
     )
     log = _write_log(tmp_path, [result_line])
-    input_tok, output_tok, compactions = _parse_worker_usage(log)
+    input_tok, output_tok, compactions, _ = _parse_worker_usage(log)
     assert input_tok == 500
     assert output_tok == 50
     assert compactions == 0  # was None under the old semantics
@@ -268,7 +268,7 @@ def test_parse_worker_usage_no_context_compactions(tmp_path: Path) -> None:
 def test_parse_worker_usage_missing_log(tmp_path: Path) -> None:
     """Missing log returns None for all three fields (unchanged)."""
     log = tmp_path / "no_such_file.log"
-    input_tok, output_tok, compactions = _parse_worker_usage(log)
+    input_tok, output_tok, compactions, _ = _parse_worker_usage(log)
     assert input_tok is None
     assert output_tok is None
     assert compactions is None
@@ -283,7 +283,7 @@ def test_parse_worker_usage_no_result_line(tmp_path: Path) -> None:
             json.dumps({"type": "assistant", "content": "hello"}),
         ],
     )
-    input_tok, output_tok, compactions = _parse_worker_usage(log)
+    input_tok, output_tok, compactions, _ = _parse_worker_usage(log)
     assert input_tok is None
     assert output_tok is None
     assert compactions == 0  # log was parseable; just no compactions
@@ -293,7 +293,7 @@ def test_parse_worker_usage_malformed_json(tmp_path: Path) -> None:
     """Fully unparseable log returns None for all three fields (unchanged)."""
     log = tmp_path / "worker.log"
     log.write_text("not json at all\n{broken\n", encoding="utf-8")
-    input_tok, output_tok, compactions = _parse_worker_usage(log)
+    input_tok, output_tok, compactions, _ = _parse_worker_usage(log)
     assert input_tok is None
     assert output_tok is None
     # No JSON parseable at all → 0 events seen, but the file IS open-able,
@@ -331,7 +331,7 @@ def test_parse_worker_usage_one_compact_boundary(tmp_path: Path) -> None:
             ),
         ],
     )
-    _, _, compactions = _parse_worker_usage(log)
+    _, _, compactions, _ = _parse_worker_usage(log)
     assert compactions == 1
 
 
@@ -360,8 +360,80 @@ def test_parse_worker_usage_multiple_compact_boundaries(tmp_path: Path) -> None:
             ),
         ],
     )
-    _, _, compactions = _parse_worker_usage(log)
+    _, _, compactions, _ = _parse_worker_usage(log)
     assert compactions == 3
+
+
+def test_parse_worker_usage_compact_duration_summed(tmp_path: Path) -> None:
+    """WOR-358: 4th tuple element sums compact_metadata.duration_ms."""
+    log = _write_log(
+        tmp_path,
+        [
+            json.dumps(
+                {
+                    "type": "system",
+                    "subtype": "compact_boundary",
+                    "compact_metadata": {"duration_ms": 50000},
+                }
+            ),
+            json.dumps(
+                {
+                    "type": "system",
+                    "subtype": "compact_boundary",
+                    "compact_metadata": {"duration_ms": 38463},
+                }
+            ),
+            json.dumps(
+                {
+                    "type": "result",
+                    "usage": {"input_tokens": 100, "output_tokens": 5},
+                }
+            ),
+        ],
+    )
+    _, _, compactions, compact_dur = _parse_worker_usage(log)
+    assert compactions == 2
+    assert compact_dur == 88463
+
+
+def test_parse_worker_usage_compact_duration_zero_when_no_compactions(
+    tmp_path: Path,
+) -> None:
+    """No compact_boundary events → compact_duration_ms is 0, not None."""
+    log = _write_log(
+        tmp_path,
+        [
+            json.dumps(
+                {"type": "result", "usage": {"input_tokens": 100, "output_tokens": 5}}
+            ),
+        ],
+    )
+    _, _, compactions, compact_dur = _parse_worker_usage(log)
+    assert compactions == 0
+    assert compact_dur == 0
+
+
+def test_parse_worker_usage_compact_duration_missing_metadata(tmp_path: Path) -> None:
+    """compact_boundary event without duration_ms → counts as compaction but adds 0."""
+    log = _write_log(
+        tmp_path,
+        [
+            json.dumps({"type": "system", "subtype": "compact_boundary"}),
+            json.dumps(
+                {
+                    "type": "system",
+                    "subtype": "compact_boundary",
+                    "compact_metadata": {"trigger": "auto"},  # no duration_ms key
+                }
+            ),
+            json.dumps(
+                {"type": "result", "usage": {"input_tokens": 100, "output_tokens": 5}}
+            ),
+        ],
+    )
+    _, _, compactions, compact_dur = _parse_worker_usage(log)
+    assert compactions == 2
+    assert compact_dur == 0
 
 
 def test_parse_worker_usage_other_system_subtypes_ignored(tmp_path: Path) -> None:
@@ -381,7 +453,7 @@ def test_parse_worker_usage_other_system_subtypes_ignored(tmp_path: Path) -> Non
             ),
         ],
     )
-    _, _, compactions = _parse_worker_usage(log)
+    _, _, compactions, _ = _parse_worker_usage(log)
     assert compactions == 0
 
 
@@ -419,7 +491,7 @@ def test_parse_worker_usage_compact_boundary_with_assistant_usage(
             ),
         ],
     )
-    input_tok, output_tok, compactions = _parse_worker_usage(log)
+    input_tok, output_tok, compactions, _ = _parse_worker_usage(log)
     assert input_tok == 1500  # 1000 + 500 (sum across assistant events)
     assert output_tok == 150  # 100 + 50
     assert compactions == 1
@@ -477,7 +549,7 @@ def test_parse_worker_usage_cumulative_output_tokens(tmp_path: Path) -> None:
     )
     log = tmp_path / "worker.log"
     log.write_text("\n".join(assistant + [result_line]) + "\n", encoding="utf-8")
-    input_tok, output_tok, compactions = _parse_worker_usage(log)
+    input_tok, output_tok, compactions, _ = _parse_worker_usage(log)
     assert output_tok == 600  # 100+200+300
     assert compactions == 0  # WOR-357: result.context_compactions field is ignored
 
@@ -534,7 +606,7 @@ def test_parse_worker_usage_cumulative_input_tokens(tmp_path: Path) -> None:
     )
     log = tmp_path / "worker.log"
     log.write_text("\n".join(assistant + [result_line]) + "\n", encoding="utf-8")
-    input_tok, output_tok, compactions = _parse_worker_usage(log)
+    input_tok, output_tok, compactions, _ = _parse_worker_usage(log)
     assert input_tok == 35000  # 8000+12000+15000
 
 
@@ -548,7 +620,7 @@ def test_parse_worker_usage_mixed_valid_invalid_lines(tmp_path: Path) -> None:
     )
     log = tmp_path / "worker.log"
     log.write_text("garbage line\n" + result_line + "\n", encoding="utf-8")
-    input_tok, output_tok, compactions = _parse_worker_usage(log)
+    input_tok, output_tok, compactions, _ = _parse_worker_usage(log)
     assert input_tok == 300
     assert output_tok == 100
     assert compactions == 0  # WOR-357: result.context_compactions field is ignored
@@ -562,7 +634,7 @@ def test_parse_worker_usage_returns_first_result_line(tmp_path: Path) -> None:
         {"type": "result", "usage": {"input_tokens": 999, "output_tokens": 999}}
     )
     log = _write_log(tmp_path, [first, second])
-    input_tok, output_tok, _ = _parse_worker_usage(log)
+    input_tok, output_tok, _, _ = _parse_worker_usage(log)
     # No assistant events — fallback uses the last result event's snapshot.
     assert input_tok == 999
     assert output_tok == 999
@@ -572,7 +644,7 @@ def test_parse_worker_usage_empty_file(tmp_path: Path) -> None:
     """Empty file is open-able and parseable → (None, None, 0)."""
     log = tmp_path / "empty.log"
     log.write_text("", encoding="utf-8")
-    input_tok, output_tok, compactions = _parse_worker_usage(log)
+    input_tok, output_tok, compactions, _ = _parse_worker_usage(log)
     assert input_tok is None
     assert output_tok is None
     assert compactions == 0  # WOR-357: parseable path returns 0, not None
@@ -625,7 +697,7 @@ def test_parse_worker_usage_returns_separate_tokens(tmp_path: Path) -> None:
         }
     )
     log = _write_log(tmp_path, [result_line])
-    input_tok, output_tok, _ = _parse_worker_usage(log)
+    input_tok, output_tok, _, _ = _parse_worker_usage(log)
     assert input_tok == 12000
     assert output_tok == 800
 
@@ -636,7 +708,7 @@ def test_parse_worker_usage_missing_input_token_returns_none(
     """When input_tokens is absent, all tokens are None."""
     result_line = json.dumps({"type": "result", "usage": {"output_tokens": 500}})
     log = _write_log(tmp_path, [result_line])
-    input_tok, output_tok, _ = _parse_worker_usage(log)
+    input_tok, output_tok, _, _ = _parse_worker_usage(log)
     assert input_tok is None
     assert output_tok is None
 
@@ -647,6 +719,6 @@ def test_parse_worker_usage_missing_output_token_returns_none(
     """When output_tokens is absent, all tokens are None."""
     result_line = json.dumps({"type": "result", "usage": {"input_tokens": 3000}})
     log = _write_log(tmp_path, [result_line])
-    input_tok, output_tok, _ = _parse_worker_usage(log)
+    input_tok, output_tok, _, _ = _parse_worker_usage(log)
     assert input_tok is None
     assert output_tok is None

--- a/tests/test_watcher_helpers.py
+++ b/tests/test_watcher_helpers.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from app.core.watcher.watcher_helpers import (
     _parse_ollama_model,
+    _parse_worker_api_retries,
     _parse_worker_usage,
     build_worker_cmd,
     build_worker_env,
@@ -648,6 +649,64 @@ def test_parse_worker_usage_empty_file(tmp_path: Path) -> None:
     assert input_tok is None
     assert output_tok is None
     assert compactions == 0  # WOR-357: parseable path returns 0, not None
+
+
+# ---------------------------------------------------------------------------
+# WOR-360 — _parse_worker_api_retries
+# ---------------------------------------------------------------------------
+
+
+def test_parse_worker_api_retries_zero(tmp_path: Path) -> None:
+    """Log with no api_retry events returns 0."""
+    log = _write_log(
+        tmp_path,
+        [
+            json.dumps({"type": "system", "subtype": "init"}),
+            json.dumps(
+                {"type": "result", "usage": {"input_tokens": 100, "output_tokens": 5}}
+            ),
+        ],
+    )
+    assert _parse_worker_api_retries(log) == 0
+
+
+def test_parse_worker_api_retries_counts_5(tmp_path: Path) -> None:
+    """5 api_retry events returns 5."""
+    retry = json.dumps({"type": "system", "subtype": "api_retry"})
+    log = _write_log(
+        tmp_path,
+        [
+            retry,
+            retry,
+            retry,
+            retry,
+            retry,
+            json.dumps(
+                {"type": "result", "usage": {"input_tokens": 100, "output_tokens": 5}}
+            ),
+        ],
+    )
+    assert _parse_worker_api_retries(log) == 5
+
+
+def test_parse_worker_api_retries_other_subtypes_ignored(tmp_path: Path) -> None:
+    """Other system subtypes (init, compact_boundary, task_started) ignored."""
+    log = _write_log(
+        tmp_path,
+        [
+            json.dumps({"type": "system", "subtype": "init"}),
+            json.dumps({"type": "system", "subtype": "compact_boundary"}),
+            json.dumps({"type": "system", "subtype": "task_started"}),
+            json.dumps({"type": "system", "subtype": "task_notification"}),
+            json.dumps({"type": "system", "subtype": "api_retry"}),
+        ],
+    )
+    assert _parse_worker_api_retries(log) == 1
+
+
+def test_parse_worker_api_retries_missing_log(tmp_path: Path) -> None:
+    """Missing log returns None (cannot read)."""
+    assert _parse_worker_api_retries(tmp_path / "no_such_file.log") is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_watcher_helpers.py
+++ b/tests/test_watcher_helpers.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from app.core.watcher.watcher_helpers import (
     _parse_ollama_model,
     _parse_worker_api_retries,
+    _parse_worker_subagent_spawns,
     _parse_worker_usage,
     build_worker_cmd,
     build_worker_env,
@@ -707,6 +708,78 @@ def test_parse_worker_api_retries_other_subtypes_ignored(tmp_path: Path) -> None
 def test_parse_worker_api_retries_missing_log(tmp_path: Path) -> None:
     """Missing log returns None (cannot read)."""
     assert _parse_worker_api_retries(tmp_path / "no_such_file.log") is None
+
+
+# ---------------------------------------------------------------------------
+# WOR-364 — _parse_worker_subagent_spawns
+# ---------------------------------------------------------------------------
+
+
+def _task_use(name: str = "Task") -> str:
+    return json.dumps(
+        {
+            "type": "assistant",
+            "message": {
+                "id": "a1",
+                "content": [{"type": "tool_use", "name": name, "input": {}}],
+            },
+        }
+    )
+
+
+def test_parse_worker_subagent_spawns_zero(tmp_path: Path) -> None:
+    """Log with no Task tool_use returns 0."""
+    log = _write_log(
+        tmp_path,
+        [
+            _task_use("Read"),
+            _task_use("Edit"),
+            _task_use("Bash"),
+            json.dumps(
+                {"type": "result", "usage": {"input_tokens": 100, "output_tokens": 5}}
+            ),
+        ],
+    )
+    assert _parse_worker_subagent_spawns(log) == 0
+
+
+def test_parse_worker_subagent_spawns_counts_3(tmp_path: Path) -> None:
+    """3 Task tool_use events returns 3."""
+    log = _write_log(
+        tmp_path,
+        [
+            _task_use("Task"),
+            _task_use("Read"),
+            _task_use("Task"),
+            _task_use("Bash"),
+            _task_use("Task"),
+            json.dumps(
+                {"type": "result", "usage": {"input_tokens": 100, "output_tokens": 5}}
+            ),
+        ],
+    )
+    assert _parse_worker_subagent_spawns(log) == 3
+
+
+def test_parse_worker_subagent_spawns_other_tools_ignored(tmp_path: Path) -> None:
+    """Read/Edit/Bash/Grep/Write/TodoWrite are not counted."""
+    log = _write_log(
+        tmp_path,
+        [
+            _task_use("Read"),
+            _task_use("Edit"),
+            _task_use("Bash"),
+            _task_use("Grep"),
+            _task_use("Write"),
+            _task_use("TodoWrite"),
+        ],
+    )
+    assert _parse_worker_subagent_spawns(log) == 0
+
+
+def test_parse_worker_subagent_spawns_missing_log(tmp_path: Path) -> None:
+    """Missing log returns None."""
+    assert _parse_worker_subagent_spawns(tmp_path / "no_such_file.log") is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Bundles 5 sub-tickets that add 4 new signal columns to \`ticket_metrics\` + rename one misleading column. All consumed by WOR-336's vLLM throughput-variance investigation.

## Sub-tickets (all merged to epic, all marked Done)

| # | PR | Adds | Approach |
|---|---|---|---|
| 1 | #715 WOR-361 | rename → \`output_tokens_per_wall_second\` | hard rename via SQLite RENAME COLUMN |
| 2 | #716 WOR-358 | \`compact_duration_ms\` | extends \`_parse_worker_usage\` to 4-tuple |
| 3 | #717 WOR-360 | \`api_retry_count\` | sibling helper \`_parse_worker_api_retries\` |
| 4 | #718 WOR-364 | \`subagent_spawns\` | sibling helper \`_parse_worker_subagent_spawns\` |
| 5 | #719 WOR-363 | \`dispatch_concurrency\` | captured at \`ActiveWorker\` construction in \`dispatch.py\` |

## Why bundled

All 5 touch the same files (\`metrics.py\`, \`watcher_finalize.py\`, \`watcher_helpers.py\`) and serve the same downstream consumer (WOR-336 spike). Single review pass is more efficient than 5 separate main-targeting PRs.

## Schema changes

\`\`\`sql
-- Idempotent migrations; old DBs upgrade in place
ALTER TABLE ticket_metrics RENAME COLUMN local_output_tokens_per_second TO output_tokens_per_wall_second;
ALTER TABLE ticket_metrics ADD COLUMN compact_duration_ms INTEGER;
ALTER TABLE ticket_metrics ADD COLUMN api_retry_count INTEGER;
ALTER TABLE ticket_metrics ADD COLUMN subagent_spawns INTEGER;
ALTER TABLE ticket_metrics ADD COLUMN dispatch_concurrency INTEGER;
\`\`\`

## Test plan

- [x] All 5 sub-PRs auto-merged to epic with passing CI
- [x] Full suite on integrated epic branch: **1150 pass**
- [x] \`ruff check\` clean, \`mypy app/\` clean
- [x] No production behavior change — telemetry-only + cosmetic rename
- [ ] Post-merge: backfill the 4 countable columns from preserved worker logs (one-shot script — runs separately after merge)

## Out of scope

- Routing decisions based on the new signals (WOR-298)
- TUI display (separate ticket if useful)
- Per-attempt versions (we stick to per-ticket aggregates for now)
- Backfilling \`dispatch_concurrency\` for existing rows — temporal-overlap SQL approximation in WOR-196 is the only retro option for those

Closes WOR-365
Closes WOR-358
Closes WOR-360
Closes WOR-361
Closes WOR-363
Closes WOR-364

🤖 Generated with [Claude Code](https://claude.com/claude-code)