### PR TITLE
WOR-392: warn workers against piping pytest through tail/head

### DIFF
--- a/.claude/commands/implement-ticket.md
+++ b/.claude/commands/implement-ticket.md
@@ -192,6 +192,31 @@ done | sort -u
 Pass that list (plus your scoped tests) to pytest during iteration. The
 final unscoped `pytest` from `required_checks` is still mandatory.
 
+**Never pipe pytest output through `tail`/`head` for self-validation (WOR-392).**
+The pipe swallows pytest's exit code — `pytest 2>&1 | tail -20` returns
+`tail`'s exit code (always 0), so even if pytest fails the surrounding
+shell sees a successful command. Worse, `tail -20` may not include the
+FAILED summary lines depending on output volume + warnings, so the worker
+sees only passing dots and concludes "all green" — then writes
+`result.json: status=success`, the watcher's unscoped pytest fails on the
+real failures, and the worker's diff is lost.
+
+Either run pytest unpiped:
+
+```bash
+pytest -q
+```
+
+Or redirect to a file and check the exit code separately:
+
+```bash
+pytest -q > /tmp/pytest-out.txt 2>&1; echo "exit=$?"; tail -50 /tmp/pytest-out.txt
+```
+
+The `echo $?` line is the gate, not the visible output. If `exit != 0`,
+inspect `/tmp/pytest-out.txt` directly with Read or grep — never trust a
+truncated tail to tell you the test summary.
+
 If any required check fails:
 - Record the failure in the result artifact (step 5)
 - If `failure_policy.on_check_failure` is `"abort"`: stop here, write a failed result


### PR DESCRIPTION
## Summary

Adds a hard rule to `.claude/commands/implement-ticket.md` step 4 (Run required checks) targeting the WOR-331 failure mode: worker piped pytest through `tail -20` for self-validation, the pipe swallowed the exit code, the visible tail didn't include the FAILED summary, the worker self-reported success, watcher caught real failures, the worker's diff was lost.

## Why this matters

Two compounding bugs in the `pytest 2>&1 | tail -20` pattern:

1. **Pipe swallows exit code.** `tail` always returns 0; pytest's actual exit code is invisible to the surrounding shell.
2. **`tail -20` may not include FAILED summary.** With 1424+ tests + warnings (Windows pytest cache permission warnings add noise), the FAILED lines can fall outside the last 20 lines, so the worker sees only passing dots and concludes "all green".

WOR-331's worker hit exactly this — wrote `result.json: status=success` despite pytest exit_code=1, lost a clean 3-line skill prose diff.

## Two acceptable patterns documented

```bash
# Unpiped — exit code propagates
pytest -q
```

```bash
# Redirect + check exit code separately
pytest -q > /tmp/pytest-out.txt 2>&1; echo "exit=$?"; tail -50 /tmp/pytest-out.txt
```

## Changes

- `.claude/commands/implement-ticket.md` — 25-line rule added after the WOR-353 pytest scope rule

Sibling discipline rules:
- WOR-353 — "always run unscoped pytest before declaring success"
- WOR-389 — "don't dismiss test failures as pre-existing"
- WOR-355 — "trust the Edit tool — don't re-read after editing"

## Test plan

- [x] Skill file passes pre-commit (trailing whitespace, EOF, etc.)
- Phase 2 measurement plan: in next 5+ ticket runs, ≥80% should run pytest without piping through tail (verified by greping worker logs)

Closes WOR-392

🤖 Generated with [Claude Code](https://claude.com/claude-code)