### PR TITLE
WOR-408 Env-configurable vLLM base URL (unblocks WSL2 broken-localhost case)

### DIFF
--- a/.semgrepignore
+++ b/.semgrepignore
@@ -11,6 +11,10 @@ scripts/bench/lifecycle/ollama_manager.py
 # No user input flows in. Same precedent as scripts/bench/drivers/.
 scripts/spikes/
 
+# Ad-hoc experiment scripts: hit localhost/WSL-IP-only vLLM endpoints during
+# WOR-400 preserve_thinking and effort A/B investigations. No user input flows in.
+.claude/effort_test/
+
 # base_url is a TOML config value validated to http/https at construction;
 # not user-controlled. Same precedent as scripts/bench/drivers/.
 scripts/bench/workloads.py

--- a/app/core/watcher/watcher_types.py
+++ b/app/core/watcher/watcher_types.py
@@ -21,7 +21,13 @@ _ARTIFACTS_DIR = "artifacts"
 _PID_FILE = Path(_CLAUDE_DIR) / "watcher.pid"
 _IN_PROGRESS_STATE = "In Progress"
 _VLLM_PORT = 8000
-_VLLM_BASE_URL = f"http://localhost:{_VLLM_PORT}"
+# WOR-408: env-configurable vLLM endpoint. Defaults to localhost:8000 (the
+# normal WSL2 → Windows port-forwarding case). Override with
+# WATCHER_VLLM_BASE_URL when localhost forwarding is broken (e.g. mirrored
+# networking glitches resolve only the WSL guest IP from Windows).
+_VLLM_BASE_URL = os.environ.get(
+    "WATCHER_VLLM_BASE_URL", f"http://localhost:{_VLLM_PORT}"
+)
 _VLLM_SERVED_MODEL = "qwen3-coder"
 # Metrics label kept for backward compatibility with rows written before WOR-368;
 # Claude Code routes by tier via ANTHROPIC_DEFAULT_*_MODEL, so the on-the-wire

--- a/tests/test_watcher_types.py
+++ b/tests/test_watcher_types.py
@@ -52,3 +52,41 @@ def test_write_and_remove_pid_file(
 
     watcher._remove_pid_file()
     assert not pid_file.exists()
+
+
+# ---------------------------------------------------------------------------
+# WOR-408: WATCHER_VLLM_BASE_URL env override
+# ---------------------------------------------------------------------------
+
+
+def test_vllm_base_url_defaults_to_localhost(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When WATCHER_VLLM_BASE_URL is unset, _VLLM_BASE_URL falls back to
+    localhost:8000 — the normal WSL2 port-forwarding case."""
+    import importlib
+
+    monkeypatch.delenv("WATCHER_VLLM_BASE_URL", raising=False)
+    import app.core.watcher.watcher_types as wt
+
+    importlib.reload(wt)
+    assert wt._VLLM_BASE_URL == "http://localhost:8000"
+
+
+def test_vllm_base_url_honors_env_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """WATCHER_VLLM_BASE_URL fully overrides _VLLM_BASE_URL — used when WSL2
+    localhost forwarding is broken and only the WSL guest IP is reachable
+    from Windows."""
+    import importlib
+
+    monkeypatch.setenv("WATCHER_VLLM_BASE_URL", "http://172.23.139.95:8000")
+    import app.core.watcher.watcher_types as wt
+
+    importlib.reload(wt)
+    assert wt._VLLM_BASE_URL == "http://172.23.139.95:8000"
+
+    # Reset to default so other tests aren't affected
+    monkeypatch.delenv("WATCHER_VLLM_BASE_URL", raising=False)
+    importlib.reload(wt)


### PR DESCRIPTION
## Summary

- The watcher hardcoded `_VLLM_BASE_URL = "http://localhost:8000"`; when WSL2 mirrored networking glitches and Windows can't route localhost to the WSL guest, the watcher and every worker fail at the model-call boundary.
- Discovered today during the WOR-400 preserve_thinking experiment: TCP handshake to localhost:8000 succeeded but no HTTP response, while the WSL guest IP (`172.23.139.95:8000`) worked fine.
- Make `_VLLM_BASE_URL` env-overridable via `WATCHER_VLLM_BASE_URL`. Default behavior unchanged (`http://localhost:8000`) for users with working port forwarding. Two regression tests cover both branches via `importlib.reload`.

Closes WOR-408

## Test plan
- [x] `pytest tests/test_watcher_types.py` — 6 passed (incl. 2 new regression tests)
- [x] Full unscoped pytest — 1453 passed
- [x] ruff / ruff format / mypy / lint-imports — clean
- [x] semgrep — clean (`.claude/effort_test/` added to `.semgrepignore` with same precedent as `scripts/spikes/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)