### PR TITLE
WOR-380 Per-worker behavior telemetry from stream-json log

### DIFF
--- a/app/core/metrics.py
+++ b/app/core/metrics.py
@@ -280,6 +280,49 @@ class TicketMetrics(BaseModel):
             "indicates KV cache pressure forced request preemption."
         ),
     )
+    # WOR-380: per-worker behavior telemetry from stream-json log.
+    # Concurrency-safe — derived from the worker's own log file.
+    turn_count: int | None = Field(
+        default=None,
+        description="Number of assistant messages (turns) in the session.",
+    )
+    tool_calls_total: int | None = Field(
+        default=None, description="Total tool_use blocks emitted during the session."
+    )
+    tool_calls_breakdown: str | None = Field(
+        default=None,
+        description=(
+            "JSON-serialized dict of tool_use counts by tool name, e.g. "
+            '\'{"Read": 7, "Edit": 6, "Bash": 10}\'.'
+        ),
+    )
+    thinking_blocks: int | None = Field(
+        default=None,
+        description="Count of `type=thinking` content blocks (Qwen3 reasoning).",
+    )
+    thinking_chars_total: int | None = Field(
+        default=None,
+        description="Sum of len(text) across all thinking blocks (reasoning depth).",
+    )
+    input_tokens_max: int | None = Field(
+        default=None,
+        description="Max input_tokens across turns (context-window pressure proxy).",
+    )
+    input_tokens_first: int | None = Field(
+        default=None, description="input_tokens of the first assistant turn."
+    )
+    input_tokens_last: int | None = Field(
+        default=None, description="input_tokens of the last assistant turn."
+    )
+    redundant_reads_count: int | None = Field(
+        default=None,
+        description=(
+            "Number of distinct file paths read more than 2 times in the "
+            "session (WOR-355 cap). With WOR-371's hook live this should "
+            "trend to 0; useful retro signal for sessions before the hook "
+            "or for cap-exceeded violations that slipped through."
+        ),
+    )
 
 
 class EpicSummary(BaseModel):
@@ -535,6 +578,43 @@ class MetricsStore:
         if "vllm_preemptions" not in existing:
             conn.execute(
                 "ALTER TABLE ticket_metrics ADD COLUMN vllm_preemptions INTEGER"
+            )
+        # WOR-380: per-worker behavior telemetry from stream-json log.
+        # Concurrency-safe sibling to WOR-370 — all derived from the
+        # worker's own log file.
+        if "turn_count" not in existing:
+            conn.execute("ALTER TABLE ticket_metrics ADD COLUMN turn_count INTEGER")
+        if "tool_calls_total" not in existing:
+            conn.execute(
+                "ALTER TABLE ticket_metrics ADD COLUMN tool_calls_total INTEGER"
+            )
+        if "tool_calls_breakdown" not in existing:
+            conn.execute(
+                "ALTER TABLE ticket_metrics ADD COLUMN tool_calls_breakdown TEXT"
+            )
+        if "thinking_blocks" not in existing:
+            conn.execute(
+                "ALTER TABLE ticket_metrics ADD COLUMN thinking_blocks INTEGER"
+            )
+        if "thinking_chars_total" not in existing:
+            conn.execute(
+                "ALTER TABLE ticket_metrics ADD COLUMN thinking_chars_total INTEGER"
+            )
+        if "input_tokens_max" not in existing:
+            conn.execute(
+                "ALTER TABLE ticket_metrics ADD COLUMN input_tokens_max INTEGER"
+            )
+        if "input_tokens_first" not in existing:
+            conn.execute(
+                "ALTER TABLE ticket_metrics ADD COLUMN input_tokens_first INTEGER"
+            )
+        if "input_tokens_last" not in existing:
+            conn.execute(
+                "ALTER TABLE ticket_metrics ADD COLUMN input_tokens_last INTEGER"
+            )
+        if "redundant_reads_count" not in existing:
+            conn.execute(
+                "ALTER TABLE ticket_metrics ADD COLUMN redundant_reads_count INTEGER"
             )
 
     @contextmanager

