### PR TITLE
WOR-377 File-size pre-commit hook (move from /finalize-ticket prose)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,6 +39,12 @@ repos:
         pass_filenames: false
         additional_dependencies: ["semgrep>=1.159.0"]
 
+      - id: check-file-sizes
+        name: check-file-sizes
+        language: system
+        entry: python scripts/check_file_sizes.py
+        types: [python]
+
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.20.2
     hooks:

--- a/scripts/check_file_sizes.py
+++ b/scripts/check_file_sizes.py
@@ -1,0 +1,126 @@
+"""Pre-commit hook: enforce per-file LOC thresholds for Python sources (WOR-377).
+
+Migrated from the prose checklist in `.claude/commands/finalize-ticket.md`
+and `/close-epic.md` so drift is caught at commit time, not just at the
+end of a ticket. Two threshold tables — one for production code and one
+for tests, recalibrated post-WOR-368 based on the observation that test
+files are read less often by LLMs and parallel-worker isolation matters
+less for fixtures.
+
+Production (app/, scripts/): ADVISORY 500 / RECOMMEND 700 / BLOCK 1200.
+Tests (tests/):              ADVISORY 800 / RECOMMEND 1200 / BLOCK 2000.
+
+Behaviour:
+
+- ADVISORY  — informational stderr line; commit proceeds.
+- RECOMMEND — warning stderr line; commit proceeds.
+- BLOCK     — error stderr line; commit fails (exit 1).
+
+Bypass with ``git commit --no-verify`` when an incidental edit to an
+already-oversized file genuinely shouldn't grow the ticket scope.
+
+Wire in ``.pre-commit-config.yaml``::
+
+    - repo: local
+      hooks:
+        - id: check-file-sizes
+          name: check-file-sizes
+          language: system
+          entry: python scripts/check_file_sizes.py
+          types: [python]
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+PROD_ADVISORY = 500
+PROD_RECOMMEND = 700
+PROD_BLOCK = 1200
+
+TEST_ADVISORY = 800
+TEST_RECOMMEND = 1200
+TEST_BLOCK = 2000
+
+
+def is_test_file(path: str) -> bool:
+    """A path is a test file if any path part is `tests`."""
+    parts = Path(path).parts
+    return "tests" in parts
+
+
+def thresholds_for(path: str) -> tuple[int, int, int]:
+    """Return (advisory, recommend, block) thresholds for the path."""
+    if is_test_file(path):
+        return TEST_ADVISORY, TEST_RECOMMEND, TEST_BLOCK
+    return PROD_ADVISORY, PROD_RECOMMEND, PROD_BLOCK
+
+
+def classify(loc: int, path: str) -> str | None:
+    """Return 'advisory'|'recommend'|'block' or None if under all thresholds."""
+    advisory, recommend, block = thresholds_for(path)
+    if loc >= block:
+        return "block"
+    if loc >= recommend:
+        return "recommend"
+    if loc >= advisory:
+        return "advisory"
+    return None
+
+
+def count_lines(path: Path) -> int:
+    """Count total lines in the file. Returns 0 on read errors."""
+    try:
+        with path.open(encoding="utf-8") as f:
+            return sum(1 for _ in f)
+    except (OSError, UnicodeDecodeError):
+        return 0
+
+
+def check_file(path_str: str) -> tuple[int, str | None]:
+    """Return (loc, severity) for a single path."""
+    path = Path(path_str)
+    if not path.exists() or path.suffix != ".py":
+        return (0, None)
+    loc = count_lines(path)
+    return (loc, classify(loc, path_str))
+
+
+def _format_message(path: str, loc: int, severity: str) -> str:
+    advisory, recommend, block = thresholds_for(path)
+    tier_label = "test" if is_test_file(path) else "production"
+    if severity == "block":
+        return (
+            f"[file-size:BLOCK] {path} is {loc} LOC "
+            f"(over the {tier_label} BLOCK threshold of {block}). "
+            "Split into themed siblings before committing, or pass "
+            "--no-verify if this edit doesn't add scope."
+        )
+    if severity == "recommend":
+        return (
+            f"[file-size:RECOMMEND] {path} is {loc} LOC "
+            f"(over the {tier_label} RECOMMEND threshold of {recommend}). "
+            "Consider splitting on the next ticket boundary."
+        )
+    return (
+        f"[file-size:advisory] {path} is {loc} LOC "
+        f"(over the {tier_label} ADVISORY threshold of {advisory})."
+    )
+
+
+def main(argv: list[str]) -> int:
+    """Entry point. Returns 1 if any file is over BLOCK; 0 otherwise."""
+    failed = False
+    for path in argv:
+        loc, severity = check_file(path)
+        if severity is None:
+            continue
+        print(_format_message(path, loc, severity), file=sys.stderr)
+        if severity == "block":
+            failed = True
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tests/test_check_file_sizes.py
+++ b/tests/test_check_file_sizes.py
@@ -1,0 +1,211 @@
+"""Tests for scripts/check_file_sizes.py (WOR-377).
+
+Covers tier classification (production vs test), severity boundaries,
+non-Python passthrough, and the main() exit code contract.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Add scripts/ to path so we can import the hook module by name.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT / "scripts"))
+
+import check_file_sizes as cfs  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# is_test_file / thresholds_for
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "path,expected_test",
+    [
+        ("tests/test_foo.py", True),
+        ("tests/sub/test_bar.py", True),
+        ("app/core/foo.py", False),
+        ("scripts/run.py", False),
+        ("tests/conftest.py", True),
+    ],
+)
+def test_is_test_file(path: str, expected_test: bool) -> None:
+    assert cfs.is_test_file(path) is expected_test
+
+
+def test_thresholds_for_production_file() -> None:
+    assert cfs.thresholds_for("app/core/foo.py") == (
+        cfs.PROD_ADVISORY,
+        cfs.PROD_RECOMMEND,
+        cfs.PROD_BLOCK,
+    )
+
+
+def test_thresholds_for_test_file() -> None:
+    assert cfs.thresholds_for("tests/test_foo.py") == (
+        cfs.TEST_ADVISORY,
+        cfs.TEST_RECOMMEND,
+        cfs.TEST_BLOCK,
+    )
+
+
+# ---------------------------------------------------------------------------
+# classify — boundary table
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "loc,path,expected",
+    [
+        # Production thresholds: 500 / 700 / 1200
+        (1, "app/core/foo.py", None),
+        (499, "app/core/foo.py", None),
+        (500, "app/core/foo.py", "advisory"),
+        (699, "app/core/foo.py", "advisory"),
+        (700, "app/core/foo.py", "recommend"),
+        (1199, "app/core/foo.py", "recommend"),
+        (1200, "app/core/foo.py", "block"),
+        (5000, "app/core/foo.py", "block"),
+        # Test thresholds: 800 / 1200 / 2000
+        (1, "tests/test_foo.py", None),
+        (799, "tests/test_foo.py", None),
+        (800, "tests/test_foo.py", "advisory"),
+        (1199, "tests/test_foo.py", "advisory"),
+        (1200, "tests/test_foo.py", "recommend"),
+        (1999, "tests/test_foo.py", "recommend"),
+        (2000, "tests/test_foo.py", "block"),
+        (5000, "tests/test_foo.py", "block"),
+    ],
+)
+def test_classify_boundaries(loc: int, path: str, expected: str | None) -> None:
+    assert cfs.classify(loc, path) == expected
+
+
+# ---------------------------------------------------------------------------
+# count_lines / check_file
+# ---------------------------------------------------------------------------
+
+
+def test_count_lines_basic(tmp_path: Path) -> None:
+    f = tmp_path / "x.py"
+    f.write_text("a\nb\nc\n", encoding="utf-8")
+    assert cfs.count_lines(f) == 3
+
+
+def test_count_lines_no_trailing_newline(tmp_path: Path) -> None:
+    f = tmp_path / "x.py"
+    f.write_text("a\nb", encoding="utf-8")
+    assert cfs.count_lines(f) == 2
+
+
+def test_count_lines_empty(tmp_path: Path) -> None:
+    f = tmp_path / "x.py"
+    f.write_text("", encoding="utf-8")
+    assert cfs.count_lines(f) == 0
+
+
+def test_check_file_under_threshold(tmp_path: Path) -> None:
+    f = tmp_path / "small.py"
+    f.write_text("\n" * 100, encoding="utf-8")
+    loc, sev = cfs.check_file(str(f))
+    assert loc == 100
+    assert sev is None
+
+
+def test_check_file_block_for_production(tmp_path: Path) -> None:
+    f = tmp_path / "big.py"
+    f.write_text("\n" * 1500, encoding="utf-8")
+    loc, sev = cfs.check_file(str(f))
+    assert loc == 1500
+    # 1500 LOC: production tier — block (>=1200), test tier — recommend (>=1200)
+    # str(f) is an absolute path with no `tests` parent, so production tier.
+    assert sev == "block"
+
+
+def test_check_file_skips_non_python(tmp_path: Path) -> None:
+    f = tmp_path / "data.txt"
+    f.write_text("\n" * 5000, encoding="utf-8")
+    loc, sev = cfs.check_file(str(f))
+    assert loc == 0
+    assert sev is None
+
+
+def test_check_file_skips_missing(tmp_path: Path) -> None:
+    loc, sev = cfs.check_file(str(tmp_path / "does_not_exist.py"))
+    assert loc == 0
+    assert sev is None
+
+
+# ---------------------------------------------------------------------------
+# main — exit code contract
+# ---------------------------------------------------------------------------
+
+
+def test_main_exit_zero_when_nothing_staged(capsys: pytest.CaptureFixture[str]) -> None:
+    rc = cfs.main([])
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == ""
+
+
+def test_main_exit_zero_for_advisory_only(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    f = tmp_path / "modest.py"
+    f.write_text("\n" * 600, encoding="utf-8")  # production advisory band
+    rc = cfs.main([str(f)])
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert "advisory" in captured.err.lower()
+
+
+def test_main_exit_zero_for_recommend(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    f = tmp_path / "warning.py"
+    f.write_text("\n" * 900, encoding="utf-8")  # production recommend band
+    rc = cfs.main([str(f)])
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert "RECOMMEND" in captured.err
+
+
+def test_main_exit_one_for_block(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    f = tmp_path / "huge.py"
+    f.write_text("\n" * 1500, encoding="utf-8")  # production block band
+    rc = cfs.main([str(f)])
+    assert rc == 1
+    captured = capsys.readouterr()
+    assert "BLOCK" in captured.err
+    assert "--no-verify" in captured.err
+
+
+def test_main_continues_after_first_block(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A block on file A should still emit info for file B; both reported."""
+    big = tmp_path / "huge.py"
+    big.write_text("\n" * 1500, encoding="utf-8")
+    medium = tmp_path / "medium.py"
+    medium.write_text("\n" * 800, encoding="utf-8")
+    rc = cfs.main([str(big), str(medium)])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "huge.py" in err
+    assert "medium.py" in err
+
+
+def test_main_skips_non_python_files(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    txt = tmp_path / "data.txt"
+    txt.write_text("\n" * 5000, encoding="utf-8")
+    rc = cfs.main([str(txt)])
+    assert rc == 0
+    assert capsys.readouterr().err == ""


### PR DESCRIPTION
## Summary

Migrates the per-file LOC threshold check from prose in `.claude/commands/finalize-ticket.md` and `close-epic.md` into a deterministic pre-commit hook. Drift now surfaces at every commit, not just at finalize/close-epic time. Identified by the WOR-374 audit pass.

## Threshold tables (recalibrated post-WOR-368)

| Tier | ADVISORY | RECOMMEND | BLOCK |
|---|---|---|---|
| Production (`app/`, `scripts/`) | 500 | 700 | 1200 |
| Tests (`tests/`) | 800 | 1200 | 2000 |

## Behaviour

| Severity | Output | Exit | Effect |
|---|---|---|---|
| ADVISORY | informational stderr line | 0 | commit proceeds |
| RECOMMEND | warning stderr line | 0 | commit proceeds |
| BLOCK | error stderr line | 1 | commit fails |

The BLOCK message includes `--no-verify` guidance for incidental edits to already-oversized files.

## Sanity check on the current repo

Running the hook against the known-large files in main:

```
[file-size:RECOMMEND] tests/test_watcher_finalize.py is 1494 LOC
[file-size:RECOMMEND] tests/test_watcher.py is 1240 LOC
[file-size:RECOMMEND] app/core/watcher/watcher.py is 1005 LOC
[file-size:RECOMMEND] app/core/metrics.py is 771 LOC
[file-size:advisory]  app/core/watcher/watcher_finalize.py is 677 LOC
[file-size:advisory]  app/core/watcher/watcher_worktrees.py is 630 LOC
... (more advisory lines)
exit: 0
```

**Zero BLOCK violations** — installing the hook today does not break any existing workflow. RECOMMEND warnings cover files already tracked by WOR-282 / WOR-369 / split-prep tickets.

## Changes

- **`scripts/check_file_sizes.py`** (~110 LOC) — pure functions (`is_test_file`, `thresholds_for`, `classify`, `count_lines`, `check_file`, `_format_message`) plus `main()`.
- **`tests/test_check_file_sizes.py`** — 36 parametrized tests covering: tier classification (5 paths), threshold equivalence per tier, severity boundaries (16 boundary cases — one per tier per file type), `count_lines` edge cases, `check_file` Python/non-Python/missing handling, `main()` exit-code contract.
- **`.pre-commit-config.yaml`** — wires the hook into the existing `repo: local` block. `types: [python]` ensures pre-commit only invokes it for `.py` changes.

## Test plan

- [x] `ruff check .` passes
- [x] `mypy app/` passes (29 source files)
- [x] `lint-imports` passes (5/5 contracts kept)
- [x] `pytest` passes (1230 tests, 36 new)
- [x] Live verification: the hook ran on its own commit (`check-file-sizes.........Passed`) and surfaced no BLOCK violations against the current main

## What this PR explicitly does NOT do

- Does NOT remove the prose threshold checks from `finalize-ticket.md` or `close-epic.md` — per WOR-374 principle, prose stays as documentation; the hook is the enforcement.
- Does NOT change any existing source file to bring it under threshold — that's the WOR-282 / WOR-369 / future split tickets' job.
- Does NOT add per-tier override config — thresholds are constants in the script. If a per-project override turns out to matter, that's a separate ticket.

## Cross-links

- WOR-377 (this ticket) — child of WOR-374
- WOR-374 — audit doc that identified this candidate (`docs/decisions/hooks_vs_skills_audit.md`)
- WOR-368 follow-up commit `fb4a8c0` — established the test-vs-prod threshold split
- WOR-282 — split test_watcher_finalize.py (RECOMMEND offender)
- `.claude/commands/finalize-ticket.md` and `close-epic.md` — original prose source

🤖 Generated with [Claude Code](https://claude.com/claude-code)
