### PR TITLE
chore: add scripts/telemetry/ helpers for solo-run vLLM /metrics capture

### DIFF
--- a/scripts/telemetry/README.md
+++ b/scripts/telemetry/README.md
@@ -1,0 +1,40 @@
+# vLLM telemetry helpers
+
+Ad-hoc scripts for capturing vLLM `/metrics` data around a worker run, used
+to diagnose run cost / cache effectiveness without baking anything into the
+watcher itself.
+
+Born from the WOR-368 E2E smoke test (WOR-359 dispatched in 154s with a
+94% prefix-cache hit ratio). Kept here as reference material — if the
+data turns out actionable, fold it into the watcher proper as a gated
+capture (see "Attribution caveat" below).
+
+## Files
+
+- `poll_vllm_metrics.sh` — append timestamped `/metrics` snapshots to a log every N seconds
+- `summarize_run.sh` — post-run summary: hit ratio, TTFT, generation totals, worker-log signals
+
+## Typical usage
+
+```bash
+# Before /start-ticket flips the ticket to ReadyForLocal:
+scripts/telemetry/poll_vllm_metrics.sh \
+    .claude/artifacts/wor_359/vllm_metrics_timeline.txt 10 &
+POLL_PID=$!
+
+# ... watcher dispatches → worker finishes → result.json appears ...
+
+kill "$POLL_PID"
+scripts/telemetry/summarize_run.sh wor_359
+```
+
+## Attribution caveat
+
+vLLM `/metrics` are **server-wide cumulative counters**, not per-request.
+The summary is only meaningful for solo runs (`dispatch_concurrency == 0`
+in `ActiveWorker`). With ≥2 concurrent workers the deltas mix everyone's
+traffic together and per-ticket attribution breaks.
+
+If we ever wire this into the watcher, gate the capture on
+`dispatch_concurrency == 0` and skip with a note when concurrent workers
+were active.

--- a/scripts/telemetry/poll_vllm_metrics.sh
+++ b/scripts/telemetry/poll_vllm_metrics.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Poll vLLM /metrics every N seconds and append timestamped snapshots to a log.
+# Designed for solo-bound smoke tests where dispatch_concurrency == 0 and the
+# server-wide counters can be cleanly attributed to one worker session.
+#
+# Usage:
+#   scripts/telemetry/poll_vllm_metrics.sh <out_path> [interval_seconds] [vllm_url]
+#
+# Example (paired with a /start-ticket → ReadyForLocal flow):
+#   scripts/telemetry/poll_vllm_metrics.sh \
+#       .claude/artifacts/wor_359/vllm_metrics_timeline.txt 10 &
+#   POLL_PID=$!
+#   # ... watcher dispatches worker, worker finishes, result.json appears ...
+#   kill "$POLL_PID"
+#
+# The script intentionally targets a *narrow* metric set — the high-signal
+# ones for diagnosing slow runs (cache, throughput, queue, KV pressure).
+# If you need other vLLM metrics, edit the grep pattern below.
+
+set -u
+
+OUT_PATH="${1:?out_path required}"
+INTERVAL="${2:-10}"
+VLLM_URL="${3:-http://localhost:8000}"
+
+mkdir -p "$(dirname "$OUT_PATH")"
+
+while true; do
+  TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  printf '===== %s =====\n' "$TS" >> "$OUT_PATH"
+  curl -s --max-time 5 "$VLLM_URL/metrics" 2>/dev/null \
+    | grep -E '^(vllm:prefix_cache_(hits|queries)_total|vllm:gpu_cache_usage_perc|vllm:num_requests_(running|waiting)|vllm:time_to_first_token_seconds_(sum|count)|vllm:time_per_output_token_seconds_(sum|count)|vllm:prompt_tokens_total|vllm:generation_tokens_total|vllm:num_preemptions_total)' \
+    >> "$OUT_PATH"
+  sleep "$INTERVAL"
+done

