### PR TITLE
WOR-372 Stop hook: enforce worker session commit + result.json

### DIFF
--- a/.claude/hooks/check_session_complete.py
+++ b/.claude/hooks/check_session_complete.py
@@ -1,0 +1,157 @@
+"""Stop hook — enforce worker-session completion contract (WOR-372).
+
+Fires when Claude Code attempts to end the session. For worker sessions
+(those running in a linked git worktree with an execution manifest), this
+hook enforces two invariants:
+
+1. ``result.json`` must exist at the manifest's ``artifact_paths.result_json``.
+2. ``git status --porcelain`` must be clean — i.e., the worker's changes
+   were committed.
+
+If either gate fails, the hook emits a JSON ``{"decision": "block",
+"reason": "..."}`` so Claude Code re-prompts the model to execute the
+missing actions. If the hook has already blocked once in this session
+(``stop_hook_active`` is true), the gate is skipped to prevent infinite
+loops.
+
+Operator sessions running in the main repo (not a linked worktree) pass
+through unconditionally — the hook only enforces in worker contexts.
+
+Wire in ``.claude/settings.json``::
+
+    "hooks": {
+      "Stop": [
+        {
+          "hooks": [
+            {
+              "type": "command",
+              "command": "python .claude/hooks/check_session_complete.py"
+            }
+          ]
+        }
+      ]
+    }
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess  # nosec B404
+import sys
+from pathlib import Path
+
+
+def _is_linked_worktree(cwd: Path) -> bool:
+    """Return True if cwd is inside a linked git worktree (not the main one).
+
+    The watcher creates worker sessions inside ``worktrees/<branch-slug>/``,
+    which are linked worktrees: their ``.git`` is a file pointing at the
+    main repo's ``.git/worktrees/<name>/`` directory. Operator sessions run
+    in the main worktree where ``.git`` is a directory.
+
+    The cleanest check: ``git rev-parse --git-dir`` and ``--git-common-dir``
+    return the same path in the main worktree, different paths in linked
+    worktrees.
+    """
+    try:
+        git_dir = subprocess.check_output(  # nosec B603 B607
+            ["git", "rev-parse", "--absolute-git-dir"],
+            cwd=str(cwd),
+            text=True,
+            timeout=5,
+        ).strip()
+        common_dir = subprocess.check_output(  # nosec B603 B607
+            ["git", "rev-parse", "--path-format=absolute", "--git-common-dir"],
+            cwd=str(cwd),
+            text=True,
+            timeout=5,
+        ).strip()
+    except (subprocess.SubprocessError, FileNotFoundError):
+        return False
+    return Path(git_dir).resolve() != Path(common_dir).resolve()
+
+
+def _find_manifest(cwd: Path) -> Path | None:
+    """Return the manifest path for the active worker session, or None."""
+    candidates = sorted(
+        cwd.glob(".claude/artifacts/*/manifest.json"),
+        key=lambda p: p.stat().st_mtime,
+        reverse=True,
+    )
+    return candidates[0] if candidates else None
+
+
+def _block(reason: str) -> int:
+    """Print the block payload to stdout and return 0 (Claude Code reads stdout)."""
+    print(json.dumps({"decision": "block", "reason": reason}))
+    return 0
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except json.JSONDecodeError:
+        return 0  # Malformed input — fail open
+
+    # Anti-loop: Claude Code sets stop_hook_active=True when it has already
+    # been blocked once. Don't block a second time.
+    if payload.get("stop_hook_active"):
+        return 0
+
+    cwd = Path(payload.get("cwd", ".")).resolve()
+
+    # Operator sessions in the main worktree pass through.
+    if not _is_linked_worktree(cwd):
+        return 0
+
+    manifest_path = _find_manifest(cwd)
+    if manifest_path is None:
+        return 0  # Linked worktree but no manifest — not enforceable
+
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return 0  # Unreadable manifest — fail open
+
+    ticket_id = manifest.get("ticket_id", "WOR-NNN")
+
+    # Gate 1: result.json must exist.
+    result_json_rel = manifest.get("artifact_paths", {}).get("result_json")
+    if result_json_rel:
+        result_json_path = cwd / result_json_rel
+        if not result_json_path.exists():
+            return _block(
+                f"Session cannot end — {result_json_rel} is missing. "
+                "Use the Write tool to create it now with these keys: "
+                'ticket_id, status ("success" or "failure"), summary, '
+                "checks_passed (list of check commands that passed), "
+                "checks_failed (list of failures, empty if status=success). "
+                "Do not run any further verification commands — your work "
+                "is verified by the checks already passed; the watcher only "
+                "needs the artifact."
+            )
+
+    # Gate 2: working tree must be clean.
+    try:
+        out = subprocess.check_output(  # nosec B603 B607
+            ["git", "status", "--porcelain"],
+            cwd=str(cwd),
+            text=True,
+            timeout=5,
+        )
+    except (subprocess.SubprocessError, FileNotFoundError):
+        return 0  # Git unavailable — fail open
+
+    if out.strip():
+        return _block(
+            "Session cannot end — uncommitted changes:\n"
+            f"{out}\n"
+            f"Run this exact command now: "
+            f"git add -A && git commit -m 'Part of {ticket_id}: <one-line summary>'"
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -75,6 +75,16 @@
           }
         ]
       }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python .claude/hooks/check_session_complete.py"
+          }
+        ]
+      }
     ]
   },
   "skills_source": "github:virppa/repo-scaffold-skills",

--- a/tests/test_hooks_session_complete.py
+++ b/tests/test_hooks_session_complete.py
@@ -1,0 +1,218 @@
+"""Tests for the Stop hook at .claude/hooks/check_session_complete.py (WOR-372).
+
+The hook runs as a subprocess (Claude Code invokes it via the settings.json
+"command" entry), so these tests exercise it the same way: spawn the script
+with a JSON payload on stdin, parse stdout/stderr/exit-code.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess  # nosec B404
+import sys
+from pathlib import Path
+
+import pytest
+
+HOOK_SCRIPT = (
+    Path(__file__).resolve().parent.parent
+    / ".claude"
+    / "hooks"
+    / "check_session_complete.py"
+)
+
+
+def _run_hook(payload: dict[str, object]) -> subprocess.CompletedProcess[str]:
+    """Run the hook with the given payload on stdin. Returns the completed process."""
+    return subprocess.run(  # nosec B603
+        [sys.executable, str(HOOK_SCRIPT)],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+
+
+def _git(args: list[str], cwd: Path) -> None:
+    subprocess.run(  # nosec B603 B607
+        ["git", *args], cwd=str(cwd), check=True, capture_output=True, text=True
+    )
+
+
+@pytest.fixture
+def main_repo(tmp_path: Path) -> Path:
+    """A fresh main-worktree git repo at tmp_path. NOT a linked worktree."""
+    _git(["init", "-q", "-b", "main"], cwd=tmp_path)
+    _git(["config", "user.email", "test@example.com"], cwd=tmp_path)
+    _git(["config", "user.name", "Test"], cwd=tmp_path)
+    (tmp_path / "README.md").write_text("seed", encoding="utf-8")
+    _git(["add", "README.md"], cwd=tmp_path)
+    _git(["commit", "-q", "-m", "seed"], cwd=tmp_path)
+    return tmp_path
+
+
+@pytest.fixture
+def linked_worktree(main_repo: Path, tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """A linked worktree (mimics what the watcher creates for a worker session)."""
+    wt_path = tmp_path_factory.mktemp("worktree")
+    # `git worktree add` requires a branch that doesn't exist yet
+    _git(["worktree", "add", "-q", "-b", "feature", str(wt_path)], cwd=main_repo)
+    return wt_path
+
+
+def _write_manifest(
+    worktree: Path,
+    ticket_id: str = "WOR-282",
+    result_json_rel: str = ".claude/artifacts/wor_282/result.json",
+) -> Path:
+    artifact_dir = worktree / ".claude" / "artifacts" / "wor_282"
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    manifest_path = artifact_dir / "manifest.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "ticket_id": ticket_id,
+                "artifact_paths": {
+                    "result_json": result_json_rel,
+                    "manifest_copy": str(manifest_path.relative_to(worktree)),
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    return manifest_path
+
+
+# ---------------------------------------------------------------------------
+# Pass-through cases (hook should NOT block)
+# ---------------------------------------------------------------------------
+
+
+def test_hook_passes_when_not_a_worker_session(main_repo: Path) -> None:
+    """Operator session in the main worktree — no manifest — pass through."""
+    proc = _run_hook({"cwd": str(main_repo), "stop_hook_active": False})
+    assert proc.returncode == 0
+    assert proc.stdout.strip() == ""
+
+
+def test_hook_passes_when_main_worktree_has_old_manifests(main_repo: Path) -> None:
+    """Main worktree with leftover manifest from past worker runs — still pass.
+
+    Without the linked-worktree gate, the hook would erroneously enforce on
+    operator sessions that happen to have historical artifacts on disk.
+    """
+    artifact_dir = main_repo / ".claude" / "artifacts" / "wor_99"
+    artifact_dir.mkdir(parents=True)
+    (artifact_dir / "manifest.json").write_text(
+        json.dumps(
+            {
+                "ticket_id": "WOR-99",
+                "artifact_paths": {
+                    "result_json": ".claude/artifacts/wor_99/result.json",
+                    "manifest_copy": ".claude/artifacts/wor_99/manifest.json",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    proc = _run_hook({"cwd": str(main_repo), "stop_hook_active": False})
+    assert proc.returncode == 0
+    assert proc.stdout.strip() == ""
+
+
+def test_hook_passes_when_all_gates_satisfied(linked_worktree: Path) -> None:
+    """Worker session where result.json exists AND working tree is clean — pass."""
+    _write_manifest(linked_worktree)
+    (linked_worktree / ".claude" / "artifacts" / "wor_282" / "result.json").write_text(
+        json.dumps({"ticket_id": "WOR-282", "status": "success"}), encoding="utf-8"
+    )
+    _git(["add", "-A"], cwd=linked_worktree)
+    _git(["commit", "-q", "-m", "Part of WOR-282: complete"], cwd=linked_worktree)
+
+    proc = _run_hook({"cwd": str(linked_worktree), "stop_hook_active": False})
+    assert proc.returncode == 0
+    assert proc.stdout.strip() == ""
+
+
+def test_hook_passes_when_stop_hook_active_even_with_violations(
+    linked_worktree: Path,
+) -> None:
+    """When stop_hook_active is True (already blocked once), do not block again."""
+    _write_manifest(linked_worktree)
+    # No result.json, dirty tree — would normally block
+    proc = _run_hook({"cwd": str(linked_worktree), "stop_hook_active": True})
+    assert proc.returncode == 0
+    assert proc.stdout.strip() == ""
+
+
+# ---------------------------------------------------------------------------
+# Block cases (hook MUST block)
+# ---------------------------------------------------------------------------
+
+
+def test_hook_blocks_when_result_json_missing(linked_worktree: Path) -> None:
+    """Worker session with no result.json — block with a Write-tool instruction."""
+    _write_manifest(linked_worktree)
+    proc = _run_hook({"cwd": str(linked_worktree), "stop_hook_active": False})
+    assert proc.returncode == 0
+    decision = json.loads(proc.stdout)
+    assert decision["decision"] == "block"
+    assert "result.json" in decision["reason"]
+    assert "Write tool" in decision["reason"]
+
+
+def test_hook_blocks_when_uncommitted_changes(linked_worktree: Path) -> None:
+    """Worker session with result.json but a dirty tree — block on commit."""
+    _write_manifest(linked_worktree)
+    (linked_worktree / ".claude" / "artifacts" / "wor_282" / "result.json").write_text(
+        json.dumps({"ticket_id": "WOR-282", "status": "success"}), encoding="utf-8"
+    )
+    # Create an unstaged change
+    (linked_worktree / "new_file.py").write_text("# dirty", encoding="utf-8")
+
+    proc = _run_hook({"cwd": str(linked_worktree), "stop_hook_active": False})
+    assert proc.returncode == 0
+    decision = json.loads(proc.stdout)
+    assert decision["decision"] == "block"
+    assert "uncommitted changes" in decision["reason"]
+    assert "git add -A && git commit" in decision["reason"]
+    assert "WOR-282" in decision["reason"]
+
+
+# ---------------------------------------------------------------------------
+# Fail-open cases (hook should NOT block on bad input)
+# ---------------------------------------------------------------------------
+
+
+def test_hook_fails_open_on_malformed_json(tmp_path: Path) -> None:
+    """Garbage stdin — hook returns 0 silently (fail open)."""
+    proc = subprocess.run(  # nosec B603
+        [sys.executable, str(HOOK_SCRIPT)],
+        input="not valid json {",
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+    assert proc.returncode == 0
+    assert proc.stdout.strip() == ""
+
+
+def test_hook_fails_open_when_cwd_is_not_a_git_repo(tmp_path: Path) -> None:
+    """Cwd outside any git repo — hook fails open (no enforcement possible)."""
+    not_a_repo = tmp_path / "not_a_repo"
+    not_a_repo.mkdir()
+    proc = _run_hook({"cwd": str(not_a_repo), "stop_hook_active": False})
+    assert proc.returncode == 0
+    assert proc.stdout.strip() == ""
+
+
+def test_hook_fails_open_on_unreadable_manifest(linked_worktree: Path) -> None:
+    """Manifest exists but is malformed — hook does not enforce."""
+    artifact_dir = linked_worktree / ".claude" / "artifacts" / "wor_282"
+    artifact_dir.mkdir(parents=True)
+    (artifact_dir / "manifest.json").write_text(
+        "this is not valid json", encoding="utf-8"
+    )
+    proc = _run_hook({"cwd": str(linked_worktree), "stop_hook_active": False})
+    assert proc.returncode == 0
+    assert proc.stdout.strip() == ""


### PR DESCRIPTION
## Summary

Closes the failure mode that bit WOR-282 attempt 1: worker completes all checks, writes a triumphant summary, and ends its session without ever running \`git add && git commit\` or writing \`result.json\`. Watcher marks Blocked, cleanup runs, all work lost.

The fix is a deterministic Stop hook — not prose in the implement-ticket skill — because skills are advisory, hooks are invariants. This is the first concrete proof of the WOR-374 architectural pattern.

## Changes

- **\`.claude/hooks/check_session_complete.py\`** — Stop hook script (~135 LOC)
  - Detects worker sessions via linked-worktree check (\`git rev-parse --absolute-git-dir\` ≠ \`--git-common-dir\`)
  - Reads the most-recent manifest in \`<worktree>/.claude/artifacts/*/manifest.json\`
  - Gate 1: \`result.json\` must exist at the manifest's \`artifact_paths.result_json\`
  - Gate 2: \`git status --porcelain\` must be clean
  - Fails open on malformed input (no infinite enforcement on edge cases)
  - Respects \`stop_hook_active\` to prevent infinite block loops

- **\`tests/test_hooks_session_complete.py\`** — 9 tests, all passing
  - Pass-through: operator session, all gates met, \`stop_hook_active\`, leftover historical manifests in main worktree
  - Block: missing \`result.json\`, uncommitted changes
  - Fail-open: malformed JSON, non-git cwd, unreadable manifest

- **\`.claude/settings.json\`** — wires the hook under \`hooks.Stop\`

## Test plan

- [x] \`ruff check .\` passes
- [x] \`mypy app/\` passes (29 source files)
- [x] \`lint-imports\` passes (5/5 contracts kept)
- [x] \`pytest\` passes (1158 tests, 9 new)
- [ ] Live verification: dispatch a worker session, observe the hook block when the session ends without commit

## Why this design

- **Standalone script vs inline shell** — existing hooks are simple one-liners; the Stop hook needs manifest parsing, worktree detection, and git status. Standalone script is testable; inline isn't.
- **Linked-worktree gate** — without this, the hook would erroneously block operator sessions in the main repo where historical \`.claude/artifacts/*/manifest.json\` files accumulate. \`git rev-parse\` is the cleanest disambiguator.
- **Fail-open posture** — malformed JSON, missing git, unreadable manifest all return 0. The hook's job is to catch the specific worker-discipline pattern; edge cases shouldn't lock up sessions.

## Cross-links

- WOR-372 — this ticket
- WOR-282 — primary evidence (worker_wor-282.log, archived attempt 1)
- WOR-374 — architectural pattern this validates
- WOR-371 — sibling discipline ticket (re-read cap), follows same hook pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)