### PR TITLE
WOR-381 Heartbeat-based stuck-worker detection (15min log silence -> SIGTERM)

### DIFF
--- a/app/core/watcher/watcher.py
+++ b/app/core/watcher/watcher.py
@@ -59,6 +59,18 @@ from .watcher_worktrees import (
 
 logger = logging.getLogger(__name__)
 
+# WOR-381: heartbeat-based stuck-worker detection. The metric is "time since
+# the worker's stream-json log file was last written" — a stuck worker
+# (network hang, deadlocked vLLM, infinite tool-result wait) does not emit
+# new lines, while a slow-but-progressing worker keeps writing. Wall-time
+# bounds proved unworkable: app.db's 33-session distribution shows median
+# 43.7 min and p99 171 min for legitimate runs, so any wall-time threshold
+# either fires on real work or misses real hangs. 15 minutes of log silence
+# is a strong signal that the model is stuck — even multi-step tool calls
+# (pytest, mypy, large diffs) emit progress within minutes.
+_WORKER_HEARTBEAT_TIMEOUT_SECONDS = 15 * 60
+_WORKER_KILL_GRACE_SECONDS = 5 * 60
+
 
 class _ProcessedTicket(NamedTuple):
     ticket_id: str
@@ -155,6 +167,7 @@ class Watcher:
         try:
             while self._running:
                 self._check_softstop_request()
+                self._terminate_overrun_workers()
                 self._reap_finished_workers()
                 if self._display is not None:
                     self._display.update_state(self._build_tui_state())
@@ -713,6 +726,101 @@ class Watcher:
     def _reap_finished_workers(self) -> None:
         self._reap_pool(self._local_active)
         self._reap_pool(self._cloud_active)
+
+    def _terminate_overrun_workers(self) -> None:
+        """Heartbeat-based stuck-worker detection (WOR-381).
+
+        Each worker tees its stream-json log to
+        ``<worktree>/.claude/worker_<ticket_lower>.log``. While the model is
+        making any progress — emitting tool calls, receiving tool results,
+        producing assistant text — the file's mtime advances. A genuinely
+        stuck worker (vLLM unresponsive, tool subprocess hung, infinite
+        deadlock) stops writing.
+
+        Two-stage shutdown:
+
+        1. Log idle (now − mtime) exceeds ``_WORKER_HEARTBEAT_TIMEOUT_SECONDS``
+           and the process is still alive: send SIGTERM via
+           ``process.terminate()``; set ``terminated_at`` to wall-clock now.
+        2. ``terminated_at`` is set and the grace period has passed without
+           the worker exiting: send SIGKILL via ``process.kill()`` and post a
+           Linear comment with the timeout context. The natural reap path
+           handles the eventual exit code.
+
+        If the log file does not exist yet (worker just dispatched), the
+        check is skipped — natural process reap handles the case where the
+        worker died before writing anything.
+        """
+        now_wall = time.time()
+        for worker in (*self._local_active, *self._cloud_active):
+            log_path = (
+                worker.worktree_path
+                / ".claude"
+                / f"worker_{worker.ticket_id.lower()}.log"
+            )
+            try:
+                last_write = log_path.stat().st_mtime
+            except (OSError, FileNotFoundError):
+                # Log not yet written — let the worker warm up. Process
+                # reap on later cycles handles the case where it never does.
+                continue
+
+            idle_seconds = now_wall - last_write
+
+            if (
+                worker.terminated_at is None
+                and idle_seconds > _WORKER_HEARTBEAT_TIMEOUT_SECONDS
+                and worker.process.poll() is None
+            ):
+                logger.warning(
+                    "Worker %s heartbeat stalled — log idle for %.0fs "
+                    "(threshold %ds). Sending SIGTERM. SIGKILL grace: %ds.",
+                    worker.ticket_id,
+                    idle_seconds,
+                    _WORKER_HEARTBEAT_TIMEOUT_SECONDS,
+                    _WORKER_KILL_GRACE_SECONDS,
+                )
+                try:
+                    worker.process.terminate()
+                except (OSError, ValueError) as exc:
+                    logger.warning("Failed to SIGTERM %s: %s", worker.ticket_id, exc)
+                worker.terminated_at = now_wall
+                continue
+
+            if (
+                worker.terminated_at is not None
+                and now_wall - worker.terminated_at > _WORKER_KILL_GRACE_SECONDS
+                and worker.process.poll() is None
+            ):
+                logger.error(
+                    "Worker %s did not exit within %ds of SIGTERM — sending SIGKILL.",
+                    worker.ticket_id,
+                    _WORKER_KILL_GRACE_SECONDS,
+                )
+                try:
+                    worker.process.kill()
+                except (OSError, ValueError) as exc:
+                    logger.warning("Failed to SIGKILL %s: %s", worker.ticket_id, exc)
+                slug = worker.ticket_id.lower().replace("-", "_")
+                try:
+                    self._linear.post_comment(
+                        worker.linear_id,
+                        (
+                            f"Worker stalled: log idle {int(idle_seconds)}s "
+                            f"(threshold {_WORKER_HEARTBEAT_TIMEOUT_SECONDS}s). "
+                            f"SIGTERM was sent, then SIGKILL after "
+                            f"{_WORKER_KILL_GRACE_SECONDS}s grace. The ticket "
+                            "will be marked Blocked by the natural failure "
+                            f"path. Inspect `.claude/artifacts/{slug}/` for "
+                            "the partial worker log."
+                        ),
+                    )
+                except Exception as exc:
+                    logger.warning(
+                        "Could not post timeout comment for %s: %s",
+                        worker.ticket_id,
+                        exc,
+                    )
 
     # ------------------------------------------------------------------
     # Epic completion detection

--- a/app/core/watcher/watcher_types.py
+++ b/app/core/watcher/watcher_types.py
@@ -70,6 +70,12 @@ class ActiveWorker:
     # WOR-363: count of OTHER active workers at the moment this one launched.
     # Captured by dispatch.start_ticket BEFORE adding self to the active pool.
     dispatch_concurrency: int = 0
+    # WOR-381: wall-clock timestamp (time.time()) at which the watcher sent
+    # SIGTERM after the worker's log file went stale. Used to track the
+    # SIGKILL grace period. None means the worker has not been signalled.
+    # Wall-clock (not monotonic) so it shares a frame of reference with the
+    # log file's st_mtime.
+    terminated_at: float | None = None
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/metrics_analysis/walltime_distribution.py
+++ b/scripts/metrics_analysis/walltime_distribution.py
@@ -1,0 +1,148 @@
+"""Distribution of worker wall times in app.db.
+
+Used to calibrate watcher-side thresholds (e.g. WOR-381's wall-time
+timeout). Future Streamlit dashboards can vendor the same SQL.
+
+Usage:
+
+    python scripts/metrics_analysis/walltime_distribution.py
+    python scripts/metrics_analysis/walltime_distribution.py --since-days 30
+    python scripts/metrics_analysis/walltime_distribution.py --mode local
+"""
+
+from __future__ import annotations
+
+import argparse
+import sqlite3
+import statistics
+import sys
+from collections import Counter
+from pathlib import Path
+
+# Allow running this script directly without `python -m` — add repo root to path.
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from app.core.metrics import MetricsStore  # noqa: E402
+
+
+def _percentile(values: list[float], p: float) -> float:
+    """Return the value at percentile p (0.0–1.0) of a sorted-once list."""
+    if not values:
+        return float("nan")
+    n = len(values)
+    return values[min(n - 1, int(n * p))]
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
+    ap.add_argument(
+        "--since-days",
+        type=int,
+        default=None,
+        help="Only include sessions recorded in the last N days.",
+    )
+    ap.add_argument(
+        "--mode",
+        choices=("local", "cloud"),
+        default=None,
+        help="Filter by implementation_mode.",
+    )
+    ap.add_argument(
+        "--top",
+        type=int,
+        default=10,
+        help="How many longest sessions to show in the tail (default 10).",
+    )
+    args = ap.parse_args()
+
+    db = MetricsStore.get_db_path()
+    print(f"DB: {db}\n")
+
+    # Static SQL with named placeholders. NULL placeholders bypass the
+    # respective filter via `IS NULL OR` so we don't need to compose the
+    # WHERE clause dynamically.
+    sql = """
+        SELECT ticket_id, local_wall_time, outcome, implementation_mode, recorded_at
+        FROM ticket_metrics
+        WHERE local_wall_time IS NOT NULL
+          AND local_wall_time > 0
+          AND (:days IS NULL OR recorded_at >= datetime('now', :days || ' days'))
+          AND (:mode IS NULL OR implementation_mode = :mode)
+        ORDER BY local_wall_time DESC
+    """
+    days_param = f"-{int(args.since_days)}" if args.since_days is not None else None
+    bind = {"days": days_param, "mode": args.mode}
+
+    conn = sqlite3.connect(str(db))
+    conn.row_factory = sqlite3.Row
+    cur = conn.cursor()
+    rows = cur.execute(sql, bind).fetchall()
+    times = [r["local_wall_time"] for r in rows]
+
+    print(f"Sessions: {len(times)}")
+    if args.since_days is not None:
+        print(f"Window: last {args.since_days} days")
+    if args.mode is not None:
+        print(f"Mode filter: {args.mode}")
+    print()
+
+    if not times:
+        print("(no data)")
+        return 0
+
+    sorted_times = sorted(times)
+    median = statistics.median(times)
+    mean = statistics.mean(times)
+    p25 = _percentile(sorted_times, 0.25)
+    p75 = _percentile(sorted_times, 0.75)
+    p90 = _percentile(sorted_times, 0.90)
+    p95 = _percentile(sorted_times, 0.95)
+    p99 = _percentile(sorted_times, 0.99)
+
+    print("=== Wall-time distribution ===")
+    print(f"  min   : {sorted_times[0]:>8.1f}s = {sorted_times[0] / 60:>5.1f} min")
+    print(f"  p25   : {p25:>8.1f}s = {p25 / 60:>5.1f} min")
+    print(f"  median: {median:>8.1f}s = {median / 60:>5.1f} min")
+    print(f"  p75   : {p75:>8.1f}s = {p75 / 60:>5.1f} min")
+    print(f"  p90   : {p90:>8.1f}s = {p90 / 60:>5.1f} min")
+    print(f"  p95   : {p95:>8.1f}s = {p95 / 60:>5.1f} min")
+    print(f"  p99   : {p99:>8.1f}s = {p99 / 60:>5.1f} min")
+    print(f"  max   : {sorted_times[-1]:>8.1f}s = {sorted_times[-1] / 60:>5.1f} min")
+    print(f"  mean  : {mean:>8.1f}s = {mean / 60:>5.1f} min")
+    print()
+
+    print(f"=== Top {args.top} longest sessions ===")
+    header = (
+        f"{'ticket':<10} {'sec':>8} {'min':>6}  "
+        f"{'outcome':<10} {'mode':<8}  recorded_at"
+    )
+    print(header)
+    for r in rows[: args.top]:
+        print(
+            f"{r['ticket_id']:<10} {r['local_wall_time']:>8.0f} "
+            f"{r['local_wall_time'] / 60:>6.1f}  {r['outcome'] or '?':<10} "
+            f"{r['implementation_mode'] or '?':<8}  {r['recorded_at']}"
+        )
+    print()
+
+    print("=== Counts over thresholds ===")
+    for thr_min in (10, 15, 20, 30, 45, 60, 90, 120):
+        over = sum(1 for t in times if t > thr_min * 60)
+        pct = 100 * over / len(times)
+        print(f"  > {thr_min:>3} min: {over:>4} sessions ({pct:>5.1f}%)")
+    print()
+
+    long_rows = [r for r in rows if r["local_wall_time"] > 30 * 60]
+    if long_rows:
+        print("=== Sessions > 30 minutes — outcome breakdown ===")
+        oc = Counter(r["outcome"] for r in long_rows)
+        for outcome, n in oc.most_common():
+            print(f"  {outcome or '(none)':<12} {n}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -1238,3 +1238,175 @@ class _LogCapture:
 
 def caplog_at_level_helper() -> _LogCapture:
     return _LogCapture()
+
+
+# ---------------------------------------------------------------------------
+# WOR-381 — heartbeat-based stuck-worker detection (SIGTERM, then SIGKILL)
+# ---------------------------------------------------------------------------
+
+
+def _stuck_worker(
+    tmp_path: Path,
+    ticket_id: str = "WOR-99",
+    *,
+    log_idle_secs: float | None = None,
+    terminated_at: float | None = None,
+) -> ActiveWorker:
+    """ActiveWorker with a worker log whose mtime is N seconds in the past.
+
+    If `log_idle_secs` is None, no log file is created (simulates a freshly-
+    dispatched worker that hasn't written anything yet).
+    """
+    import os
+    import time as _time
+
+    worktree = tmp_path / ticket_id
+    worktree.mkdir(parents=True, exist_ok=True)
+    log_path = worktree / ".claude" / f"worker_{ticket_id.lower()}.log"
+    if log_idle_secs is not None:
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        log_path.write_text("dummy stream-json line\n", encoding="utf-8")
+        target_mtime = _time.time() - log_idle_secs
+        os.utime(log_path, (target_mtime, target_mtime))
+
+    proc = MagicMock(spec=subprocess.Popen)
+    proc.poll.return_value = None  # still running
+    return ActiveWorker(
+        ticket_id=ticket_id,
+        linear_id=f"linear-{ticket_id}",
+        manifest=_make_manifest(ticket_id=ticket_id),
+        worktree_path=worktree,
+        process=proc,
+        terminated_at=terminated_at,
+    )
+
+
+def test_terminate_overrun_no_op_when_log_fresh(tmp_path: Path) -> None:
+    """A worker whose log was written 5 minutes ago is left alone (under 15-min cap)."""
+    w = Watcher(linear_client=MagicMock(), repo_root=tmp_path)
+    worker = _stuck_worker(tmp_path, log_idle_secs=5 * 60)
+    w._local_active.append(worker)
+
+    w._terminate_overrun_workers()
+
+    worker.process.terminate.assert_not_called()
+    worker.process.kill.assert_not_called()
+    assert worker.terminated_at is None
+
+
+def test_terminate_overrun_no_op_when_log_missing(tmp_path: Path) -> None:
+    """Freshly-dispatched worker (no log yet) is not signalled."""
+    w = Watcher(linear_client=MagicMock(), repo_root=tmp_path)
+    worker = _stuck_worker(tmp_path, log_idle_secs=None)
+    w._local_active.append(worker)
+
+    w._terminate_overrun_workers()
+
+    worker.process.terminate.assert_not_called()
+    worker.process.kill.assert_not_called()
+
+
+def test_terminate_overrun_sigterm_when_log_idle_past_threshold(tmp_path: Path) -> None:
+    """Log idle > 15 min triggers SIGTERM."""
+    w = Watcher(linear_client=MagicMock(), repo_root=tmp_path)
+    worker = _stuck_worker(tmp_path, log_idle_secs=16 * 60)  # over 15-min threshold
+    w._local_active.append(worker)
+
+    w._terminate_overrun_workers()
+
+    worker.process.terminate.assert_called_once()
+    worker.process.kill.assert_not_called()
+    assert worker.terminated_at is not None
+
+
+def test_terminate_overrun_sigterm_only_once(tmp_path: Path) -> None:
+    """Repeated calls do not re-SIGTERM after the first one."""
+    w = Watcher(linear_client=MagicMock(), repo_root=tmp_path)
+    worker = _stuck_worker(tmp_path, log_idle_secs=20 * 60)
+    w._local_active.append(worker)
+
+    w._terminate_overrun_workers()
+    first_terminated_at = worker.terminated_at
+    w._terminate_overrun_workers()
+
+    worker.process.terminate.assert_called_once()
+    assert worker.terminated_at == first_terminated_at
+
+
+def test_terminate_overrun_sigkill_after_grace(tmp_path: Path) -> None:
+    """Worker still alive 6 min after SIGTERM is SIGKILL'd."""
+    import time as _time
+
+    linear = MagicMock()
+    w = Watcher(linear_client=linear, repo_root=tmp_path)
+    worker = _stuck_worker(
+        tmp_path,
+        log_idle_secs=20 * 60,
+        terminated_at=_time.time() - 6 * 60,
+    )
+    w._local_active.append(worker)
+
+    w._terminate_overrun_workers()
+
+    worker.process.kill.assert_called_once()
+    linear.post_comment.assert_called_once()
+    body = linear.post_comment.call_args[0][1]
+    assert "stalled" in body
+    assert "SIGTERM" in body
+    assert "SIGKILL" in body
+
+
+def test_terminate_overrun_no_sigkill_within_grace(tmp_path: Path) -> None:
+    """Worker still alive <5 min after SIGTERM gets more grace."""
+    import time as _time
+
+    w = Watcher(linear_client=MagicMock(), repo_root=tmp_path)
+    worker = _stuck_worker(
+        tmp_path,
+        log_idle_secs=18 * 60,
+        terminated_at=_time.time() - 2 * 60,
+    )
+    w._local_active.append(worker)
+
+    w._terminate_overrun_workers()
+
+    worker.process.kill.assert_not_called()
+
+
+def test_terminate_overrun_skips_already_exited(tmp_path: Path) -> None:
+    """A worker whose process has exited (poll != None) is not signalled."""
+    w = Watcher(linear_client=MagicMock(), repo_root=tmp_path)
+    worker = _stuck_worker(tmp_path, log_idle_secs=20 * 60)
+    worker.process.poll.return_value = 0
+    w._local_active.append(worker)
+
+    w._terminate_overrun_workers()
+
+    worker.process.terminate.assert_not_called()
+    worker.process.kill.assert_not_called()
+
+
+def test_terminate_overrun_handles_terminate_oserror(tmp_path: Path) -> None:
+    """OSError from terminate() doesn't loop us into retrying."""
+    w = Watcher(linear_client=MagicMock(), repo_root=tmp_path)
+    worker = _stuck_worker(tmp_path, log_idle_secs=20 * 60)
+    worker.process.terminate.side_effect = OSError("no such process")
+    w._local_active.append(worker)
+
+    w._terminate_overrun_workers()
+
+    assert worker.terminated_at is not None
+
+
+def test_terminate_overrun_covers_both_pools(tmp_path: Path) -> None:
+    """Both _local_active and _cloud_active are scanned."""
+    w = Watcher(linear_client=MagicMock(), repo_root=tmp_path)
+    local_worker = _stuck_worker(tmp_path, ticket_id="WOR-100", log_idle_secs=20 * 60)
+    cloud_worker = _stuck_worker(tmp_path, ticket_id="WOR-101", log_idle_secs=20 * 60)
+    w._local_active.append(local_worker)
+    w._cloud_active.append(cloud_worker)
+
+    w._terminate_overrun_workers()
+
+    local_worker.process.terminate.assert_called_once()
+    cloud_worker.process.terminate.assert_called_once()


### PR DESCRIPTION
## Summary

Closes the gap WOR-372 left open: the Stop hook enforces graceful session termination when the model voluntarily ends, but a stuck worker subprocess (vLLM unresponsive, deadlocked tool, infinite tool-result wait) was previously unbounded. Add heartbeat-based detection with a two-stage shutdown.

## Why heartbeat, not wall-time

The original ticket draft was a wall-time bound (60-min SIGTERM). Querying `app.db` before committing exposed that as wrong:

| Percentile | Wall time |
|---|---|
| Median | 43.7 min |
| p75 | 86.9 min |
| p90 | 159.7 min |
| p99 | 170.9 min |
| Max | 170.9 min (legitimate `success`) |

**45% of all sessions exceed 60 min**, and **65% of long sessions succeed**. A 60-min wall-time bound would interrupt nearly half of legitimate work.

The heartbeat signal (log-file mtime) catches genuine hangs without false-positiving long-but-progressing sessions. Even WOR-317 (the 171-min legitimate maximum) emits log lines continuously throughout — no 15-min silence gap during normal pytest/mypy/git operations.

## Changes

- **`app/core/watcher/watcher.py`** — `_WORKER_HEARTBEAT_TIMEOUT_SECONDS = 15*60` and `_WORKER_KILL_GRACE_SECONDS = 5*60` constants. New `_terminate_overrun_workers()` method called each poll cycle (between `_check_softstop_request` and `_reap_finished_workers`). Iterates both `_local_active` and `_cloud_active`, stats `<worktree>/.claude/worker_<ticket_lower>.log`, applies two-stage shutdown.

- **`app/core/watcher/watcher_types.py`** — `ActiveWorker.terminated_at: float | None` field. Wall-clock (not monotonic) so it shares a frame of reference with `st_mtime`.

- **`tests/test_watcher.py`** — 9 tests using `os.utime(log_path, (mtime, mtime))` to simulate log staleness. Cover: log fresh / log missing / log stale → SIGTERM / SIGTERM idempotent / SIGKILL after grace / SIGKILL skipped within grace / process already exited / OSError handling / both pools scanned.

- **`scripts/metrics_analysis/walltime_distribution.py`** (new) — the query that produced the threshold-rationale data. Static SQL with named placeholders. Generalizable for future Streamlit dashboards. Run: `python scripts/metrics_analysis/walltime_distribution.py [--since-days N] [--mode local|cloud]`.

## Behaviour

| State | Action |
|---|---|
| Log idle ≤ 15 min, alive | no-op |
| Log file missing (worker just dispatched) | no-op |
| Log idle > 15 min, alive, not yet signalled | SIGTERM, set `terminated_at = time.time()` |
| Same condition on subsequent polls | idempotent — still one SIGTERM |
| Alive 5 min after SIGTERM | SIGKILL + Linear comment |
| Alive < 5 min after SIGTERM | wait |
| Process exited (poll() != None) | no signal — natural reap takes over |
| `terminate()` raises OSError | `terminated_at` still set so we don't loop |

## Test plan

- [x] `ruff check .` passes
- [x] `mypy app/` passes (29 source files)
- [x] `lint-imports` passes (5/5 contracts kept)
- [x] `pytest` passes (1250 tests, 9 new)
- [ ] Live verification: induce a deliberate worker hang (e.g., a `required_check` of `python -c "import time; time.sleep(99999)"`), observe SIGTERM at 15 min, SIGKILL at 20 min, ticket goes Blocked.

## Cross-links

- WOR-381 (this ticket)
- WOR-372 (PR #740, merged) — sibling: graceful exit; this PR handles ungraceful
- WOR-282 — primary evidence of long hangs (~7 min before natural exit)
- `scripts/metrics_analysis/walltime_distribution.py` — calibration source

🤖 Generated with [Claude Code](https://claude.com/claude-code)
