### PR TITLE
Fix WOR-130 test broken by WOR-343 sibling merge — wave-2 unblocker

### DIFF
--- a/tests/test_watcher_integration.py
+++ b/tests/test_watcher_integration.py
@@ -166,9 +166,10 @@ def test_finalize_worker_happy_path_all_enriched_fields(
     # 6) pr_url set — confirmed by create_pr being called (checked above)
     # The pr_url is not returned by finalize_worker, but create_pr was called
     # which only happens in the success path of attempt_pr.
-    # We verify the PR URL flows through by checking linear mock was NOT called
-    # with set_state (success path does not change state).
-    linear_mock.set_state.assert_not_called()
+    # We verify the PR URL flows through by checking linear mock was called
+    # exactly once with the WOR-343 branch-aware MergedToEpic transition
+    # (non-main base_branch → "MergedToEpic"; the manifest's base is the epic).
+    linear_mock.set_state.assert_called_once_with("fake-linear-id", "MergedToEpic")
 
 
 def test_finalize_worker_pr_url_via_attempt_pr_direct(


### PR DESCRIPTION
## Summary

**Root cause of the wave-2 disaster.** WOR-130's integration test was written based on the pre-WOR-343 finalize_worker semantics, asserting `linear_mock.set_state.assert_not_called()`. But WOR-343 (PR #765) added a branch-aware state setter that calls `set_state("MergedToEpic")` for epic-targeting workers. The two PRs merged in the wrong order — their interaction was never tested together.

The epic branch has been failing `test_finalize_worker_happy_path_all_enriched_fields` ever since WOR-130 merged.

## Wave-2 forensic

5 of 6 dispatched tickets blocked because:
1. Watcher's `required_checks` step ran unscoped pytest (correct WOR-353 behavior)
2. Pytest hit this pre-existing failure
3. Workers correctly identified it as pre-existing but wrote `result.json: status=success` anyway (the WOR-389 pattern)
4. Watcher invalidated the success on its own pytest run

```
WOR-135 worker last assistant: "All required checks pass... One pre-existing failure
                                  in test_watcher_integration.py is unrelated to this ticket"
```

The worker was technically correct — the failure WAS pre-existing.

## Fix

```diff
-    linear_mock.set_state.assert_not_called()
+    linear_mock.set_state.assert_called_once_with("fake-linear-id", "MergedToEpic")
```

Updates the test to match the post-WOR-343 reality.

## Test plan

- [x] `pytest tests/test_watcher_integration.py` — 2 passed
- [x] Full pytest (1282 tests) — all pass
- [x] ruff / mypy / lint-imports / pre-commit clean

## After this lands

The 5 blocked wave-2 tickets (WOR-369, WOR-362, WOR-245, WOR-135, WOR-68) can be reset to ReadyForLocal and re-dispatched. Their workers will run pytest cleanly.

WOR-389 (worker discipline / Stop hook) is still valuable defense-in-depth for FUTURE pre-existing-failure cases, but is no longer load-bearing for THIS batch.

Part of WOR-383

🤖 Generated with [Claude Code](https://claude.com/claude-code)