### PR TITLE
WOR-371 PreToolUse Read hook: enforce per-file 2-read cap

### DIFF
--- a/.claude/hooks/check_read_cap.py
+++ b/.claude/hooks/check_read_cap.py
@@ -1,0 +1,119 @@
+"""PreToolUse hook on Read — enforce the per-file 2-read cap (WOR-355, WOR-371).
+
+Fires before every Read tool call. Tracks per-file read counts in a
+session-scoped state file, and emits a ``{"decision": "block"}`` payload
+when a file is read more than ``CAP`` times in a single session.
+
+The 2-read cap was established in WOR-355: a file may be read at most
+twice per session, regardless of whether ``context_snippets`` was populated
+in the manifest. Re-reads are most often the "verify after edit"
+anti-pattern — the Edit tool result is authoritative; trusting it saves
+a round-trip.
+
+State file: ``<cwd>/.claude/.read_counts.json``. Keyed by ``session_id`` so
+a stale file from a prior session does not leak into the current one.
+Persisted before any potential block so the count is always durable.
+
+Wire in ``.claude/settings.json``::
+
+    "hooks": {
+      "PreToolUse": [
+        {
+          "matcher": "Read",
+          "hooks": [
+            {
+              "type": "command",
+              "command": "python .claude/hooks/check_read_cap.py"
+            }
+          ]
+        }
+      ]
+    }
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+CAP = 2
+STATE_FILENAME = ".claude/.read_counts.json"
+
+
+def _block(reason: str) -> int:
+    print(json.dumps({"decision": "block", "reason": reason}))
+    return 0
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except json.JSONDecodeError:
+        return 0
+
+    if payload.get("tool_name") != "Read":
+        return 0
+
+    file_path_raw = payload.get("tool_input", {}).get("file_path")
+    if not file_path_raw:
+        return 0
+
+    cwd = Path(payload.get("cwd", ".")).resolve()
+    session_id = payload.get("session_id", "")
+    state_path = cwd / STATE_FILENAME
+
+    # Normalize the file path so different relative spellings of the same
+    # file collapse to one key. Resolve against the payload's cwd, not the
+    # hook process's — Claude Code passes absolute paths in practice, but
+    # relative ones must anchor to the worker's cwd to be meaningful.
+    try:
+        candidate = Path(file_path_raw)
+        if not candidate.is_absolute():
+            candidate = cwd / candidate
+        normalized = str(candidate.resolve())
+    except (OSError, RuntimeError):
+        normalized = file_path_raw
+
+    # Load existing state; reset if session_id changed (stale from prior run).
+    state: dict[str, object] = {"session_id": session_id, "counts": {}}
+    if state_path.exists():
+        try:
+            existing = json.loads(state_path.read_text(encoding="utf-8"))
+            if isinstance(existing, dict) and existing.get("session_id") == session_id:
+                state = existing
+        except (OSError, json.JSONDecodeError):
+            pass
+
+    counts = state.setdefault("counts", {})
+    if not isinstance(counts, dict):
+        counts = {}
+        state["counts"] = counts
+
+    new_count = int(counts.get(normalized, 0)) + 1
+    counts[normalized] = new_count
+    state["session_id"] = session_id
+
+    # Persist before deciding. If write fails, fail open (don't block on infra issues).
+    try:
+        state_path.parent.mkdir(parents=True, exist_ok=True)
+        state_path.write_text(json.dumps(state), encoding="utf-8")
+    except OSError:
+        return 0
+
+    if new_count > CAP:
+        leaf = Path(file_path_raw).name
+        return _block(
+            f"Read blocked: {leaf} has already been read {new_count - 1} times "
+            f"this session. The per-file {CAP}-read cap (WOR-355) prevents "
+            "context bloat. If you need a different section of the file, use "
+            "Grep with a narrow pattern instead. If you are trying to verify "
+            "that an Edit landed, do not — the Edit tool result already shows "
+            "the exact diff applied; that result is authoritative."
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -27,6 +27,15 @@
             "command": "python -c \"import json,sys,re; d=json.load(sys.stdin); f=d.get('tool_input',{}).get('file_path',''); t=d.get('tool_name',''); skip = not re.search(r'\\.(md|toml|yaml|yml|json)$',f) or 'tests/' in f or f.endswith('.py'); c=(d.get('tool_input',{}).get('content','') if t=='Write' else d.get('tool_input',{}).get('new_string','')); sys.exit(1) if not skip and re.search(r'[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}',c) and print(f'Blocked: email detected in {f}',file=sys.stderr) is None else sys.exit(0)\""
           }
         ]
+      },
+      {
+        "matcher": "Read",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python .claude/hooks/check_read_cap.py"
+          }
+        ]
       }
     ],
     "PostToolUse": [

--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,9 @@ litellm-local.yaml
 .claude/*.pid
 .claude/*.lock
 
+# Claude Code hook state (per-session, machine-generated)
+.claude/.read_counts.json
+
 # Forensic log dumps under retros/ (raw worker logs + manifests captured during
 # post-mortem analysis). The retro markdown itself is committed; raw evidence
 # lives in private gists or Linear attachments instead.

--- a/tests/test_hooks_read_cap.py
+++ b/tests/test_hooks_read_cap.py
@@ -1,0 +1,175 @@
+"""Tests for the PreToolUse Read-cap hook (.claude/hooks/check_read_cap.py).
+
+Covers WOR-371 / WOR-355: a file may be read at most twice per session;
+the third Read call is blocked with a clear reason citing Grep as the
+alternative for finding a different section.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess  # nosec B404
+import sys
+from pathlib import Path
+
+import pytest
+
+HOOK_SCRIPT = (
+    Path(__file__).resolve().parent.parent / ".claude" / "hooks" / "check_read_cap.py"
+)
+
+
+def _run_hook(payload: dict[str, object]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(  # nosec B603
+        [sys.executable, str(HOOK_SCRIPT)],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+
+
+def _read_payload(
+    cwd: Path,
+    file_path: str,
+    *,
+    session_id: str = "session-A",
+) -> dict[str, object]:
+    return {
+        "session_id": session_id,
+        "cwd": str(cwd),
+        "tool_name": "Read",
+        "tool_input": {"file_path": file_path},
+    }
+
+
+@pytest.fixture
+def workdir(tmp_path: Path) -> Path:
+    """Tmp dir that has a target file the hook can resolve."""
+    target = tmp_path / "src.py"
+    target.write_text("# target\n", encoding="utf-8")
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Pass-through cases
+# ---------------------------------------------------------------------------
+
+
+def test_first_read_passes(workdir: Path) -> None:
+    """A single Read of a file: hook returns 0, no block."""
+    proc = _run_hook(_read_payload(workdir, str(workdir / "src.py")))
+    assert proc.returncode == 0
+    assert proc.stdout.strip() == ""
+
+
+def test_second_read_passes(workdir: Path) -> None:
+    """Two reads of the same file are still under the cap (cap is 2, 3rd blocks)."""
+    p = _read_payload(workdir, str(workdir / "src.py"))
+    _run_hook(p)
+    proc = _run_hook(p)
+    assert proc.returncode == 0
+    assert proc.stdout.strip() == ""
+
+
+def test_different_files_counted_independently(workdir: Path) -> None:
+    """File A read 2x and file B read 2x: neither blocks, counts independent."""
+    other = workdir / "other.py"
+    other.write_text("# other\n", encoding="utf-8")
+    pa = _read_payload(workdir, str(workdir / "src.py"))
+    pb = _read_payload(workdir, str(other))
+    for _ in range(2):
+        for p in (pa, pb):
+            proc = _run_hook(p)
+            assert proc.returncode == 0
+            assert proc.stdout.strip() == ""
+
+
+def test_session_change_resets_counts(workdir: Path) -> None:
+    """A new session_id resets the counter — old counts do not leak."""
+    p_old = _read_payload(workdir, str(workdir / "src.py"), session_id="session-A")
+    for _ in range(2):
+        _run_hook(p_old)
+    # Third read in session-A would block, but we switch session
+    p_new = _read_payload(workdir, str(workdir / "src.py"), session_id="session-B")
+    proc = _run_hook(p_new)
+    assert proc.returncode == 0
+    assert proc.stdout.strip() == ""
+
+
+def test_non_read_tool_passes(workdir: Path) -> None:
+    """Bash/Edit/Write tool calls don't trigger the cap."""
+    proc = _run_hook(
+        {
+            "session_id": "x",
+            "cwd": str(workdir),
+            "tool_name": "Bash",
+            "tool_input": {"command": "ls"},
+        }
+    )
+    assert proc.returncode == 0
+    assert proc.stdout.strip() == ""
+
+
+# ---------------------------------------------------------------------------
+# Block cases
+# ---------------------------------------------------------------------------
+
+
+def test_third_read_blocks_with_clear_reason(workdir: Path) -> None:
+    """The 3rd read of the same file is blocked; reason cites WOR-355 + Grep."""
+    p = _read_payload(workdir, str(workdir / "src.py"))
+    _run_hook(p)
+    _run_hook(p)
+    proc = _run_hook(p)
+    assert proc.returncode == 0
+    decision = json.loads(proc.stdout)
+    assert decision["decision"] == "block"
+    assert "WOR-355" in decision["reason"]
+    assert "Grep" in decision["reason"]
+    assert "src.py" in decision["reason"]
+
+
+def test_paths_normalize_so_different_spellings_share_a_count(workdir: Path) -> None:
+    """An absolute and a relative path to the same file share the same counter."""
+    p_abs = _read_payload(workdir, str(workdir / "src.py"))
+    p_rel = _read_payload(workdir, "src.py")
+    _run_hook(p_abs)
+    _run_hook(p_rel)
+    # Two reads consumed (2/2). The third must block regardless of spelling.
+    proc = _run_hook(p_abs)
+    assert proc.returncode == 0
+    decision = json.loads(proc.stdout)
+    assert decision["decision"] == "block"
+
+
+# ---------------------------------------------------------------------------
+# Fail-open cases
+# ---------------------------------------------------------------------------
+
+
+def test_fails_open_on_malformed_json(tmp_path: Path) -> None:
+    """Garbage stdin: returns 0, no output (does not block)."""
+    proc = subprocess.run(  # nosec B603
+        [sys.executable, str(HOOK_SCRIPT)],
+        input="not valid json {",
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+    assert proc.returncode == 0
+    assert proc.stdout.strip() == ""
+
+
+def test_fails_open_when_file_path_missing(workdir: Path) -> None:
+    """A Read payload with no file_path: hook returns 0 silently."""
+    proc = _run_hook(
+        {
+            "session_id": "x",
+            "cwd": str(workdir),
+            "tool_name": "Read",
+            "tool_input": {},  # no file_path
+        }
+    )
+    assert proc.returncode == 0
+    assert proc.stdout.strip() == ""


### PR DESCRIPTION
## Summary

Closes the discipline gap that surfaced in 7 of 8 sampled historical sessions: the per-file 2-read cap from WOR-355 was prose in CLAUDE.md, not enforcement. Re-reads waste round-trips and contribute to mid-session compaction (which destroys the prefix cache).

The fix is a deterministic PreToolUse hook on Read — same architecture as WOR-372's Stop hook (PR #740). Second concrete validation of the WOR-374 \"skills for judgment, hooks for invariants\" pattern.

## Changes

- **\`.claude/hooks/check_read_cap.py\`** — PreToolUse hook (~95 LOC)
  - Tracks per-file Read counts in \`.claude/.read_counts.json\` (gitignored)
  - State scoped by \`session_id\` — counts reset on session change
  - 3rd Read of any file is blocked with a reason citing WOR-355 and Grep as the alternative
  - Resolves relative paths against the payload's cwd, not the hook process's
  - Fails open on malformed JSON, missing file_path, or write errors

- **\`tests/test_hooks_read_cap.py\`** — 9 tests, all passing
  - Pass-through: 1st/2nd read, independent file counts, session-id reset, non-Read tools
  - Block: 3rd read with clear reason; absolute and relative paths to the same file share a count
  - Fail-open: malformed JSON, missing file_path

- **\`.claude/settings.json\`** — wires the hook under \`hooks.PreToolUse[matcher=Read]\`
- **\`.gitignore\`** — ignores \`.claude/.read_counts.json\`

## Test plan

- [x] \`ruff check .\` passes
- [x] \`mypy app/\` passes (29 source files)
- [x] \`lint-imports\` passes (5/5 contracts kept)
- [x] \`pytest\` passes (1167 tests, 9 new)
- [ ] Live verification: dispatch a worker session that reads the same file 3+ times, observe the hook block on the 3rd

## Cross-links

- WOR-371 — this ticket
- WOR-355 — established the 2-read cap (universal)
- WOR-372 — sibling hook ticket (PR #740, merged) — this PR follows the same pattern
- WOR-374 — architectural pattern this validates
- WOR-368 — the broader context (94% prefix cache hit rate makes re-reads cheap, but this still helps in cloud mode and prevents compaction)

🤖 Generated with [Claude Code](https://claude.com/claude-code)