### PR TITLE
WOR-359 Watcher metrics: add `mid_session_compaction` tag rule to compute_tags

### DIFF
--- a/app/core/metrics.py
+++ b/app/core/metrics.py
@@ -676,7 +676,7 @@ def compute_tags(
 
     Pure function — no I/O, no logging, no side effects.  Easy to unit-test.
 
-    Four anomaly-detection rules (from the 2026-05-03 retro) and four
+    Four anomaly-detection rules (from the 2026-05-03 retro) and five
     categorization rules (from existing result.json signals).
 
     Args:
@@ -696,6 +696,7 @@ def compute_tags(
     local_tokens = ticket_metrics_row.local_tokens
     local_wall_time = ticket_metrics_row.local_wall_time
     api_retry_count = ticket_metrics_row.api_retry_count
+    context_compactions = ticket_metrics_row.context_compactions
 
     # --- Anomaly detection rules (4) ---
     # Type-strict guards (isinstance vs `is not None`) so the function is
@@ -743,6 +744,11 @@ def compute_tags(
     # rework: the ticket required at least one retry.
     if isinstance(retry_count, int) and retry_count > 0:
         tags.append("rework")
+
+    # mid_session_compaction: the session performed at least one context
+    # compaction — the LLM context was truncated during the run.
+    if isinstance(context_compactions, int) and context_compactions > 0:
+        tags.append("mid_session_compaction")
 
     # backend_unstable: high count of Claude Code internal api_retry events.
     # Threshold 6 calibrated on 2026-05-04 backfill — Pearson r=0.665 vs

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -697,7 +697,7 @@ class TestTicketRunLog:
 
 
 # ---------------------------------------------------------------------------
-# compute_tags — individual rule tests (8 rules)
+# compute_tags — individual rule tests (9 rules)
 # ---------------------------------------------------------------------------
 
 
@@ -718,7 +718,7 @@ def _metrics(**kwargs) -> TicketMetrics:
 
 
 class TestComputeTags:
-    """compute_tags — 8 rules, multi-rule, no-rule, set_tags, _migrate."""
+    """compute_tags — 9 rules, multi-rule, no-rule, set_tags, _migrate."""
 
     # --- Anomaly detection rules (4) ---
 
@@ -866,6 +866,26 @@ class TestComputeTags:
         """Does not fire when api_retry_count is None (defensive)."""
         m = _metrics(api_retry_count=None)
         assert "backend_unstable" not in compute_tags(m, "success")
+
+    def test_mid_session_compaction_when_one(self):
+        """Fires when context_compactions is 1."""
+        m = _metrics(context_compactions=1)
+        assert "mid_session_compaction" in compute_tags(m, "success")
+
+    def test_mid_session_compaction_when_two(self):
+        """Fires when context_compactions is 2."""
+        m = _metrics(context_compactions=2)
+        assert "mid_session_compaction" in compute_tags(m, "success")
+
+    def test_mid_session_compaction_not_when_zero(self):
+        """Does not fire when context_compactions is 0."""
+        m = _metrics(context_compactions=0)
+        assert "mid_session_compaction" not in compute_tags(m, "success")
+
+    def test_mid_session_compaction_not_when_none(self):
+        """Does not fire when context_compactions is None."""
+        m = _metrics(context_compactions=None)
+        assert "mid_session_compaction" not in compute_tags(m, "success")
 
     # --- Multi-rule and no-rule ---
 


### PR DESCRIPTION
Closes WOR-359

compute_tags appends 'mid_session_compaction' to the returned tag list iff context_compactions is a positive integer; 4 new tests in tests/test_metrics.py covering =1, =2, =0, =None all pass; full pytest suite passes; ruff and mypy clean.