### PR TITLE
WOR-378 Refuse manifest dispatch with empty allowed_paths or required_checks

### DIFF
--- a/app/core/watcher/dispatch.py
+++ b/app/core/watcher/dispatch.py
@@ -46,6 +46,39 @@ def start_ticket(
     """Execute the full ticket-start flow extracted from Watcher._start_ticket."""
     # Prerequisite checks (open_blockers + overlap) are handled by
     # Watcher._start_ticket before calling this function.
+
+    # Manifest quality gates (WOR-378) — Pydantic validation accepts these as
+    # legal but they are almost certainly authoring mistakes. Refuse early
+    # with a clear Linear comment so the operator knows to re-author.
+    if manifest.implementation_mode == "local" and not manifest.allowed_paths:
+        logger.warning(
+            "Refusing %s — local manifest has empty allowed_paths", ticket_id
+        )
+        safe_set_state(linear, linear_id, "Backlog", ticket_id)
+        linear.post_comment(
+            linear_id,
+            (
+                "Manifest refused: `allowed_paths` is empty. Local worker "
+                "dispatch requires explicit path scoping so the watcher can "
+                "guarantee path-overlap parallelism. Re-run `/start-ticket` "
+                "to populate the field."
+            ),
+        )
+        return
+    if not manifest.required_checks:
+        logger.warning("Refusing %s — manifest has empty required_checks", ticket_id)
+        safe_set_state(linear, linear_id, "Backlog", ticket_id)
+        linear.post_comment(
+            linear_id,
+            (
+                "Manifest refused: `required_checks` is empty. Worker must "
+                "have at least one check (typically: `ruff check .`, "
+                "`mypy app/`, `pytest`) before declaring success. Re-run "
+                "`/start-ticket`."
+            ),
+        )
+        return
+
     effective_mode = resolve_effective_mode(
         services._mode if hasattr(services, "_mode") else "local",
         manifest.implementation_mode,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,10 @@ def make_manifest(**overrides: object) -> ExecutionManifest:
         "objective": "Do the thing.",
         "artifact_paths": ArtifactPaths.from_ticket_id("WOR-10"),
         "allowed_paths": ["app/core/foo.py"],
+        # WOR-378: dispatch refuses manifests with empty required_checks, so
+        # the conftest fixture defaults a non-empty list. Tests that exercise
+        # the empty-required_checks path can override explicitly.
+        "required_checks": ["pytest"],
     }
     defaults.update(overrides)
     return ExecutionManifest(**defaults)  # type: ignore[arg-type]

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -43,6 +43,9 @@ def _make_manifest(**overrides: Any) -> ExecutionManifest:
         "objective": "Do the thing.",
         "artifact_paths": ArtifactPaths.from_ticket_id("WOR-10"),
         "allowed_paths": ["app/core/foo.py"],
+        # WOR-378: dispatch refuses manifests with empty required_checks; default
+        # a non-empty list to match the conftest fixture.
+        "required_checks": ["pytest"],
     }
     defaults.update(overrides)
     return ExecutionManifest(**defaults)

