### PR TITLE
WOR-396 SonarCloud watcher_helpers.py: S7519 ×2 dict.fromkeys (lines 595-596)

### DIFF
--- a/app/core/watcher/watcher_helpers.py
+++ b/app/core/watcher/watcher_helpers.py
@@ -592,8 +592,8 @@ def capture_vllm_metrics(timeout: float = 5.0) -> dict[str, float] | None:
         return None
 
     targets = set(_VLLM_COUNTERS)
-    aggregated: dict[str, float] = {name: 0.0 for name in targets}
-    seen: dict[str, bool] = {name: False for name in targets}
+    aggregated: dict[str, float] = dict.fromkeys(targets, 0.0)
+    seen: dict[str, bool] = dict.fromkeys(targets, False)
 
     for raw in body.splitlines():
         line = raw.strip()


### PR DESCRIPTION
Closes WOR-396

Resolve 2 SonarCloud S7519 findings on app/core/watcher/watcher_helpers.py lines 595-596. Replace `{k: None for k in iterable}` (or similar comprehension) with `dict.fromkeys(iterable)`. Same fix on b