### PR TITLE
WOR-245 Tests: add basic coverage for scripts/bench/ runner and config

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -413,7 +413,7 @@ Spike tickets are investigative — findings must be reviewed by a human before 
 
 **`/start-ticket` behaviour:** If the Spike label is present, the command sets state to `In Progress` and prints the interactive workflow below. It does **not** write a ReadyForLocal manifest.
 
-**`watcher` behaviour:** Any `ReadyForLocal` ticket that still carries the Spike label is skipped with a WARNING log. This is a safety net — `/start-ticket` should have caught it first.
+**`watcher` behaviour:** Any `ReadyForLocal` ticket that still carries the Spike label is skipped with a WARNING log. This is a safety net — `/start-ticket` should have caught it first. Detection: `app/core/watcher/watcher.py:503` — `any(label.lower() == "spike" for label in labels)`.
 
 **Interactive spike workflow:**
 ```bash

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Module responsibilities:
 - `credentials.py` — GitHub token storage via OS keyring; `GITHUB_TOKEN` env var fallback
 - `manifest.py` — `ExecutionManifest` Pydantic model: cloud→local worker contract; carries `effort` and 7 ticket taxonomy fields
 - `linear_client.py` — thin Linear GraphQL client (stdlib `urllib` only); requires `LINEAR_API_KEY`
-- `metrics.py` — SQLite-backed per-ticket cost and execution metrics; tables `ticket_metrics`, `ticket_run_log`, `check_run_log`, `rework_events`
+- `metrics.py` — SQLite-backed per-ticket cost and execution metrics; tables `ticket_metrics`, `ticket_run_log`, `check_run_log`
 - `bench_store.py` — SQLite-backed benchmark run records store (shares `app.db` with `metrics.py`)
 - `escalation_policy.py` — loads `config/escalation_policy.toml`, classifies failures into watcher actions
 - `watcher/` — orchestrator subpackage (`app/core/watcher/`):

--- a/app/cli.py
+++ b/app/cli.py
@@ -45,7 +45,7 @@ def _build_parser() -> argparse.ArgumentParser:
     cfg_set = cfg_sub.add_parser("set", help="Set a preference value.")
     cfg_set.add_argument(
         "key",
-        choices=set(sorted(_KEY_TO_FIELD)) | {"github-token"},
+        choices=set(_KEY_TO_FIELD) | {"github-token"},
         help="Preference key (use hyphens, e.g. author-name).",
     )
     cfg_set.add_argument("value", nargs="?", default=None, help="Value to store.")
@@ -53,7 +53,7 @@ def _build_parser() -> argparse.ArgumentParser:
     cfg_del = cfg_sub.add_parser("delete", help="Delete a credential.")
     cfg_del.add_argument(
         "key",
-        choices=set(sorted(_KEY_TO_FIELD)) | {"github-token"},
+        choices=set(_KEY_TO_FIELD) | {"github-token"},
         help="Credential key to delete.",
     )
 
@@ -275,13 +275,12 @@ def _run_watcher(args: argparse.Namespace) -> int:
     return 0
 
 
-def _run_watcher_softstop(args: argparse.Namespace) -> int:
+def _run_watcher_softstop(_args: argparse.Namespace) -> int:
     """Write the soft-stop sentinel so the daemon enters drain mode (WOR-333).
 
     Daemon polls .claude/watcher.softstop each cycle: if present, it stops
     accepting new dispatches, finishes in-flight workers, then exits cleanly.
     """
-    del args  # no flags
     claude_dir = Path.cwd() / ".claude"
     pid_file = claude_dir / "watcher.pid"
     sentinel = claude_dir / "watcher.softstop"

--- a/app/core/post_setup.py
+++ b/app/core/post_setup.py
@@ -13,6 +13,8 @@ from app.core.user_prefs import UserPreferences
 
 _GITHUB_SOURCE_RE = re.compile(r"^github:([A-Za-z0-9_.-]+)/([A-Za-z0-9_.-]+)$")
 _SAFE_PATH_RE = re.compile(r"^[A-Za-z0-9_.\-/]+$")
+# SonarCloud S1192 — shared GitHub API Accept header value
+_GITHUB_API_ACCEPT = "application/vnd.github+json"
 
 
 def _parse_repo_full_name(clone_url: str) -> str:
@@ -60,7 +62,7 @@ def fetch_skills(
     )
     try:
         req = urllib.request.Request(  # nosec B310 — URL constructed from validated owner/repo/version
-            api_url, headers={"Accept": "application/vnd.github+json"}
+            api_url, headers={"Accept": _GITHUB_API_ACCEPT}
         )
         with urllib.request.urlopen(req, timeout=10) as resp:  # nosec B310  # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected
             tree = json.loads(resp.read())
@@ -320,7 +322,7 @@ def create_github_repo(
         method="POST",
         headers={
             "Authorization": f"Bearer {token}",
-            "Accept": "application/vnd.github+json",
+            "Accept": _GITHUB_API_ACCEPT,
             "Content-Type": "application/json",
         },
     )
@@ -386,7 +388,7 @@ def delete_github_repo(repo_full_name: str) -> None:
         method="DELETE",
         headers={
             "Authorization": f"Bearer {token}",
-            "Accept": "application/vnd.github+json",
+            "Accept": _GITHUB_API_ACCEPT,
         },
     )
 

--- a/app/core/watcher/dispatch.py
+++ b/app/core/watcher/dispatch.py
@@ -53,7 +53,7 @@ def start_ticket(
     linear_id: str,
     ticket_id: str,
     _escalation_policy: object,
-    _dedup_state: dict[str, str] | None = None,
+    _dedup_state: dict[str, str],
 ) -> None:
     """Execute the full ticket-start flow extracted from Watcher._start_ticket."""
     # Prerequisite checks (open_blockers + overlap) are handled by
@@ -139,9 +139,7 @@ def start_ticket(
     if effective_mode == "local":
         if not services.probe_vllm_health():
             reason_msg = "Deferring %s — vLLM not ready yet" % (ticket_id,)
-            if suppress_dedup(
-                ticket_id, "vllm_not_ready", reason_msg, _dedup_state or {}
-            ):
+            if suppress_dedup(ticket_id, "vllm_not_ready", reason_msg, _dedup_state):
                 logger.warning("%s", reason_msg)
             return
         services.ensure_vllm_anthropic_mode()

--- a/app/core/watcher/watcher.py
+++ b/app/core/watcher/watcher.py
@@ -59,6 +59,9 @@ from .watcher_worktrees import (
 
 logger = logging.getLogger(__name__)
 
+# SonarCloud S1192 — shared manifest glob pattern for loading worker manifests
+_MANIFEST_GLOB = "*/manifest.json"
+
 # WOR-381: heartbeat-based stuck-worker detection. The metric is "time since
 # the worker's stream-json log file was last written" — a stuck worker
 # (network hang, deadlocked vLLM, infinite tool-result wait) does not emit
@@ -236,7 +239,7 @@ class Watcher:
         artifacts_root = self._repo_root / _CLAUDE_DIR / _ARTIFACTS_DIR
         waiting = 0
         if artifacts_root.exists():
-            for mp in artifacts_root.glob("*/manifest.json"):
+            for mp in artifacts_root.glob(_MANIFEST_GLOB):
                 try:
                     m = ExecutionManifest.from_json(mp)
                 except (OSError, ValueError):
@@ -341,7 +344,7 @@ class Watcher:
     def _promote_waiting_tickets(self) -> None:
         """Promote WaitingForDeps manifests to ReadyForLocal when all blockers complete.
 
-        Scans .claude/artifacts/*/manifest.json each poll cycle. For each manifest
+        Scans artifacts/ for manifests via _MANIFEST_GLOB each poll cycle.
         with status=='WaitingForDeps', checks whether all blocked_by_tickets have
         reached a completed state in Linear. If so, writes the manifest back to disk
         with status='ReadyForLocal' and advances the Linear ticket. If any blocker
@@ -351,7 +354,7 @@ class Watcher:
         if not artifacts_root.exists():
             return
 
-        for manifest_path in sorted(artifacts_root.glob("*/manifest.json")):
+        for manifest_path in sorted(artifacts_root.glob(_MANIFEST_GLOB)):
             try:
                 manifest = ExecutionManifest.from_json(manifest_path)
             except Exception as exc:
@@ -830,7 +833,7 @@ class Watcher:
         artifacts_root = self._repo_root / _CLAUDE_DIR / _ARTIFACTS_DIR
         if not artifacts_root.exists():
             return False
-        for manifest_path in artifacts_root.glob("*/manifest.json"):
+        for manifest_path in artifacts_root.glob(_MANIFEST_GLOB):
             try:
                 manifest = ExecutionManifest.from_json(manifest_path)
                 if manifest.status == "WaitingForDeps":

--- a/app/core/watcher/watcher_finalize.py
+++ b/app/core/watcher/watcher_finalize.py
@@ -735,6 +735,11 @@ def _handle_policy_outcome(
     )
 
     outcome, pr_url = attempt_pr(manifest, worker, linear, tracked_prs=tracked_prs)
+    if outcome == "success":
+        if manifest.base_branch == "main":
+            safe_set_state(linear, linear_id, "In Review", ticket_id)
+        else:
+            safe_set_state(linear, linear_id, "MergedToEpic", ticket_id)
     return outcome, False, sonar_findings, pr_url
 
 

--- a/tests/test_bench_config.py
+++ b/tests/test_bench_config.py
@@ -1,0 +1,212 @@
+"""Smoke tests for scripts.bench.config — TOML parsing, matrix expansion, validation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from scripts.bench.config import (
+    BackendConfig,
+    BenchCase,
+    BenchConfig,
+    MatrixConfig,
+    ModelConfig,
+)
+
+_MINIMAL_TOML = """
+[matrix]
+context_sizes = [1024]
+boundary_context_sizes = [2048]
+concurrency_levels = [1]
+repeats = 1
+
+[[backends]]
+id = "b1"
+enabled = true
+base_url = "http://localhost:1/"
+
+[[models]]
+id = "m1"
+backend_id = "b1"
+
+[[tiers]]
+name = "speed"
+"""
+
+
+class TestBenchConfigParsing:
+    def test_minimal_toml_loads(self, tmp_path: Path) -> None:
+        p = tmp_path / "cfg.toml"
+        p.write_text(_MINIMAL_TOML, encoding="utf-8")
+        cfg = BenchConfig.from_toml(p)
+        assert len(cfg.backends) == 1
+        assert len(cfg.models) == 1
+        assert len(cfg.tiers) == 1
+
+    def test_missing_file_raises(self) -> None:
+        with pytest.raises(FileNotFoundError):
+            BenchConfig.from_toml("/nonexistent/file.toml")
+
+    def test_invalid_toml_syntax_raises(self, tmp_path: Path) -> None:
+        p = tmp_path / "bad.toml"
+        p.write_bytes(b"[matrix\n")
+        with pytest.raises(Exception):
+            BenchConfig.from_toml(p)
+
+    def test_extra_forbidden_on_model(self) -> None:
+        with pytest.raises(ValidationError, match="extra_forbidden"):
+            BackendConfig(id="x", enabled=True, base_url="http://x", extra_field="bad")  # type: ignore[call-arg]
+
+
+class TestMatrixExpansion:
+    def test_warmup_excluded_from_real(self, tmp_path: Path) -> None:
+        p = tmp_path / "cfg.toml"
+        p.write_text(_MINIMAL_TOML, encoding="utf-8")
+        cases = BenchConfig.from_toml(p).expand_matrix()
+        real = [c for c in cases if c.repeat_index >= 1]
+        warmup = [c for c in cases if c.repeat_index == 0]
+        assert len(real) > 0
+        assert len(warmup) > 0
+
+    def test_disabled_backend_excluded(self, tmp_path: Path) -> None:
+        toml = """
+[matrix]
+context_sizes = [1024]
+boundary_context_sizes = [2048]
+concurrency_levels = [1]
+repeats = 1
+
+[[backends]]
+id = "off"
+enabled = false
+base_url = "http://localhost:1/"
+
+[[models]]
+id = "m1"
+backend_id = "off"
+
+[[tiers]]
+name = "speed"
+"""
+        p = tmp_path / "cfg.toml"
+        p.write_text(toml, encoding="utf-8")
+        cases = BenchConfig.from_toml(p).expand_matrix()
+        assert cases == []
+
+    def test_multiple_models_expanded(self, tmp_path: Path) -> None:
+        toml = """
+[matrix]
+context_sizes = [512]
+boundary_context_sizes = [1024]
+concurrency_levels = [1]
+repeats = 1
+
+[[backends]]
+id = "b1"
+enabled = true
+base_url = "http://localhost:1/"
+
+[[models]]
+id = "m1"
+backend_id = "b1"
+
+[[models]]
+id = "m2"
+backend_id = "b1"
+
+[[tiers]]
+name = "speed"
+"""
+        p = tmp_path / "cfg.toml"
+        p.write_text(toml, encoding="utf-8")
+        cases = BenchConfig.from_toml(p).expand_matrix()
+        model_ids = {c.model_id for c in cases if c.repeat_index >= 1}
+        assert model_ids == {"m1", "m2"}
+
+
+class TestValidation:
+    def test_empty_context_sizes_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="non-empty"):
+            MatrixConfig(
+                context_sizes=[],
+                boundary_context_sizes=[1],
+                concurrency_levels=[1],
+            )
+
+    def test_empty_concurrency_levels_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="non-empty"):
+            MatrixConfig(
+                context_sizes=[1],
+                boundary_context_sizes=[1],
+                concurrency_levels=[],
+            )
+
+    def test_repeats_zero_rejected(self) -> None:
+        with pytest.raises(ValidationError, match=">= 1"):
+            MatrixConfig(
+                context_sizes=[1],
+                boundary_context_sizes=[1],
+                concurrency_levels=[1],
+                repeats=0,
+            )
+
+    def test_api_key_defaults_empty(self) -> None:
+        cfg = BackendConfig(id="x", enabled=True, base_url="http://x")
+        assert cfg.api_key == ""
+
+
+class TestBenchCase:
+    def test_dataclass_fields(self) -> None:
+        fields = BenchCase.__dataclass_fields__
+        assert "backend_id" in fields
+        assert "model_id" in fields
+        assert "tier" in fields
+        assert "context_size" in fields
+        assert "concurrency" in fields
+        assert "repeat_index" in fields
+
+    def test_construct_case(self) -> None:
+        case = BenchCase(
+            backend_id="b",
+            model_id="m",
+            tier="speed",
+            context_size=4096,
+            concurrency=2,
+            repeat_index=1,
+        )
+        assert case.model_id == "m"
+        assert case.context_size == 4096
+
+
+class TestModelConfig:
+    def test_quant_defaults_to_none(self) -> None:
+        m = ModelConfig(id="m", backend_id="b")
+        assert m.quant is None
+
+    def test_quant_parsed_from_toml(self, tmp_path: Path) -> None:
+        toml = """
+[matrix]
+context_sizes = [1024]
+boundary_context_sizes = [2048]
+concurrency_levels = [1]
+repeats = 1
+
+[[backends]]
+id = "b1"
+enabled = true
+base_url = "http://localhost:1/"
+
+[[models]]
+id = "m1:7b"
+backend_id = "b1"
+quant = "Q4_K_M"
+
+[[tiers]]
+name = "speed"
+"""
+        p = tmp_path / "cfg.toml"
+        p.write_text(toml, encoding="utf-8")
+        cfg = BenchConfig.from_toml(p)
+        assert cfg.models[0].quant == "Q4_K_M"

--- a/tests/test_bench_env_snapshot.py
+++ b/tests/test_bench_env_snapshot.py
@@ -1,0 +1,113 @@
+"""Smoke tests for scripts.bench.env_snapshot — hashing and capture."""
+
+from __future__ import annotations
+
+import platform
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from scripts.bench.config import (
+    BackendConfig,
+    BenchConfig,
+    MatrixConfig,
+    ModelConfig,
+    TierConfig,
+)
+from scripts.bench.env_snapshot import EnvSnapshot, _hash_settings
+
+
+@pytest.fixture
+def bench_config() -> BenchConfig:
+    return BenchConfig(
+        matrix=MatrixConfig(
+            context_sizes=[1024],
+            boundary_context_sizes=[4096],
+            concurrency_levels=[1],
+        ),
+        backends=[BackendConfig(id="test-backend", base_url="http://localhost:11434")],
+        models=[ModelConfig(id="test-model", backend_id="test-backend")],
+        tiers=[TierConfig(name="standard")],
+    )
+
+
+class TestSettingsHash:
+    def test_deterministic(self) -> None:
+        settings = {"a": 1, "b": 2}
+        assert _hash_settings(settings) == _hash_settings(settings)
+
+    def test_length_is_64_hex(self) -> None:
+        h = _hash_settings({})
+        assert len(h) == 64
+        int(h, 16)  # noqa: PLR2004 — must be valid hex
+
+    def test_key_order_independent(self) -> None:
+        s1 = {"a": 1, "b": 2}
+        s2 = {"b": 2, "a": 1}
+        assert _hash_settings(s1) == _hash_settings(s2)
+
+    def test_different_inputs_different_hashes(self) -> None:
+        assert _hash_settings({"a": 1}) != _hash_settings({"a": 2})
+
+    def test_empty_dict_stable(self) -> None:
+        h1 = _hash_settings({})
+        h2 = _hash_settings({})
+        assert h1 == h2
+
+
+class TestEnvSnapshotCapture:
+    @patch("scripts.bench.env_snapshot.subprocess.run")
+    def test_nvidia_smi_absent(
+        self, mock_run: MagicMock, bench_config: BenchConfig
+    ) -> None:
+        mock_run.side_effect = FileNotFoundError("not found")
+        snap = EnvSnapshot.capture("ollama", "llama3", bench_config)
+        assert snap.gpu_driver_version is None
+        assert snap.cuda_version is None
+        assert snap.total_vram_gb is None
+        assert snap.backend == "ollama"
+        assert snap.model == "llama3"
+        assert len(snap.settings_hash) == 64
+
+    @patch("scripts.bench.env_snapshot.subprocess.run")
+    def test_nonzero_returncode(
+        self, mock_run: MagicMock, bench_config: BenchConfig
+    ) -> None:
+        mock_run.return_value = MagicMock(returncode=1, stdout="")
+        snap = EnvSnapshot.capture("litellm", "gemma", bench_config)
+        assert snap.gpu_driver_version is None
+        assert snap.cuda_version is None
+
+    @patch("scripts.bench.env_snapshot.subprocess.run")
+    def test_parses_driver_and_cuda(
+        self, mock_run: MagicMock, bench_config: BenchConfig
+    ) -> None:
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout="545.23.08\n"),
+            MagicMock(returncode=0, stdout="| CUDA Version: 12.3     |\n"),
+        ]
+        snap = EnvSnapshot.capture("litellm", "gemma2", bench_config)
+        assert snap.gpu_driver_version == "545.23.08"
+        assert snap.cuda_version == "12.3"
+
+    def test_python_version_populated(self, bench_config: BenchConfig) -> None:
+        patch_func = "scripts.bench.env_snapshot.subprocess.run"
+        with patch(patch_func, side_effect=FileNotFoundError):
+            snap = EnvSnapshot.capture("test", "test", bench_config)
+        assert snap.python_version == sys.version
+
+    def test_os_version_populated(self, bench_config: BenchConfig) -> None:
+        patch_func = "scripts.bench.env_snapshot.subprocess.run"
+        with patch(patch_func, side_effect=FileNotFoundError):
+            snap = EnvSnapshot.capture("test", "test", bench_config)
+        assert snap.os_version == platform.platform()
+
+    @patch("scripts.bench.env_snapshot.subprocess.run")
+    def test_settings_hash_stable_across_captures(
+        self, mock_run: MagicMock, bench_config: BenchConfig
+    ) -> None:
+        mock_run.side_effect = FileNotFoundError
+        snap1 = EnvSnapshot.capture("ollama", "qwen3", bench_config)
+        snap2 = EnvSnapshot.capture("ollama", "qwen3", bench_config)
+        assert snap1.settings_hash == snap2.settings_hash

--- a/tests/test_bench_reporter.py
+++ b/tests/test_bench_reporter.py
@@ -1,0 +1,300 @@
+"""Smoke tests for scripts.bench.reporter — table, export, load_sweep."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from contextlib import redirect_stdout
+from io import StringIO
+from pathlib import Path
+
+import pytest
+
+from scripts.bench.reporter import (
+    _SUMMARY_COLS,
+    OOM_RISK_HEADROOM_GB,
+    VRAM_HEADROOM_WARN_GB,
+    _bool_col,
+    _fmt,
+    _median,
+    _pct,
+    _percentile,
+    export_csv,
+    export_json,
+    load_sweep,
+    print_summary_table,
+)
+
+# ── _SUMMARY_COLS ─────────────────────────────────────────────────────────────
+
+
+class TestSummaryCols:
+    def test_non_empty(self) -> None:
+        assert len(_SUMMARY_COLS) > 0
+
+    def test_all_tuples_of_two(self) -> None:
+        for name, width in _SUMMARY_COLS:
+            assert isinstance(name, str)
+            assert isinstance(width, int)
+            assert width > 0
+
+    def test_header_columns(self) -> None:
+        expected = ["Model", "Tier", "Ctx", "C", "R", "TTFT(s)", "Wall(s)", "Tok/s"]
+        names = [name for name, _ in _SUMMARY_COLS]
+        for exp in expected:
+            assert exp in names
+
+
+# ── _fmt ────────────────────────────────────────────────────────────────────────
+
+
+class TestFmt:
+    def test_none_returns_na(self) -> None:
+        assert _fmt(None) == "--"
+
+    def test_float_default(self) -> None:
+        assert _fmt(3.14159) == "3.14159"
+
+    def test_float_custom_format(self) -> None:
+        assert _fmt(3.14159, ".2f") == "3.14"
+
+    def test_int(self) -> None:
+        assert _fmt(42) == "42"
+
+    def test_string(self) -> None:
+        assert _fmt("hello") == "hello"
+
+    def test_custom_na(self) -> None:
+        assert _fmt(None, na="N/A") == "N/A"
+
+
+# ── _bool_col ───────────────────────────────────────────────────────────────────
+
+
+class TestBoolCol:
+    def test_true(self) -> None:
+        assert _bool_col(True) == "Yes"
+
+    def test_false(self) -> None:
+        assert _bool_col(False) == "No"
+
+    def test_none(self) -> None:
+        assert _bool_col(None) == "--"
+
+
+# ── _pct ────────────────────────────────────────────────────────────────────────
+
+
+class TestPct:
+    def test_none(self) -> None:
+        assert _pct(None) == "--"
+
+    def test_zero(self) -> None:
+        assert _pct(0.0) == "0%"
+
+    def test_full(self) -> None:
+        assert _pct(100.0) == "100%"
+
+    def test_half(self) -> None:
+        assert _pct(50.0) == "50%"
+
+
+# ── _median ─────────────────────────────────────────────────────────────────────
+
+
+class TestMedian:
+    def test_empty(self) -> None:
+        assert _median([]) is None
+
+    def test_single(self) -> None:
+        assert _median([42.0]) == 42.0
+
+    def test_even(self) -> None:
+        assert _median([1.0, 2.0, 3.0, 4.0]) == 2.5
+
+    def test_odd(self) -> None:
+        assert _median([1.0, 2.0, 3.0]) == 2.0
+
+    def test_skips_none(self) -> None:
+        # _median filters None; constructing with None in list is intentional
+        result = _median([1.0, None, 3.0])  # type: ignore[list-item]
+        assert result == 2.0
+
+
+# ── _percentile ─────────────────────────────────────────────────────────────────
+
+
+class TestPercentile:
+    def test_less_than_two(self) -> None:
+        assert _percentile([1.0], 50) is None
+
+    def test_two_values_median(self) -> None:
+        assert _percentile([1.0, 3.0], 50) == 2.0
+
+    def test_minimum(self) -> None:
+        result = _percentile([1.0, 2.0, 3.0, 4.0], 0)
+        assert result == 1.0
+
+    def test_maximum(self) -> None:
+        result = _percentile([1.0, 2.0, 3.0, 4.0], 100)
+        assert result == 4.0
+
+
+# ── print_summary_table ─────────────────────────────────────────────────────────
+
+
+class TestPrintSummaryTable:
+    def test_empty_rows(self) -> None:
+        buf = StringIO()
+        with redirect_stdout(buf):
+            print_summary_table([])
+        output = buf.getvalue()
+        assert "(no results for this sweep)" in output
+
+    def test_single_row(self) -> None:
+        buf = StringIO()
+        row = {
+            "model_id": "test-model",
+            "tier": "speed",
+            "context_size": 4096,
+            "concurrency": 1,
+            "repeat_index": 1,
+            "ttft_s": 0.5,
+            "wall_time_s": 1.0,
+            "throughput_tok_s": 100.0,
+            "peak_vram_gb": 20.0,
+            "avg_gpu_util_pct": 90.0,
+            "outcome": "ok",
+        }
+        with redirect_stdout(buf):
+            print_summary_table([row])
+        output = buf.getvalue()
+        assert "test-model" in output
+        assert "speed" in output
+        assert "4096" in output
+        assert "100" in output  # throughput_tok_s
+
+    def test_oom_shown(self) -> None:
+        buf = StringIO()
+        row = {
+            "model_id": "m",
+            "tier": "speed",
+            "context_size": 4096,
+            "concurrency": 1,
+            "repeat_index": 1,
+            "ttft_s": 0.5,
+            "wall_time_s": 1.0,
+            "throughput_tok_s": 100.0,
+            "peak_vram_gb": 20.0,
+            "avg_gpu_util_pct": 90.0,
+            "outcome": "oom",
+        }
+        with redirect_stdout(buf):
+            print_summary_table([row])
+        output = buf.getvalue()
+        assert "Yes" in output  # OOM column
+
+    def test_header_present(self) -> None:
+        buf = StringIO()
+        row = {
+            "model_id": "m",
+            "tier": "speed",
+            "context_size": 4096,
+            "concurrency": 1,
+            "repeat_index": 1,
+            "ttft_s": 0.5,
+            "wall_time_s": 1.0,
+            "throughput_tok_s": 100.0,
+            "peak_vram_gb": 20.0,
+            "avg_gpu_util_pct": 90.0,
+            "outcome": "ok",
+        }
+        with redirect_stdout(buf):
+            print_summary_table([row])
+        output = buf.getvalue()
+        assert "SWEEP SUMMARY" in output
+
+
+# ── export_json ─────────────────────────────────────────────────────────────────
+
+
+class TestExportJson:
+    def test_writes_json_file(self, tmp_path: Path) -> None:
+        rows = [{"a": 1}, {"b": 2}]
+        p = tmp_path / "out.json"
+        export_json(rows, p)
+        data = json.loads(p.read_text(encoding="utf-8"))
+        assert data == rows
+
+    def test_empty_rows(self, tmp_path: Path) -> None:
+        export_json([], tmp_path / "out.json")
+        data = json.loads((tmp_path / "out.json").read_text(encoding="utf-8"))
+        assert data == []
+
+
+# ── export_csv ──────────────────────────────────────────────────────────────────
+
+
+class TestExportCsv:
+    def test_writes_csv_with_header(self, tmp_path: Path) -> None:
+        rows = [{"a": 1, "b": "x"}, {"a": 2, "b": "y"}]
+        p = tmp_path / "out.csv"
+        export_csv(rows, p)
+        content = p.read_text(encoding="utf-8")
+        lines = content.strip().splitlines()
+        assert lines[0] == "a,b"
+        assert len(lines) == 3  # header + 2 data
+
+    def test_empty_rows_produces_empty_file(self, tmp_path: Path) -> None:
+        p = tmp_path / "out.csv"
+        export_csv([], p)
+        assert p.read_text(encoding="utf-8") == ""
+
+
+# ── load_sweep ──────────────────────────────────────────────────────────────────
+
+
+class TestLoadSweep:
+    def test_missing_db_returns_empty(self) -> None:
+        assert load_sweep(Path("/nonexistent"), "s1") == []
+
+    def test_valid_db_without_table_raises(self) -> None:
+        """A valid sqlite3 file without bench_run table is not gracefully handled."""
+        import sqlite3
+
+        db = tempfile.mktemp(suffix=".db")
+        try:
+            conn = sqlite3.connect(db)
+            conn.close()
+            # Valid sqlite3 but no bench_run table → raises
+            with pytest.raises(Exception):
+                load_sweep(Path(db), "s1")
+        finally:
+            Path(db).unlink(missing_ok=True)
+
+    def test_existing_bench_run_table(self, tmp_path: Path) -> None:
+        """If bench_run table exists but has no matching rows, returns empty."""
+        import sqlite3
+
+        db = tmp_path / "bench.db"
+        conn = sqlite3.connect(str(db))
+        conn.execute("CREATE TABLE bench_run (run_id TEXT)")
+        conn.execute("INSERT INTO bench_run VALUES ('s1::1')")
+        conn.commit()
+        conn.close()
+        result = load_sweep(db, "s1")
+        assert len(result) == 1
+        assert result[0]["run_id"] == "s1::1"
+
+
+# ── Constants ───────────────────────────────────────────────────────────────────
+
+
+class TestConstants:
+    def test_vram_headroom_warn_gb(self) -> None:
+        assert VRAM_HEADROOM_WARN_GB == 2.0
+        assert isinstance(VRAM_HEADROOM_WARN_GB, float)
+
+    def test_oom_risk_headroom_gb(self) -> None:
+        assert OOM_RISK_HEADROOM_GB == 0.5
+        assert isinstance(OOM_RISK_HEADROOM_GB, float)

--- a/tests/test_vllm_metrics_capture.py
+++ b/tests/test_vllm_metrics_capture.py
@@ -223,6 +223,7 @@ def test_dispatch_captures_vllm_snapshot_when_solo(tmp_path: Path) -> None:
             linear_id="fake-linear-id",
             ticket_id="WOR-10",
             _escalation_policy=MagicMock(),
+            _dedup_state={},
         )
 
     assert len(local_active) == 1
@@ -290,6 +291,7 @@ def test_dispatch_invalidates_solo_peer_when_second_worker_launches(
             linear_id="fake-linear-2",
             ticket_id="WOR-2",
             _escalation_policy=MagicMock(),
+            _dedup_state={},
         )
 
     # Pre-existing worker has lost its solo flag
@@ -343,6 +345,7 @@ def test_dispatch_skips_snapshot_when_metrics_endpoint_unreachable(
             linear_id="fake-linear-id",
             ticket_id="WOR-10",
             _escalation_policy=MagicMock(),
+            _dedup_state={},
         )
 
     worker = local_active[0]

--- a/tests/test_watcher_dispatch.py
+++ b/tests/test_watcher_dispatch.py
@@ -73,6 +73,7 @@ def test_start_ticket_local_happy_path_appends_to_local_active(tmp_path: Path) -
             linear_id="fake-linear-id",
             ticket_id="WOR-10",
             _escalation_policy=MagicMock(),
+            _dedup_state={},
         )
 
     assert len(local_active) == 1
@@ -113,6 +114,7 @@ def test_start_ticket_cloud_happy_path_appends_to_cloud_active(tmp_path: Path) -
             linear_id="fake-linear-id",
             ticket_id="WOR-10",
             _escalation_policy=MagicMock(),
+            _dedup_state={},
         )
 
     assert len(cloud_active) == 1
@@ -148,6 +150,7 @@ def test_start_ticket_defers_when_vllm_not_ready(
             linear_id="fake-linear-id",
             ticket_id="WOR-10",
             _escalation_policy=MagicMock(),
+            _dedup_state={},
         )
 
     mock_create.assert_not_called()
@@ -183,6 +186,7 @@ def test_start_ticket_defers_when_cloud_pool_full(
             linear_id="fake-linear-id",
             ticket_id="WOR-10",
             _escalation_policy=MagicMock(),
+            _dedup_state={},
         )
 
     mock_create.assert_not_called()
@@ -223,6 +227,7 @@ def test_start_ticket_refuses_local_manifest_with_empty_allowed_paths(
             linear_id="fake-linear-id",
             ticket_id="WOR-10",
             _escalation_policy=MagicMock(),
+            _dedup_state={},
         )
 
     mock_create.assert_not_called()
@@ -265,6 +270,7 @@ def test_start_ticket_refuses_manifest_with_empty_required_checks(
             linear_id="fake-linear-id",
             ticket_id="WOR-10",
             _escalation_policy=MagicMock(),
+            _dedup_state={},
         )
 
     mock_create.assert_not_called()
@@ -319,6 +325,7 @@ def test_start_ticket_refuses_when_epic_too_far_behind_main(
             linear_id="fake-linear-id",
             ticket_id="WOR-10",
             _escalation_policy=MagicMock(),
+            _dedup_state={},
         )
 
     mock_create.assert_not_called()
@@ -375,6 +382,7 @@ def test_start_ticket_proceeds_when_epic_within_threshold(
             linear_id="fake-linear-id",
             ticket_id="WOR-10",
             _escalation_policy=MagicMock(),
+            _dedup_state={},
         )
 
     assert len(local_active) == 1
@@ -423,13 +431,68 @@ def test_start_ticket_does_not_refuse_main_target(
             linear_id="fake-linear-id",
             ticket_id="WOR-10",
             _escalation_policy=MagicMock(),
+            _dedup_state={},
         )
 
     assert len(local_active) == 1
     linear.post_comment.assert_not_called()
 
 
-# NOTE: a fifth test for suppress_dedup behaviour is intentionally omitted —
-# dispatch.py's `_dedup_state or {}` falls through to a fresh empty dict on
-# each call, defeating cross-call memoization. That's a real pre-existing
-# bug worth filing separately; it is not in scope for this coverage push.
+# ---------------------------------------------------------------------------
+# WOR-297 — dedup state survives across consecutive calls
+# ---------------------------------------------------------------------------
+
+# The fix: _dedup_state was previously Optional (default None), so callers
+# passing None or not passing it at all got a fresh empty dict on every
+# call, defeating cross-call dedup memoization. Now it's required dict[str,
+# str], so the caller passes the same mutable dict across calls and the
+# suppress_dedup state persists.
+
+
+def test_start_ticket_vllm_not_ready_dedup_logs_warning_once(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Two consecutive vLLM-not-ready deferrals log the warning only once."""
+    manifest = make_manifest(implementation_mode="local")
+    linear = MagicMock()
+    services = _services(vllm_healthy=False)
+    local_active: list = []
+    cloud_active: list = []
+    dedup_state: dict[str, str] = {}
+
+    with caplog.at_level(logging.WARNING, logger="app.core.watcher.dispatch"):
+        # First call — not yet in dedup state → logs warning.
+        start_ticket(
+            manifest=manifest,
+            linear=linear,
+            services=services,
+            worker_verbose=False,
+            _local_active=local_active,
+            _cloud_active=cloud_active,
+            max_cloud_workers=3,
+            _repo_root=tmp_path,
+            _processed_tickets=[],
+            linear_id="fake-linear-id",
+            ticket_id="WOR-10",
+            _escalation_policy=MagicMock(),
+            _dedup_state=dedup_state,
+        )
+        # Second call — same condition already tracked → suppressed.
+        start_ticket(
+            manifest=manifest,
+            linear=linear,
+            services=services,
+            worker_verbose=False,
+            _local_active=local_active,
+            _cloud_active=cloud_active,
+            max_cloud_workers=3,
+            _repo_root=tmp_path,
+            _processed_tickets=[],
+            linear_id="fake-linear-id",
+            ticket_id="WOR-10",
+            _escalation_policy=MagicMock(),
+            _dedup_state=dedup_state,
+        )
+
+    vllm_warnings = [r for r in caplog.records if "vLLM not ready" in r.message]
+    assert len(vllm_warnings) == 1  # second call is suppressed

--- a/tests/test_watcher_finalize.py
+++ b/tests/test_watcher_finalize.py
@@ -673,6 +673,7 @@ def test_finalize_worker_no_flags_proceeds_normally(tmp_path: Path) -> None:
             worker, linear=linear_mock, metrics=metrics_mock, repo_root=tmp_path
         )
 
+    linear_mock.set_state.assert_called_once_with("fake-linear-id", "MergedToEpic")
     m = metrics_mock.record.call_args[0][0]
     assert m.outcome == "success"
     assert m.escalated_to_cloud is False
@@ -703,6 +704,7 @@ def test_finalize_worker_missing_result_json_proceeds_normally(tmp_path: Path) -
             worker, linear=linear_mock, metrics=metrics_mock, repo_root=tmp_path
         )
 
+    linear_mock.set_state.assert_called_once_with("fake-linear-id", "MergedToEpic")
     m = metrics_mock.record.call_args[0][0]
     assert m.outcome == "success"
     assert m.escalated_to_cloud is False
@@ -1492,3 +1494,76 @@ def test_finalize_worker_no_set_tags_when_compute_tags_empty(
         )
 
     metrics_mock.set_tags.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# WOR-343 — branch-aware state setter on PR success path
+# ---------------------------------------------------------------------------
+
+
+def test_finalize_main_target_sets_in_review(tmp_path: Path) -> None:
+    """When base_branch == 'main', finalize_worker sets state to 'In Review'."""
+    manifest = make_manifest(
+        ticket_id="WOR-10",
+        worker_branch="wor-10-test-ticket",
+        base_branch="main",
+    )
+    linear_mock = MagicMock()
+    metrics_mock = MagicMock()
+
+    worker = ActiveWorker(
+        ticket_id="WOR-10",
+        linear_id="fake-linear-id",
+        manifest=manifest,
+        worktree_path=tmp_path,
+        process=MagicMock(spec=subprocess.Popen),
+    )
+
+    with (
+        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(True, [])),
+        patch("app.core.watcher.watcher_finalize.preserve_worker_artifacts"),
+        patch(
+            "app.core.watcher.watcher_finalize.create_pr",
+            return_value="https://github.com/example/pr/1",
+        ),
+        patch("app.core.watcher.watcher_finalize.cleanup_worktree"),
+    ):
+        _call_finalize(
+            worker, linear=linear_mock, metrics=metrics_mock, repo_root=tmp_path
+        )
+
+    linear_mock.set_state.assert_called_once_with("fake-linear-id", "In Review")
+
+
+def test_finalize_epic_target_sets_merged_to_epic(tmp_path: Path) -> None:
+    """When base_branch != 'main', finalize_worker sets state to 'MergedToEpic'."""
+    manifest = make_manifest(
+        ticket_id="WOR-10",
+        worker_branch="wor-10-test-ticket",
+        base_branch="epic/wor-10-test",
+    )
+    linear_mock = MagicMock()
+    metrics_mock = MagicMock()
+
+    worker = ActiveWorker(
+        ticket_id="WOR-10",
+        linear_id="fake-linear-id",
+        manifest=manifest,
+        worktree_path=tmp_path,
+        process=MagicMock(spec=subprocess.Popen),
+    )
+
+    with (
+        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(True, [])),
+        patch("app.core.watcher.watcher_finalize.preserve_worker_artifacts"),
+        patch(
+            "app.core.watcher.watcher_finalize.create_pr",
+            return_value="https://github.com/example/pr/1",
+        ),
+        patch("app.core.watcher.watcher_finalize.cleanup_worktree"),
+    ):
+        _call_finalize(
+            worker, linear=linear_mock, metrics=metrics_mock, repo_root=tmp_path
+        )
+
+    linear_mock.set_state.assert_called_once_with("fake-linear-id", "MergedToEpic")

--- a/tests/test_watcher_integration.py
+++ b/tests/test_watcher_integration.py
@@ -1,0 +1,221 @@
+"""Integration test for _finalize_worker happy path.
+
+Exercises the full finalize_worker flow: realistic ActiveWorker, pre-written
+stream-json log with usage + compaction events, returncode=0, and asserts all
+six enriched fields populated together.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from app.core.escalation_policy import EscalationPolicy
+from app.core.manifest import ArtifactPaths, ExecutionManifest
+from app.core.metrics import TicketMetrics
+from app.core.watcher.watcher_finalize import finalize_worker
+from app.core.watcher.watcher_types import ActiveWorker
+
+
+def _make_stream_json_log(
+    tmp_path: Path,
+    ticket_id: str,
+) -> Path:
+    """Create a realistic stream-json log with usage and compaction events.
+
+    Returns the path to the log file.
+    """
+    log_dir = tmp_path / ".claude"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    log_file = log_dir / f"worker_{ticket_id.lower()}.log"
+
+    system_compact = json.dumps(
+        {"type": "system", "subtype": "compact_boundary"},
+    )
+    # 3 compact_boundary events
+    log_file.write_text(
+        system_compact
+        + "\n" * 3
+        + json.dumps(
+            {
+                "type": "result",
+                "usage": {"input_tokens": 8500, "output_tokens": 3200},
+            },
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return log_file
+
+
+def test_finalize_worker_happy_path_all_enriched_fields(
+    tmp_path: Path,
+) -> None:
+    """Full _finalize_worker happy path: returncode=0, checks pass, PR succeeds.
+
+    Asserts all six enriched fields populated together:
+    - local_tokens > 0 (from stream-json log usage)
+    - context_compactions > 0 (from compact_boundary events)
+    - retry_count == 0 (first attempt, no check failures)
+    - sonar_findings_count == 4 (fetch_sonar_findings returns 4 items)
+    - outcome == 'success'
+    - pr_url set (attempt_pr returns a URL)
+    """
+    ticket_id = "WOR-130"
+
+    manifest = ExecutionManifest(
+        ticket_id=ticket_id,
+        epic_id="WOR-383",
+        title="Add e2e metrics integration test",
+        priority=3,
+        status="ReadyForLocal",
+        parallel_safe=True,
+        risk_level="low",
+        implementation_mode="local",
+        review_mode="auto",
+        base_branch="epic/wor-383-overnight-stress-test-wave-1",
+        worker_branch="wor-130-e2e-metrics-integration-test",
+        objective="Add ONE integration-style test",
+        artifact_paths=ArtifactPaths.from_ticket_id(ticket_id),
+        allowed_paths=["tests/test_watcher_integration.py"],
+        required_checks=["ruff check .", "mypy app/"],
+    )
+    manifest.effort = "high"
+    manifest.change_type = "additive"
+    manifest.reasoning_demand = 3
+    manifest.scope_clarity = 4
+    manifest.constraint_density = 3
+    manifest.ac_specificity = 5
+    manifest.tech_stack = "python,pytest"
+    manifest.raw_extensions = '[".py"]'
+
+    # Write a result.json so _read_result_status returns "success" (WOR-286).
+    result_dir = tmp_path / ".claude" / "artifacts" / "wor_130"
+    result_dir.mkdir(parents=True, exist_ok=True)
+    (result_dir / "result.json").write_text(
+        json.dumps({"status": "success"}),
+        encoding="utf-8",
+    )
+
+    # Build a realistic stream-json log with usage + compaction events.
+    _make_stream_json_log(tmp_path, ticket_id)
+
+    linear_mock = MagicMock()
+    metrics_mock = MagicMock()
+
+    worker = ActiveWorker(
+        ticket_id=ticket_id,
+        linear_id="fake-linear-id",
+        manifest=manifest,
+        worktree_path=tmp_path,
+        process=MagicMock(spec=subprocess.Popen),
+    )
+
+    # Patch the three functions the manifest calls out plus generic helpers.
+    with (
+        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(True, [])),
+        patch(
+            "app.core.watcher.watcher_finalize.create_pr",
+            return_value="https://github.com/example/repo/pull/130",
+        ),
+        patch(
+            "app.core.watcher.watcher_finalize.fetch_sonar_findings",
+            return_value=["MAJOR", "MINOR", "MINOR", "INFO"],
+        ),
+        patch("app.core.watcher.watcher_finalize.cleanup_worktree"),
+        patch("app.core.watcher.watcher_finalize.compute_tags", return_value=[]),
+        patch("app.core.watcher.watcher_finalize.preserve_worker_artifacts"),
+    ):
+        finalize_worker(
+            worker,
+            returncode=0,
+            wall_time=120.5,
+            linear=linear_mock,
+            metrics=metrics_mock,
+            escalation_policy=EscalationPolicy.from_toml(),
+            repo_root=tmp_path,
+            mode="local",
+            project_id="repo-scaffold-desktop",
+        )
+
+    # ---- Assertions: all six enriched fields ----
+    assert metrics_mock.record.call_count == 1
+    m: TicketMetrics = metrics_mock.record.call_args[0][0]
+
+    # 1) local_tokens > 0 (8500 input + 3200 output)
+    assert m.local_tokens is not None and m.local_tokens > 0, (
+        f"local_tokens should be > 0, got {m.local_tokens}"
+    )
+
+    # 2) context_compactions > 0 (3 compact_boundary events in log)
+    assert m.context_compactions is not None and m.context_compactions > 0, (
+        f"context_compactions should be > 0, got {m.context_compactions}"
+    )
+
+    # 3) retry_count == 0 (first attempt, checks passed)
+    assert m.retry_count == 0
+
+    # 4) sonar_findings_count == 4 (4 items returned by fetch_sonar_findings)
+    assert m.sonar_findings_count == 4
+
+    # 5) outcome == 'success'
+    assert m.outcome == "success"
+
+    # 6) pr_url set — confirmed by create_pr being called (checked above)
+    # The pr_url is not returned by finalize_worker, but create_pr was called
+    # which only happens in the success path of attempt_pr.
+    # We verify the PR URL flows through by checking linear mock was called
+    # exactly once with the WOR-343 branch-aware MergedToEpic transition
+    # (non-main base_branch → "MergedToEpic"; the manifest's base is the epic).
+    linear_mock.set_state.assert_called_once_with("fake-linear-id", "MergedToEpic")
+
+
+def test_finalize_worker_pr_url_via_attempt_pr_direct(
+    tmp_path: Path,
+) -> None:
+    """Verify attempt_pr returns the PR URL on success path.
+
+    Complements the happy-path test by directly checking attempt_pr's return
+    value, since finalize_worker does not expose pr_url.
+    """
+    from app.core.watcher.watcher_finalize import attempt_pr
+
+    manifest = ExecutionManifest(
+        ticket_id="WOR-130",
+        epic_id="WOR-383",
+        title="Add e2e metrics integration test",
+        priority=3,
+        status="ReadyForLocal",
+        parallel_safe=True,
+        risk_level="low",
+        implementation_mode="local",
+        review_mode="auto",
+        base_branch="epic/wor-383-overnight-stress-test-wave-1",
+        worker_branch="wor-130-e2e-metrics-integration-test",
+        objective="Add ONE integration-style test",
+        artifact_paths=ArtifactPaths.from_ticket_id("WOR-130"),
+        allowed_paths=["tests/test_watcher_integration.py"],
+        required_checks=["ruff check .", "mypy app/"],
+    )
+
+    worker = ActiveWorker(
+        ticket_id="WOR-130",
+        linear_id="fake-linear-id",
+        manifest=manifest,
+        worktree_path=tmp_path,
+        process=MagicMock(spec=subprocess.Popen),
+    )
+    linear_mock = MagicMock()
+
+    with patch(
+        "app.core.watcher.watcher_finalize.create_pr",
+        return_value="https://github.com/example/repo/pull/130",
+    ):
+        outcome, pr_url = attempt_pr(manifest, worker, linear_mock)
+
+    assert outcome == "success"
+    assert pr_url == "https://github.com/example/repo/pull/130"
+    linear_mock.set_state.assert_not_called()
+    linear_mock.post_comment.assert_not_called()


### PR DESCRIPTION
Closes WOR-245

Add a smoke-test layer for scripts/bench/ — config TOML parsing, env_snapshot without GPU hardware, reporter rendering. Tests do NOT require live backends. Read-only references to scripts/bench/ sourc