### PR TITLE
Part of WOR-368: drop strict vLLM gate at watcher startup

### DIFF
--- a/app/core/watcher/watcher.py
+++ b/app/core/watcher/watcher.py
@@ -150,9 +150,6 @@ class Watcher:
         if self._mode in ("local", "default"):
             self._services.probe_vllm_health()
 
-        if self._mode == "local":
-            self._services.ensure_vllm_anthropic_mode()
-
         self._log_startup_info()
 
         try:


### PR DESCRIPTION
## Summary

Follow-up to PR #729. The watcher crashed at startup with `RuntimeError: vLLM not serving on port 8000` because `ensure_vllm_anthropic_mode()` fired immediately after `probe_vllm_health()` opened the WSL2 terminal — before vLLM had time to load the 35B model.

The dispatch-time gate in `_start_ticket` already handles this correctly: `probe_vllm_health()` defers the ticket if vLLM isn't responding (no crash), and `ensure_vllm_anthropic_mode()` raises only after the soft probe passes. The startup gate was redundant.

## Test plan

- [x] `pytest tests/test_watcher.py tests/test_watcher_services.py tests/test_watcher_dispatch.py` — all 60 pass
- [x] Manual: start watcher with vLLM not yet running, confirm it stays up and dispatches once vLLM warms up

🤖 Generated with [Claude Code](https://claude.com/claude-code)