### PR TITLE
WOR-405 Add preserve_thinking toggle to bench harness

### DIFF
--- a/app/core/bench_store.py
+++ b/app/core/bench_store.py
@@ -74,6 +74,7 @@ CREATE TABLE IF NOT EXISTS bench_run (
     error_message           TEXT,
     finish_reason           TEXT,
     enable_thinking         INTEGER,
+    preserve_thinking       INTEGER,
     recorded_at             TEXT NOT NULL DEFAULT (datetime('now')),
     PRIMARY KEY (run_id, case_id, repeat_index)
 )
@@ -102,7 +103,7 @@ INSERT INTO bench_run (
     model_param_count,
     quality_task_success, quality_pytest_passed,
     quality_ruff_passed, quality_mypy_passed,
-    outcome, error_message, finish_reason, enable_thinking
+    outcome, error_message, finish_reason, enable_thinking, preserve_thinking
 ) VALUES (
     :run_id, :case_id, :repeat_index,
     :tier, :context_size, :concurrency, :backend_id, :model_id,
@@ -120,7 +121,7 @@ INSERT INTO bench_run (
     :model_param_count,
     :quality_task_success, :quality_pytest_passed,
     :quality_ruff_passed, :quality_mypy_passed,
-    :outcome, :error_message, :finish_reason, :enable_thinking
+    :outcome, :error_message, :finish_reason, :enable_thinking, :preserve_thinking
 )
 """
 
@@ -134,6 +135,7 @@ _BOOL_COLUMNS = frozenset(
         "quality_ruff_passed",
         "quality_mypy_passed",
         "enable_thinking",
+        "preserve_thinking",
     }
 )
 
@@ -228,6 +230,7 @@ class BenchRun(BaseModel):
 
     # inference settings
     enable_thinking: bool | None = None
+    preserve_thinking: bool | None = None
 
 
 def hash_settings(settings: dict[str, Any]) -> str:
@@ -296,6 +299,8 @@ class BenchStore:
             conn.execute("ALTER TABLE bench_run ADD COLUMN finish_reason TEXT")
         if "enable_thinking" not in existing:
             conn.execute("ALTER TABLE bench_run ADD COLUMN enable_thinking INTEGER")
+        if "preserve_thinking" not in existing:
+            conn.execute("ALTER TABLE bench_run ADD COLUMN preserve_thinking INTEGER")
 
     @contextmanager
     def _connect(self) -> Generator[sqlite3.Connection, None, None]:

--- a/scripts/bench/config.py
+++ b/scripts/bench/config.py
@@ -54,6 +54,7 @@ class BackendConfig(BaseModel):
     base_url: str
     api_key: str = ""
     enable_thinking: bool = True
+    preserve_thinking: bool = False
 
 
 class ModelConfig(BaseModel):

--- a/scripts/bench/drivers/vllm.py
+++ b/scripts/bench/drivers/vllm.py
@@ -30,10 +30,14 @@ class VllmDriver:
     """Implements BackendDriver for vLLM's /v1/chat/completions SSE endpoint."""
 
     def __init__(
-        self, base_url: str = "http://localhost:8000", enable_thinking: bool = True
+        self,
+        base_url: str = "http://localhost:8000",
+        enable_thinking: bool = True,
+        preserve_thinking: bool = False,
     ) -> None:
         self._base_url = _validated_base_url(base_url)
         self._enable_thinking = enable_thinking
+        self._preserve_thinking = preserve_thinking
 
     def is_available(self) -> bool:
         try:
@@ -59,7 +63,10 @@ class VllmDriver:
             "stream_options": {"include_usage": True},
             "max_tokens": max_tokens,
             "temperature": temperature,
-            "chat_template_kwargs": {"enable_thinking": self._enable_thinking},
+            "chat_template_kwargs": {
+                "enable_thinking": self._enable_thinking,
+                "preserve_thinking": self._preserve_thinking,
+            },
         }
         if seed is not None:
             body["seed"] = seed

