### PR TITLE
WOR-395 SonarCloud cli.py: S1172 unused parameter (line 360)

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -357,7 +357,7 @@ def _run_metrics(args: argparse.Namespace) -> int:
     return 1
 
 
-def _config_get(args: argparse.Namespace) -> int:
+def _config_get(_args: argparse.Namespace) -> int:
     prefs = PrefsStore.load()
     for field, value in prefs.model_dump().items():
         key = field.replace("_", "-")


### PR DESCRIPTION
Closes WOR-395

Resolve SonarCloud S1172 finding on app/cli.py line 360: unused `args` parameter. Either remove the param (and update callers) or rename to `_args` if interface-fixed. Pure mechanical cleanup. WOR-340