### PR TITLE
WOR-389: forbid dismissing failing tests as 'pre-existing' without verification

### DIFF
--- a/.claude/commands/implement-ticket.md
+++ b/.claude/commands/implement-ticket.md
@@ -217,6 +217,38 @@ The `echo $?` line is the gate, not the visible output. If `exit != 0`,
 inspect `/tmp/pytest-out.txt` directly with Read or grep — never trust a
 truncated tail to tell you the test summary.
 
+**A failing test is never "pre-existing" without verification (WOR-389).**
+If pytest fails, the temptation is to dismiss the failure as "unrelated to
+my ticket" and write `result.json: status=success` with a footnote. That
+is forbidden. Workflow when pytest fails:
+
+1. **Investigate.** Is it caused by your change? Most often yes — a
+   sibling test imports a module you edited and its fixtures don't
+   anticipate your change. The failure name is a strong signal.
+2. **If yes, fix it.** Do not write success. The fix is part of the
+   ticket scope by definition (your change broke a test).
+3. **Only if you genuinely believe the failure is pre-existing**
+   (failure existed on the `base_branch` tip BEFORE your first commit),
+   verify with:
+
+   ```bash
+   git stash
+   pytest <failing_test_path>::<failing_test_name>
+   git stash pop
+   ```
+
+   If the test still fails on the stashed (pre-your-change) tree,
+   the failure is genuinely pre-existing. Document it explicitly in
+   the `notes` field of `result.json` and you may write
+   `status=success`. The watcher will see the same failure on its
+   `required_checks` run; it tags `success_outcome_state_mismatch`,
+   which the operator reviews.
+4. **Never** write `status=success` with a footnote like "one
+   pre-existing failure unrelated to this ticket" without performing
+   step 3. Workers that did this on WOR-135 wave-1 and WOR-331 lost
+   real diffs because the watcher's pytest correctly invalidated the
+   self-reported success.
+
 If any required check fails:
 - Record the failure in the result artifact (step 5)
 - If `failure_policy.on_check_failure` is `"abort"`: stop here, write a failed result


### PR DESCRIPTION
## Summary

Adds a hard rule to `.claude/commands/implement-ticket.md` step 4. Targets the WOR-135 wave-1 + WOR-331 failure mode: worker sees pytest fail, decides it's "pre-existing and unrelated to this ticket," writes `result.json: status=success`, the watcher's pytest catches the failure, worker's diff is lost.

## Workflow now mandated when pytest fails

1. **Investigate.** Most often the worker's own change broke a sibling test (a sibling test imports the module you edited).
2. **If caused by the change:** fix it. The fix is part of ticket scope by definition.
3. **Only if genuinely pre-existing:** verify with `git stash; pytest <failing_test>; git stash pop`. If the test still fails on the pre-change tree, document explicitly in `result.json` `notes` field. Then status=success is acceptable.
4. **Never** write `status=success` with a footnote dismissing the failure without step 3.

## Sibling rules in the same skill section

This is the third worker-discipline rule landing in step 4 today:

| Rule | Targets |
|---|---|
| WOR-353 (existing) | Run unscoped pytest before declaring success |
| **WOR-389 (this)** | Don't dismiss failures as pre-existing without `git stash` verification |
| WOR-392 (PR #793) | Don't pipe pytest through `tail`/`head` (swallows exit code) |

Together they close the gap: workers must run unscoped pytest, must see its real exit code, and must verify any "pre-existing" claims.

## Test plan

- [x] Skill file passes pre-commit (trailing whitespace, EOF, etc.)
- Phase 2: in next 5+ ticket runs, no worker should write `status=success` while `check_failures_json` is non-empty (verified against ticket_metrics rows)

## Out of scope (defer)

- Stop hook that intercepts `status=success` when pytest is failing. Useful but adds another hook surface; prose first, hook only if prose is ignored.
- Detection of confabulated "all passed" claims (separate failure mode, harder problem).

## Merge interaction

PR #793 (WOR-392) edits the same file in the adjacent block. They may need a rebase but the conflict region is small and trivial.

Closes WOR-389

🤖 Generated with [Claude Code](https://claude.com/claude-code)