### PR TITLE
WOR-350 README.md: remove stale `rework_events` table reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Module responsibilities:
 - `credentials.py` — GitHub token storage via OS keyring; `GITHUB_TOKEN` env var fallback
 - `manifest.py` — `ExecutionManifest` Pydantic model: cloud→local worker contract; carries `effort` and 7 ticket taxonomy fields
 - `linear_client.py` — thin Linear GraphQL client (stdlib `urllib` only); requires `LINEAR_API_KEY`
-- `metrics.py` — SQLite-backed per-ticket cost and execution metrics; tables `ticket_metrics`, `ticket_run_log`, `check_run_log`, `rework_events`
+- `metrics.py` — SQLite-backed per-ticket cost and execution metrics; tables `ticket_metrics`, `ticket_run_log`, `check_run_log`
 - `bench_store.py` — SQLite-backed benchmark run records store (shares `app.db` with `metrics.py`)
 - `escalation_policy.py` — loads `config/escalation_policy.toml`, classifies failures into watcher actions
 - `watcher/` — orchestrator subpackage (`app/core/watcher/`):


### PR DESCRIPTION
Closes WOR-350

Remove the stale `, rework_events` reference from README.md line 88. The table doesn't exist; CLAUDE.md is already correct. One-line diff.