### PR TITLE
WOR-373 Refuse dispatch when epic branch is too far behind main

### DIFF
--- a/app/core/watcher/dispatch.py
+++ b/app/core/watcher/dispatch.py
@@ -14,7 +14,11 @@ from pathlib import Path
 from app.core.manifest import ExecutionManifest
 
 from .watcher_finalize import safe_set_state
-from .watcher_helpers import resolve_effective_mode, suppress_dedup
+from .watcher_helpers import (
+    count_main_ahead_of_epic,
+    resolve_effective_mode,
+    suppress_dedup,
+)
 from .watcher_services import ServiceManager
 from .watcher_subprocess import launch_worker
 from .watcher_types import ActiveWorker, LinearClientProtocol
@@ -26,6 +30,13 @@ from .watcher_worktrees import (
 )
 
 logger = logging.getLogger(__name__)
+
+# WOR-373: epic branches that lag main by more than this many commits are
+# refused at dispatch. Long-lived epics silently shed main-side changes
+# during periodic merge conflict resolution; the WOR-282 forensic uncovered
+# 13 lost tests on a 107-commit-behind epic. 30 commits is roughly 3-7 days
+# of drift in this repo; healthy epics stay well under it.
+_EPIC_DRIFT_THRESHOLD = 30
 
 
 def start_ticket(
@@ -75,6 +86,37 @@ def start_ticket(
                 "have at least one check (typically: `ruff check .`, "
                 "`mypy app/`, `pytest`) before declaring success. Re-run "
                 "`/start-ticket`."
+            ),
+        )
+        return
+
+    # WOR-373: stale-epic refusal. If the sub-ticket's base_branch is an
+    # epic that has fallen too far behind main, block dispatch. Stale epics
+    # silently drop main-side work during the next merge conflict resolution
+    # (see WOR-282 forensic — 13 tests lost on a 107-commit-behind epic).
+    drift = count_main_ahead_of_epic(manifest.base_branch, _repo_root)
+    if drift > _EPIC_DRIFT_THRESHOLD:
+        logger.warning(
+            "Refusing %s — epic %s is %d commits behind origin/main (threshold %d)",
+            ticket_id,
+            manifest.base_branch,
+            drift,
+            _EPIC_DRIFT_THRESHOLD,
+        )
+        safe_set_state(linear, linear_id, "Backlog", ticket_id)
+        linear.post_comment(
+            linear_id,
+            (
+                f"Manifest refused: epic branch `{manifest.base_branch}` is "
+                f"{drift} commits behind `origin/main` (threshold: "
+                f"{_EPIC_DRIFT_THRESHOLD}). Stale epics silently drop tests "
+                f"during merge conflict resolution — see WOR-282 forensic. "
+                f"Merge main into the epic first, then re-dispatch:\n\n"
+                f"  git fetch origin\n"
+                f"  git checkout {manifest.base_branch}\n"
+                f"  git merge origin/main\n"
+                f"  # resolve conflicts...\n"
+                f"  git push"
             ),
         )
         return

--- a/app/core/watcher/watcher_helpers.py
+++ b/app/core/watcher/watcher_helpers.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 import logging
+import subprocess  # nosec B404
 from pathlib import Path
 from typing import IO
 
