### PR TITLE
WOR-391: env-aware skip for contribute_skills tests in watcher worker subprocess

### DIFF
--- a/app/core/watcher/watcher_helpers.py
+++ b/app/core/watcher/watcher_helpers.py
@@ -327,6 +327,12 @@ def build_worker_env(
     if mode == "cloud":
         for var in _ENV_VARS_TO_STRIP_FOR_CLOUD:
             env.pop(var, None)
+        # WOR-391: signal to downstream tests that they're running inside the
+        # watcher's worker subprocess. Tests that interact with bash, system
+        # PATH-resolved binaries, or other env-divergent code paths can use
+        # this flag to skip themselves and avoid env-dependent flakiness.
+        # Set in cloud + local branches; default branch is a no-op fallback.
+        env["WATCHER_WORKER"] = "1"
     elif mode == "local":
         env["ANTHROPIC_BASE_URL"] = _VLLM_BASE_URL
         env.setdefault("ANTHROPIC_API_KEY", "dummy")
@@ -334,6 +340,8 @@ def build_worker_env(
         env["ANTHROPIC_DEFAULT_OPUS_MODEL"] = _VLLM_SERVED_MODEL
         env["ANTHROPIC_DEFAULT_SONNET_MODEL"] = _VLLM_SERVED_MODEL
         env["ANTHROPIC_DEFAULT_HAIKU_MODEL"] = _VLLM_SERVED_MODEL
+        # WOR-391: see cloud branch above for rationale.
+        env["WATCHER_WORKER"] = "1"
         # Compact at ~180K tokens: 240K window × 75% PCT trigger.
         # vLLM FP8 throughput is flat 16K→262K (WOR-234/WOR-118), so there is no
         # throughput cliff to avoid — 240K gives generous context while leaving 80K

--- a/tests/test_contribute_skills_workflow.py
+++ b/tests/test_contribute_skills_workflow.py
@@ -9,7 +9,21 @@ import subprocess
 import tempfile
 from pathlib import Path
 
+import pytest
+
 SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "contribute_skills.sh"
+
+# WOR-391: these tests fail inside watcher worker subprocesses despite passing
+# in operator shells, fresh manual worktrees, and CI. The exact env divergence
+# is unidentified (likely PATH/bash-binary resolution in the deeply-nested
+# subprocess context). Skip when the watcher signals its presence via
+# WATCHER_WORKER=1 (set by watcher_helpers.build_worker_env) until the
+# env-divergence diagnostic step lands. Operator pytest runs and CI both
+# keep the coverage; only watcher worker dispatches skip.
+pytestmark = pytest.mark.skipif(
+    os.environ.get("WATCHER_WORKER") == "1",
+    reason="WOR-391: contribute_skills.sh subprocess fails in watcher worker env",
+)
 
 
 def _git(repo: Path, *args: str, capture: bool = True) -> subprocess.CompletedProcess:

--- a/tests/test_watcher_helpers.py
+++ b/tests/test_watcher_helpers.py
@@ -108,6 +108,27 @@ def test_default_mode_passes_env_unchanged() -> None:
     assert env == base
 
 
+def test_local_mode_sets_watcher_worker_flag() -> None:
+    """WOR-391: local-mode worker subprocesses get WATCHER_WORKER=1 in env so
+    env-divergent tests (e.g. test_contribute_skills_workflow) can self-skip."""
+    env = build_worker_env("local", {"PATH": "/usr/bin"})
+    assert env["WATCHER_WORKER"] == "1"
+
+
+def test_cloud_mode_sets_watcher_worker_flag() -> None:
+    """WOR-391: cloud-mode worker subprocesses also get WATCHER_WORKER=1."""
+    env = build_worker_env("cloud", {"PATH": "/usr/bin"})
+    assert env["WATCHER_WORKER"] == "1"
+
+
+def test_default_mode_does_not_set_watcher_worker_flag() -> None:
+    """Default mode is a fallback for non-watcher contexts (tests, edge cases);
+    WATCHER_WORKER must NOT be set there to avoid breaking the WOR-391 skip
+    contract for callers that build env manually for non-worker uses."""
+    env = build_worker_env("default", {"PATH": "/usr/bin"})
+    assert "WATCHER_WORKER" not in env
+
+
 def test_cloud_mode_does_not_inject_base_url_if_absent() -> None:
     base = {"PATH": "/usr/bin"}
     env = build_worker_env("cloud", base)


### PR DESCRIPTION
## Summary

Immediate fix for the WOR-391 P1 — contribute_skills tests fail inside the watcher's worker subprocess but pass everywhere else (operator pytest, fresh manual worktrees, CI). WOR-331's worker hit this and lost a clean 3-line skill prose diff.

This PR ships the unblocking pattern from the ticket: an env-aware skip. Diagnostic (which-bash + PATH probe) and permanent fix (absolute bash path or pure-Python rewrite) deferred per the ticket's plan.

## Changes

### `app/core/watcher/watcher_helpers.py`
`build_worker_env` now sets `WATCHER_WORKER=1` in env for both cloud and local modes. Default mode unchanged — it's a fallback for non-watcher contexts (tests, edge cases) and breaking that contract would surprise other callers.

### `tests/test_contribute_skills_workflow.py`
Adds `pytestmark = pytest.mark.skipif(os.environ.get("WATCHER_WORKER") == "1", ...)` to skip the 4 tests when the flag is set. Operator runs and CI both retain coverage.

### `tests/test_watcher_helpers.py`
3 new regression tests:
- `test_local_mode_sets_watcher_worker_flag`
- `test_cloud_mode_sets_watcher_worker_flag`
- `test_default_mode_does_not_set_watcher_worker_flag`

## Test plan

- [x] `pytest tests/test_watcher_helpers.py -k "watcher_worker or build_worker_env"` — 11 passed (3 new + 8 existing)
- [x] `pytest tests/test_contribute_skills_workflow.py` — 4 passed (operator mode)
- [x] `WATCHER_WORKER=1 pytest tests/test_contribute_skills_workflow.py` — 4 skipped
- [x] Full `pytest -q` — 1427 passed (+3 new from this PR)
- [x] ruff / mypy / lint-imports clean

## What this does not fix

- The actual env divergence (a workaround, not a root-cause fix)
- The diagnostic step proposed in WOR-391 (next session — needs a live failing worker)
- Other tests that may have similar env-sensitive bash subprocess patterns (none currently identified)

## Why this is the right immediate move

- **Unblocks workers** — WOR-331-class failures stop happening on the next dispatch
- **Preserves coverage** where it matters — CI runs the tests on every PR; operator pytest runs them locally
- **Easy to revert** — single import + 4-line marker. Once the diagnostic identifies the root cause, this skip can be removed
- **Forward-compatible** — `WATCHER_WORKER=1` flag is reusable for any future tests that need worker-context awareness

Closes WOR-391

🤖 Generated with [Claude Code](https://claude.com/claude-code)