### PR TITLE
WOR-69 Add pytest-qt and pytest-snapshot to dev dependencies

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Force LF line endings for test snapshot files (Python-generated, LF-only)
+tests/snapshots/** text eol=lf

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,7 @@ repos:
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
+        exclude: tests/snapshots/
       - id: check-yaml
       - id: check-toml
       - id: check-merge-conflict

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,4 +9,6 @@ detect-secrets>=1.4
 deptry>=0.12
 import-linter>=2.0
 mypy>=1.0
+pytest-qt>=4.0
+pytest-snapshot>=0.9
 datasette>=0.64

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,8 +6,30 @@ import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock
 
+import pytest
+
 from app.core.manifest import ArtifactPaths, ExecutionManifest
 from app.core.watcher.watcher_types import ActiveWorker
+
+
+# Session-scoped QApplication fixture (pytest-qt)
+@pytest.fixture(scope="session")
+def qapp():
+    """Create a single QApplication instance for the test session.
+
+    Guards against missing Qt so the fixture skips gracefully when
+    pytest-qt is not installed in the dev environment.
+    """
+    try:
+        from PySide6.QtWidgets import QApplication
+    except ImportError:
+        pytest.skip("PySide6 not installed — Qt fixture unavailable")
+
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    yield app
+    app.quit()
 
 
 def make_manifest(**overrides: object) -> ExecutionManifest:

--- a/tests/snapshots/test_generator/test_preset_file_trees/full_agentic-my-agentic-project/full_agentic_files
+++ b/tests/snapshots/test_generator/test_preset_file_trees/full_agentic-my-agentic-project/full_agentic_files
@@ -1,0 +1,10 @@
+[
+  ".claude/settings.json",
+  ".gitignore",
+  ".mcp.json",
+  "CLAUDE.md",
+  "README.md",
+  "app/__init__.py",
+  "pyproject.toml",
+  "tests/__init__.py"
+]

--- a/tests/snapshots/test_generator/test_preset_file_trees/python_basic-my-project/python_basic_files
+++ b/tests/snapshots/test_generator/test_preset_file_trees/python_basic-my-project/python_basic_files
@@ -1,0 +1,7 @@
+[
+  ".gitignore",
+  "README.md",
+  "app/__init__.py",
+  "pyproject.toml",
+  "tests/__init__.py"
+]

--- a/tests/snapshots/test_generator/test_preset_file_trees/python_desktop-my-desktop-app/python_desktop_files
+++ b/tests/snapshots/test_generator/test_preset_file_trees/python_desktop-my-desktop-app/python_desktop_files
@@ -1,0 +1,11 @@
+[
+  ".gitignore",
+  "README.md",
+  "app/__init__.py",
+  "app/main.py",
+  "app/ui/__init__.py",
+  "pyproject.toml",
+  "tests/__init__.py",
+  "tests/conftest.py",
+  "tests/test_ui_smoke.py"
+]

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -549,3 +549,25 @@ def test_playwright_deps_absent_when_disabled(output_dir):
     generate(config, output_dir)
     content = (output_dir / "pyproject.toml").read_text(encoding="utf-8")
     assert "playwright" not in content
+
+
+# ── Snapshot tests ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "preset,repo_name",
+    [
+        ("python_basic", "my-project"),
+        ("python_desktop", "my-desktop-app"),
+        ("full_agentic", "my-agentic-project"),
+    ],
+)
+def test_preset_file_trees(snapshot, repo_name, preset, tmp_path):
+    """Snapshot each preset's generated file tree to catch regressions."""
+    config = RepoConfig(repo_name=repo_name, preset=preset)
+    generated = generate(config, tmp_path)
+    # Snapshot just the file-list (relative paths) as JSON for a stable comparison
+    snapshot.assert_match(
+        json.dumps(sorted(generated), indent=2, sort_keys=True),
+        f"{preset}_files",
+    )


### PR DESCRIPTION
Closes WOR-69

Add pytest-qt>=4.0 and pytest-snapshot>=0.9 to requirements-dev.txt. Add session-scoped QApplication fixture to tests/conftest.py. Add snapshot tests to tests/test_generator.py for all preset file tre