### PR TITLE
Fix CI: install requirements-ui.txt for pytest-qt plugin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,11 @@ jobs:
           cache-dependency-path: 'requirements-dev.txt'
 
       - name: Install dependencies
-        run: pip install -r requirements-dev.txt
+        # WOR-69 added pytest-qt to requirements-dev.txt, which loads its
+        # plugin at pytest collection time and requires PySide6/PyQt5/PyQt6
+        # to be installed. PySide6 lives in requirements-ui.txt, so install
+        # both here.
+        run: pip install -r requirements-dev.txt -r requirements-ui.txt
 
       - name: Lint
         run: ruff check .
@@ -86,7 +90,11 @@ jobs:
           cache-dependency-path: 'requirements-dev.txt'
 
       - name: Install dependencies
-        run: pip install -r requirements-dev.txt
+        # WOR-69 added pytest-qt to requirements-dev.txt, which loads its
+        # plugin at pytest collection time and requires PySide6/PyQt5/PyQt6
+        # to be installed. PySide6 lives in requirements-ui.txt, so install
+        # both here.
+        run: pip install -r requirements-dev.txt -r requirements-ui.txt
 
       - name: Watcher smoke test (5s)
         run: |


### PR DESCRIPTION
## Summary

WOR-69 added `pytest-qt` to `requirements-dev.txt`. The plugin loads at pytest collection time and requires `PySide6`/`PyQt5`/`PyQt6` to be installed, but `PySide6` lives in `requirements-ui.txt`. Result: CI fails on every epic-branch run after WOR-69 merged with:

```
ERROR: pytest-qt requires either PySide6, PyQt5 or PyQt6 installed.
```

Earlier wave-2 PRs (#779/#781/#782/#780) merged before their CI re-ran on the post-WOR-69 base, so the failure first appeared on PR #778 (WOR-369), which became the canary.

## Fix

Install both `requirements-dev.txt` and `requirements-ui.txt` in both `lint-and-test` and `watcher-smoke` jobs.

## Test plan

- [x] CI on this PR shows tests collect + run cleanly
- [x] Re-running CI on PR #778 should now pass

Part of WOR-383

🤖 Generated with [Claude Code](https://claude.com/claude-code)