### PR TITLE
WOR-398 Pass WATCHER_WORKER=1 to run_checks subprocess

### DIFF
--- a/app/core/watcher/watcher_subprocess.py
+++ b/app/core/watcher/watcher_subprocess.py
@@ -173,6 +173,13 @@ def run_checks(
     failure_artifact = artifact_dir / _LAST_FAILURE_FILENAME
 
     failed_checks: list[dict[str, int | str]] = []
+    check_env = os.environ.copy()
+    # WOR-398: WOR-391's skipif on tests/test_contribute_skills_workflow.py only
+    # fires when WATCHER_WORKER=1. The worker subprocess gets that flag from
+    # build_worker_env, but the watcher's post-worker required_checks step runs
+    # in a fresh subprocess that inherits the daemon's env, where the flag is
+    # absent — so the skip misses and pytest fails on contribute-skills tests.
+    check_env["WATCHER_WORKER"] = "1"
     for check_cmd in manifest.required_checks:
         logger.info("Running check: %s", check_cmd)
         start = datetime.now(timezone.utc).timestamp()
@@ -181,6 +188,7 @@ def run_checks(
             cwd=str(worktree_path),
             capture_output=True,
             text=True,
+            env=check_env,
         )
         duration = datetime.now(timezone.utc).timestamp() - start
         if metrics is not None and ticket_id:

--- a/tests/test_watcher_subprocess.py
+++ b/tests/test_watcher_subprocess.py
@@ -571,6 +571,33 @@ def test_run_checks_returns_true_when_all_pass(tmp_path: Path) -> None:
         assert failures == []
 
 
+def test_run_checks_propagates_watcher_worker_env(tmp_path: Path) -> None:
+    """WOR-398: every check subprocess must see WATCHER_WORKER=1 so that
+    WOR-391's skipif on tests/test_contribute_skills_workflow.py fires during
+    the watcher's post-worker required_checks step."""
+    manifest = _make_manifest(required_checks=["ruff check .", "pytest"])
+    captured_envs: list[dict[str, str] | None] = []
+
+    def fake_run(cmd: list[str], **kwargs: object) -> MagicMock:
+        env_arg = kwargs.get("env")
+        captured_envs.append(env_arg)  # type: ignore[arg-type]
+        result = MagicMock()
+        result.returncode = 0
+        result.stdout = ""
+        result.stderr = ""
+        return result
+
+    with patch(
+        "app.core.watcher.watcher_subprocess.subprocess.run", side_effect=fake_run
+    ):
+        run_checks(manifest, tmp_path)
+
+    assert len(captured_envs) == 2
+    for env in captured_envs:
+        assert env is not None, "run_checks must pass an env dict to subprocess.run"
+        assert env.get("WATCHER_WORKER") == "1"
+
+
 def test_run_checks_returns_false_on_check_failure(
     tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:


### PR DESCRIPTION
## Summary

- Watcher's post-worker `required_checks` step ran pytest with no `env=` arg, missing the `WATCHER_WORKER=1` flag that WOR-391's `skipif` on `tests/test_contribute_skills_workflow.py` keys off.
- All 5 sub-tickets in the WOR-394 overnight wave 2 batch failed at this step with the same `tests\test_contribute_skills_workflow.py FFFF` failure — telemetry was invalidated.
- Fix: build `check_env = os.environ.copy() | {"WATCHER_WORKER": "1"}` once in `run_checks`, pass it to every check `subprocess.run`. Regression test asserts the flag is present in the env of every check call.

Closes WOR-398

## Test plan
- [x] `pytest tests/test_watcher_subprocess.py` — 37 passed (incl. new `test_run_checks_propagates_watcher_worker_env`)
- [x] Full unscoped `pytest` — 1428 passed
- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy app/core/watcher/watcher_subprocess.py` — clean
- [x] `lint-imports` — 5 contracts kept

🤖 Generated with [Claude Code](https://claude.com/claude-code)