### PR TITLE
WOR-408: revert preserve_thinking flag from _VLLM_FP8_CMD (broken auto-start)

### DIFF
--- a/app/core/watcher/watcher_services.py
+++ b/app/core/watcher/watcher_services.py
@@ -31,7 +31,17 @@ _VLLM_FP8_CMD = (
     " --reasoning-parser qwen3 --enable-prefix-caching"
     " --language-model-only --safetensors-load-strategy prefetch"
     " --enable-auto-tool-choice --tool-call-parser qwen3_coder"
-    " --default-chat-template-kwargs '{\"preserve_thinking\": true}'"
+    # NOTE: --default-chat-template-kwargs '{"preserve_thinking": true}' is
+    # intentionally OMITTED from this auto-start command. The watcher passes
+    # _VLLM_FP8_CMD as a string argument through Python subprocess →
+    # wt.exe → wsl → bash, and JSON literals containing both single and
+    # double quotes get mangled by each successive shell's quoting rules.
+    # The canonical operator commands in CLAUDE.md / README.md /
+    # .claude/commands/start-{ticket,epic}.md DO include the flag — that's
+    # the path you should normally take. The watcher's auto-start tab is a
+    # best-effort fallback for when vLLM is not already running; it'll start
+    # vLLM without preserve_thinking, and you can restart manually with the
+    # full command if you need that flag.
 )
 
 


### PR DESCRIPTION
## Summary

Revert the `--default-chat-template-kwargs '{\"preserve_thinking\": true}'` addition to `_VLLM_FP8_CMD` (added in PR #825 commit 45b8bb2).

## Why

`_VLLM_FP8_CMD` is passed as a string argument through Python `subprocess.list2cmdline` → `wt.exe` → `wsl` → `bash`. Each successive shell layer rewrites quotes, and the JSON literal `'{"preserve_thinking": true}'` does not survive — vLLM receives the malformed string `{preserve_thinking: true}` (no double quotes on the key) and `json.loads` rejects it.

Operator-confirmed reproduction: when WSL2 localhost forwarding was broken (the original WOR-408 trigger), the watcher's probe failed and fired `_open_vllm_terminal`, spawning the broken command.

## What stays

The flag remains in the canonical operator commands (CLAUDE.md, README.md, `.claude/commands/start-{ticket,epic}.md`) — those run in a single bash shell so the JSON quoting is preserved.

## What changes

`_VLLM_FP8_CMD` (the watcher's auto-start fallback) reverts to the pre-flag form. If the watcher auto-starts vLLM (i.e. operator doesn't have one running), it'll spin up without preserve_thinking. Operator can restart manually with the canonical command for the experiment workload.

## Follow-up

A clean fix is possible — write the JSON to a temp file at watcher startup, reference it in `_VLLM_FP8_CMD` via `--default-chat-template-kwargs "$(cat /tmp/...)"` — but it's out of scope for tonight's wave-3 launch.

## Test plan
- [x] `pytest tests/test_watcher_services.py` — 14 passed
- [x] ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)