### PR TITLE
WOR-370 Capture vLLM /metrics deltas per ticket (gated on solo dispatch)

### DIFF
--- a/app/core/metrics.py
+++ b/app/core/metrics.py
@@ -232,6 +232,54 @@ class TicketMetrics(BaseModel):
             "throughput-vs-concurrency analysis."
         ),
     )
+    # WOR-370: vLLM /metrics deltas captured during this session. Only
+    # populated when dispatch_concurrency==0 at dispatch AND no peer was
+    # launched during the session. attribute=False sessions leave all fields
+    # below as None.
+    vllm_metrics_attributable: bool | None = Field(
+        default=None,
+        description=(
+            "True iff the worker was solo throughout its session and the "
+            "vLLM /metrics deltas below are attributable to this ticket. "
+            "False if a peer was dispatched during the session. None if "
+            "the snapshot was never captured (e.g. /metrics unreachable)."
+        ),
+    )
+    vllm_prefix_cache_hits: int | None = Field(
+        default=None, description="Delta of vllm:prefix_cache_hits_total"
+    )
+    vllm_prefix_cache_queries: int | None = Field(
+        default=None, description="Delta of vllm:prefix_cache_queries_total"
+    )
+    vllm_prefix_cache_hit_ratio: float | None = Field(
+        default=None,
+        description="Derived: hits/queries during the session, range 0-1",
+    )
+    vllm_prompt_tokens: int | None = Field(
+        default=None, description="Delta of vllm:prompt_tokens_total"
+    )
+    vllm_generation_tokens: int | None = Field(
+        default=None, description="Delta of vllm:generation_tokens_total"
+    )
+    vllm_ttft_seconds_sum: float | None = Field(
+        default=None,
+        description="Delta of vllm:time_to_first_token_seconds_sum",
+    )
+    vllm_ttft_count: int | None = Field(
+        default=None,
+        description="Delta of vllm:time_to_first_token_seconds_count",
+    )
+    vllm_ttft_mean_seconds: float | None = Field(
+        default=None,
+        description="Derived: ttft_seconds_sum / ttft_count for the session",
+    )
+    vllm_preemptions: int | None = Field(
+        default=None,
+        description=(
+            "Delta of vllm:num_preemptions_total during the session. >0 "
+            "indicates KV cache pressure forced request preemption."
+        ),
+    )
 
 
 class EpicSummary(BaseModel):
@@ -441,6 +489,52 @@ class MetricsStore:
         if "dispatch_concurrency" not in existing:
             conn.execute(
                 "ALTER TABLE ticket_metrics ADD COLUMN dispatch_concurrency INTEGER"
+            )
+        # WOR-370: vLLM /metrics delta capture (only populated when
+        # dispatch_concurrency==0 at dispatch AND no peer was launched
+        # during the session — otherwise the server-wide counters mix
+        # multiple workers' traffic and per-ticket attribution breaks).
+        if "vllm_metrics_attributable" not in existing:
+            conn.execute(
+                "ALTER TABLE ticket_metrics "
+                "ADD COLUMN vllm_metrics_attributable INTEGER"
+            )
+        if "vllm_prefix_cache_hits" not in existing:
+            conn.execute(
+                "ALTER TABLE ticket_metrics ADD COLUMN vllm_prefix_cache_hits INTEGER"
+            )
+        if "vllm_prefix_cache_queries" not in existing:
+            conn.execute(
+                "ALTER TABLE ticket_metrics "
+                "ADD COLUMN vllm_prefix_cache_queries INTEGER"
+            )
+        if "vllm_prefix_cache_hit_ratio" not in existing:
+            conn.execute(
+                "ALTER TABLE ticket_metrics ADD COLUMN vllm_prefix_cache_hit_ratio REAL"
+            )
+        if "vllm_prompt_tokens" not in existing:
+            conn.execute(
+                "ALTER TABLE ticket_metrics ADD COLUMN vllm_prompt_tokens INTEGER"
+            )
+        if "vllm_generation_tokens" not in existing:
+            conn.execute(
+                "ALTER TABLE ticket_metrics ADD COLUMN vllm_generation_tokens INTEGER"
+            )
+        if "vllm_ttft_seconds_sum" not in existing:
+            conn.execute(
+                "ALTER TABLE ticket_metrics ADD COLUMN vllm_ttft_seconds_sum REAL"
+            )
+        if "vllm_ttft_count" not in existing:
+            conn.execute(
+                "ALTER TABLE ticket_metrics ADD COLUMN vllm_ttft_count INTEGER"
+            )
+        if "vllm_ttft_mean_seconds" not in existing:
+            conn.execute(
+                "ALTER TABLE ticket_metrics ADD COLUMN vllm_ttft_mean_seconds REAL"
+            )
+        if "vllm_preemptions" not in existing:
+            conn.execute(
+                "ALTER TABLE ticket_metrics ADD COLUMN vllm_preemptions INTEGER"
             )
 
     @contextmanager