@@ -421,3 +422,54 @@ def suppress_dedup(
 
     dedup_state[ticket_id] = reason
     return reason_msg
+
+
+# ---------------------------------------------------------------------------
+# Stale-epic detection (WOR-373)
+# ---------------------------------------------------------------------------
+
+
+def count_main_ahead_of_epic(epic_branch: str, repo_root: Path) -> int:
+    """Return how many commits ``origin/main`` has that ``epic_branch`` doesn't.
+
+    Used by dispatch to refuse sub-ticket launches against epic branches that
+    have drifted too far from main. A long-lived epic branch silently sheds
+    main-side changes during periodic merge conflict resolutions; the WOR-282
+    forensic uncovered 13 lost tests on a 107-commit-behind epic.
+
+    Returns 0 (no drift) if:
+      * ``epic_branch`` does not start with ``epic/`` (only epic branches
+        are subject to the staleness check; sub-tickets targeting main
+        directly are by definition not stale).
+      * ``git fetch`` or ``git rev-list`` fails for any reason (fail open
+        — do not block dispatch on infra glitches).
+
+    Otherwise returns the integer commit count.
+    """
+    if not epic_branch.startswith("epic/"):
+        return 0
+
+    # Best-effort fetch so the count reflects the latest origin state.
+    # We fetch both refs explicitly; failures are non-fatal (a stale
+    # local view simply means the count is conservative, not wrong).
+    try:
+        subprocess.run(  # nosec B603 B607
+            ["git", "fetch", "origin", "main", epic_branch],
+            cwd=str(repo_root),
+            check=False,
+            capture_output=True,
+            timeout=30,
+        )
+    except (subprocess.SubprocessError, FileNotFoundError):
+        pass
+
+    try:
+        out = subprocess.check_output(  # nosec B603 B607
+            ["git", "rev-list", "--count", f"origin/{epic_branch}..origin/main"],
+            cwd=str(repo_root),
+            text=True,
+            timeout=10,
+        )
+        return int(out.strip())
+    except (subprocess.SubprocessError, ValueError, FileNotFoundError):
+        return 0

--- a/tests/test_watcher_dispatch.py
+++ b/tests/test_watcher_dispatch.py
@@ -279,6 +279,156 @@ def test_start_ticket_refuses_manifest_with_empty_required_checks(
     assert any("empty required_checks" in r.message for r in caplog.records)
 
 
+# ---------------------------------------------------------------------------
+# WOR-373 — stale-epic refusal at dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_start_ticket_refuses_when_epic_too_far_behind_main(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Epic branch with drift > threshold is refused, ticket sent to Backlog."""
+    manifest = make_manifest(
+        implementation_mode="local",
+        base_branch="epic/wor-100-stale",
+    )
+    linear = MagicMock()
+    services = _services()
+    local_active: list = []
+    cloud_active: list = []
+
+    with (
+        patch("app.core.watcher.dispatch.create_worktree") as mock_create,
+        patch("app.core.watcher.dispatch.safe_set_state") as mock_set_state,
+        patch(
+            "app.core.watcher.dispatch.count_main_ahead_of_epic",
+            return_value=107,
+        ),
+        caplog.at_level(logging.WARNING, logger="app.core.watcher.dispatch"),
+    ):
+        start_ticket(
+            manifest=manifest,
+            linear=linear,
+            services=services,
+            worker_verbose=False,
+            _local_active=local_active,
+            _cloud_active=cloud_active,
+            max_cloud_workers=3,
+            _repo_root=tmp_path,
+            _processed_tickets=[],
+            linear_id="fake-linear-id",
+            ticket_id="WOR-10",
+            _escalation_policy=MagicMock(),
+        )
+
+    mock_create.assert_not_called()
+    assert local_active == []
+    mock_set_state.assert_called_once_with(
+        linear, "fake-linear-id", "Backlog", "WOR-10"
+    )
+    linear.post_comment.assert_called_once()
+    body = linear.post_comment.call_args[0][1]
+    assert "epic/wor-100-stale" in body
+    assert "107" in body
+    assert "git merge origin/main" in body
+    assert any("behind origin/main" in r.message for r in caplog.records)
+
+
+def test_start_ticket_proceeds_when_epic_within_threshold(
+    tmp_path: Path,
+) -> None:
+    """An epic branch with drift below the threshold dispatches normally."""
+    manifest = make_manifest(
+        implementation_mode="local",
+        base_branch="epic/wor-100-fresh",
+    )
+    linear = MagicMock()
+    services = _services()
+    local_active: list = []
+    cloud_active: list = []
+
+    with (
+        patch(
+            "app.core.watcher.dispatch.create_worktree",
+            return_value=tmp_path / "worktree",
+        ),
+        patch("app.core.watcher.dispatch.copy_manifest_to_worktree"),
+        patch("app.core.watcher.dispatch.write_worker_pytest_config"),
+        patch("app.core.watcher.dispatch.backup_plan_files", return_value=[]),
+        patch("app.core.watcher.dispatch.launch_worker", return_value=MagicMock()),
+        patch("app.core.watcher.dispatch.safe_set_state"),
+        patch(
+            "app.core.watcher.dispatch.count_main_ahead_of_epic",
+            return_value=5,  # well under the 30 threshold
+        ),
+    ):
+        start_ticket(
+            manifest=manifest,
+            linear=linear,
+            services=services,
+            worker_verbose=False,
+            _local_active=local_active,
+            _cloud_active=cloud_active,
+            max_cloud_workers=3,
+            _repo_root=tmp_path,
+            _processed_tickets=[],
+            linear_id="fake-linear-id",
+            ticket_id="WOR-10",
+            _escalation_policy=MagicMock(),
+        )
+
+    assert len(local_active) == 1
+    linear.post_comment.assert_not_called()
+
+
+def test_start_ticket_does_not_refuse_main_target(
+    tmp_path: Path,
+) -> None:
+    """Sub-tickets targeting main directly are not refused.
+
+    The helper fast-paths to 0 for non-epic branches, so dispatch proceeds
+    normally without refusal.
+    """
+    manifest = make_manifest(
+        implementation_mode="local",
+        base_branch="main",
+    )
+    linear = MagicMock()
+    services = _services()
+    local_active: list = []
+    cloud_active: list = []
+
+    with (
+        patch(
+            "app.core.watcher.dispatch.create_worktree",
+            return_value=tmp_path / "worktree",
+        ),
+        patch("app.core.watcher.dispatch.copy_manifest_to_worktree"),
+        patch("app.core.watcher.dispatch.write_worker_pytest_config"),
+        patch("app.core.watcher.dispatch.backup_plan_files", return_value=[]),
+        patch("app.core.watcher.dispatch.launch_worker", return_value=MagicMock()),
+        patch("app.core.watcher.dispatch.safe_set_state"),
+    ):
+        # Helper not patched — real helper returns 0 for non-epic branches.
+        start_ticket(
+            manifest=manifest,
+            linear=linear,
+            services=services,
+            worker_verbose=False,
+            _local_active=local_active,
+            _cloud_active=cloud_active,
+            max_cloud_workers=3,
+            _repo_root=tmp_path,
+            _processed_tickets=[],
+            linear_id="fake-linear-id",
+            ticket_id="WOR-10",
+            _escalation_policy=MagicMock(),
+        )
+
+    assert len(local_active) == 1
+    linear.post_comment.assert_not_called()
+
+
 # NOTE: a fifth test for suppress_dedup behaviour is intentionally omitted —
 # dispatch.py's `_dedup_state or {}` falls through to a fresh empty dict on
 # each call, defeating cross-call memoization. That's a real pre-existing

--- a/tests/test_watcher_helpers.py
+++ b/tests/test_watcher_helpers.py
@@ -12,6 +12,7 @@ from app.core.watcher.watcher_helpers import (
     build_worker_cmd,
     build_worker_env,
     check_allowed_paths_overlap,
+    count_main_ahead_of_epic,
     resolve_effective_mode,
 )
 from tests.conftest import make_active_worker, make_manifest
@@ -841,3 +842,100 @@ def test_parse_worker_usage_missing_output_token_returns_none(
     input_tok, output_tok, _, _ = _parse_worker_usage(log)
     assert input_tok is None
     assert output_tok is None
+
+
+# ---------------------------------------------------------------------------
+# count_main_ahead_of_epic — WOR-373 stale-epic detection
+# ---------------------------------------------------------------------------
+
+
+def _git(args: list[str], cwd: Path) -> None:
+    import subprocess  # nosec B404
+
+    subprocess.run(  # nosec B603 B607
+        ["git", *args],
+        cwd=str(cwd),
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _setup_remote_and_main(tmp_path: Path) -> tuple[Path, Path]:
+    """Create a bare 'origin' repo and a working clone with a main branch.
+
+    Returns (origin_path, clone_path). Caller can then create epic branches
+    and push them to origin to simulate the watcher's view of the repo.
+    """
+    origin = tmp_path / "origin.git"
+    _git(["init", "-q", "--bare", "-b", "main", str(origin)], cwd=tmp_path)
+
+    clone = tmp_path / "clone"
+    _git(["clone", "-q", str(origin), str(clone)], cwd=tmp_path)
+    _git(["config", "user.email", "test@example.com"], cwd=clone)
+    _git(["config", "user.name", "Test"], cwd=clone)
+    (clone / "README.md").write_text("seed\n", encoding="utf-8")
+    _git(["add", "README.md"], cwd=clone)
+    _git(["commit", "-q", "-m", "seed"], cwd=clone)
+    _git(["push", "-q", "origin", "main"], cwd=clone)
+    return origin, clone
+
+
+def test_count_main_ahead_of_epic_returns_zero_for_main_branch(
+    tmp_path: Path,
+) -> None:
+    """Sub-tickets targeting main directly are not subject to the check."""
+    _, clone = _setup_remote_and_main(tmp_path)
+    assert count_main_ahead_of_epic("main", clone) == 0
+
+
+def test_count_main_ahead_of_epic_returns_zero_for_random_branch(
+    tmp_path: Path,
+) -> None:
+    """Branches that don't start with `epic/` are not checked."""
+    _, clone = _setup_remote_and_main(tmp_path)
+    assert count_main_ahead_of_epic("feat/something", clone) == 0
+    assert count_main_ahead_of_epic("wor-100-some-ticket", clone) == 0
+
+
+def test_count_main_ahead_of_epic_returns_zero_when_in_sync(
+    tmp_path: Path,
+) -> None:
+    """An epic branch at the same commit as main has zero drift."""
+    _, clone = _setup_remote_and_main(tmp_path)
+    _git(["checkout", "-b", "epic/wor-100-fresh"], cwd=clone)
+    _git(["push", "-q", "origin", "epic/wor-100-fresh"], cwd=clone)
+    assert count_main_ahead_of_epic("epic/wor-100-fresh", clone) == 0
+
+
+def test_count_main_ahead_of_epic_returns_drift_count(tmp_path: Path) -> None:
+    """An epic that's N commits behind main returns N."""
+    _, clone = _setup_remote_and_main(tmp_path)
+    # Create epic from current main
+    _git(["checkout", "-b", "epic/wor-100-stale"], cwd=clone)
+    _git(["push", "-q", "origin", "epic/wor-100-stale"], cwd=clone)
+    # Add 5 commits to main only
+    _git(["checkout", "main"], cwd=clone)
+    for i in range(5):
+        f = clone / f"file_{i}.md"
+        f.write_text(f"content {i}\n", encoding="utf-8")
+        _git(["add", str(f)], cwd=clone)
+        _git(["commit", "-q", "-m", f"commit {i}"], cwd=clone)
+    _git(["push", "-q", "origin", "main"], cwd=clone)
+    # Epic is 5 commits behind main now
+    assert count_main_ahead_of_epic("epic/wor-100-stale", clone) == 5
+
+
+def test_count_main_ahead_of_epic_fails_open_outside_git(tmp_path: Path) -> None:
+    """When cwd is not a git repo, the helper returns 0 (does not crash)."""
+    not_a_repo = tmp_path / "not_a_repo"
+    not_a_repo.mkdir()
+    assert count_main_ahead_of_epic("epic/wor-100-stale", not_a_repo) == 0
+
+
+def test_count_main_ahead_of_epic_fails_open_when_branch_missing(
+    tmp_path: Path,
+) -> None:
+    """If the epic branch doesn't exist on origin, return 0 (do not block)."""
+    _, clone = _setup_remote_and_main(tmp_path)
+    assert count_main_ahead_of_epic("epic/wor-100-nonexistent", clone) == 0


### PR DESCRIPTION
## Summary

Closes the urgent process gap surfaced by WOR-282: a 107-commit-behind epic silently dropped 13 main-side tests during merge conflict resolution, caught only by coincidence. This PR refuses dispatch when a sub-ticket's `base_branch` is an epic with too much drift from origin/main.

Same fail-fast-at-dispatch pattern as WOR-378 (manifest-quality refusal). Filed by the WOR-374 audit pass. P2 High.

## Threshold

**30 commits.** Roughly 3-7 days of drift at this repo's PR cadence. Healthy epics stay well under it; the WOR-282 disaster (107 commits) is well over.

```python
_EPIC_DRIFT_THRESHOLD = 30
```

Constant in `dispatch.py`. If the threshold turns out to be too aggressive or too lax in practice, tune it there — no config file overhead until we have data justifying one.

## Behaviour

| Sub-ticket `base_branch` | Drift | Action |
|---|---|---|
| `main` | (skipped) | Dispatch normally |
| `wor-NNN-foo`, `feat/x`, anything not `epic/...` | (skipped) | Dispatch normally |
| `epic/wor-NNN-foo` | ≤ 30 | Dispatch normally |
| `epic/wor-NNN-foo` | > 30 | **Refuse**: state→Backlog, Linear comment with `git merge origin/main` remediation |

Refusal Linear comment includes the exact commands the operator runs:

```
Manifest refused: epic branch `epic/wor-NNN-foo` is N commits behind origin/main
(threshold: 30). Stale epics silently drop tests during merge conflict resolution
— see WOR-282 forensic. Merge main into the epic first, then re-dispatch:

  git fetch origin
  git checkout epic/wor-NNN-foo
  git merge origin/main
  # resolve conflicts...
  git push
```

## Implementation

### `app/core/watcher/watcher_helpers.py` — `count_main_ahead_of_epic()`

```python
def count_main_ahead_of_epic(epic_branch: str, repo_root: Path) -> int:
    """Return how many commits origin/main has that <epic_branch> doesn't."""
    if not epic_branch.startswith("epic/"):
        return 0  # Fast-path for main + non-epic branches

    # Best-effort fetch (failures are non-fatal — a stale local view just
    # means the count is conservative).
    try:
        subprocess.run(["git", "fetch", "origin", "main", epic_branch], ...)
    except (subprocess.SubprocessError, FileNotFoundError):
        pass

    try:
        out = subprocess.check_output(
            ["git", "rev-list", "--count", f"origin/{epic_branch}..origin/main"],
            cwd=str(repo_root), text=True, timeout=10,
        )
        return int(out.strip())
    except (subprocess.SubprocessError, ValueError, FileNotFoundError):
        return 0  # Fail open on git/network errors
```

### `app/core/watcher/dispatch.py` — `start_ticket()` integration

Refusal block added after the WOR-378 manifest-quality gates. Both run before any side effects (worktree creation, state transition, worker launch).

## Test plan

- [x] `ruff check .` passes
- [x] `mypy app/` passes (29 source files)
- [x] `lint-imports` passes (5/5 contracts kept)
- [x] `pytest` passes (1241 tests, 11 new — 6 helper + 3 dispatch + 2 sanity)
- [x] Helper tests use a real bare repo + clone, so they exercise actual `git rev-list` semantics, not just mocks
- [ ] Live verification: queue a sub-ticket against an epic >30 behind main, observe refusal + Linear comment

## Cross-links

- WOR-373 (this ticket) — P2 High
- WOR-374 — audit doc that prioritized this
- WOR-378 (PR #747, merged) — sibling refusal pattern (manifest quality)
- WOR-282 — primary evidence (107 commits behind, 13 lost tests)
- WOR-375 — one-off recovery for the WOR-302 epic that triggered this; orthogonal but related

🤖 Generated with [Claude Code](https://claude.com/claude-code)
