### PR TITLE
WOR-388: raise stuck-worker heartbeat threshold from 15 to 90 min

### DIFF
--- a/app/core/watcher/watcher.py
+++ b/app/core/watcher/watcher.py
@@ -59,16 +59,33 @@ from .watcher_worktrees import (
 
 logger = logging.getLogger(__name__)
 
-# WOR-381: heartbeat-based stuck-worker detection. The metric is "time since
-# the worker's stream-json log file was last written" — a stuck worker
-# (network hang, deadlocked vLLM, infinite tool-result wait) does not emit
-# new lines, while a slow-but-progressing worker keeps writing. Wall-time
-# bounds proved unworkable: app.db's 33-session distribution shows median
-# 43.7 min and p99 171 min for legitimate runs, so any wall-time threshold
-# either fires on real work or misses real hangs. 15 minutes of log silence
-# is a strong signal that the model is stuck — even multi-step tool calls
-# (pytest, mypy, large diffs) emit progress within minutes.
-_WORKER_HEARTBEAT_TIMEOUT_SECONDS = 15 * 60
+# WOR-381 + WOR-388: heartbeat-based stuck-worker detection. The metric is
+# "time since the worker's stream-json log file was last written" — a stuck
+# worker (network hang, deadlocked vLLM, infinite tool-result wait) does not
+# emit new lines, while a slow-but-progressing worker keeps writing.
+# Wall-time bounds proved unworkable: app.db's 33-session distribution shows
+# median 43.7 min and p99 171 min for legitimate runs, so any wall-time
+# threshold either fires on real work or misses real hangs.
+#
+# WOR-388 post-mortem (2026-05-05): the original 15-min threshold killed
+# WOR-369 (23m wall, 1.3M input) and WOR-362 (26m wall, 2.7M input)
+# mid-decode after their last log event. Both were legitimately reasoning —
+# log tails ended mid-Read tool-result with no `"type":"result"` event, and
+# both artifacts ended up tagged `no_diff_against_base` because the kill
+# preceded the worker's edit phase. Single-decode silences of 15-30 min are
+# plausible for effort=high refactor sessions on qwen3-coder when extended-
+# thinking blocks run long. Threshold raised to 90 min — well above any
+# legitimate single-event-gap we have forensic evidence for (the WOR-322
+# 76-min total run had no individual gap exceeding ~10 min). 90 min still
+# catches genuinely-stuck workers within a single overnight cycle. Override
+# at launch with WATCHER_WORKER_HEARTBEAT_TIMEOUT_SECONDS=N for tuning.
+_DEFAULT_HEARTBEAT_TIMEOUT_SECONDS = 90 * 60
+_WORKER_HEARTBEAT_TIMEOUT_SECONDS = int(
+    os.environ.get(
+        "WATCHER_WORKER_HEARTBEAT_TIMEOUT_SECONDS",
+        _DEFAULT_HEARTBEAT_TIMEOUT_SECONDS,
+    )
+)
 _WORKER_KILL_GRACE_SECONDS = 5 * 60
 
 

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -19,7 +19,11 @@ import pytest
 
 from app.core.linear_client import LinearError
 from app.core.manifest import ArtifactPaths, ExecutionManifest
-from app.core.watcher.watcher import Watcher, _ProcessedTicket
+from app.core.watcher.watcher import (
+    _WORKER_HEARTBEAT_TIMEOUT_SECONDS,
+    Watcher,
+    _ProcessedTicket,
+)
 from app.core.watcher.watcher_types import ActiveWorker
 
 # ---------------------------------------------------------------------------
@@ -1282,9 +1286,28 @@ def _stuck_worker(
 
 
 def test_terminate_overrun_no_op_when_log_fresh(tmp_path: Path) -> None:
-    """A worker whose log was written 5 minutes ago is left alone (under 15-min cap)."""
+    """Log written 5 min ago is left alone (under heartbeat threshold)."""
     w = Watcher(linear_client=MagicMock(), repo_root=tmp_path)
     worker = _stuck_worker(tmp_path, log_idle_secs=5 * 60)
+    w._local_active.append(worker)
+
+    w._terminate_overrun_workers()
+
+    worker.process.terminate.assert_not_called()
+    worker.process.kill.assert_not_called()
+    assert worker.terminated_at is None
+
+
+def test_terminate_overrun_no_op_below_threshold_with_long_decode(
+    tmp_path: Path,
+) -> None:
+    """WOR-388 regression: a worker silent for 30 min (long extended-thinking decode)
+    is NOT killed under the post-WOR-388 90-min threshold. Pre-WOR-388 (15-min cap)
+    this would have triggered SIGTERM and lost the legitimate work — exactly the
+    failure mode that destroyed WOR-369 + WOR-362 on the WOR-383 batch."""
+    w = Watcher(linear_client=MagicMock(), repo_root=tmp_path)
+    # 30 min idle: well past the old 15-min threshold, well under the new 90-min one.
+    worker = _stuck_worker(tmp_path, log_idle_secs=30 * 60)
     w._local_active.append(worker)
 
     w._terminate_overrun_workers()
@@ -1307,9 +1330,13 @@ def test_terminate_overrun_no_op_when_log_missing(tmp_path: Path) -> None:
 
 
 def test_terminate_overrun_sigterm_when_log_idle_past_threshold(tmp_path: Path) -> None:
-    """Log idle > 15 min triggers SIGTERM."""
+    """Log idle > heartbeat threshold triggers SIGTERM."""
     w = Watcher(linear_client=MagicMock(), repo_root=tmp_path)
-    worker = _stuck_worker(tmp_path, log_idle_secs=16 * 60)  # over 15-min threshold
+    # One minute past whatever the threshold is at runtime — keeps test self-tuning
+    # if the constant changes again (per WOR-388 forensic).
+    worker = _stuck_worker(
+        tmp_path, log_idle_secs=_WORKER_HEARTBEAT_TIMEOUT_SECONDS + 60
+    )
     w._local_active.append(worker)
 
     w._terminate_overrun_workers()
@@ -1322,7 +1349,9 @@ def test_terminate_overrun_sigterm_when_log_idle_past_threshold(tmp_path: Path) 
 def test_terminate_overrun_sigterm_only_once(tmp_path: Path) -> None:
     """Repeated calls do not re-SIGTERM after the first one."""
     w = Watcher(linear_client=MagicMock(), repo_root=tmp_path)
-    worker = _stuck_worker(tmp_path, log_idle_secs=20 * 60)
+    worker = _stuck_worker(
+        tmp_path, log_idle_secs=_WORKER_HEARTBEAT_TIMEOUT_SECONDS + 60
+    )
     w._local_active.append(worker)
 
     w._terminate_overrun_workers()
@@ -1341,7 +1370,7 @@ def test_terminate_overrun_sigkill_after_grace(tmp_path: Path) -> None:
     w = Watcher(linear_client=linear, repo_root=tmp_path)
     worker = _stuck_worker(
         tmp_path,
-        log_idle_secs=20 * 60,
+        log_idle_secs=_WORKER_HEARTBEAT_TIMEOUT_SECONDS + 60,
         terminated_at=_time.time() - 6 * 60,
     )
     w._local_active.append(worker)
@@ -1363,7 +1392,7 @@ def test_terminate_overrun_no_sigkill_within_grace(tmp_path: Path) -> None:
     w = Watcher(linear_client=MagicMock(), repo_root=tmp_path)
     worker = _stuck_worker(
         tmp_path,
-        log_idle_secs=18 * 60,
+        log_idle_secs=_WORKER_HEARTBEAT_TIMEOUT_SECONDS + 60,
         terminated_at=_time.time() - 2 * 60,
     )
     w._local_active.append(worker)
@@ -1376,7 +1405,9 @@ def test_terminate_overrun_no_sigkill_within_grace(tmp_path: Path) -> None:
 def test_terminate_overrun_skips_already_exited(tmp_path: Path) -> None:
     """A worker whose process has exited (poll != None) is not signalled."""
     w = Watcher(linear_client=MagicMock(), repo_root=tmp_path)
-    worker = _stuck_worker(tmp_path, log_idle_secs=20 * 60)
+    worker = _stuck_worker(
+        tmp_path, log_idle_secs=_WORKER_HEARTBEAT_TIMEOUT_SECONDS + 60
+    )
     worker.process.poll.return_value = 0
     w._local_active.append(worker)
 
@@ -1389,7 +1420,9 @@ def test_terminate_overrun_skips_already_exited(tmp_path: Path) -> None:
 def test_terminate_overrun_handles_terminate_oserror(tmp_path: Path) -> None:
     """OSError from terminate() doesn't loop us into retrying."""
     w = Watcher(linear_client=MagicMock(), repo_root=tmp_path)
-    worker = _stuck_worker(tmp_path, log_idle_secs=20 * 60)
+    worker = _stuck_worker(
+        tmp_path, log_idle_secs=_WORKER_HEARTBEAT_TIMEOUT_SECONDS + 60
+    )
     worker.process.terminate.side_effect = OSError("no such process")
     w._local_active.append(worker)
 
@@ -1401,8 +1434,16 @@ def test_terminate_overrun_handles_terminate_oserror(tmp_path: Path) -> None:
 def test_terminate_overrun_covers_both_pools(tmp_path: Path) -> None:
     """Both _local_active and _cloud_active are scanned."""
     w = Watcher(linear_client=MagicMock(), repo_root=tmp_path)
-    local_worker = _stuck_worker(tmp_path, ticket_id="WOR-100", log_idle_secs=20 * 60)
-    cloud_worker = _stuck_worker(tmp_path, ticket_id="WOR-101", log_idle_secs=20 * 60)
+    local_worker = _stuck_worker(
+        tmp_path,
+        ticket_id="WOR-100",
+        log_idle_secs=_WORKER_HEARTBEAT_TIMEOUT_SECONDS + 60,
+    )
+    cloud_worker = _stuck_worker(
+        tmp_path,
+        ticket_id="WOR-101",
+        log_idle_secs=_WORKER_HEARTBEAT_TIMEOUT_SECONDS + 60,
+    )
     w._local_active.append(local_worker)
     w._cloud_active.append(cloud_worker)
 


### PR DESCRIPTION
## Summary

Fixes the WOR-381 heartbeat-based stuck-worker detector from killing legitimate long-running workers mid-decode. Raises the silence-threshold from 15 → 90 min.

## Forensic (the WOR-383 batch)

```
WOR-369  wall=23m  in_tok=1.3M  ended mid-Read tool-result, no result event
WOR-362  wall=26m  in_tok=2.7M  ended mid-Read tool-result, no result event
```

Both workers were **actively progressing** — last log events are successful tool_results. Both were SIGTERM'd at the 15-min idle mark, then SIGKILL'd 5 min later by `_terminate_overrun_workers`. The watcher then computed empty diffs and tagged each `no_diff_against_base` — a misleading symptom; the workers never reached the edit phase before being killed.

Single-decode silences of 15-30 min are plausible for `effort=high` refactor sessions on qwen3-coder when extended-thinking blocks run long. WOR-322's 76-min total run had no individual gap exceeding ~10 min, so 90 min is well above any legitimate single-event-gap in our forensic record.

## Changes

- `app/core/watcher/watcher.py` — `_WORKER_HEARTBEAT_TIMEOUT_SECONDS` raised from 15→90 min, exposed as env-var override `WATCHER_WORKER_HEARTBEAT_TIMEOUT_SECONDS` for runtime tuning. Comment block extended with the WOR-388 post-mortem.
- `tests/test_watcher.py` — 5 existing tests refactored to reference the constant directly so they remain self-tuning if the threshold changes again. New test `test_terminate_overrun_no_op_below_threshold_with_long_decode` pins the exact WOR-369/362 failure mode: a 30-min-idle worker MUST NOT be killed.

## Test plan

- [x] All 10 `test_terminate_overrun_*` tests pass
- [x] Full pytest (1278 tests) pass
- [x] ruff check + ruff format clean
- [x] mypy clean
- [x] lint-imports clean
- [x] Existing kill semantics preserved (SIGTERM → 5-min grace → SIGKILL → Linear comment)

## Out of scope

- The metrics regression (`local_output_tokens=0`, `vllm_*` NULL) is tracked separately in WOR-384
- The `tags: ["killed_by_watcher_heartbeat"]` augmentation suggested in WOR-388's AC is deferred — the no_diff tag still fires, just less often now that fewer workers get killed mid-decode

Closes WOR-388

🤖 Generated with [Claude Code](https://claude.com/claude-code)