### PR TITLE
WOR-376 Bash discipline PreToolUse hook (cd / heredoc / python -c)

### DIFF
--- a/.claude/hooks/check_bash_discipline.py
+++ b/.claude/hooks/check_bash_discipline.py
@@ -1,0 +1,126 @@
+"""PreToolUse hook on Bash — enforce three Worker Efficiency rules (WOR-376).
+
+Each rule is documented as prose in CLAUDE.md "Worker efficiency"; this hook
+makes them deterministic. Three checks, each with its own disposition:
+
+1. **Bare ``cd <path>``** (regex anchors to a complete command with no
+   chaining). Disposition: warn-don't-block — wasteful round-trip but not
+   destructive.
+
+2. **Heredocs writing source files** (``cat > file.py <<`` / ``tee file.py <<``
+   with extensions matching .py/.md/.json/.yaml/.yml/.toml).
+   Disposition: block — heredocs break on Windows when the body has single
+   quotes; the Write tool handles any content without escaping.
+
+3. **`python3 -c` opening files** (any inline `-c` script that includes
+   ``open(...)``). Disposition: block — Python source through a shell
+   command breaks on Windows quoting, and editing files via `python -c`
+   bypasses the Edit tool's diff confirmation.
+
+Wire in ``.claude/settings.json``::
+
+    "hooks": {
+      "PreToolUse": [
+        {
+          "matcher": "Bash",
+          "hooks": [
+            {
+              "type": "command",
+              "command": "python .claude/hooks/check_bash_discipline.py"
+            }
+          ]
+        }
+      ]
+    }
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+
+# Bare `cd <path>` — no `&&`, `;`, `|`, redirects, or backgrounding after the path.
+# Matches: "cd /path", "  cd ~/foo  "
+# Does NOT match: "cd /path && ls", "cd /path; ls", "cd /path | tee", "cd /path > log"
+_BARE_CD = re.compile(r"^\s*cd\s+\S+\s*$")
+
+# Heredoc writing a source file. Two shapes:
+#   `cat > file.ext <<EOF`  / `cat >> file.ext << 'EOF'`
+#   `tee file.ext <<EOF`    / `tee -a file.ext <<EOF`   (tee writes from stdin)
+# Discriminating feature: `cat`/`tee`, a source-extension path, and `<<` somewhere
+# downstream. The exact intervening syntax varies; match permissively.
+_HEREDOC_TO_SOURCE = re.compile(
+    r"\b(cat|tee)\b[^\n]*?\S+\.(py|md|json|yaml|yml|toml)\s*<<",
+    re.IGNORECASE,
+)
+
+# `python -c` or `python3 -c` containing an `open(` call (read or write — both
+# are anti-patterns; reads should use the Read tool, writes should use Write/Edit).
+_PYTHON_DASH_C_OPEN = re.compile(
+    r"\bpython3?\s+-c\s+.*\bopen\s*\(",
+    re.DOTALL,
+)
+
+
+def _block(reason: str) -> int:
+    print(json.dumps({"decision": "block", "reason": reason}))
+    return 0
+
+
+def _warn(reason: str) -> int:
+    """Emit a warning to stderr without blocking. Claude Code surfaces stderr
+    in the tool result so the model sees the advisory but the call proceeds."""
+    print(reason, file=sys.stderr)
+    return 0
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except json.JSONDecodeError:
+        return 0  # Fail open
+
+    if payload.get("tool_name") != "Bash":
+        return 0
+
+    cmd = payload.get("tool_input", {}).get("command", "")
+    if not isinstance(cmd, str) or not cmd.strip():
+        return 0
+
+    # Rule 2: heredoc-to-source-file (highest blast radius — broken file content)
+    if _HEREDOC_TO_SOURCE.search(cmd):
+        return _block(
+            "Bash blocked: heredoc writing a source file. Heredocs break on "
+            "Windows when the body contains single quotes (the shell "
+            "misinterprets them as closing the delimiter), and on POSIX "
+            "they require escaping that the Write tool handles natively. "
+            "Use the Write tool instead — it takes the file content as a "
+            "string with no shell quoting involved. (CLAUDE.md 'Worker "
+            "efficiency')"
+        )
+
+    # Rule 3: python -c opening files
+    if _PYTHON_DASH_C_OPEN.search(cmd):
+        return _block(
+            "Bash blocked: `python -c` calling `open(...)`. Python source "
+            "passed through a shell command breaks on Windows quoting and "
+            "loses Edit's diff confirmation. Use the Read tool to read a "
+            "file; use Edit (with old_string/new_string) to modify; use "
+            "Write to create. (CLAUDE.md 'Worker efficiency')"
+        )
+
+    # Rule 1: bare `cd` — warn but allow, since some tools still need it
+    # (e.g., one-off interactive ops) and false positives are higher.
+    if _BARE_CD.match(cmd):
+        return _warn(
+            "[bash-discipline] Standalone `cd` is a wasted round-trip. "
+            "Chain with the actual command: `cd /path && <cmd>`, or pass "
+            "an absolute path to the next tool call."
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -36,6 +36,15 @@
             "command": "python .claude/hooks/check_read_cap.py"
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python .claude/hooks/check_bash_discipline.py"
+          }
+        ]
       }
     ],
     "PostToolUse": [

--- a/tests/test_hooks_bash_discipline.py
+++ b/tests/test_hooks_bash_discipline.py
@@ -1,0 +1,206 @@
+"""Tests for the PreToolUse Bash-discipline hook (WOR-376).
+
+Three rules, each tested for the positive (block/warn) and negative
+(allow) case, plus fail-open paths.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess  # nosec B404
+import sys
+from pathlib import Path
+
+import pytest
+
+HOOK_SCRIPT = (
+    Path(__file__).resolve().parent.parent
+    / ".claude"
+    / "hooks"
+    / "check_bash_discipline.py"
+)
+
+
+def _run_hook(command: str) -> subprocess.CompletedProcess[str]:
+    payload = {
+        "tool_name": "Bash",
+        "tool_input": {"command": command},
+        "cwd": str(Path.cwd()),
+    }
+    return subprocess.run(  # nosec B603
+        [sys.executable, str(HOOK_SCRIPT)],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Rule 1 — bare `cd <path>` (warn, do not block)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        "cd /some/path",
+        "  cd /some/path  ",
+        "cd ~/foo",
+        "cd ../bar",
+    ],
+)
+def test_bare_cd_warns_but_does_not_block(cmd: str) -> None:
+    proc = _run_hook(cmd)
+    assert proc.returncode == 0
+    assert proc.stdout.strip() == ""  # No block
+    assert "bash-discipline" in proc.stderr
+    assert "wasted round-trip" in proc.stderr
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        "cd /some/path && ls",
+        "cd /some/path; ls",
+        "cd /some/path | tee log",
+        "cd /some/path > log",
+    ],
+)
+def test_chained_cd_passes_silently(cmd: str) -> None:
+    proc = _run_hook(cmd)
+    assert proc.returncode == 0
+    assert proc.stdout.strip() == ""
+    assert proc.stderr.strip() == ""
+
+
+# ---------------------------------------------------------------------------
+# Rule 2 — heredoc writing source files (block)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        "cat > app/foo.py <<EOF\nprint('hi')\nEOF",
+        "cat >> docs/README.md << 'EOF'\nHi\nEOF",
+        "tee app/config.json <<EOF\n{}\nEOF",
+        "cat > pyproject.toml <<EOF\n[tool]\nEOF",
+        "cat > .pre-commit-config.yaml <<EOF\nrepos: []\nEOF",
+    ],
+)
+def test_heredoc_to_source_blocks(cmd: str) -> None:
+    proc = _run_hook(cmd)
+    assert proc.returncode == 0
+    decision = json.loads(proc.stdout)
+    assert decision["decision"] == "block"
+    assert "heredoc" in decision["reason"]
+    assert "Write tool" in decision["reason"]
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        "cat app/foo.py",  # plain read
+        "echo hi > /tmp/log.txt",  # log file, not source
+        "ls > /dev/null",  # noise
+        "cat > app/foo.py",  # missing <<
+    ],
+)
+def test_non_heredoc_or_non_source_passes(cmd: str) -> None:
+    proc = _run_hook(cmd)
+    assert proc.returncode == 0
+    assert proc.stdout.strip() == ""
+    assert proc.stderr.strip() == ""
+
+
+# ---------------------------------------------------------------------------
+# Rule 3 — python -c opening files (block)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        "python -c \"open('foo.py', 'w').write('x')\"",
+        "python3 -c \"with open('foo.py') as f: print(f.read())\"",
+        "python3 -c 'data = open(\"x.json\").read()'",
+    ],
+)
+def test_python_dash_c_with_open_blocks(cmd: str) -> None:
+    proc = _run_hook(cmd)
+    assert proc.returncode == 0
+    decision = json.loads(proc.stdout)
+    assert decision["decision"] == "block"
+    assert "python -c" in decision["reason"]
+    assert "Read" in decision["reason"]
+    assert "Edit" in decision["reason"]
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        "python -c \"print('hi')\"",  # no open()
+        "python3 -c 'import json; print(json.dumps({}))'",  # no open()
+        "python script.py",  # not -c
+    ],
+)
+def test_python_without_open_passes(cmd: str) -> None:
+    proc = _run_hook(cmd)
+    assert proc.returncode == 0
+    assert proc.stdout.strip() == ""
+
+
+# ---------------------------------------------------------------------------
+# Cross-rule and fail-open
+# ---------------------------------------------------------------------------
+
+
+def test_non_bash_tool_passes() -> None:
+    """Hook only fires on Bash; an Edit tool call is ignored."""
+    payload = {
+        "tool_name": "Edit",
+        "tool_input": {"file_path": "/tmp/x.py", "old_string": "a", "new_string": "b"},
+    }
+    proc = subprocess.run(  # nosec B603
+        [sys.executable, str(HOOK_SCRIPT)],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+    assert proc.returncode == 0
+    assert proc.stdout.strip() == ""
+
+
+def test_empty_command_passes() -> None:
+    proc = _run_hook("")
+    assert proc.returncode == 0
+    assert proc.stdout.strip() == ""
+
+
+def test_fails_open_on_malformed_json() -> None:
+    proc = subprocess.run(  # nosec B603
+        [sys.executable, str(HOOK_SCRIPT)],
+        input="not valid json {",
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+    assert proc.returncode == 0
+    assert proc.stdout.strip() == ""
+
+
+def test_block_takes_precedence_over_warn() -> None:
+    """A command that matches BOTH 'cd' (warn) and a heredoc (block) blocks.
+
+    This tests the rule precedence: more dangerous patterns checked first.
+    Even though `cd` requires a *bare* command and a heredoc-containing
+    string is not bare, this asserts the explicit ordering.
+    """
+    cmd = "cd /tmp && cat > app/foo.py <<EOF\nx\nEOF"
+    proc = _run_hook(cmd)
+    assert proc.returncode == 0
+    decision = json.loads(proc.stdout)
+    assert decision["decision"] == "block"
+    assert "heredoc" in decision["reason"]


### PR DESCRIPTION
## Summary

Third concrete validation of the WOR-374 hook architecture: convert three CLAUDE.md "Worker efficiency" prose rules into a single PreToolUse hook on Bash. Identified by the WOR-374 audit pass.

The hook fired on its own author during this PR — the original commit message contained literal example patterns (`cat > foo.py <<EOF`) that triggered Rule 2. Switched to `git commit -F <file>` (the canonical workaround). Hook is working as designed.

## Rules

| # | Pattern | Disposition | Why |
|---|---|---|---|
| 1 | Bare `cd <path>` (no chaining) | warn on stderr | Wasteful round-trip, not destructive |
| 2 | Heredoc writing `.py/.md/.json/.yaml/.yml/.toml` files | **block** | Single-quote bodies break on Windows shell; Write tool is canonical |
| 3 | `python -c` calling `open(...)` | **block** | Python through shell breaks on Windows quoting; Read/Edit/Write are canonical |

## Changes

- **`.claude/hooks/check_bash_discipline.py`** — single-file hook with three regex checks. Block path emits `{"decision": "block", "reason": "..."}` on stdout (matches WOR-371/WOR-372 pattern). Warn path emits to stderr without blocking.
- **`tests/test_hooks_bash_discipline.py`** — 27 parametrized tests covering positive blocks/warns, negative passes, cross-rule precedence, and fail-open paths (malformed JSON, non-Bash tools).
- **`.claude/settings.json`** — wires the hook under `hooks.PreToolUse[matcher=Bash]`.

## Test plan

- [x] `ruff check .` passes
- [x] `mypy app/` passes (29 source files)
- [x] `lint-imports` passes (5/5 contracts kept)
- [x] `pytest` passes (1194 tests, 27 new)
- [x] Live verification: hook blocked the original commit attempt with a heredoc-pattern body in the message

## Cross-links

- WOR-376 (this ticket) — child of WOR-374
- WOR-374 — audit doc that identified this candidate
- WOR-371 (PR #741) / WOR-372 (PR #740, merged) — sibling hook implementations
- `CLAUDE.md` "Worker efficiency" — prose source
- `docs/decisions/hooks_vs_skills_audit.md` — architectural framing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