--- a/tests/test_watcher_dispatch.py
+++ b/tests/test_watcher_dispatch.py
@@ -190,6 +190,95 @@ def test_start_ticket_defers_when_cloud_pool_full(
     assert any("cloud pool full" in r.message for r in caplog.records)
 
 
+# ---------------------------------------------------------------------------
+# WOR-378 — manifest-quality refusal at dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_start_ticket_refuses_local_manifest_with_empty_allowed_paths(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Local-mode manifest with allowed_paths=[] is refused, ticket sent to Backlog."""
+    manifest = make_manifest(implementation_mode="local", allowed_paths=[])
+    linear = MagicMock()
+    services = _services()
+    local_active: list = []
+    cloud_active: list = []
+
+    with (
+        patch("app.core.watcher.dispatch.create_worktree") as mock_create,
+        patch("app.core.watcher.dispatch.safe_set_state") as mock_set_state,
+        caplog.at_level(logging.WARNING, logger="app.core.watcher.dispatch"),
+    ):
+        start_ticket(
+            manifest=manifest,
+            linear=linear,
+            services=services,
+            worker_verbose=False,
+            _local_active=local_active,
+            _cloud_active=cloud_active,
+            max_cloud_workers=3,
+            _repo_root=tmp_path,
+            _processed_tickets=[],
+            linear_id="fake-linear-id",
+            ticket_id="WOR-10",
+            _escalation_policy=MagicMock(),
+        )
+
+    mock_create.assert_not_called()
+    assert local_active == []
+    mock_set_state.assert_called_once_with(
+        linear, "fake-linear-id", "Backlog", "WOR-10"
+    )
+    linear.post_comment.assert_called_once()
+    body = linear.post_comment.call_args[0][1]
+    assert "allowed_paths" in body
+    assert "/start-ticket" in body
+    assert any("empty allowed_paths" in r.message for r in caplog.records)
+
+
+def test_start_ticket_refuses_manifest_with_empty_required_checks(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Manifest with required_checks=[] is refused regardless of mode."""
+    manifest = make_manifest(implementation_mode="cloud", required_checks=[])
+    linear = MagicMock()
+    services = _services()
+    local_active: list = []
+    cloud_active: list = []
+
+    with (
+        patch("app.core.watcher.dispatch.create_worktree") as mock_create,
+        patch("app.core.watcher.dispatch.safe_set_state") as mock_set_state,
+        caplog.at_level(logging.WARNING, logger="app.core.watcher.dispatch"),
+    ):
+        start_ticket(
+            manifest=manifest,
+            linear=linear,
+            services=services,
+            worker_verbose=False,
+            _local_active=local_active,
+            _cloud_active=cloud_active,
+            max_cloud_workers=3,
+            _repo_root=tmp_path,
+            _processed_tickets=[],
+            linear_id="fake-linear-id",
+            ticket_id="WOR-10",
+            _escalation_policy=MagicMock(),
+        )
+
+    mock_create.assert_not_called()
+    assert cloud_active == []
+    mock_set_state.assert_called_once_with(
+        linear, "fake-linear-id", "Backlog", "WOR-10"
+    )
+    linear.post_comment.assert_called_once()
+    body = linear.post_comment.call_args[0][1]
+    assert "required_checks" in body
+    assert "ruff check" in body or "pytest" in body
+    assert any("empty required_checks" in r.message for r in caplog.records)
+
+
 # NOTE: a fifth test for suppress_dedup behaviour is intentionally omitted —
 # dispatch.py's `_dedup_state or {}` falls through to a fresh empty dict on
 # each call, defeating cross-call memoization. That's a real pre-existing

--- a/tests/test_watcher_subprocess.py
+++ b/tests/test_watcher_subprocess.py
@@ -46,6 +46,9 @@ def _make_manifest(**overrides: object) -> ExecutionManifest:
         "artifact_paths": ArtifactPaths.from_ticket_id("WOR-10"),
         "allowed_paths": ["app/core/foo.py"],
         "done_definition": "It works.",
+        # WOR-378: dispatch refuses manifests with empty required_checks; default
+        # a non-empty list. Tests that need to override pass it explicitly.
+        "required_checks": ["pytest"],
     }
     defaults.update(overrides)
     return ExecutionManifest(**defaults)


### PR DESCRIPTION
## Summary

Watcher's \`dispatch.start_ticket\` already runs \`ExecutionManifest.model_validate()\`, but the schema accepts \`allowed_paths=[]\` and \`required_checks=[]\` as legal — even though both are almost always authoring mistakes from a \`/start-ticket\` template that wasn't fully populated.

Adds two refusal paths at the top of \`start_ticket\`. Same \"fail fast at dispatch\" pattern as WOR-373 (stale-epic refusal). Identified by the WOR-374 audit.

## Changes

- **\`app/core/watcher/dispatch.py\`** — two refusal blocks before any side effects:
  - Local mode + empty \`allowed_paths\` → refuse, set Backlog, comment with \`/start-ticket\` remediation
  - Empty \`required_checks\` (any mode) → refuse, set Backlog, comment with example checks

- **Test fixtures updated** to default \`required_checks=[\"pytest\"]\` so existing dispatch tests don't trip the new gate:
  - \`tests/conftest.py::make_manifest\`
  - \`tests/test_watcher.py::_make_manifest\`
  - \`tests/test_watcher_subprocess.py::_make_manifest\`
  - \`tests/test_manifest.py::_make_manifest\` left **unchanged** — that helper tests schema defaults directly, which intentionally remain empty.

- **\`tests/test_watcher_dispatch.py\`** — 2 new tests covering both refusal paths.

## Test plan

- [x] \`pytest tests/test_watcher_dispatch.py\` — 6 pass (4 existing + 2 new)
- [x] \`pytest\` full suite — **1169 pass** (was 1167; 2 new)
- [x] \`ruff check .\` passes
- [x] \`mypy app/\` passes (29 source files)
- [x] \`lint-imports\` passes (5/5 contracts kept)

## Refusal behavior summary

| Manifest state | Result |
|---|---|
| local + allowed_paths=[] | Refuse → Backlog + comment |
| any mode + required_checks=[] | Refuse → Backlog + comment |
| cloud + allowed_paths=[] | **Allowed** (cloud workers can scope freely; watcher's parallelism guarantee is local-mode-specific) |
| Both fields populated | Normal dispatch |

## Cross-links

- WOR-378 (this ticket) — child of WOR-374
- WOR-374 — audit doc that identified this candidate
- WOR-373 — sibling refusal pattern (stale-epic)
- \`docs/decisions/hooks_vs_skills_audit.md\` — references the principle

🤖 Generated with [Claude Code](https://claude.com/claude-code)