--- a/app/core/watcher/dispatch.py
+++ b/app/core/watcher/dispatch.py
@@ -15,6 +15,7 @@ from app.core.manifest import ExecutionManifest
 
 from .watcher_finalize import safe_set_state
 from .watcher_helpers import (
+    capture_vllm_metrics,
     count_main_ahead_of_epic,
     resolve_effective_mode,
     suppress_dedup,
@@ -161,6 +162,25 @@ def start_ticket(
     # WOR-363: capture pool size BEFORE launching this worker. Counts OTHER
     # workers — does not include the one we're about to add.
     dispatch_concurrency = len(_local_active) + len(_cloud_active)
+
+    # WOR-370: vLLM /metrics attribution gate.
+    # 1. If we're solo (dispatch_concurrency==0) and the /metrics endpoint
+    #    responds, snapshot for later delta computation.
+    # 2. If we're NOT solo, any peer that previously had remained_solo=True
+    #    must lose that flag — they're no longer alone, so their session's
+    #    deltas would be polluted by this worker's traffic.
+    vllm_metrics_before: dict[str, float] | None = None
+    remained_solo = False
+    if dispatch_concurrency == 0:
+        snapshot = capture_vllm_metrics()
+        if snapshot is not None:
+            vllm_metrics_before = snapshot
+            remained_solo = True
+    else:
+        for peer in (*_local_active, *_cloud_active):
+            if peer.remained_solo:
+                peer.remained_solo = False
+
     process = launch_worker(
         _repo_root, manifest, worktree_path, effective_mode, worker_verbose
     )
@@ -172,6 +192,8 @@ def start_ticket(
         process=process,
         backed_up_plans=backed_up_plans,
         dispatch_concurrency=dispatch_concurrency,
+        vllm_metrics_before=vllm_metrics_before,
+        remained_solo=remained_solo,
     )
     if effective_mode == "local":
         _local_active.append(worker)

--- a/app/core/watcher/watcher_finalize.py
+++ b/app/core/watcher/watcher_finalize.py
@@ -29,6 +29,8 @@ from .watcher_helpers import (
     _parse_worker_subagent_spawns,
     _parse_worker_usage,
     _read_result_flags,
+    capture_vllm_metrics,
+    compute_vllm_metrics_delta,
     resolve_effective_mode,
 )
 from .watcher_subprocess import (
@@ -99,6 +101,48 @@ def _estimate_cloud_cost(
     return (input_tokens / 1_000_000) * pricing["input"] + (
         output_tokens / 1_000_000
     ) * pricing["output"]
+
+
+def _write_vllm_metrics_artifact(
+    repo_root: Path,
+    ticket_id: str,
+    *,
+    attributable: bool,
+    before: dict[str, float] | None,
+    after: dict[str, float] | None,
+    deltas: dict[str, float | int | None],
+    reason: str | None = None,
+) -> None:
+    """Write the WOR-370 vLLM /metrics audit artifact for one session.
+
+    Goes to ``.claude/artifacts/<ticket>/vllm_metrics.json`` next to the
+    existing manifest copy. Failure is non-fatal — finalize_worker should
+    not crash on disk write errors.
+    """
+    slug = ticket_id.lower().replace("-", "_")
+    artifact_dir = repo_root / ".claude" / "artifacts" / slug
+    payload: dict[str, object] = {
+        "ticket_id": ticket_id,
+        "attributable": attributable,
+    }
+    if reason is not None:
+        payload["reason"] = reason
+    if before is not None:
+        payload["before"] = before
+    if after is not None:
+        payload["after"] = after
+    if deltas:
+        payload["deltas"] = deltas
+    try:
+        artifact_dir.mkdir(parents=True, exist_ok=True)
+        (artifact_dir / "vllm_metrics.json").write_text(
+            json.dumps(payload, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+    except OSError as exc:
+        logger.warning(
+            "Could not write vLLM metrics artifact for %s: %s", ticket_id, exc
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -290,6 +334,54 @@ def finalize_worker(
     # check_failures: store the list when non-empty, else None
     check_failures = failed_checks if failed_checks else None
 
+    # WOR-370: vLLM /metrics delta capture. Three states:
+    #   1. Attributable — worker was solo throughout. Take after-snapshot,
+    #      compute deltas, write artifact + populate TicketMetrics columns.
+    #   2. Concurrent during session — sentinel artifact, columns stay None,
+    #      attributable=False on the row.
+    #   3. Never captured — no artifact, columns stay None, attributable=None.
+    vllm_attributable: bool | None = None
+    vllm_deltas: dict[str, float | int | None] = {}
+    if worker.vllm_metrics_before is not None:
+        if worker.remained_solo:
+            after = capture_vllm_metrics()
+            if after is not None:
+                vllm_attributable = True
+                vllm_deltas = compute_vllm_metrics_delta(
+                    worker.vllm_metrics_before, after
+                )
+                _write_vllm_metrics_artifact(
+                    repo_root,
+                    worker.ticket_id,
+                    attributable=True,
+                    before=worker.vllm_metrics_before,
+                    after=after,
+                    deltas=vllm_deltas,
+                )
+            else:
+                # before captured, after failed — un-attributable, but the
+                # before is still useful for audit. Write sentinel.
+                _write_vllm_metrics_artifact(
+                    repo_root,
+                    worker.ticket_id,
+                    attributable=False,
+                    before=worker.vllm_metrics_before,
+                    after=None,
+                    deltas={},
+                    reason="after-snapshot failed (vLLM /metrics unreachable)",
+                )
+        else:
+            vllm_attributable = False
+            _write_vllm_metrics_artifact(
+                repo_root,
+                worker.ticket_id,
+                attributable=False,
+                before=worker.vllm_metrics_before,
+                after=None,
+                deltas={},
+                reason="concurrent worker dispatched during session",
+            )
+
     metrics.record(
         TicketMetrics(
             ticket_id=worker.ticket_id,
@@ -337,6 +429,17 @@ def finalize_worker(
             subagent_spawns=subagent_spawns,
             # WOR-363: persist dispatch-time worker pool size
             dispatch_concurrency=worker.dispatch_concurrency,
+            # WOR-370: vLLM /metrics deltas (None unless solo throughout)
+            vllm_metrics_attributable=vllm_attributable,
+            vllm_prefix_cache_hits=vllm_deltas.get("prefix_cache_hits"),  # type: ignore[arg-type]
+            vllm_prefix_cache_queries=vllm_deltas.get("prefix_cache_queries"),  # type: ignore[arg-type]
+            vllm_prefix_cache_hit_ratio=vllm_deltas.get("prefix_cache_hit_ratio"),
+            vllm_prompt_tokens=vllm_deltas.get("prompt_tokens"),  # type: ignore[arg-type]
+            vllm_generation_tokens=vllm_deltas.get("generation_tokens"),  # type: ignore[arg-type]
+            vllm_ttft_seconds_sum=vllm_deltas.get("ttft_seconds_sum"),
+            vllm_ttft_count=vllm_deltas.get("ttft_count"),  # type: ignore[arg-type]
+            vllm_ttft_mean_seconds=vllm_deltas.get("ttft_mean_seconds"),
+            vllm_preemptions=vllm_deltas.get("preemptions"),  # type: ignore[arg-type]
         )
     )
     metrics.record_run(

--- a/app/core/watcher/watcher_helpers.py
+++ b/app/core/watcher/watcher_helpers.py
@@ -473,3 +473,164 @@ def count_main_ahead_of_epic(epic_branch: str, repo_root: Path) -> int:
         return int(out.strip())
     except (subprocess.SubprocessError, ValueError, FileNotFoundError):
         return 0
+
+
+# ---------------------------------------------------------------------------
+# vLLM /metrics capture (WOR-370)
+# ---------------------------------------------------------------------------
+
+# Counters and gauges to snapshot. Keep in one place so capture and delta
+# parsing stay in sync. Each entry: (metric_name, kind) where kind is
+# "counter" (cumulative; produce delta = after-before) or "gauge" (point-in-
+# time; produce just `before` and `after` snapshots, no delta).
+_VLLM_COUNTERS = (
+    "vllm:prefix_cache_hits_total",
+    "vllm:prefix_cache_queries_total",
+    "vllm:prompt_tokens_total",
+    "vllm:generation_tokens_total",
+    "vllm:time_to_first_token_seconds_sum",
+    "vllm:time_to_first_token_seconds_count",
+    "vllm:num_preemptions_total",
+)
+
+
+def capture_vllm_metrics(timeout: float = 5.0) -> dict[str, float] | None:
+    """Snapshot the small subset of vLLM Prometheus metrics needed for
+    per-ticket attribution.
+
+    Returns a dict keyed by metric name (without label suffixes) mapping to
+    the most recent value, or ``None`` if the endpoint is unreachable or
+    returns malformed text. Failure is non-fatal — callers treat ``None``
+    as "no snapshot, skip attribution."
+
+    Prometheus text format lines look like:
+        vllm:prefix_cache_hits_total{model="qwen3-coder",engine="0"} 12345.0
+
+    We strip everything after the metric name, sum across labels (there's
+    typically just one model/engine combo, but be safe), and emit a flat dict.
+
+    Uses ``http.client`` (matching ``watcher_services.probe_vllm_health``)
+    rather than ``urllib.request`` — the latter accepts ``file://`` URLs
+    so semgrep flags any urlopen call. This API only speaks HTTP to a
+    fixed localhost host:port pair so there is no SSRF surface.
+    """
+    import http.client
+
+    # _VLLM_BASE_URL has the form "http://localhost:8000"; strip the scheme
+    # and split host:port for http.client.HTTPConnection.
+    netloc = _VLLM_BASE_URL.split("://", 1)[1]
+    host, _, port_str = netloc.partition(":")
+    port = int(port_str) if port_str else 80
+
+    try:
+        conn = http.client.HTTPConnection(host, port, timeout=timeout)
+        try:
+            conn.request("GET", "/metrics")
+            resp = conn.getresponse()
+            if resp.status != 200:
+                return None
+            body = resp.read().decode("utf-8", errors="replace")
+        finally:
+            conn.close()
+    except (OSError, http.client.HTTPException):
+        return None
+
+    targets = set(_VLLM_COUNTERS)
+    aggregated: dict[str, float] = {name: 0.0 for name in targets}
+    seen: dict[str, bool] = {name: False for name in targets}
+
+    for raw in body.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        # Metric name extends from start to first '{' or whitespace
+        for ch_idx, ch in enumerate(line):
+            if ch == "{" or ch.isspace():
+                metric_name = line[:ch_idx]
+                rest = line[ch_idx:]
+                break
+        else:
+            continue
+        if metric_name not in targets:
+            continue
+        # Value is the LAST whitespace-separated token
+        try:
+            value = float(rest.rsplit(maxsplit=1)[-1])
+        except (ValueError, IndexError):
+            continue
+        aggregated[metric_name] += value
+        seen[metric_name] = True
+
+    # If we saw none of the target metrics, treat as failure — endpoint
+    # responded but probably isn't a vLLM /metrics endpoint.
+    if not any(seen.values()):
+        return None
+    return aggregated
+
+
+def compute_vllm_metrics_delta(
+    before: dict[str, float],
+    after: dict[str, float],
+) -> dict[str, float | None]:
+    """Compute deltas + derived ratios from two snapshots taken via
+    ``capture_vllm_metrics``.
+
+    Counter deltas can be negative if vLLM was restarted between the two
+    snapshots (counters reset on restart). In that case the delta is
+    meaningless; callers should treat ratios as None when raw counts go
+    negative.
+
+    Returns a flat dict suitable for direct assignment to TicketMetrics
+    columns (keys match the column names without the ``vllm_`` prefix
+    being added by the caller).
+    """
+
+    def _delta(key: str) -> float:
+        return float(after.get(key, 0.0)) - float(before.get(key, 0.0))
+
+    hits = _delta("vllm:prefix_cache_hits_total")
+    queries = _delta("vllm:prefix_cache_queries_total")
+    prompt = _delta("vllm:prompt_tokens_total")
+    gen = _delta("vllm:generation_tokens_total")
+    ttft_sum = _delta("vllm:time_to_first_token_seconds_sum")
+    ttft_count = _delta("vllm:time_to_first_token_seconds_count")
+    preempt = _delta("vllm:num_preemptions_total")
+
+    # Negative delta = vLLM restarted between snapshots; flag as
+    # non-attributable by setting all derived to None.
+    counter_corrupt = any(
+        v < 0 for v in (hits, queries, prompt, gen, ttft_sum, ttft_count, preempt)
+    )
+
+    hit_ratio: float | None = None
+    if not counter_corrupt and queries > 0:
+        hit_ratio = hits / queries
+
+    ttft_mean: float | None = None
+    if not counter_corrupt and ttft_count > 0:
+        ttft_mean = ttft_sum / ttft_count
+
+    if counter_corrupt:
+        return {
+            "prefix_cache_hits": None,
+            "prefix_cache_queries": None,
+            "prefix_cache_hit_ratio": None,
+            "prompt_tokens": None,
+            "generation_tokens": None,
+            "ttft_seconds_sum": None,
+            "ttft_count": None,
+            "ttft_mean_seconds": None,
+            "preemptions": None,
+        }
+
+    return {
+        "prefix_cache_hits": int(hits),
+        "prefix_cache_queries": int(queries),
+        "prefix_cache_hit_ratio": hit_ratio,
+        "prompt_tokens": int(prompt),
+        "generation_tokens": int(gen),
+        "ttft_seconds_sum": ttft_sum,
+        "ttft_count": int(ttft_count),
+        "ttft_mean_seconds": ttft_mean,
+        "preemptions": int(preempt),
+    }

--- a/app/core/watcher/watcher_types.py
+++ b/app/core/watcher/watcher_types.py
@@ -76,6 +76,16 @@ class ActiveWorker:
     # Wall-clock (not monotonic) so it shares a frame of reference with the
     # log file's st_mtime.
     terminated_at: float | None = None
+    # WOR-370: vLLM /metrics snapshot taken at dispatch time when the
+    # worker was the only active session (dispatch_concurrency == 0).
+    # None means no snapshot (either concurrency > 0 at dispatch, or the
+    # /metrics endpoint was unreachable).
+    vllm_metrics_before: dict[str, float] | None = None
+    # WOR-370: True iff the worker was solo at dispatch AND no other worker
+    # was dispatched during this session. Flipped to False whenever a peer
+    # is dispatched. At reap, only workers with remained_solo=True get
+    # attributable vLLM /metrics deltas; the rest get a sentinel artifact.
+    remained_solo: bool = False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_vllm_metrics_capture.py
+++ b/tests/test_vllm_metrics_capture.py
@@ -1,0 +1,404 @@
+"""Tests for the WOR-370 vLLM /metrics capture helpers + integrations.
+
+Three layers:
+
+1. ``capture_vllm_metrics`` — Prometheus text parsing + HTTP fetch handling.
+2. ``compute_vllm_metrics_delta`` — counter math + derived ratios.
+3. Dispatch + finalize integration — solo-tracking flag flow and the
+   sentinel artifact path under concurrent dispatch.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.core.watcher.watcher_helpers import (
+    capture_vllm_metrics,
+    compute_vllm_metrics_delta,
+)
+
+# ---------------------------------------------------------------------------
+# capture_vllm_metrics — HTTP + Prometheus text parsing
+# ---------------------------------------------------------------------------
+
+
+_SAMPLE_METRICS = b"""\
+# HELP vllm:prefix_cache_hits_total ...
+# TYPE vllm:prefix_cache_hits_total counter
+vllm:prefix_cache_hits_total{model="qwen3-coder",engine="0"} 1454624.0
+vllm:prefix_cache_queries_total{model="qwen3-coder",engine="0"} 1546626.0
+vllm:prompt_tokens_total{model="qwen3-coder",engine="0"} 1546626.0
+vllm:generation_tokens_total{model="qwen3-coder",engine="0"} 6839.0
+vllm:time_to_first_token_seconds_sum{model="qwen3-coder",engine="0"} 42.5
+vllm:time_to_first_token_seconds_count{model="qwen3-coder",engine="0"} 28.0
+vllm:num_preemptions_total{model="qwen3-coder",engine="0"} 0.0
+# An unrelated metric we should ignore
+some_other_metric{foo="bar"} 999.0
+"""
+
+
+def _conn_with_response(status: int, body: bytes) -> MagicMock:
+    """Build a mock that emulates http.client.HTTPConnection."""
+    resp = MagicMock()
+    resp.status = status
+    resp.read.return_value = body
+    conn = MagicMock()
+    conn.getresponse.return_value = resp
+    return conn
+
+
+def test_capture_returns_aggregated_dict() -> None:
+    conn = _conn_with_response(200, _SAMPLE_METRICS)
+    with patch("http.client.HTTPConnection", return_value=conn):
+        result = capture_vllm_metrics()
+    assert result is not None
+    assert result["vllm:prefix_cache_hits_total"] == 1454624.0
+    assert result["vllm:prefix_cache_queries_total"] == 1546626.0
+    assert result["vllm:num_preemptions_total"] == 0.0
+
+
+def test_capture_returns_none_on_oserror() -> None:
+    conn = MagicMock()
+    conn.request.side_effect = OSError("network down")
+    with patch("http.client.HTTPConnection", return_value=conn):
+        result = capture_vllm_metrics()
+    assert result is None
+
+
+def test_capture_returns_none_on_http_exception() -> None:
+    import http.client as http_client
+
+    conn = MagicMock()
+    conn.request.side_effect = http_client.HTTPException("bad response")
+    with patch("http.client.HTTPConnection", return_value=conn):
+        result = capture_vllm_metrics()
+    assert result is None
+
+
+def test_capture_returns_none_on_non_200_status() -> None:
+    """A 4xx/5xx response means the endpoint isn't healthy — treat as failure."""
+    conn = _conn_with_response(503, b"")
+    with patch("http.client.HTTPConnection", return_value=conn):
+        result = capture_vllm_metrics()
+    assert result is None
+
+
+def test_capture_returns_none_when_no_target_metrics_present() -> None:
+    """An endpoint that responds 200 with unrelated content is treated as failure."""
+    body = b'# random metrics\nsome_unrelated{foo="bar"} 1.0\n'
+    conn = _conn_with_response(200, body)
+    with patch("http.client.HTTPConnection", return_value=conn):
+        result = capture_vllm_metrics()
+    assert result is None
+
+
+def test_capture_aggregates_across_label_combinations() -> None:
+    """Two label sets for the same metric should sum (defensive)."""
+    body = (
+        b'vllm:prompt_tokens_total{engine="0"} 100.0\n'
+        b'vllm:prompt_tokens_total{engine="1"} 50.0\n'
+    )
+    conn = _conn_with_response(200, body)
+    with patch("http.client.HTTPConnection", return_value=conn):
+        result = capture_vllm_metrics()
+    assert result is not None
+    assert result["vllm:prompt_tokens_total"] == 150.0
+
+
+# ---------------------------------------------------------------------------
+# compute_vllm_metrics_delta
+# ---------------------------------------------------------------------------
+
+
+def test_delta_basic_arithmetic() -> None:
+    before = {
+        "vllm:prefix_cache_hits_total": 100.0,
+        "vllm:prefix_cache_queries_total": 200.0,
+        "vllm:prompt_tokens_total": 1000.0,
+        "vllm:generation_tokens_total": 50.0,
+        "vllm:time_to_first_token_seconds_sum": 5.0,
+        "vllm:time_to_first_token_seconds_count": 10.0,
+        "vllm:num_preemptions_total": 0.0,
+    }
+    after = {
+        "vllm:prefix_cache_hits_total": 196.0,
+        "vllm:prefix_cache_queries_total": 300.0,
+        "vllm:prompt_tokens_total": 1500.0,
+        "vllm:generation_tokens_total": 70.0,
+        "vllm:time_to_first_token_seconds_sum": 11.0,
+        "vllm:time_to_first_token_seconds_count": 14.0,
+        "vllm:num_preemptions_total": 1.0,
+    }
+    d = compute_vllm_metrics_delta(before, after)
+    assert d["prefix_cache_hits"] == 96
+    assert d["prefix_cache_queries"] == 100
+    assert d["prefix_cache_hit_ratio"] == pytest.approx(0.96)
+    assert d["prompt_tokens"] == 500
+    assert d["generation_tokens"] == 20
+    assert d["ttft_seconds_sum"] == pytest.approx(6.0)
+    assert d["ttft_count"] == 4
+    assert d["ttft_mean_seconds"] == pytest.approx(1.5)
+    assert d["preemptions"] == 1
+
+
+def test_delta_zero_queries_yields_none_hit_ratio() -> None:
+    before = {
+        "vllm:prefix_cache_hits_total": 0.0,
+        "vllm:prefix_cache_queries_total": 0.0,
+        "vllm:time_to_first_token_seconds_count": 0.0,
+        "vllm:time_to_first_token_seconds_sum": 0.0,
+    }
+    after = dict(before)
+    d = compute_vllm_metrics_delta(before, after)
+    assert d["prefix_cache_hit_ratio"] is None
+    assert d["ttft_mean_seconds"] is None
+
+
+def test_delta_negative_counter_treated_as_corrupt() -> None:
+    """vLLM restart between snapshots resets counters; treat result as None."""
+    before = {"vllm:prefix_cache_hits_total": 1000.0}
+    after = {"vllm:prefix_cache_hits_total": 50.0}  # restart happened
+    d = compute_vllm_metrics_delta(before, after)
+    assert d["prefix_cache_hits"] is None
+    assert d["prefix_cache_hit_ratio"] is None
+
+
+# ---------------------------------------------------------------------------
+# Integration: dispatch.start_ticket
+# ---------------------------------------------------------------------------
+
+
+def _services(mode: str = "default", vllm_healthy: bool = True) -> MagicMock:
+    services = MagicMock()
+    services._mode = mode
+    services.probe_vllm_health.return_value = vllm_healthy
+    return services
+
+
+def test_dispatch_captures_vllm_snapshot_when_solo(tmp_path: Path) -> None:
+    """First worker: dispatch_concurrency=0, snapshot taken, remained_solo=True."""
+    from app.core.watcher.dispatch import start_ticket
+    from tests.conftest import make_manifest
+
+    manifest = make_manifest(
+        implementation_mode="local",
+        base_branch="main",
+    )
+    linear = MagicMock()
+    services = _services()
+    local_active: list = []
+    cloud_active: list = []
+
+    sample_snapshot = {"vllm:prompt_tokens_total": 100.0}
+
+    with (
+        patch(
+            "app.core.watcher.dispatch.create_worktree",
+            return_value=tmp_path / "worktree",
+        ),
+        patch("app.core.watcher.dispatch.copy_manifest_to_worktree"),
+        patch("app.core.watcher.dispatch.write_worker_pytest_config"),
+        patch("app.core.watcher.dispatch.backup_plan_files", return_value=[]),
+        patch("app.core.watcher.dispatch.launch_worker", return_value=MagicMock()),
+        patch("app.core.watcher.dispatch.safe_set_state"),
+        patch(
+            "app.core.watcher.dispatch.capture_vllm_metrics",
+            return_value=sample_snapshot,
+        ) as mock_capture,
+    ):
+        start_ticket(
+            manifest=manifest,
+            linear=linear,
+            services=services,
+            worker_verbose=False,
+            _local_active=local_active,
+            _cloud_active=cloud_active,
+            max_cloud_workers=3,
+            _repo_root=tmp_path,
+            _processed_tickets=[],
+            linear_id="fake-linear-id",
+            ticket_id="WOR-10",
+            _escalation_policy=MagicMock(),
+        )
+
+    assert len(local_active) == 1
+    worker = local_active[0]
+    assert worker.dispatch_concurrency == 0
+    assert worker.vllm_metrics_before == sample_snapshot
+    assert worker.remained_solo is True
+    mock_capture.assert_called_once()
+
+
+def test_dispatch_invalidates_solo_peer_when_second_worker_launches(
+    tmp_path: Path,
+) -> None:
+    """When a second worker dispatches, any existing solo worker loses its flag."""
+    from app.core.watcher.dispatch import start_ticket
+    from app.core.watcher.watcher_types import ActiveWorker
+    from tests.conftest import make_manifest
+
+    # Pre-existing solo worker in the pool
+    solo_manifest = make_manifest(ticket_id="WOR-1")
+    solo_worker = ActiveWorker(
+        ticket_id="WOR-1",
+        linear_id="linear-1",
+        manifest=solo_manifest,
+        worktree_path=tmp_path / "wt-1",
+        process=MagicMock(),
+        vllm_metrics_before={"vllm:prompt_tokens_total": 100.0},
+        remained_solo=True,
+    )
+    local_active: list = [solo_worker]
+    cloud_active: list = []
+
+    new_manifest = make_manifest(
+        ticket_id="WOR-2", base_branch="main", worker_branch="wor-2"
+    )
+    linear = MagicMock()
+    services = _services()
+
+    with (
+        patch(
+            "app.core.watcher.dispatch.create_worktree",
+            return_value=tmp_path / "wt-2",
+        ),
+        patch("app.core.watcher.dispatch.copy_manifest_to_worktree"),
+        patch("app.core.watcher.dispatch.write_worker_pytest_config"),
+        patch("app.core.watcher.dispatch.backup_plan_files", return_value=[]),
+        patch("app.core.watcher.dispatch.launch_worker", return_value=MagicMock()),
+        patch("app.core.watcher.dispatch.safe_set_state"),
+        # Should NOT be called: dispatch_concurrency > 0 means no snapshot
+        patch(
+            "app.core.watcher.dispatch.capture_vllm_metrics",
+            return_value={"vllm:prompt_tokens_total": 200.0},
+        ) as mock_capture,
+    ):
+        start_ticket(
+            manifest=new_manifest,
+            linear=linear,
+            services=services,
+            worker_verbose=False,
+            _local_active=local_active,
+            _cloud_active=cloud_active,
+            max_cloud_workers=3,
+            _repo_root=tmp_path,
+            _processed_tickets=[],
+            linear_id="fake-linear-2",
+            ticket_id="WOR-2",
+            _escalation_policy=MagicMock(),
+        )
+
+    # Pre-existing worker has lost its solo flag
+    assert solo_worker.remained_solo is False
+    # The new worker did NOT take its own snapshot (concurrency > 0)
+    new_worker = local_active[-1]
+    assert new_worker.dispatch_concurrency == 1
+    assert new_worker.remained_solo is False
+    assert new_worker.vllm_metrics_before is None
+    mock_capture.assert_not_called()
+
+
+def test_dispatch_skips_snapshot_when_metrics_endpoint_unreachable(
+    tmp_path: Path,
+) -> None:
+    """If /metrics returns None (unreachable), worker proceeds without solo flag."""
+    from app.core.watcher.dispatch import start_ticket
+    from tests.conftest import make_manifest
+
+    manifest = make_manifest(implementation_mode="local", base_branch="main")
+    linear = MagicMock()
+    services = _services()
+    local_active: list = []
+    cloud_active: list = []
+
+    with (
+        patch(
+            "app.core.watcher.dispatch.create_worktree",
+            return_value=tmp_path / "worktree",
+        ),
+        patch("app.core.watcher.dispatch.copy_manifest_to_worktree"),
+        patch("app.core.watcher.dispatch.write_worker_pytest_config"),
+        patch("app.core.watcher.dispatch.backup_plan_files", return_value=[]),
+        patch("app.core.watcher.dispatch.launch_worker", return_value=MagicMock()),
+        patch("app.core.watcher.dispatch.safe_set_state"),
+        patch(
+            "app.core.watcher.dispatch.capture_vllm_metrics",
+            return_value=None,  # endpoint unreachable
+        ),
+    ):
+        start_ticket(
+            manifest=manifest,
+            linear=linear,
+            services=services,
+            worker_verbose=False,
+            _local_active=local_active,
+            _cloud_active=cloud_active,
+            max_cloud_workers=3,
+            _repo_root=tmp_path,
+            _processed_tickets=[],
+            linear_id="fake-linear-id",
+            ticket_id="WOR-10",
+            _escalation_policy=MagicMock(),
+        )
+
+    worker = local_active[0]
+    assert worker.dispatch_concurrency == 0
+    assert worker.vllm_metrics_before is None
+    assert worker.remained_solo is False
+
+
+# ---------------------------------------------------------------------------
+# Integration: finalize_worker — sentinel artifact paths
+# ---------------------------------------------------------------------------
+
+
+def test_finalize_writes_attributable_artifact_for_solo_worker(tmp_path: Path) -> None:
+    """A solo worker with valid before/after produces the full deltas artifact."""
+    from app.core.watcher.watcher_finalize import _write_vllm_metrics_artifact
+
+    _write_vllm_metrics_artifact(
+        tmp_path,
+        "WOR-50",
+        attributable=True,
+        before={"vllm:prefix_cache_hits_total": 100.0},
+        after={"vllm:prefix_cache_hits_total": 150.0},
+        deltas={"prefix_cache_hits": 50, "prefix_cache_hit_ratio": 0.85},
+    )
+
+    artifact = tmp_path / ".claude" / "artifacts" / "wor_50" / "vllm_metrics.json"
+    assert artifact.exists()
+    payload = json.loads(artifact.read_text(encoding="utf-8"))
+    assert payload["ticket_id"] == "WOR-50"
+    assert payload["attributable"] is True
+    assert payload["before"]["vllm:prefix_cache_hits_total"] == 100.0
+    assert payload["after"]["vllm:prefix_cache_hits_total"] == 150.0
+    assert payload["deltas"]["prefix_cache_hits"] == 50
+
+
+def test_finalize_writes_sentinel_artifact_for_concurrent_session(
+    tmp_path: Path,
+) -> None:
+    """Non-solo session writes a sentinel with reason; no after/deltas."""
+    from app.core.watcher.watcher_finalize import _write_vllm_metrics_artifact
+
+    _write_vllm_metrics_artifact(
+        tmp_path,
+        "WOR-51",
+        attributable=False,
+        before={"vllm:prompt_tokens_total": 1000.0},
+        after=None,
+        deltas={},
+        reason="concurrent worker dispatched during session",
+    )
+
+    artifact = tmp_path / ".claude" / "artifacts" / "wor_51" / "vllm_metrics.json"
+    payload = json.loads(artifact.read_text(encoding="utf-8"))
+    assert payload["attributable"] is False
+    assert "concurrent" in payload["reason"]
+    assert "before" in payload  # before is still useful for audit
+    assert "after" not in payload
+    assert "deltas" not in payload


### PR DESCRIPTION
## Summary

Captures vLLM `/metrics` deltas per ticket — the system-side companion to today's WOR-359/WOR-282 manual forensics that surfaced 94% prefix cache hit ratio and 1.5s mean TTFT as the headline post-WOR-368 numbers.

Server-side counters are global, so per-ticket attribution requires snapshots before/after with no concurrent traffic mixing in. This PR implements the gate, the capture, the artifact, and the queryable columns. No backfill (per ticket — explicitly out of scope).

## Three states per session

| Condition | Outcome |
|---|---|
| `dispatch_concurrency=0` at dispatch AND no peer dispatched during session | **Attributable**: full audit artifact + 10 populated columns |
| `dispatch_concurrency=0` at dispatch BUT peer dispatched mid-session | **Concurrent**: sentinel artifact, columns NULL, `vllm_metrics_attributable=False` |
| Snapshot at dispatch failed (or `concurrency != 0` at dispatch) | **Never captured**: no artifact, columns NULL, `vllm_metrics_attributable=NULL` |

## New `ticket_metrics` columns (10)

```
vllm_metrics_attributable    INTEGER (boolean)
vllm_prefix_cache_hits       INTEGER     -- delta during session
vllm_prefix_cache_queries    INTEGER     -- delta
vllm_prefix_cache_hit_ratio  REAL        -- derived: hits/queries
vllm_prompt_tokens           INTEGER     -- delta
vllm_generation_tokens       INTEGER     -- delta
vllm_ttft_seconds_sum        REAL        -- delta of histogram sum
vllm_ttft_count              INTEGER     -- delta of histogram count
vllm_ttft_mean_seconds       REAL        -- derived: sum/count
vllm_preemptions             INTEGER     -- delta
```

All nullable; existing rows unaffected.

## Implementation

- **`app/core/watcher/watcher_helpers.py`** — `capture_vllm_metrics()` and `compute_vllm_metrics_delta()`. Uses `http.client` (matching `watcher_services.probe_vllm_health` rather than `urllib.request`, which has the SSRF surface semgrep flags). Negative deltas (vLLM restart between snapshots) collapse to NULL rather than emitting garbage.
- **`app/core/watcher/watcher_types.py`** — `ActiveWorker.vllm_metrics_before` (snapshot dict) and `ActiveWorker.remained_solo` (flag flipped to False on peer dispatch).
- **`app/core/watcher/dispatch.py`** — at `start_ticket`: snapshot when solo, invalidate any existing solo peer when not.
- **`app/core/watcher/watcher_finalize.py`** — at reap: branch on `(vllm_metrics_before, remained_solo)`, capture after-snapshot, compute deltas, write `.claude/artifacts/<ticket>/vllm_metrics.json`, populate columns. `_write_vllm_metrics_artifact()` helper isolates the JSON write.
- **`app/core/metrics.py`** — 10 new Pydantic fields + matching `ALTER TABLE ADD COLUMN` migrations.

## Test plan

- [x] `ruff check .` passes
- [x] `mypy app/` passes (29 source files)
- [x] `lint-imports` passes (5/5 contracts kept)
- [x] `pytest` passes (1264 tests, 14 new in `tests/test_vllm_metrics_capture.py`)
- [x] Test coverage: HTTP capture (success/oserror/http-exception/non-200/no-target-metrics/label-aggregation), delta math (basic/divide-by-zero/negative-counter), dispatch integration (solo capture, peer-invalidation, unreachable endpoint), finalize artifact (attributable/sentinel)
- [ ] Live verification: dispatch a worker solo, observe `vllm_metrics.json` artifact + populated columns. Then dispatch a second worker mid-session and observe sentinel artifact for the original.

## Cross-links

- WOR-370 (this ticket)
- WOR-380 — sibling: per-worker behavior telemetry from stream-json log (concurrency-safe). Together they cover both isolated and any-concurrency runs.
- WOR-368 — established the direct-vLLM path that made these counters useful
- `scripts/telemetry/poll_vllm_metrics.sh` — manual capture pattern this productionalizes
- `scripts/metrics_analysis/walltime_distribution.py` — example of querying the new columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)