--- a/scripts/bench/runner.py
+++ b/scripts/bench/runner.py
@@ -70,10 +70,17 @@ def _make_prompt(tier: str, repeat_index: int, context_size: int) -> BenchPrompt
 
 
 def _make_driver(
-    backend_id: str, base_url: str, enable_thinking: bool = True
+    backend_id: str,
+    base_url: str,
+    enable_thinking: bool = True,
+    preserve_thinking: bool = False,
 ) -> OllamaDriver | VllmDriver:
     if "vllm" in backend_id.lower():
-        return VllmDriver(base_url=base_url, enable_thinking=enable_thinking)
+        return VllmDriver(
+            base_url=base_url,
+            enable_thinking=enable_thinking,
+            preserve_thinking=preserve_thinking,
+        )
     return OllamaDriver(base_url=base_url)
 
 
@@ -274,7 +281,10 @@ def run(
             continue
 
         driver = _make_driver(
-            case.backend_id, backend_cfg.base_url, backend_cfg.enable_thinking
+            case.backend_id,
+            backend_cfg.base_url,
+            backend_cfg.enable_thinking,
+            backend_cfg.preserve_thinking,
         )
 
         info_key = (case.backend_id, case.model_id)
@@ -452,6 +462,11 @@ def run(
             finish_reason=result.finish_reason,
             enable_thinking=(
                 backend_cfg.enable_thinking
+                if "vllm" in case.backend_id.lower()
+                else None
+            ),
+            preserve_thinking=(
+                backend_cfg.preserve_thinking
                 if "vllm" in case.backend_id.lower()
                 else None
             ),

--- a/tests/bench/test_bench_config.py
+++ b/tests/bench/test_bench_config.py
@@ -204,6 +204,40 @@ name = "speed"
     assert cfg.models[0].quant == "Q4_K_M"
 
 
+def test_backend_preserve_thinking_defaults_to_false(tmp_path: Path) -> None:
+    """WOR-405: backend without preserve_thinking gets False (vendor default)."""
+    cfg = BenchConfig.from_toml(_write_toml(tmp_path, _STANDARD_TOML))
+    for backend in cfg.backends:
+        assert backend.preserve_thinking is False
+
+
+def test_backend_preserve_thinking_parsed_from_toml(tmp_path: Path) -> None:
+    """WOR-405: preserve_thinking=true in TOML reaches the BackendConfig."""
+    toml = """
+[matrix]
+context_sizes = [1024]
+boundary_context_sizes = [8192]
+concurrency_levels = [1]
+repeats = 1
+
+[[backends]]
+id = "vllm-preserve"
+enabled = true
+base_url = "http://localhost:8000/"
+preserve_thinking = true
+
+[[models]]
+id = "qwen3-coder"
+backend_id = "vllm-preserve"
+
+[[tiers]]
+name = "speed"
+"""
+    cfg = BenchConfig.from_toml(_write_toml(tmp_path, toml))
+    assert len(cfg.backends) == 1
+    assert cfg.backends[0].preserve_thinking is True
+
+
 def test_model_quant_field_is_optional(tmp_path: Path) -> None:
     toml = """
 [matrix]

--- a/tests/bench/test_bench_drivers.py
+++ b/tests/bench/test_bench_drivers.py
@@ -541,6 +541,31 @@ def test_vllm_generate_payload_contains_max_tokens_and_temperature():
     assert "seed" not in payload
 
 
+def test_vllm_generate_payload_includes_preserve_thinking_default_false():
+    """WOR-405: every request body must declare preserve_thinking; default is False."""
+    with patch("urllib.request.urlopen") as mock_open:
+        mock_open.return_value = io.BytesIO(_VLLM_BODY)
+        VllmDriver().generate(
+            "m", [{"role": "user", "content": "hi"}], 4096, 256, 0.7, None
+        )
+        payload = _captured_payload(mock_open)
+
+    assert payload["chat_template_kwargs"]["preserve_thinking"] is False
+    assert payload["chat_template_kwargs"]["enable_thinking"] is True
+
+
+def test_vllm_generate_payload_propagates_preserve_thinking_when_enabled():
+    """WOR-405: preserve_thinking=True must reach the request body verbatim."""
+    with patch("urllib.request.urlopen") as mock_open:
+        mock_open.return_value = io.BytesIO(_VLLM_BODY)
+        VllmDriver(preserve_thinking=True).generate(
+            "m", [{"role": "user", "content": "hi"}], 4096, 256, 0.7, None
+        )
+        payload = _captured_payload(mock_open)
+
+    assert payload["chat_template_kwargs"]["preserve_thinking"] is True
+
+
 def test_vllm_generate_payload_includes_seed_when_set():
     with patch("urllib.request.urlopen") as mock_open:
         mock_open.return_value = io.BytesIO(_VLLM_BODY)

--- a/tests/bench/test_bench_store.py
+++ b/tests/bench/test_bench_store.py
@@ -371,6 +371,42 @@ class TestNewColumns:
         assert result.cache_state == "prefix_warm"
 
 
+class TestPreserveThinkingColumn:
+    """Tests for preserve_thinking column added in WOR-405."""
+
+    def test_preserve_thinking_defaults_to_none(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        store.record(_run(run_id="r1"))
+        result = store.get_by_run_id("r1")[0]
+        assert result.preserve_thinking is None
+
+    def test_preserve_thinking_true_round_trips(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        store.record(_run(run_id="r1", preserve_thinking=True))
+        result = store.get_by_run_id("r1")[0]
+        assert result.preserve_thinking is True
+
+    def test_preserve_thinking_false_round_trips(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        store.record(_run(run_id="r1", preserve_thinking=False))
+        result = store.get_by_run_id("r1")[0]
+        assert result.preserve_thinking is False
+
+    def test_migrate_idempotent_preserves_column(self, tmp_path: Path) -> None:
+        """WOR-405: column exists after init; second init is idempotent."""
+        import sqlite3
+
+        db = tmp_path / "app.db"
+        BenchStore(db_path=db)
+        BenchStore(db_path=db)  # second init must not raise
+        conn = sqlite3.connect(db)
+        cols = {
+            row[1] for row in conn.execute("PRAGMA table_info(bench_run)").fetchall()
+        }
+        conn.close()
+        assert "preserve_thinking" in cols
+
+
 class TestModelMetadataColumns:
     """Tests for model_quant and model_family added in WOR-207."""
 

--- a/tests/bench/test_runner.py
+++ b/tests/bench/test_runner.py
@@ -61,6 +61,18 @@ def test_make_driver_returns_vllm_for_vllm_backend() -> None:
     assert isinstance(_make_driver("vllm-local", "http://localhost:8000"), VllmDriver)
 
 
+def test_make_driver_propagates_preserve_thinking() -> None:
+    """WOR-405: preserve_thinking flag must reach the constructed VllmDriver."""
+    driver = _make_driver(
+        "vllm-local",
+        "http://localhost:8000",
+        enable_thinking=True,
+        preserve_thinking=True,
+    )
+    assert isinstance(driver, VllmDriver)
+    assert driver._preserve_thinking is True
+
+
 def test_make_driver_vllm_match_is_case_insensitive() -> None:
     assert isinstance(_make_driver("VLLM", "http://localhost:8000"), VllmDriver)
 


### PR DESCRIPTION
## Summary

- Adds `preserve_thinking: bool = False` to `BackendConfig`; mirrors the existing `enable_thinking` plumbing exactly through `runner._make_driver`, `VllmDriver`, and the `bench_run` SQLite table.
- Default is False (vendor default — interleaved-only). When True, vLLM receives `chat_template_kwargs={"preserve_thinking": True}` and Qwen3.6 echoes prior thinking traces back into the prompt.
- Unblocks WOR-400 (production-side preserve_thinking enablement) — gives us a controlled paired-bench A/B before flipping the production default.

Closes WOR-405

## Test plan
- [x] `pytest tests/bench/` — 149 passed (incl. 6 new regression tests)
- [x] Full unscoped pytest — 1451 passed
- [x] ruff / ruff format / mypy / lint-imports — clean
- [ ] Run a paired bench (this is the WOR-400 follow-up; not part of this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)