### PR TITLE
WOR-340 SonarCloud bundle X1: cli.py mechanical sweep — 5 findings (S7508/S7516/S1172)

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Module responsibilities:
 - `credentials.py` — GitHub token storage via OS keyring; `GITHUB_TOKEN` env var fallback
 - `manifest.py` — `ExecutionManifest` Pydantic model: cloud→local worker contract; carries `effort` and 7 ticket taxonomy fields
 - `linear_client.py` — thin Linear GraphQL client (stdlib `urllib` only); requires `LINEAR_API_KEY`
-- `metrics.py` — SQLite-backed per-ticket cost and execution metrics; tables `ticket_metrics`, `ticket_run_log`, `check_run_log`, `rework_events`
+- `metrics.py` — SQLite-backed per-ticket cost and execution metrics; tables `ticket_metrics`, `ticket_run_log`, `check_run_log`
 - `bench_store.py` — SQLite-backed benchmark run records store (shares `app.db` with `metrics.py`)
 - `escalation_policy.py` — loads `config/escalation_policy.toml`, classifies failures into watcher actions
 - `watcher/` — orchestrator subpackage (`app/core/watcher/`):

--- a/app/cli.py
+++ b/app/cli.py
@@ -45,7 +45,7 @@ def _build_parser() -> argparse.ArgumentParser:
     cfg_set = cfg_sub.add_parser("set", help="Set a preference value.")
     cfg_set.add_argument(
         "key",
-        choices=set(sorted(_KEY_TO_FIELD)) | {"github-token"},
+        choices=set(_KEY_TO_FIELD) | {"github-token"},
         help="Preference key (use hyphens, e.g. author-name).",
     )
     cfg_set.add_argument("value", nargs="?", default=None, help="Value to store.")
@@ -53,7 +53,7 @@ def _build_parser() -> argparse.ArgumentParser:
     cfg_del = cfg_sub.add_parser("delete", help="Delete a credential.")
     cfg_del.add_argument(
         "key",
-        choices=set(sorted(_KEY_TO_FIELD)) | {"github-token"},
+        choices=set(_KEY_TO_FIELD) | {"github-token"},
         help="Credential key to delete.",
     )
 
@@ -275,13 +275,12 @@ def _run_watcher(args: argparse.Namespace) -> int:
     return 0
 
 
-def _run_watcher_softstop(args: argparse.Namespace) -> int:
+def _run_watcher_softstop(_args: argparse.Namespace) -> int:
     """Write the soft-stop sentinel so the daemon enters drain mode (WOR-333).
 
     Daemon polls .claude/watcher.softstop each cycle: if present, it stops
     accepting new dispatches, finishes in-flight workers, then exits cleanly.
     """
-    del args  # no flags
     claude_dir = Path.cwd() / ".claude"
     pid_file = claude_dir / "watcher.pid"
     sentinel = claude_dir / "watcher.softstop"


### PR DESCRIPTION
Closes WOR-340

Resolve 5 mechanical SonarCloud findings in app/cli.py: lines 48 + 56 (paired S7516/S7508 — redundant set()/sorted() calls) and line 292 (S1172 unused `args` parameter). Pure mechanical cleanup, no be