--- a/app/core/watcher/watcher_finalize.py
+++ b/app/core/watcher/watcher_finalize.py
@@ -26,6 +26,7 @@ from app.core.metrics import (
 from .watcher_helpers import (
     _POLICY_FLAGS,
     _parse_worker_api_retries,
+    _parse_worker_behavior,
     _parse_worker_subagent_spawns,
     _parse_worker_usage,
     _read_result_flags,
@@ -251,6 +252,14 @@ def finalize_worker(
     )
     api_retry_count = _parse_worker_api_retries(log_path)
     subagent_spawns = _parse_worker_subagent_spawns(log_path)
+    # WOR-380: per-worker behavior telemetry. Concurrency-safe — extracted
+    # from this worker's own log file.
+    behavior = _parse_worker_behavior(log_path)
+    tool_breakdown_json: str | None = (
+        json.dumps(behavior.tool_calls_breakdown, sort_keys=True)
+        if behavior.tool_calls_breakdown is not None
+        else None
+    )
     eff = resolve_effective_mode(mode, worker.manifest.implementation_mode)
 
     # Parse git diff --shortstat to populate lines_changed / files_changed.
@@ -440,6 +449,16 @@ def finalize_worker(
             vllm_ttft_count=vllm_deltas.get("ttft_count"),  # type: ignore[arg-type]
             vllm_ttft_mean_seconds=vllm_deltas.get("ttft_mean_seconds"),
             vllm_preemptions=vllm_deltas.get("preemptions"),  # type: ignore[arg-type]
+            # WOR-380: per-worker behavior telemetry (any concurrency)
+            turn_count=behavior.turn_count,
+            tool_calls_total=behavior.tool_calls_total,
+            tool_calls_breakdown=tool_breakdown_json,
+            thinking_blocks=behavior.thinking_blocks,
+            thinking_chars_total=behavior.thinking_chars_total,
+            input_tokens_max=behavior.input_tokens_max,
+            input_tokens_first=behavior.input_tokens_first,
+            input_tokens_last=behavior.input_tokens_last,
+            redundant_reads_count=behavior.redundant_reads_count,
         )
     )
     metrics.record_run(

--- a/app/core/watcher/watcher_helpers.py
+++ b/app/core/watcher/watcher_helpers.py
@@ -634,3 +634,147 @@ def compute_vllm_metrics_delta(
         "ttft_mean_seconds": ttft_mean,
         "preemptions": int(preempt),
     }
+
+
+# ---------------------------------------------------------------------------
+# Per-worker behavior telemetry (WOR-380)
+# ---------------------------------------------------------------------------
+
+
+class WorkerBehavior:
+    """Per-worker behavior summary parsed from a stream-json log.
+
+    Concurrency-safe sibling to WOR-370 (server-side /metrics): every value
+    here is derived from the worker's own log file, so multiple concurrent
+    workers each produce their own attributable summary.
+
+    All fields are Optional to distinguish "definitely zero" from
+    "couldn't read the log" (None means the log was missing or unparseable
+    at the file-handle level; 0 / {} means the log was readable but the
+    feature didn't appear).
+    """
+
+    __slots__ = (
+        "turn_count",
+        "tool_calls_total",
+        "tool_calls_breakdown",
+        "thinking_blocks",
+        "thinking_chars_total",
+        "input_tokens_max",
+        "input_tokens_first",
+        "input_tokens_last",
+        "redundant_reads_count",
+    )
+
+    def __init__(
+        self,
+        turn_count: int | None,
+        tool_calls_total: int | None,
+        tool_calls_breakdown: dict[str, int] | None,
+        thinking_blocks: int | None,
+        thinking_chars_total: int | None,
+        input_tokens_max: int | None,
+        input_tokens_first: int | None,
+        input_tokens_last: int | None,
+        redundant_reads_count: int | None,
+    ) -> None:
+        self.turn_count = turn_count
+        self.tool_calls_total = tool_calls_total
+        self.tool_calls_breakdown = tool_calls_breakdown
+        self.thinking_blocks = thinking_blocks
+        self.thinking_chars_total = thinking_chars_total
+        self.input_tokens_max = input_tokens_max
+        self.input_tokens_first = input_tokens_first
+        self.input_tokens_last = input_tokens_last
+        self.redundant_reads_count = redundant_reads_count
+
+    @classmethod
+    def empty_unparseable(cls) -> "WorkerBehavior":
+        """Sentinel: log unreadable, so every field is None."""
+        return cls(None, None, None, None, None, None, None, None, None)
+
+    @classmethod
+    def empty_readable(cls) -> "WorkerBehavior":
+        """Sentinel: log was readable but had no assistant turns."""
+        return cls(0, 0, {}, 0, 0, None, None, None, 0)
+
+
+def _parse_worker_behavior(log_path: Path) -> WorkerBehavior:
+    """Extract per-session behavior signals from the stream-json worker log.
+
+    Counts assistant turns, tool-call totals + breakdown by name, thinking
+    blocks + their text length, and per-file Read counts to derive a
+    redundant-reads count. Also captures the input_tokens trajectory
+    (first / last / max) which is a proxy for context-window pressure.
+
+    Returns a WorkerBehavior with None fields if the log is missing or
+    cannot be opened. Returns zero-valued fields if the log is parseable
+    but has no assistant turns.
+    """
+    try:
+        with log_path.open(encoding="utf-8") as f:
+            turn_count = 0
+            tool_calls_total = 0
+            tool_breakdown: dict[str, int] = {}
+            thinking_blocks = 0
+            thinking_chars = 0
+            input_tokens_first: int | None = None
+            input_tokens_last: int | None = None
+            input_tokens_max: int | None = None
+            read_counts: dict[str, int] = {}
+            for raw in f:
+                line = raw.strip()
+                if not line:
+                    continue
+                try:
+                    obj = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if obj.get("type") != "assistant":
+                    continue
+                turn_count += 1
+                msg = obj.get("message") or {}
+                usage = msg.get("usage") or {}
+                inp = usage.get("input_tokens")
+                if isinstance(inp, int):
+                    if input_tokens_first is None:
+                        input_tokens_first = inp
+                    input_tokens_last = inp
+                    input_tokens_max = (
+                        inp if input_tokens_max is None else max(input_tokens_max, inp)
+                    )
+                for blk in msg.get("content") or []:
+                    if not isinstance(blk, dict):
+                        continue
+                    btype = blk.get("type")
+                    if btype == "thinking":
+                        thinking_blocks += 1
+                        text = blk.get("thinking") or blk.get("text") or ""
+                        if isinstance(text, str):
+                            thinking_chars += len(text)
+                    elif btype == "tool_use":
+                        tool_calls_total += 1
+                        name = blk.get("name") or "?"
+                        tool_breakdown[name] = tool_breakdown.get(name, 0) + 1
+                        if name == "Read":
+                            fp = (blk.get("input") or {}).get("file_path")
+                            if isinstance(fp, str) and fp:
+                                # Normalize Windows back-slashes for grouping
+                                key = fp.replace("\\", "/")
+                                read_counts[key] = read_counts.get(key, 0) + 1
+            if turn_count == 0:
+                return WorkerBehavior.empty_readable()
+            redundant = sum(1 for n in read_counts.values() if n > 2)
+            return WorkerBehavior(
+                turn_count=turn_count,
+                tool_calls_total=tool_calls_total,
+                tool_calls_breakdown=tool_breakdown,
+                thinking_blocks=thinking_blocks,
+                thinking_chars_total=thinking_chars,
+                input_tokens_max=input_tokens_max,
+                input_tokens_first=input_tokens_first,
+                input_tokens_last=input_tokens_last,
+                redundant_reads_count=redundant,
+            )
+    except (OSError, ValueError):
+        return WorkerBehavior.empty_unparseable()

--- a/tests/test_worker_behavior_parser.py
+++ b/tests/test_worker_behavior_parser.py
@@ -1,0 +1,369 @@
+"""Tests for the WOR-380 per-worker behavior parser
+(``_parse_worker_behavior`` in ``watcher_helpers``).
+
+Concurrency-safe sibling to the WOR-370 vLLM /metrics capture: every
+field here is derived from the worker's own log file, so the test cases
+only need to construct stream-json bytes — no HTTP mocking, no shared
+state to reason about.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from app.core.watcher.watcher_helpers import (
+    WorkerBehavior,
+    _parse_worker_behavior,
+)
+
+
+def _write_log(tmp_path: Path, lines: list[dict[str, object]]) -> Path:
+    """Write a JSONL log file and return its path."""
+    log = tmp_path / "worker.log"
+    log.write_text(
+        "\n".join(json.dumps(line) for line in lines) + "\n",
+        encoding="utf-8",
+    )
+    return log
+
+
+def _assistant_turn(
+    *,
+    input_tokens: int | None = None,
+    output_tokens: int | None = None,
+    content: list[dict[str, object]] | None = None,
+) -> dict[str, object]:
+    """Build a single assistant-turn JSONL line."""
+    msg: dict[str, object] = {"content": content or []}
+    if input_tokens is not None or output_tokens is not None:
+        usage: dict[str, int] = {}
+        if input_tokens is not None:
+            usage["input_tokens"] = input_tokens
+        if output_tokens is not None:
+            usage["output_tokens"] = output_tokens
+        msg["usage"] = usage
+    return {"type": "assistant", "message": msg}
+
+
+# ---------------------------------------------------------------------------
+# Sentinel returns
+# ---------------------------------------------------------------------------
+
+
+def test_parse_returns_unparseable_when_log_missing(tmp_path: Path) -> None:
+    """Missing log file → all None (couldn't determine anything)."""
+    result = _parse_worker_behavior(tmp_path / "no_such_log.log")
+    assert result.turn_count is None
+    assert result.tool_calls_total is None
+    assert result.tool_calls_breakdown is None
+    assert result.thinking_blocks is None
+    assert result.input_tokens_max is None
+
+
+def test_parse_returns_readable_zero_when_log_empty(tmp_path: Path) -> None:
+    """Empty log file → all zero (definitively no activity)."""
+    log = tmp_path / "worker.log"
+    log.write_text("", encoding="utf-8")
+    result = _parse_worker_behavior(log)
+    assert result.turn_count == 0
+    assert result.tool_calls_total == 0
+    assert result.tool_calls_breakdown == {}
+    assert result.thinking_blocks == 0
+    assert result.thinking_chars_total == 0
+    assert result.input_tokens_max is None
+    assert result.redundant_reads_count == 0
+
+
+def test_parse_skips_non_assistant_events(tmp_path: Path) -> None:
+    """A log of system / result / user events with no assistant → zero."""
+    log = _write_log(
+        tmp_path,
+        [
+            {"type": "system", "subtype": "init"},
+            {"type": "user", "message": {"content": "hi"}},
+            {"type": "result", "usage": {"input_tokens": 50, "output_tokens": 10}},
+        ],
+    )
+    result = _parse_worker_behavior(log)
+    assert result.turn_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Counting basics
+# ---------------------------------------------------------------------------
+
+
+def test_parse_counts_turns_and_input_tokens_trajectory(tmp_path: Path) -> None:
+    """First/last/max input_tokens are captured across multiple turns."""
+    log = _write_log(
+        tmp_path,
+        [
+            _assistant_turn(input_tokens=49000, output_tokens=10),
+            _assistant_turn(input_tokens=51000, output_tokens=20),
+            _assistant_turn(input_tokens=55000, output_tokens=30),
+            _assistant_turn(input_tokens=53000, output_tokens=40),
+        ],
+    )
+    result = _parse_worker_behavior(log)
+    assert result.turn_count == 4
+    assert result.input_tokens_first == 49000
+    assert result.input_tokens_last == 53000
+    assert result.input_tokens_max == 55000
+
+
+def test_parse_counts_tool_uses_with_breakdown(tmp_path: Path) -> None:
+    """tool_use blocks are tallied + bucketed by name."""
+    log = _write_log(
+        tmp_path,
+        [
+            _assistant_turn(
+                input_tokens=1000,
+                content=[
+                    {
+                        "type": "tool_use",
+                        "name": "Read",
+                        "input": {"file_path": "a.py"},
+                    },
+                    {"type": "tool_use", "name": "Edit", "input": {}},
+                ],
+            ),
+            _assistant_turn(
+                input_tokens=1100,
+                content=[
+                    {
+                        "type": "tool_use",
+                        "name": "Read",
+                        "input": {"file_path": "b.py"},
+                    },
+                    {"type": "tool_use", "name": "Bash", "input": {"command": "ls"}},
+                    {"type": "tool_use", "name": "Bash", "input": {"command": "ls"}},
+                ],
+            ),
+        ],
+    )
+    result = _parse_worker_behavior(log)
+    assert result.tool_calls_total == 5
+    assert result.tool_calls_breakdown == {"Read": 2, "Edit": 1, "Bash": 2}
+
+
+def test_parse_counts_thinking_blocks_and_chars(tmp_path: Path) -> None:
+    """`type=thinking` content blocks are counted and their text length summed."""
+    log = _write_log(
+        tmp_path,
+        [
+            _assistant_turn(
+                input_tokens=100,
+                content=[
+                    {"type": "thinking", "thinking": "first thought"},
+                    {"type": "tool_use", "name": "Read", "input": {"file_path": "x"}},
+                ],
+            ),
+            _assistant_turn(
+                input_tokens=200,
+                content=[{"type": "thinking", "thinking": "second longer thought."}],
+            ),
+        ],
+    )
+    result = _parse_worker_behavior(log)
+    assert result.thinking_blocks == 2
+    # "first thought" (13) + "second longer thought." (22)
+    assert result.thinking_chars_total == 13 + 22
+
+
+def test_parse_thinking_supports_text_field_fallback(tmp_path: Path) -> None:
+    """Some emitters use 'text' instead of 'thinking' as the content key."""
+    log = _write_log(
+        tmp_path,
+        [
+            _assistant_turn(
+                input_tokens=1,
+                content=[{"type": "thinking", "text": "via-text-field"}],
+            ),
+        ],
+    )
+    result = _parse_worker_behavior(log)
+    assert result.thinking_blocks == 1
+    assert result.thinking_chars_total == len("via-text-field")
+
+
+# ---------------------------------------------------------------------------
+# Redundant reads (the WOR-355 cap signal)
+# ---------------------------------------------------------------------------
+
+
+def test_parse_redundant_reads_zero_when_each_file_read_at_most_twice(
+    tmp_path: Path,
+) -> None:
+    log = _write_log(
+        tmp_path,
+        [
+            _assistant_turn(
+                input_tokens=1,
+                content=[
+                    {
+                        "type": "tool_use",
+                        "name": "Read",
+                        "input": {"file_path": "a.py"},
+                    },
+                    {
+                        "type": "tool_use",
+                        "name": "Read",
+                        "input": {"file_path": "a.py"},
+                    },
+                    {
+                        "type": "tool_use",
+                        "name": "Read",
+                        "input": {"file_path": "b.py"},
+                    },
+                ],
+            ),
+        ],
+    )
+    result = _parse_worker_behavior(log)
+    assert result.redundant_reads_count == 0
+
+
+def test_parse_redundant_reads_counts_files_over_cap(tmp_path: Path) -> None:
+    """A file read 3+ times in the session counts as one redundant-read offender."""
+    log = _write_log(
+        tmp_path,
+        [
+            _assistant_turn(
+                input_tokens=1,
+                content=[
+                    {
+                        "type": "tool_use",
+                        "name": "Read",
+                        "input": {"file_path": "a.py"},
+                    },
+                    {
+                        "type": "tool_use",
+                        "name": "Read",
+                        "input": {"file_path": "a.py"},
+                    },
+                    {
+                        "type": "tool_use",
+                        "name": "Read",
+                        "input": {"file_path": "a.py"},
+                    },
+                    {
+                        "type": "tool_use",
+                        "name": "Read",
+                        "input": {"file_path": "a.py"},
+                    },
+                    {
+                        "type": "tool_use",
+                        "name": "Read",
+                        "input": {"file_path": "b.py"},
+                    },
+                    {
+                        "type": "tool_use",
+                        "name": "Read",
+                        "input": {"file_path": "b.py"},
+                    },
+                    {
+                        "type": "tool_use",
+                        "name": "Read",
+                        "input": {"file_path": "c.py"},
+                    },
+                    {
+                        "type": "tool_use",
+                        "name": "Read",
+                        "input": {"file_path": "c.py"},
+                    },
+                    {
+                        "type": "tool_use",
+                        "name": "Read",
+                        "input": {"file_path": "c.py"},
+                    },
+                ],
+            ),
+        ],
+    )
+    result = _parse_worker_behavior(log)
+    # a.py (4 reads) and c.py (3 reads) — 2 offenders. b.py (2) is at the cap.
+    assert result.redundant_reads_count == 2
+
+
+def test_parse_redundant_reads_normalizes_windows_paths(tmp_path: Path) -> None:
+    """Mixed slashes for the same logical path collapse to one counter."""
+    log = _write_log(
+        tmp_path,
+        [
+            _assistant_turn(
+                input_tokens=1,
+                content=[
+                    {
+                        "type": "tool_use",
+                        "name": "Read",
+                        "input": {"file_path": "tests\\foo.py"},
+                    },
+                    {
+                        "type": "tool_use",
+                        "name": "Read",
+                        "input": {"file_path": "tests/foo.py"},
+                    },
+                    {
+                        "type": "tool_use",
+                        "name": "Read",
+                        "input": {"file_path": "tests/foo.py"},
+                    },
+                ],
+            ),
+        ],
+    )
+    result = _parse_worker_behavior(log)
+    assert result.redundant_reads_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Robustness
+# ---------------------------------------------------------------------------
+
+
+def test_parse_skips_malformed_json_lines(tmp_path: Path) -> None:
+    """A garbage line doesn't crash the parser; valid lines around it parse."""
+    log = tmp_path / "worker.log"
+    log.write_text(
+        "\n".join(
+            [
+                json.dumps(_assistant_turn(input_tokens=1, output_tokens=1)),
+                "not valid json {",
+                json.dumps(_assistant_turn(input_tokens=2, output_tokens=2)),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    result = _parse_worker_behavior(log)
+    assert result.turn_count == 2
+
+
+def test_parse_treats_missing_input_tokens_gracefully(tmp_path: Path) -> None:
+    """Assistant turns without usage still count as turns; trajectory ignores them."""
+    log = _write_log(
+        tmp_path,
+        [
+            _assistant_turn(),
+            _assistant_turn(input_tokens=500),
+            _assistant_turn(),
+        ],
+    )
+    result = _parse_worker_behavior(log)
+    assert result.turn_count == 3
+    assert result.input_tokens_first == 500
+    assert result.input_tokens_last == 500
+    assert result.input_tokens_max == 500
+
+
+def test_worker_behavior_sentinels_distinguish_unparseable_from_readable() -> None:
+    """The two factory sentinels emit semantically different field values."""
+    unp = WorkerBehavior.empty_unparseable()
+    rdb = WorkerBehavior.empty_readable()
+    assert unp.turn_count is None
+    assert rdb.turn_count == 0
+    assert unp.tool_calls_breakdown is None
+    assert rdb.tool_calls_breakdown == {}
+    assert unp.input_tokens_max is None
+    assert rdb.input_tokens_max is None  # both — readable-empty has no turns


### PR DESCRIPTION
## Summary

Concurrency-safe sibling to WOR-370. The vLLM `/metrics` capture in WOR-370 (PR #754) is gated on solo dispatch because server counters mix concurrent traffic; this PR captures *per-worker* behavior signals from each worker's own stream-json log file, which has no shared-state problem.

Together they answer "why was this run slow?" for both isolated runs (WOR-370) and any-concurrency runs (this PR).

## What gets captured

All from `<worktree>/.claude/worker_<ticket_lower>.log`:

| Field | Meaning |
|---|---|
| `turn_count` | Number of assistant messages |
| `tool_calls_total` | Total `tool_use` blocks |
| `tool_calls_breakdown` | JSON dict by tool name, e.g. `{"Read":7,"Edit":6,"Bash":10}` |
| `thinking_blocks` | Count of `type=thinking` content blocks |
| `thinking_chars_total` | Sum of `len(text)` across thinking blocks |
| `input_tokens_max` | Max `input_tokens` across turns (context-pressure proxy) |
| `input_tokens_first` | `input_tokens` of the first turn |
| `input_tokens_last` | `input_tokens` of the last turn |
| `redundant_reads_count` | Distinct file paths read >2 times (WOR-355 cap signal) |

The redundant-reads field is retro signal: sessions before WOR-371's read-cap hook landed will show >0; sessions after should trend to 0.

## Implementation

- **`app/core/watcher/watcher_helpers.py`** — `WorkerBehavior` class with two factory sentinels (`empty_unparseable()` = all None; `empty_readable()` = all 0/{}). `_parse_worker_behavior()` is a single-pass JSONL parser. Robust against malformed lines and Windows path slashes.
- **`app/core/metrics.py`** — 9 new TicketMetrics fields + matching `ALTER TABLE ADD COLUMN` migrations. All nullable; existing rows unaffected. No backfill.
- **`app/core/watcher/watcher_finalize.py`** — calls `_parse_worker_behavior()` alongside the existing parsers; serializes the breakdown dict to JSON before insert.

## Test plan

- [x] `ruff check .` passes
- [x] `mypy app/` passes (29 source files)
- [x] `lint-imports` passes (5/5 contracts kept)
- [x] `pytest` passes (1277 tests, 13 new)
- [x] Test coverage: missing-log sentinel, empty-log sentinel, no-assistant-events sentinel, turn count + token trajectory, tool count + breakdown bucketing, thinking blocks + char accumulation, `text` field fallback, redundant-reads (under-cap / over-cap / Windows-path normalization), malformed JSON line robustness, missing-usage assistant turns
- [ ] Live verification: dispatch a worker, observe new columns populated in `app.db` via `python -m app.cli metrics browse`

## Cross-links

- WOR-380 (this ticket)
- WOR-370 (PR #754) — sibling: server-side vLLM /metrics, solo-only
- WOR-371 (merged) — read-cap hook; `redundant_reads_count` is a forensic complement
- WOR-368 — direct vLLM path that surfaced thinking-block presence
- `tests/test_worker_behavior_parser.py` — 13 focused tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
