### PR TITLE
WOR-366 Add backend_unstable tag rule (api_retry_count >= 6)

### DIFF
--- a/app/core/metrics.py
+++ b/app/core/metrics.py
@@ -695,6 +695,7 @@ def compute_tags(
     retry_count = ticket_metrics_row.retry_count
     local_tokens = ticket_metrics_row.local_tokens
     local_wall_time = ticket_metrics_row.local_wall_time
+    api_retry_count = ticket_metrics_row.api_retry_count
 
     # --- Anomaly detection rules (4) ---
     # Type-strict guards (isinstance vs `is not None`) so the function is
@@ -742,6 +743,13 @@ def compute_tags(
     # rework: the ticket required at least one retry.
     if isinstance(retry_count, int) and retry_count > 0:
         tags.append("rework")
+
+    # backend_unstable: high count of Claude Code internal api_retry events.
+    # Threshold 6 calibrated on 2026-05-04 backfill — Pearson r=0.665 vs
+    # wall_time, with the 6+ bucket running 4× slower than the no-retry
+    # baseline (28 min vs 121 min mean). WOR-366.
+    if isinstance(api_retry_count, int) and api_retry_count >= 6:
+        tags.append("backend_unstable")
 
     return tags
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -840,6 +840,33 @@ class TestComputeTags:
         m = _metrics(retry_count=0)
         assert "rework" not in compute_tags(m, "success")
 
+    # --- WOR-366: backend_unstable rule ---
+
+    def test_backend_unstable_at_threshold(self):
+        """backend_unstable: api_retry_count >= 6."""
+        m = _metrics(api_retry_count=6)
+        assert "backend_unstable" in compute_tags(m, "success")
+
+    def test_backend_unstable_max_retries(self):
+        """Fires for high counts (e.g. WOR-317 had 19 retries)."""
+        m = _metrics(api_retry_count=19)
+        assert "backend_unstable" in compute_tags(m, "success")
+
+    def test_backend_unstable_below_threshold(self):
+        """Does not fire at api_retry_count == 5 (boundary)."""
+        m = _metrics(api_retry_count=5)
+        assert "backend_unstable" not in compute_tags(m, "success")
+
+    def test_backend_unstable_zero(self):
+        """Does not fire when api_retry_count == 0."""
+        m = _metrics(api_retry_count=0)
+        assert "backend_unstable" not in compute_tags(m, "success")
+
+    def test_backend_unstable_none(self):
+        """Does not fire when api_retry_count is None (defensive)."""
+        m = _metrics(api_retry_count=None)
+        assert "backend_unstable" not in compute_tags(m, "success")
+
     # --- Multi-rule and no-rule ---
 
     def test_multi_rule_match(self):


### PR DESCRIPTION
## Summary

New \`compute_tags\` rule that tags any ticket with \`api_retry_count >= 6\` as \`backend_unstable\`. Threshold calibrated on 2026-05-04 backfill correlation (Pearson r=0.665 between api_retry_count and wall_time).

## Evidence

| api_retries | n | mean wall time |
|---|---|---|
| 0 | 13 | 28 min |
| 1-5 | 11 | 74 min |
| **6+** | **7** | **121 min** (4× baseline) |

The 6+ bucket has clearly elevated wall time. Tag makes that queryable.

## Tests

- 5 new unit tests in TestComputeTags (at-threshold, max=19, below=5, zero, None)
- Full suite 1155 pass (was 1150 + 5 new)
- ruff + mypy clean

## Out of scope

- Backfill on existing rows (will run manually after merge — should mark 7 rows)
- TUI surfacing
- Tag-based escalation policy

Closes WOR-366