--- a/scripts/telemetry/summarize_run.sh
+++ b/scripts/telemetry/summarize_run.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Post-run summary for a worker session that ran while poll_vllm_metrics.sh
+# was capturing /metrics. Reports prefix-cache hit ratio, mean TTFT, total
+# generation, and worker-log signals (thinking-block count, input_tokens
+# growth) for the named ticket.
+#
+# Usage:
+#   scripts/telemetry/summarize_run.sh <ticket_id_lower>
+#   scripts/telemetry/summarize_run.sh wor_359
+#
+# Reads:
+#   .claude/artifacts/<ticket>/result.json            (worker outcome)
+#   .claude/artifacts/<ticket>/worker_<ticket>.log    (Claude Code stream-json)
+#
+# Pulls live cumulative counters from vLLM /metrics for the cache-hit headline.
+# Numbers are session-wide, so the summary is only meaningful when this was
+# the only worker active during the captured window.
+
+set -eu
+
+TICKET_LOWER="${1:?ticket_id_lower required, e.g. wor_359}"
+ART_DIR=".claude/artifacts/${TICKET_LOWER}"
+RESULT_JSON="${ART_DIR}/result.json"
+WORKER_LOG="${ART_DIR}/worker_${TICKET_LOWER//_/-}.log"
+VLLM_URL="${VLLM_URL:-http://localhost:8000}"
+
+echo "=== ${TICKET_LOWER} ==="
+
+if [ -f "$RESULT_JSON" ]; then
+  echo "--- result.json ---"
+  cat "$RESULT_JSON"
+  echo
+else
+  echo "(no result.json — worker not yet finished?)"
+fi
+
+echo "--- vLLM cumulative counters ---"
+METRICS=$(curl -s --max-time 5 "$VLLM_URL/metrics" 2>/dev/null)
+HITS=$(printf '%s' "$METRICS" | awk '/^vllm:prefix_cache_hits_total\{/  {print $2; exit}')
+QUERIES=$(printf '%s' "$METRICS" | awk '/^vllm:prefix_cache_queries_total\{/ {print $2; exit}')
+TTFT_SUM=$(printf '%s' "$METRICS" | awk '/^vllm:time_to_first_token_seconds_sum\{/ {print $2; exit}')
+TTFT_CNT=$(printf '%s' "$METRICS" | awk '/^vllm:time_to_first_token_seconds_count\{/ {print $2; exit}')
+PROMPT_TOK=$(printf '%s' "$METRICS" | awk '/^vllm:prompt_tokens_total\{/ {print $2; exit}')
+GEN_TOK=$(printf '%s' "$METRICS" | awk '/^vllm:generation_tokens_total\{/ {print $2; exit}')
+PREEMPT=$(printf '%s' "$METRICS" | awk '/^vllm:num_preemptions_total\{/ {print $2; exit}')
+
+if [ -n "${QUERIES:-}" ] && [ "${QUERIES%.*}" != "0" ]; then
+  HIT_RATIO=$(awk -v h="$HITS" -v q="$QUERIES" 'BEGIN { printf "%.2f%%", (h/q)*100 }')
+else
+  HIT_RATIO="(no queries)"
+fi
+if [ -n "${TTFT_CNT:-}" ] && [ "${TTFT_CNT%.*}" != "0" ]; then
+  TTFT_MEAN=$(awk -v s="$TTFT_SUM" -v n="$TTFT_CNT" 'BEGIN { printf "%.3fs", s/n }')
+else
+  TTFT_MEAN="(no requests)"
+fi
+
+printf '  prefix_cache_hits_total    : %s\n' "${HITS:-?}"
+printf '  prefix_cache_queries_total : %s\n' "${QUERIES:-?}"
+printf '  prefix_cache_hit_ratio     : %s\n' "$HIT_RATIO"
+printf '  prompt_tokens_total        : %s\n' "${PROMPT_TOK:-?}"
+printf '  generation_tokens_total    : %s\n' "${GEN_TOK:-?}"
+printf '  ttft_mean                  : %s (n=%s)\n' "$TTFT_MEAN" "${TTFT_CNT:-0}"
+printf '  num_preemptions_total      : %s\n' "${PREEMPT:-?}"
+echo
+
+if [ -f "$WORKER_LOG" ]; then
+  echo "--- worker log signals ---"
+  THINK_BLOCKS=$(grep -c '"thinking":"' "$WORKER_LOG" || true)
+  THINK_CHARS=$(grep -o '"thinking":"[^"]*"' "$WORKER_LOG" | awk '{sum+=length($0)} END {print sum+0}')
+  INPUT_FIRST=$(grep -oE '"input_tokens":[0-9]+' "$WORKER_LOG" | head -1 | cut -d: -f2)
+  INPUT_LAST=$(grep -oE '"input_tokens":[0-9]+' "$WORKER_LOG" | tail -1 | cut -d: -f2)
+  OUTPUT_TOTAL=$(grep -oE '"output_tokens":[0-9]+' "$WORKER_LOG" | awk -F: '{sum+=$2} END {print sum+0}')
+  printf '  thinking_blocks      : %s\n' "$THINK_BLOCKS"
+  printf '  thinking_chars_total : %s\n' "$THINK_CHARS"
+  printf '  input_tokens_first   : %s\n' "${INPUT_FIRST:-?}"
+  printf '  input_tokens_last    : %s\n' "${INPUT_LAST:-?}"
+  printf '  output_tokens_sum    : %s\n' "$OUTPUT_TOTAL"
+else
+  echo "(no worker log at ${WORKER_LOG})"
+fi


### PR DESCRIPTION
## Summary

Two small bash utilities that were used ad-hoc during the WOR-368 E2E smoke test (WOR-359 → PR #731). Parking them in \`scripts/telemetry/\` as reference material — not wired into the watcher.

- \`poll_vllm_metrics.sh\` — append timestamped \`/metrics\` snapshots every N seconds
- \`summarize_run.sh\` — post-run summary (cache hit ratio, mean TTFT, generation totals, thinking-block count, input_tokens growth)

## Attribution caveat (documented in README)

vLLM \`/metrics\` are server-wide cumulative counters. Per-ticket attribution is only meaningful when \`dispatch_concurrency == 0\`. If we ever wire this into the watcher, gate the capture on that condition.

## Test plan

- [x] \`bash -n\` syntax check both scripts
- [x] \`summarize_run.sh wor_359\` reproduces the same numbers reported in conversation: 94.05% hit ratio, 1.519s mean TTFT, 26 thinking blocks
- [ ] (no automated test — bash utility scripts, exercised manually next solo run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)