### PR TITLE
WOR-404 Split watcher_finalize.py (804 LOC) and test_watcher_finalize.py (1569 LOC)

### DIFF
--- a/app/core/watcher/watcher_finalize.py
+++ b/app/core/watcher/watcher_finalize.py
@@ -13,7 +13,6 @@ import subprocess  # nosec B404
 from pathlib import Path
 
 from app.core.escalation_policy import EscalationPolicy, get_waste_warn_threshold
-from app.core.linear_client import LinearError
 from app.core.manifest import ExecutionManifest
 from app.core.metrics import (
     MetricsStore,
@@ -23,8 +22,14 @@ from app.core.metrics import (
     compute_tags,
 )
 
+from .watcher_finalize_helpers import (
+    _execute_finalization,
+    _read_result_status,
+    _try_post_comment,
+    _write_wip_sha_to_last_failure,
+    safe_set_state,
+)
 from .watcher_helpers import (
-    _POLICY_FLAGS,
     _parse_worker_api_retries,
     _parse_worker_behavior,
     _parse_worker_subagent_spawns,
@@ -36,14 +41,11 @@ from .watcher_helpers import (
 )
 from .watcher_subprocess import (
     create_pr,
-    fetch_sonar_findings,
     parse_git_shortstat,
-    run_checks,
 )
 from .watcher_tui import TrackedPR
 from .watcher_types import (
     _CLAUDE_DIR,
-    _IN_PROGRESS_STATE,
     _LOCAL_MODEL,
     ActiveWorker,
     LinearClientProtocol,
@@ -54,9 +56,10 @@ from .watcher_worktrees import (
     commit_wip_state,
     preserve_worker_artifacts,
     restore_plan_files,
-    squash_wip_commits,
 )
 from .worker_waste import compute_waste_score
+
+__all__ = ["attempt_pr", "finalize_worker", "safe_set_state"]
 
 logger = logging.getLogger(__name__)
 
@@ -149,18 +152,6 @@ def _write_vllm_metrics_artifact(
 # ---------------------------------------------------------------------------
 # Public helpers
 # ---------------------------------------------------------------------------
-
-
-def safe_set_state(
-    linear: LinearClientProtocol,
-    linear_id: str,
-    state: str,
-    ticket_id: str,
-) -> None:
-    try:
-        linear.set_state(linear_id, state)
-    except LinearError as exc:
-        logger.warning("set_state failed for %s (state=%s): %s", ticket_id, state, exc)
 
 
 def attempt_pr(
@@ -531,274 +522,3 @@ def finalize_worker(
             worker.manifest.worker_branch,
         )
     return outcome
-
-
-# ---------------------------------------------------------------------------
-# Internal helpers (reduce cognitive complexity of finalize_worker)
-# ---------------------------------------------------------------------------
-
-
-def _read_result_status(repo_root: Path, manifest: ExecutionManifest) -> str | None:
-    """Return the worker's self-reported status from result.json, or None.
-
-    Workers write a ``status`` field of ``"success"`` or ``"failure"`` (or
-    similar) to ``result.json`` immediately before exiting. This is the
-    in-band signal of how the work actually went, distinct from the OS-level
-    subprocess exit code (which can be non-zero even after a successful run
-    due to Claude Code CLI teardown quirks — see WOR-286).
-
-    Returns None when the file is missing or unreadable; callers should treat
-    that as "no in-band signal" rather than success.
-    """
-    result_path = repo_root / manifest.artifact_paths.result_json
-    try:
-        raw = result_path.read_text(encoding="utf-8")
-    except OSError:
-        return None
-    try:
-        data = json.loads(raw)
-    except ValueError:
-        return None
-    status = data.get("status") if isinstance(data, dict) else None
-    return status if isinstance(status, str) else None
-
-
-def _execute_finalization(
-    worker: ActiveWorker,
-    returncode: int,
-    linear: LinearClientProtocol,
-    escalation_policy: EscalationPolicy,
-    repo_root: Path,
-    tracked_prs: list[TrackedPR] | None = None,
-    metrics: MetricsStore | None = None,
-    project_id: str = "",
-) -> tuple[
-    Outcome, bool, bool, list[str] | None, list[dict[str, int | str]], str | None
-]:
-    """Determine outcome, escalation status, and artifact state.
-
-    Returns (outcome, escalated, artifacts_preserved, sonar_findings,
-             failed_checks, pr_url).  *pr_url* is only populated when the
-             action is ``"fix_locally"`` and the PR is created successfully.
-    """
-    manifest = worker.manifest
-    ticket_id = worker.ticket_id
-    linear_id = worker.linear_id
-
-    # WOR-286: Trust the worker's in-band success signal (result.json) over
-    # the subprocess exit code. Claude Code CLI sometimes exits non-zero
-    # during teardown after a fully successful run — that should not destroy
-    # the work. Only treat non-zero exit as failure when result.json is
-    # missing or also reports failure.
-    result_status = _read_result_status(repo_root, manifest)
-    if returncode != 0:
-        if result_status == "success":
-            logger.warning(
-                "Worker %s exited non-zero (%d) but result.json reports "
-                "status=success — trusting in-band signal and proceeding "
-                "with checks.",
-                ticket_id,
-                returncode,
-            )
-            # Fall through to run_checks; treat as if returncode == 0.
-        else:
-            logger.error(
-                "Worker %s exited non-zero (%d); result.json status=%s — "
-                "routing to failure path",
-                ticket_id,
-                returncode,
-                result_status if result_status is not None else "missing",
-            )
-            escalated = bool(manifest.failure_policy.escalate_to_cloud)
-            if escalated:
-                logger.info("Escalating %s to cloud per failure policy", ticket_id)
-                safe_set_state(linear, linear_id, _IN_PROGRESS_STATE, ticket_id)
-                _try_post_comment(
-                    linear,
-                    linear_id,
-                    ticket_id,
-                    f"Local worker failed for `{ticket_id}` (non-zero exit). "
-                    f"Escalating to cloud per failure policy.",
-                )
-            else:
-                safe_set_state(
-                    linear, linear_id, manifest.ticket_state_map.failed, ticket_id
-                )
-            return "failure", escalated, False, None, [], None
-
-    checks_ok, failed_checks = run_checks(
-        manifest,
-        worker.worktree_path,
-        metrics=metrics,
-        ticket_id=ticket_id,
-        project_id=project_id,
-    )
-    if not checks_ok:
-        worker.retry_count += 1
-    if not checks_ok and manifest.failure_policy.on_check_failure == "abort":
-        escalated = bool(manifest.failure_policy.escalate_to_cloud)
-        if escalated:
-            logger.info("Escalating %s to cloud after check failure", ticket_id)
-            safe_set_state(linear, linear_id, _IN_PROGRESS_STATE, ticket_id)
-            _try_post_comment(
-                linear,
-                linear_id,
-                ticket_id,
-                f"Local worker failed checks for `{ticket_id}`. "
-                f"Escalating to cloud per failure policy.",
-            )
-        else:
-            safe_set_state(
-                linear, linear_id, manifest.ticket_state_map.failed, ticket_id
-            )
-        return "failure", escalated, False, None, failed_checks, None
-
-    preserve_worker_artifacts(repo_root, worker)
-    flags = _read_result_flags(repo_root / manifest.artifact_paths.result_json)
-    action = escalation_policy.classify_result(**flags)
-
-    outcome, escalated, sonar_findings, pr_url = _handle_policy_outcome(
-        action,
-        flags,
-        worker,
-        linear,
-        escalation_policy,
-        manifest.objective,
-        tracked_prs=tracked_prs,
-    )
-    return outcome, escalated, True, sonar_findings, [], pr_url
-
-
-def _handle_policy_outcome(
-    action: str,
-    flags: dict[str, bool],
-    worker: ActiveWorker,
-    linear: LinearClientProtocol,
-    escalation_policy: EscalationPolicy,
-    final_message: str = "Implementation complete",
-    tracked_prs: list[TrackedPR] | None = None,
-) -> tuple[Outcome, bool, list[str] | None, str | None]:
-    """Map a policy action to an outcome, posting Linear comments as needed.
-
-    Returns (outcome, escalated, sonar_findings, pr_url).  *pr_url* is only
-    populated when the action is ``"fix_locally"`` and the PR is created
-    successfully.
-    """
-    ticket_id = worker.ticket_id
-    linear_id = worker.linear_id
-    manifest = worker.manifest
-
-    if action == "escalate":
-        triggering = next((f for f in _POLICY_FLAGS if flags.get(f)), "unknown")
-        logger.info("Escalating %s to cloud (flag=%s)", ticket_id, triggering)
-        safe_set_state(linear, linear_id, _IN_PROGRESS_STATE, ticket_id)
-        _try_post_comment(
-            linear,
-            linear_id,
-            ticket_id,
-            f"Local worker escalating `{ticket_id}` to cloud. "
-            f"Triggering flag: `{triggering}`.",
-        )
-        return "escalated", True, None, None
-
-    if action == "human":
-        logger.info("Human review required for %s per policy", ticket_id)
-        _try_post_comment(
-            linear,
-            linear_id,
-            ticket_id,
-            f"Human review required for `{ticket_id}` before "
-            f"proceeding. Please inspect the result artifact.",
-        )
-        return "aborted", False, None, None
-
-    # fix_locally — check Sonar findings before creating PR
-    sonar_findings = fetch_sonar_findings(manifest.worker_branch)
-    if _sonar_requires_escalation(sonar_findings, ticket_id, escalation_policy):
-        safe_set_state(linear, linear_id, _IN_PROGRESS_STATE, ticket_id)
-        _try_post_comment(
-            linear,
-            linear_id,
-            ticket_id,
-            f"Local worker escalating `{ticket_id}` to cloud due "
-            f"to Sonar finding requiring immediate action.",
-        )
-        return "escalated", True, sonar_findings, None
-
-    # Squash any wip commits into a single commit so retry workers can
-    # diff the final_message commit and resume from a clean state.
-    squash_wip_commits(
-        worker.worktree_path,
-        ticket_id,
-        manifest.base_branch,
-        final_message,
-    )
-
-    outcome, pr_url = attempt_pr(manifest, worker, linear, tracked_prs=tracked_prs)
-    if outcome == "success":
-        if manifest.base_branch == "main":
-            safe_set_state(linear, linear_id, "In Review", ticket_id)
-        else:
-            safe_set_state(linear, linear_id, "MergedToEpic", ticket_id)
-    return outcome, False, sonar_findings, pr_url
-
-
-def _sonar_requires_escalation(
-    sonar_findings: list[str] | None,
-    ticket_id: str,
-    escalation_policy: EscalationPolicy,
-) -> bool:
-    if not sonar_findings:
-        return False
-    for severity in sonar_findings:
-        action = escalation_policy.classify_sonar_finding(severity.lower())
-        if action == "escalate":
-            return True
-        logger.warning(
-            "Sonar finding for %s: severity=%s — fix_locally", ticket_id, severity
-        )
-    return False
-
-
-def _write_wip_sha_to_last_failure(
-    worker: ActiveWorker,
-    wip_sha: str,
-) -> None:
-    """Add wip_commit_sha to last_failure.json in the worktree artifact dir."""
-    artifact_dir = (
-        worker.worktree_path / worker.manifest.artifact_paths.result_json
-    ).parent
-    failure_file = artifact_dir / "last_failure.json"
-    try:
-        data: dict[str, object] = {}
-        if failure_file.exists():
-            data.update(json.loads(failure_file.read_text(encoding="utf-8")))
-        data["wip_commit_sha"] = wip_sha
-        failure_file.write_text(
-            json.dumps(data, indent=2),
-            encoding="utf-8",
-        )
-        logger.debug(
-            "WIP commit SHA written to %s for %s",
-            failure_file,
-            worker.ticket_id,
-        )
-    except (json.JSONDecodeError, OSError) as exc:
-        logger.warning(
-            "Could not write wip_commit_sha to %s for %s: %s",
-            failure_file,
-            worker.ticket_id,
-            exc,
-        )
-
-
-def _try_post_comment(
-    linear: LinearClientProtocol,
-    linear_id: str,
-    ticket_id: str,
-    body: str,
-) -> None:
-    try:
-        linear.post_comment(linear_id, body)
-    except Exception:
-        logger.warning("Could not post comment for %s", ticket_id)

--- a/app/core/watcher/watcher_finalize_helpers.py
+++ b/app/core/watcher/watcher_finalize_helpers.py
@@ -1,0 +1,317 @@
+"""Internal helpers for worker finalization logic.
+
+Extracted from watcher_finalize.py to reduce its LOC toward the ≤700 target.
+All functions are internal to the watcher — callers in other modules import
+them through the re-exports in watcher_finalize.py.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+from app.core.escalation_policy import EscalationPolicy
+from app.core.linear_client import LinearError
+from app.core.manifest import ExecutionManifest
+from app.core.metrics import MetricsStore, Outcome
+from app.core.watcher.watcher_helpers import (
+    _POLICY_FLAGS,
+    _read_result_flags,
+)
+from app.core.watcher.watcher_subprocess import (
+    fetch_sonar_findings,
+    run_checks,
+)
+from app.core.watcher.watcher_tui import TrackedPR
+from app.core.watcher.watcher_types import (
+    _IN_PROGRESS_STATE,
+    ActiveWorker,
+    LinearClientProtocol,
+)
+from app.core.watcher.watcher_worktrees import (
+    preserve_worker_artifacts,
+    squash_wip_commits,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def safe_set_state(
+    linear: LinearClientProtocol,
+    linear_id: str,
+    state: str,
+    ticket_id: str,
+) -> None:
+    try:
+        linear.set_state(linear_id, state)
+    except LinearError as exc:
+        logger.warning("set_state failed for %s (state=%s): %s", ticket_id, state, exc)
+
+
+def _read_result_status(repo_root: Path, manifest: ExecutionManifest) -> str | None:
+    """Return the worker's self-reported status from result.json, or None.
+
+    Workers write a ``status`` field of ``"success"`` or ``"failure"`` (or
+    similar) to ``result.json`` immediately before exiting. This is the
+    in-band signal of how the work actually went, distinct from the OS-level
+    subprocess exit code (which can be non-zero even after a successful run
+    due to Claude Code CLI teardown quirks — see WOR-286).
+
+    Returns None when the file is missing or unreadable; callers should treat
+    that as "no in-band signal" rather than success.
+    """
+    result_path = repo_root / manifest.artifact_paths.result_json
+    try:
+        raw = result_path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    try:
+        data = json.loads(raw)
+    except ValueError:
+        return None
+    status = data.get("status") if isinstance(data, dict) else None
+    return status if isinstance(status, str) else None
+
+
+def _execute_finalization(
+    worker: ActiveWorker,
+    returncode: int,
+    linear: LinearClientProtocol,
+    escalation_policy: EscalationPolicy,
+    repo_root: Path,
+    tracked_prs: list[TrackedPR] | None = None,
+    metrics: MetricsStore | None = None,
+    project_id: str = "",
+) -> tuple[
+    Outcome, bool, bool, list[str] | None, list[dict[str, int | str]], str | None
+]:
+    """Determine outcome, escalation status, and artifact state.
+
+    Returns (outcome, escalated, artifacts_preserved, sonar_findings,
+             failed_checks, pr_url).  *pr_url* is only populated when the
+             action is ``"fix_locally"`` and the PR is created successfully.
+    """
+    manifest = worker.manifest
+    ticket_id = worker.ticket_id
+    linear_id = worker.linear_id
+
+    # WOR-286: Trust the worker's in-band success signal (result.json) over
+    # the subprocess exit code. Claude Code CLI sometimes exits non-zero
+    # during teardown after a fully successful run — that should not destroy
+    # the work. Only treat non-zero exit as failure when result.json is
+    # missing or also reports failure.
+    result_status = _read_result_status(repo_root, manifest)
+    if returncode != 0:
+        if result_status == "success":
+            logger.warning(
+                "Worker %s exited non-zero (%d) but result.json reports "
+                "status=success — trusting in-band signal and proceeding "
+                "with checks.",
+                ticket_id,
+                returncode,
+            )
+            # Fall through to run_checks; treat as if returncode == 0.
+        else:
+            logger.error(
+                "Worker %s exited non-zero (%d); result.json status=%s — "
+                "routing to failure path",
+                ticket_id,
+                returncode,
+                result_status if result_status is not None else "missing",
+            )
+            escalated = bool(manifest.failure_policy.escalate_to_cloud)
+            if escalated:
+                logger.info("Escalating %s to cloud per failure policy", ticket_id)
+                safe_set_state(linear, linear_id, _IN_PROGRESS_STATE, ticket_id)
+                _try_post_comment(
+                    linear,
+                    linear_id,
+                    ticket_id,
+                    f"Local worker failed for `{ticket_id}` (non-zero exit). "
+                    f"Escalating to cloud per failure policy.",
+                )
+            else:
+                safe_set_state(
+                    linear, linear_id, manifest.ticket_state_map.failed, ticket_id
+                )
+            return "failure", escalated, False, None, [], None
+
+    checks_ok, failed_checks = run_checks(
+        manifest,
+        worker.worktree_path,
+        metrics=metrics,
+        ticket_id=ticket_id,
+        project_id=project_id,
+    )
+    if not checks_ok:
+        worker.retry_count += 1
+    if not checks_ok and manifest.failure_policy.on_check_failure == "abort":
+        escalated = bool(manifest.failure_policy.escalate_to_cloud)
+        if escalated:
+            logger.info("Escalating %s to cloud after check failure", ticket_id)
+            safe_set_state(linear, linear_id, _IN_PROGRESS_STATE, ticket_id)
+            _try_post_comment(
+                linear,
+                linear_id,
+                ticket_id,
+                f"Local worker failed checks for `{ticket_id}`. "
+                f"Escalating to cloud per failure policy.",
+            )
+        else:
+            safe_set_state(
+                linear, linear_id, manifest.ticket_state_map.failed, ticket_id
+            )
+        return "failure", escalated, False, None, failed_checks, None
+
+    preserve_worker_artifacts(repo_root, worker)
+    flags = _read_result_flags(repo_root / manifest.artifact_paths.result_json)
+    action = escalation_policy.classify_result(**flags)
+
+    outcome, escalated, sonar_findings, pr_url = _handle_policy_outcome(
+        action,
+        flags,
+        worker,
+        linear,
+        escalation_policy,
+        manifest.objective,
+        tracked_prs=tracked_prs,
+    )
+    return outcome, escalated, True, sonar_findings, [], pr_url
+
+
+def _handle_policy_outcome(
+    action: str,
+    flags: dict[str, bool],
+    worker: ActiveWorker,
+    linear: LinearClientProtocol,
+    escalation_policy: EscalationPolicy,
+    final_message: str = "Implementation complete",
+    tracked_prs: list[TrackedPR] | None = None,
+) -> tuple[Outcome, bool, list[str] | None, str | None]:
+    """Map a policy action to an outcome, posting Linear comments as needed.
+
+    Returns (outcome, escalated, sonar_findings, pr_url).  *pr_url* is only
+    populated when the action is ``"fix_locally"`` and the PR is created
+    successfully.
+    """
+    ticket_id = worker.ticket_id
+    linear_id = worker.linear_id
+    manifest = worker.manifest
+
+    if action == "escalate":
+        triggering = next((f for f in _POLICY_FLAGS if flags.get(f)), "unknown")
+        logger.info("Escalating %s to cloud (flag=%s)", ticket_id, triggering)
+        safe_set_state(linear, linear_id, _IN_PROGRESS_STATE, ticket_id)
+        _try_post_comment(
+            linear,
+            linear_id,
+            ticket_id,
+            f"Local worker escalating `{ticket_id}` to cloud. "
+            f"Triggering flag: `{triggering}`.",
+        )
+        return "escalated", True, None, None
+
+    if action == "human":
+        logger.info("Human review required for %s per policy", ticket_id)
+        _try_post_comment(
+            linear,
+            linear_id,
+            ticket_id,
+            f"Human review required for `{ticket_id}` before "
+            f"proceeding. Please inspect the result artifact.",
+        )
+        return "aborted", False, None, None
+
+    # fix_locally — check Sonar findings before creating PR
+    sonar_findings = fetch_sonar_findings(manifest.worker_branch)
+    if _sonar_requires_escalation(sonar_findings, ticket_id, escalation_policy):
+        safe_set_state(linear, linear_id, _IN_PROGRESS_STATE, ticket_id)
+        _try_post_comment(
+            linear,
+            linear_id,
+            ticket_id,
+            f"Local worker escalating `{ticket_id}` to cloud due "
+            f"to Sonar finding requiring immediate action.",
+        )
+        return "escalated", True, sonar_findings, None
+
+    # Squash any wip commits into a single commit so retry workers can
+    # diff the final_message commit and resume from a clean state.
+    squash_wip_commits(
+        worker.worktree_path,
+        ticket_id,
+        manifest.base_branch,
+        final_message,
+    )
+
+    from .watcher_finalize import attempt_pr
+
+    outcome, pr_url = attempt_pr(manifest, worker, linear, tracked_prs=tracked_prs)
+    if outcome == "success":
+        if manifest.base_branch == "main":
+            safe_set_state(linear, linear_id, "In Review", ticket_id)
+        else:
+            safe_set_state(linear, linear_id, "MergedToEpic", ticket_id)
+    return outcome, False, sonar_findings, pr_url
+
+
+def _sonar_requires_escalation(
+    sonar_findings: list[str] | None,
+    ticket_id: str,
+    escalation_policy: EscalationPolicy,
+) -> bool:
+    if not sonar_findings:
+        return False
+    for severity in sonar_findings:
+        action = escalation_policy.classify_sonar_finding(severity.lower())
+        if action == "escalate":
+            return True
+        logger.warning(
+            "Sonar finding for %s: severity=%s — fix_locally", ticket_id, severity
+        )
+    return False
+
+
+def _write_wip_sha_to_last_failure(
+    worker: ActiveWorker,
+    wip_sha: str,
+) -> None:
+    """Add wip_commit_sha to last_failure.json in the worktree artifact dir."""
+    artifact_dir = (
+        worker.worktree_path / worker.manifest.artifact_paths.result_json
+    ).parent
+    failure_file = artifact_dir / "last_failure.json"
+    try:
+        data: dict[str, object] = {}
+        if failure_file.exists():
+            data.update(json.loads(failure_file.read_text(encoding="utf-8")))
+        data["wip_commit_sha"] = wip_sha
+        failure_file.write_text(
+            json.dumps(data, indent=2),
+            encoding="utf-8",
+        )
+        logger.debug(
+            "WIP commit SHA written to %s for %s",
+            failure_file,
+            worker.ticket_id,
+        )
+    except (json.JSONDecodeError, OSError) as exc:
+        logger.warning(
+            "Could not write wip_commit_sha to %s for %s: %s",
+            failure_file,
+            worker.ticket_id,
+            exc,
+        )
+
+
+def _try_post_comment(
+    linear: LinearClientProtocol,
+    linear_id: str,
+    ticket_id: str,
+    body: str,
+) -> None:
+    try:
+        linear.post_comment(linear_id, body)
+    except Exception:
+        logger.warning("Could not post comment for %s", ticket_id)

--- a/tests/test_watcher_finalize.py
+++ b/tests/test_watcher_finalize.py
@@ -12,11 +12,8 @@ import pytest
 
 from app.core.escalation_policy import EscalationPolicy
 from app.core.linear_client import LinearError
-from app.core.manifest import FailurePolicy
-from app.core.metrics import TicketMetrics
-from app.core.watcher.watcher_finalize import _try_post_comment, finalize_worker
+from app.core.watcher.watcher_finalize import finalize_worker
 from app.core.watcher.watcher_types import ActiveWorker
-from app.core.watcher.watcher_worktrees import WipPreservationResult
 from tests.conftest import make_manifest
 
 # ---------------------------------------------------------------------------
@@ -79,7 +76,10 @@ def test_finalize_worker_pr_failure_marks_blocked(tmp_path: Path) -> None:
     exc = subprocess.CalledProcessError(1, "gh", stderr="Head sha can't be blank")
 
     with (
-        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(True, [])),
+        patch(
+            "app.core.watcher.watcher_finalize_helpers.run_checks",
+            return_value=(True, []),
+        ),
         patch("app.core.watcher.watcher_finalize.create_pr", side_effect=exc),
         patch("app.core.watcher.watcher_finalize.cleanup_worktree"),
     ):
@@ -109,7 +109,10 @@ def test_finalize_worker_retry_count_zero_on_success(tmp_path: Path) -> None:
         process=MagicMock(spec=subprocess.Popen),
     )
     with (
-        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(True, [])),
+        patch(
+            "app.core.watcher.watcher_finalize_helpers.run_checks",
+            return_value=(True, []),
+        ),
         patch(
             "app.core.watcher.watcher_finalize.create_pr",
             return_value="https://github.com/example/pr/1",
@@ -134,7 +137,10 @@ def test_finalize_worker_retry_count_increments_on_check_failure(
         process=MagicMock(spec=subprocess.Popen),
     )
     with (
-        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(False, [])),
+        patch(
+            "app.core.watcher.watcher_finalize_helpers.run_checks",
+            return_value=(False, []),
+        ),
         patch("app.core.watcher.watcher_finalize.cleanup_worktree"),
     ):
         _call_finalize(worker)
@@ -158,7 +164,8 @@ def test_finalize_worker_retry_count_two_failures_then_success(
     check_results = [(False, []), (False, []), (True, [])]
     with (
         patch(
-            "app.core.watcher.watcher_finalize.run_checks", side_effect=check_results
+            "app.core.watcher.watcher_finalize_helpers.run_checks",
+            side_effect=check_results,
         ),
         patch(
             "app.core.watcher.watcher_finalize.create_pr",
@@ -212,7 +219,10 @@ def test_finalize_worker_set_state_failure_success_path_no_crash(
     )
 
     with (
-        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(True, [])),
+        patch(
+            "app.core.watcher.watcher_finalize_helpers.run_checks",
+            return_value=(True, []),
+        ),
         patch(
             "app.core.watcher.watcher_finalize.create_pr",
             return_value="https://github.com/example/pr/1",
@@ -259,7 +269,10 @@ def test_finalize_worker_passes_usage_to_metrics(tmp_path: Path) -> None:
     )
 
     with (
-        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(True, [])),
+        patch(
+            "app.core.watcher.watcher_finalize_helpers.run_checks",
+            return_value=(True, []),
+        ),
         patch(
             "app.core.watcher.watcher_finalize.create_pr",
             return_value="https://github.com/example/pr/1",
@@ -286,7 +299,10 @@ def test_finalize_worker_usage_none_when_no_log(tmp_path: Path) -> None:
     )
 
     with (
-        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(True, [])),
+        patch(
+            "app.core.watcher.watcher_finalize_helpers.run_checks",
+            return_value=(True, []),
+        ),
         patch(
             "app.core.watcher.watcher_finalize.create_pr",
             return_value="https://github.com/example/pr/1",
@@ -328,7 +344,10 @@ def test_finalize_worker_copies_taxonomy_fields_to_metrics(tmp_path: Path) -> No
     )
 
     with (
-        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(True, [])),
+        patch(
+            "app.core.watcher.watcher_finalize_helpers.run_checks",
+            return_value=(True, []),
+        ),
         patch(
             "app.core.watcher.watcher_finalize.create_pr",
             return_value="https://github.com/example/pr/1",
@@ -360,7 +379,10 @@ def test_finalize_worker_taxonomy_none_when_manifest_lacks_them(tmp_path: Path) 
     )
 
     with (
-        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(True, [])),
+        patch(
+            "app.core.watcher.watcher_finalize_helpers.run_checks",
+            return_value=(True, []),
+        ),
         patch(
             "app.core.watcher.watcher_finalize.create_pr",
             return_value="https://github.com/example/pr/1",
@@ -401,7 +423,10 @@ def test_finalize_worker_copies_effort_to_metrics(tmp_path: Path) -> None:
     )
 
     with (
-        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(True, [])),
+        patch(
+            "app.core.watcher.watcher_finalize_helpers.run_checks",
+            return_value=(True, []),
+        ),
         patch(
             "app.core.watcher.watcher_finalize.create_pr",
             return_value="https://github.com/example/pr/1",
@@ -428,7 +453,10 @@ def test_finalize_worker_effort_none_when_manifest_lacks_it(tmp_path: Path) -> N
     )
 
     with (
-        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(True, [])),
+        patch(
+            "app.core.watcher.watcher_finalize_helpers.run_checks",
+            return_value=(True, []),
+        ),
         patch(
             "app.core.watcher.watcher_finalize.create_pr",
             return_value="https://github.com/example/pr/1",
@@ -457,14 +485,17 @@ def test_finalize_worker_sonar_count_wired_to_metrics(tmp_path: Path) -> None:
         process=MagicMock(spec=subprocess.Popen),
     )
     with (
-        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(True, [])),
+        patch(
+            "app.core.watcher.watcher_finalize_helpers.run_checks",
+            return_value=(True, []),
+        ),
         patch(
             "app.core.watcher.watcher_finalize.create_pr",
             return_value="https://github.com/example/pr/1",
         ),
         patch("app.core.watcher.watcher_finalize.cleanup_worktree"),
         patch(
-            "app.core.watcher.watcher_finalize.fetch_sonar_findings",
+            "app.core.watcher.watcher_finalize_helpers.fetch_sonar_findings",
             return_value=["MAJOR", "MINOR", "MINOR"],
         ),
     ):
@@ -485,14 +516,18 @@ def test_finalize_worker_sonar_count_none_when_unavailable(tmp_path: Path) -> No
         process=MagicMock(spec=subprocess.Popen),
     )
     with (
-        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(True, [])),
+        patch(
+            "app.core.watcher.watcher_finalize_helpers.run_checks",
+            return_value=(True, []),
+        ),
         patch(
             "app.core.watcher.watcher_finalize.create_pr",
             return_value="https://github.com/example/pr/1",
         ),
         patch("app.core.watcher.watcher_finalize.cleanup_worktree"),
         patch(
-            "app.core.watcher.watcher_finalize.fetch_sonar_findings", return_value=None
+            "app.core.watcher.watcher_finalize_helpers.fetch_sonar_findings",
+            return_value=None,
         ),
     ):
         _call_finalize(worker, metrics=metrics_mock)
@@ -530,10 +565,13 @@ def test_finalize_worker_sonar_blocker_escalates(tmp_path: Path) -> None:
     linear_mock, worker = _make_worker_with_result(tmp_path, {})
     metrics_mock = MagicMock()
     with (
-        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(True, [])),
-        patch("app.core.watcher.watcher_finalize.preserve_worker_artifacts"),
         patch(
-            "app.core.watcher.watcher_finalize.fetch_sonar_findings",
+            "app.core.watcher.watcher_finalize_helpers.run_checks",
+            return_value=(True, []),
+        ),
+        patch("app.core.watcher.watcher_finalize_helpers.preserve_worker_artifacts"),
+        patch(
+            "app.core.watcher.watcher_finalize_helpers.fetch_sonar_findings",
             return_value=["BLOCKER"],
         ),
         patch("app.core.watcher.watcher_finalize.create_pr") as mock_create_pr,
@@ -557,10 +595,13 @@ def test_finalize_worker_sonar_major_advisory_warning(
     linear_mock, worker = _make_worker_with_result(tmp_path, {})
     metrics_mock = MagicMock()
     with (
-        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(True, [])),
-        patch("app.core.watcher.watcher_finalize.preserve_worker_artifacts"),
         patch(
-            "app.core.watcher.watcher_finalize.fetch_sonar_findings",
+            "app.core.watcher.watcher_finalize_helpers.run_checks",
+            return_value=(True, []),
+        ),
+        patch("app.core.watcher.watcher_finalize_helpers.preserve_worker_artifacts"),
+        patch(
+            "app.core.watcher.watcher_finalize_helpers.fetch_sonar_findings",
             return_value=["MAJOR"],
         ),
         patch(
@@ -585,10 +626,14 @@ def test_finalize_worker_sonar_none_no_escalation(tmp_path: Path) -> None:
     linear_mock, worker = _make_worker_with_result(tmp_path, {})
     metrics_mock = MagicMock()
     with (
-        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(True, [])),
-        patch("app.core.watcher.watcher_finalize.preserve_worker_artifacts"),
         patch(
-            "app.core.watcher.watcher_finalize.fetch_sonar_findings", return_value=None
+            "app.core.watcher.watcher_finalize_helpers.run_checks",
+            return_value=(True, []),
+        ),
+        patch("app.core.watcher.watcher_finalize_helpers.preserve_worker_artifacts"),
+        patch(
+            "app.core.watcher.watcher_finalize_helpers.fetch_sonar_findings",
+            return_value=None,
         ),
         patch(
             "app.core.watcher.watcher_finalize.create_pr",
@@ -615,8 +660,11 @@ def test_finalize_worker_scope_drift_escalates(tmp_path: Path) -> None:
     linear_mock, worker = _make_worker_with_result(tmp_path, {"scope_drift": True})
     metrics_mock = MagicMock()
     with (
-        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(True, [])),
-        patch("app.core.watcher.watcher_finalize.preserve_worker_artifacts"),
+        patch(
+            "app.core.watcher.watcher_finalize_helpers.run_checks",
+            return_value=(True, []),
+        ),
+        patch("app.core.watcher.watcher_finalize_helpers.preserve_worker_artifacts"),
         patch("app.core.watcher.watcher_finalize.create_pr") as mock_create_pr,
         patch("app.core.watcher.watcher_finalize.cleanup_worktree"),
     ):
@@ -639,8 +687,11 @@ def test_finalize_worker_forbidden_path_touched_escalates(tmp_path: Path) -> Non
     )
     metrics_mock = MagicMock()
     with (
-        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(True, [])),
-        patch("app.core.watcher.watcher_finalize.preserve_worker_artifacts"),
+        patch(
+            "app.core.watcher.watcher_finalize_helpers.run_checks",
+            return_value=(True, []),
+        ),
+        patch("app.core.watcher.watcher_finalize_helpers.preserve_worker_artifacts"),
         patch("app.core.watcher.watcher_finalize.create_pr") as mock_create_pr,
         patch("app.core.watcher.watcher_finalize.cleanup_worktree"),
     ):
@@ -661,8 +712,11 @@ def test_finalize_worker_no_flags_proceeds_normally(tmp_path: Path) -> None:
     linear_mock, worker = _make_worker_with_result(tmp_path, {})
     metrics_mock = MagicMock()
     with (
-        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(True, [])),
-        patch("app.core.watcher.watcher_finalize.preserve_worker_artifacts"),
+        patch(
+            "app.core.watcher.watcher_finalize_helpers.run_checks",
+            return_value=(True, []),
+        ),
+        patch("app.core.watcher.watcher_finalize_helpers.preserve_worker_artifacts"),
         patch(
             "app.core.watcher.watcher_finalize.create_pr",
             return_value="https://github.com/example/pr/1",
@@ -692,8 +746,11 @@ def test_finalize_worker_missing_result_json_proceeds_normally(tmp_path: Path) -
         process=MagicMock(spec=subprocess.Popen),
     )
     with (
-        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(True, [])),
-        patch("app.core.watcher.watcher_finalize.preserve_worker_artifacts"),
+        patch(
+            "app.core.watcher.watcher_finalize_helpers.run_checks",
+            return_value=(True, []),
+        ),
+        patch("app.core.watcher.watcher_finalize_helpers.preserve_worker_artifacts"),
         patch(
             "app.core.watcher.watcher_finalize.create_pr",
             return_value="https://github.com/example/pr/1",
@@ -721,8 +778,11 @@ def test_finalize_worker_human_policy_posts_comment_and_aborts(
     linear_mock, worker = _make_worker_with_result(tmp_path, {})
     metrics_mock = MagicMock()
     with (
-        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(True, [])),
-        patch("app.core.watcher.watcher_finalize.preserve_worker_artifacts"),
+        patch(
+            "app.core.watcher.watcher_finalize_helpers.run_checks",
+            return_value=(True, []),
+        ),
+        patch("app.core.watcher.watcher_finalize_helpers.preserve_worker_artifacts"),
         patch("app.core.watcher.watcher_finalize.create_pr") as mock_create_pr,
         patch("app.core.watcher.watcher_finalize.cleanup_worktree"),
         patch.object(EscalationPolicy, "classify_result", return_value="human"),
@@ -743,827 +803,3 @@ def test_finalize_worker_human_policy_posts_comment_and_aborts(
 
 
 # ---------------------------------------------------------------------------
-# _try_post_comment exception guard (lines 257-258)
-# ---------------------------------------------------------------------------
-
-
-def test_try_post_comment_swallows_exception(
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    linear_mock = MagicMock()
-    linear_mock.post_comment.side_effect = Exception("connection reset by peer")
-
-    with caplog.at_level(logging.WARNING, logger="app.core.watcher.watcher_finalize"):
-        _try_post_comment(linear_mock, "lin-id", "WOR-10", "some comment body")
-
-    assert any("Could not post comment" in msg for msg in caplog.messages)
-
-
-# ---------------------------------------------------------------------------
-# escalate_to_cloud branching in _execute_finalization
-# ---------------------------------------------------------------------------
-
-
-def test_execute_finalization_check_failure_escalates_to_cloud(tmp_path: Path) -> None:
-    manifest = make_manifest(
-        ticket_id="WOR-10",
-        worker_branch="wor-10-test-ticket",
-        failure_policy=FailurePolicy(on_check_failure="abort", escalate_to_cloud=True),
-    )
-    linear_mock = MagicMock()
-    metrics_mock = MagicMock()
-    worker = ActiveWorker(
-        ticket_id="WOR-10",
-        linear_id="fake-linear-id",
-        manifest=manifest,
-        worktree_path=tmp_path,
-        process=MagicMock(spec=subprocess.Popen),
-    )
-    with (
-        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(False, [])),
-        patch("app.core.watcher.watcher_finalize.cleanup_worktree"),
-    ):
-        _call_finalize(worker, linear=linear_mock, metrics=metrics_mock)
-
-    linear_mock.set_state.assert_called_with("fake-linear-id", "In Progress")
-    linear_mock.post_comment.assert_called_once()
-    m = metrics_mock.record.call_args[0][0]
-    assert m.escalated_to_cloud is True
-
-
-def test_execute_finalization_check_failure_blocked_when_no_escalate(
-    tmp_path: Path,
-) -> None:
-    manifest = make_manifest(
-        ticket_id="WOR-10",
-        worker_branch="wor-10-test-ticket",
-    )
-    linear_mock = MagicMock()
-    metrics_mock = MagicMock()
-    worker = ActiveWorker(
-        ticket_id="WOR-10",
-        linear_id="fake-linear-id",
-        manifest=manifest,
-        worktree_path=tmp_path,
-        process=MagicMock(spec=subprocess.Popen),
-    )
-    with (
-        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(False, [])),
-        patch("app.core.watcher.watcher_finalize.cleanup_worktree"),
-    ):
-        _call_finalize(worker, linear=linear_mock, metrics=metrics_mock)
-
-    linear_mock.set_state.assert_called_with("fake-linear-id", "Blocked")
-    m = metrics_mock.record.call_args[0][0]
-    assert m.escalated_to_cloud is False
-
-
-def test_execute_finalization_nonzero_exit_escalates_to_cloud(tmp_path: Path) -> None:
-    manifest = make_manifest(
-        ticket_id="WOR-10",
-        worker_branch="wor-10-test-ticket",
-        failure_policy=FailurePolicy(escalate_to_cloud=True),
-    )
-    linear_mock = MagicMock()
-    metrics_mock = MagicMock()
-    worker = ActiveWorker(
-        ticket_id="WOR-10",
-        linear_id="fake-linear-id",
-        manifest=manifest,
-        worktree_path=tmp_path,
-        process=MagicMock(spec=subprocess.Popen),
-    )
-    with patch("app.core.watcher.watcher_finalize.cleanup_worktree"):
-        _call_finalize(worker, returncode=1, linear=linear_mock, metrics=metrics_mock)
-
-    linear_mock.set_state.assert_called_with("fake-linear-id", "In Progress")
-    linear_mock.post_comment.assert_called_once()
-    m = metrics_mock.record.call_args[0][0]
-    assert m.escalated_to_cloud is True
-
-
-# ---------------------------------------------------------------------------
-# _execute_finalization — explicit return-value assertions (AC)
-# ---------------------------------------------------------------------------
-
-
-def test_execute_finalization_nonzero_returncode_returns_failure(
-    tmp_path: Path,
-) -> None:
-    """non-zero returncode → 'failure' returned (not just logged)."""
-    manifest = make_manifest(ticket_id="WOR-10", worker_branch="wor-10-test-ticket")
-    linear_mock = MagicMock()
-    worker = ActiveWorker(
-        ticket_id="WOR-10",
-        linear_id="fake-linear-id",
-        manifest=manifest,
-        worktree_path=tmp_path,
-        process=MagicMock(spec=subprocess.Popen),
-    )
-    from app.core.watcher.watcher_finalize import _execute_finalization
-
-    outcome, escalated, preserved, findings, _, _ = _execute_finalization(
-        worker, 1, linear_mock, EscalationPolicy.from_toml(), tmp_path
-    )
-
-    assert outcome == "failure"
-    assert escalated is False
-    assert preserved is False
-    assert findings is None
-
-
-def test_execute_finalization_check_failure_abort_returns_failure(
-    tmp_path: Path,
-) -> None:
-    """checks fail with on_check_failure='abort' → 'failure' returned."""
-    manifest = make_manifest(
-        ticket_id="WOR-10",
-        worker_branch="wor-10-test-ticket",
-        failure_policy=FailurePolicy(on_check_failure="abort"),
-    )
-    linear_mock = MagicMock()
-    worker = ActiveWorker(
-        ticket_id="WOR-10",
-        linear_id="fake-linear-id",
-        manifest=manifest,
-        worktree_path=tmp_path,
-        process=MagicMock(spec=subprocess.Popen),
-    )
-    from app.core.watcher.watcher_finalize import _execute_finalization
-
-    with patch(
-        "app.core.watcher.watcher_finalize.run_checks",
-        return_value=(False, []),
-    ):
-        outcome, escalated, preserved, findings, _, _ = _execute_finalization(
-            worker, 0, linear_mock, EscalationPolicy.from_toml(), tmp_path
-        )
-
-    assert outcome == "failure"
-    assert escalated is False
-    assert preserved is False
-    assert findings is None
-
-
-# ---------------------------------------------------------------------------
-# _handle_policy_outcome — explicit return-value assertions (AC)
-# ---------------------------------------------------------------------------
-
-
-def test_handle_policy_outcome_escalate_returns_escalated(
-    tmp_path: Path,
-) -> None:
-    """action='escalate' → returns 'escalated'."""
-    linear_mock = MagicMock()
-    manifest = make_manifest(ticket_id="WOR-10", worker_branch="wor-10-test-ticket")
-    worker = ActiveWorker(
-        ticket_id="WOR-10",
-        linear_id="fake-linear-id",
-        manifest=manifest,
-        worktree_path=tmp_path,
-        process=MagicMock(spec=subprocess.Popen),
-    )
-    from app.core.watcher.watcher_finalize import _handle_policy_outcome
-
-    outcome, escalated, findings, pr_url = _handle_policy_outcome(
-        "escalate",
-        {"scope_drift": True},
-        worker,
-        linear_mock,
-        EscalationPolicy.from_toml(),
-    )
-
-    assert outcome == "escalated"
-    assert escalated is True
-    assert findings is None
-    assert pr_url is None
-
-
-def test_handle_policy_outcome_human_returns_aborted(tmp_path: Path) -> None:
-    """action='human' → returns 'aborted'."""
-    linear_mock = MagicMock()
-    manifest = make_manifest(ticket_id="WOR-10", worker_branch="wor-10-test-ticket")
-    worker = ActiveWorker(
-        ticket_id="WOR-10",
-        linear_id="fake-linear-id",
-        manifest=manifest,
-        worktree_path=tmp_path,
-        process=MagicMock(spec=subprocess.Popen),
-    )
-    from app.core.watcher.watcher_finalize import _handle_policy_outcome
-
-    outcome, escalated, findings, pr_url = _handle_policy_outcome(
-        "human",
-        {"scope_drift": True},
-        worker,
-        linear_mock,
-        EscalationPolicy.from_toml(),
-    )
-
-    assert outcome == "aborted"
-    assert escalated is False
-    assert findings is None
-    assert pr_url is None
-
-
-# ---------------------------------------------------------------------------
-# _sonar_requires_escalation — boundary cases (AC)
-# ---------------------------------------------------------------------------
-
-
-def test_sonar_requires_escalation_empty_list(tmp_path: Path) -> None:
-    """returns False for empty findings list."""
-    from app.core.watcher.watcher_finalize import _sonar_requires_escalation
-
-    assert (
-        _sonar_requires_escalation([], "WOR-10", EscalationPolicy.from_toml()) is False
-    )
-
-
-def test_sonar_requires_escalation_severity_triggers_true() -> None:
-    """returns True when escalation_policy maps severity to 'escalate'."""
-    from app.core.watcher.watcher_finalize import _sonar_requires_escalation
-
-    # Default policy: BLOCKER → escalate
-    assert (
-        _sonar_requires_escalation(["BLOCKER"], "WOR-10", EscalationPolicy.from_toml())
-        is True
-    )
-    assert (
-        _sonar_requires_escalation(["CRITICAL"], "WOR-10", EscalationPolicy.from_toml())
-        is True
-    )
-
-
-def test_sonar_requires_escalation_no_triggers_false() -> None:
-    """returns False when no severity maps to 'escalate'."""
-    from app.core.watcher.watcher_finalize import _sonar_requires_escalation
-
-    # Default policy: MAJOR, MINOR, INFO → fix_locally (not escalate)
-    assert (
-        _sonar_requires_escalation(
-            ["MAJOR", "MINOR", "INFO"],
-            "WOR-10",
-            EscalationPolicy.from_toml(),
-        )
-        is False
-    )
-
-
-# ---------------------------------------------------------------------------
-# safe_set_state — direct (AC: LinearError caught and logged as warning)
-# ---------------------------------------------------------------------------
-
-
-def test_safe_set_state_linear_error_logged_as_warning(
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """LinearError is caught and logged as warning (does not raise)."""
-    linear_mock = MagicMock()
-    linear_mock.set_state.side_effect = LinearError("network timeout")
-
-    with caplog.at_level(logging.WARNING, logger="app.core.watcher.watcher_finalize"):
-        # Should NOT raise — catches LinearError internally
-        from app.core.watcher.watcher_finalize import safe_set_state
-
-        safe_set_state(linear_mock, "fake-linear-id", "Blocked", "WOR-10")
-
-    # set_state was called but the exception was caught and not re-raised
-    linear_mock.set_state.assert_called_once_with("fake-linear-id", "Blocked")
-    assert any("set_state failed" in msg for msg in caplog.messages)
-
-
-def test_safe_set_state_success_no_warning(caplog: pytest.LogCaptureFixture) -> None:
-    """Successful set_state produces no warning log."""
-    linear_mock = MagicMock()
-    with caplog.at_level(logging.WARNING, logger="app.core.watcher.watcher_finalize"):
-        from app.core.watcher.watcher_finalize import safe_set_state
-
-        safe_set_state(linear_mock, "fake-linear-id", "In Progress", "WOR-10")
-
-    assert not caplog.text or "set_state failed" not in caplog.text
-    linear_mock.set_state.assert_called_once_with("fake-linear-id", "In Progress")
-
-
-# ---------------------------------------------------------------------------
-# attempt_pr — direct (AC: success path returns 'success'; error → 'failure')
-# ---------------------------------------------------------------------------
-
-
-def test_attempt_pr_success_returns_success(
-    tmp_path: Path,
-) -> None:
-    """PR creation succeeds → 'success' returned."""
-    manifest = make_manifest(ticket_id="WOR-10", worker_branch="wor-10-test-ticket")
-    worker = ActiveWorker(
-        ticket_id="WOR-10",
-        linear_id="fake-linear-id",
-        manifest=manifest,
-        worktree_path=tmp_path,
-        process=MagicMock(spec=subprocess.Popen),
-    )
-    linear_mock = MagicMock()
-    from app.core.watcher.watcher_finalize import attempt_pr
-
-    with patch(
-        "app.core.watcher.watcher_finalize.create_pr",
-        return_value="https://github.com/example/pr/1",
-    ):
-        result = attempt_pr(manifest, worker, linear_mock)
-
-    assert result[0] == "success"
-    linear_mock.set_state.assert_not_called()
-    linear_mock.post_comment.assert_not_called()
-
-
-def test_attempt_pr_called_process_error_returns_failure(
-    tmp_path: Path,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """CalledProcessError → state set to failed, returns 'failure'."""
-    manifest = make_manifest(
-        ticket_id="WOR-10",
-        worker_branch="wor-10-test-ticket",
-    )
-    linear_mock = MagicMock()
-    worker = ActiveWorker(
-        ticket_id="WOR-10",
-        linear_id="fake-linear-id",
-        manifest=manifest,
-        worktree_path=tmp_path,
-        process=MagicMock(spec=subprocess.Popen),
-    )
-    from app.core.watcher.watcher_finalize import attempt_pr
-
-    exc = subprocess.CalledProcessError(1, "gh pr create", stderr="validation failed")
-    with patch("app.core.watcher.watcher_finalize.create_pr", side_effect=exc):
-        result = attempt_pr(manifest, worker, linear_mock)
-
-    assert result[0] == "failure"
-    linear_mock.set_state.assert_called_with("fake-linear-id", "Blocked")
-    linear_mock.post_comment.assert_called_once()
-    comment_body = linear_mock.post_comment.call_args[0][1]
-    assert "WOR-10" in comment_body
-    assert "validation failed" in comment_body
-
-
-# ---------------------------------------------------------------------------
-# WOR-267 — attempt_pr calls commit_wip_state on failure
-# ---------------------------------------------------------------------------
-
-
-def test_attempt_pr_calls_commit_wip_state_on_failure(
-    tmp_path: Path,
-) -> None:
-    """On CalledProcessError, commit_wip_state is called to preserve changes."""
-    manifest = make_manifest(
-        ticket_id="WOR-10",
-        worker_branch="wor-10-test-ticket",
-    )
-    linear_mock = MagicMock()
-    worker = ActiveWorker(
-        ticket_id="WOR-10",
-        linear_id="fake-linear-id",
-        manifest=manifest,
-        worktree_path=tmp_path,
-        process=MagicMock(spec=subprocess.Popen),
-    )
-    from app.core.watcher.watcher_finalize import attempt_pr
-
-    exc = subprocess.CalledProcessError(1, "gh pr create", stderr="validation failed")
-    with (
-        patch(
-            "app.core.watcher.watcher_finalize.commit_wip_state",
-            return_value=WipPreservationResult(
-                status="clean", sha=None, backup_path=None, error=None
-            ),
-        ) as mock_commit,
-        patch("app.core.watcher.watcher_finalize.create_pr", side_effect=exc),
-    ):
-        result = attempt_pr(manifest, worker, linear_mock)
-
-    assert result[0] == "failure"
-    mock_commit.assert_called_once_with(
-        tmp_path,
-        "WOR-10",
-        "wor-10-test-ticket",
-    )
-
-
-# ---------------------------------------------------------------------------
-# WOR-230 — local_input_tokens / local_output_tokens wired to metrics
-# ---------------------------------------------------------------------------
-
-
-def test_finalize_worker_writes_separate_token_fields(tmp_path: Path) -> None:
-    """input_tokens and output_tokens are passed to TicketMetrics."""
-    manifest = make_manifest(ticket_id="WOR-10", worker_branch="wor-10-test-ticket")
-    metrics_mock = MagicMock()
-
-    log_dir = tmp_path / ".claude"
-    log_dir.mkdir(parents=True)
-    log_file = log_dir / "worker_wor-10.log"
-    log_file.write_text(
-        json.dumps(
-            {
-                "type": "result",
-                "usage": {"input_tokens": 15000, "output_tokens": 600},
-                "context_compactions": 2,
-            }
-        )
-        + "\n",
-        encoding="utf-8",
-    )
-
-    worker = ActiveWorker(
-        ticket_id="WOR-10",
-        linear_id="fake-linear-id",
-        manifest=manifest,
-        worktree_path=tmp_path,
-        process=MagicMock(spec=subprocess.Popen),
-    )
-
-    with (
-        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(True, [])),
-        patch(
-            "app.core.watcher.watcher_finalize.create_pr",
-            return_value="https://github.com/example/pr/1",
-        ),
-        patch("app.core.watcher.watcher_finalize.cleanup_worktree"),
-    ):
-        _call_finalize(worker, wall_time=10.0, metrics=metrics_mock)
-
-    m = metrics_mock.record.call_args[0][0]
-    assert m.local_input_tokens == 15000
-    assert m.local_output_tokens == 600
-    assert m.local_tokens == 15600  # backward-compat sum
-    assert m.output_tokens_per_wall_second == pytest.approx(60.0)  # 600/10
-
-
-def test_finalize_worker_token_fields_none_when_no_log(
-    tmp_path: Path,
-) -> None:
-    """When log is missing, all new token fields are None."""
-    manifest = make_manifest(ticket_id="WOR-10", worker_branch="wor-10-test-ticket")
-    metrics_mock = MagicMock()
-
-    worker = ActiveWorker(
-        ticket_id="WOR-10",
-        linear_id="fake-linear-id",
-        manifest=manifest,
-        worktree_path=tmp_path,
-        process=MagicMock(spec=subprocess.Popen),
-    )
-
-    with (
-        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(True, [])),
-        patch(
-            "app.core.watcher.watcher_finalize.create_pr",
-            return_value="https://github.com/example/pr/1",
-        ),
-        patch("app.core.watcher.watcher_finalize.cleanup_worktree"),
-    ):
-        _call_finalize(worker, metrics=metrics_mock)
-
-    m = metrics_mock.record.call_args[0][0]
-    assert m.local_input_tokens is None
-    assert m.local_output_tokens is None
-    assert m.local_tokens is None
-    assert m.output_tokens_per_wall_second is None
-
-
-# ---------------------------------------------------------------------------
-# WOR-277 — waste_score wired to metrics
-# ---------------------------------------------------------------------------
-
-
-def test_finalize_worker_waste_score_passed_to_metrics(tmp_path: Path) -> None:
-    """Waste score from the worker log is passed to TicketMetrics."""
-    manifest = make_manifest(ticket_id="WOR-10", worker_branch="wor-10-test-ticket")
-    metrics_mock = MagicMock()
-
-    log_dir = tmp_path / ".claude"
-    log_dir.mkdir(parents=True, exist_ok=True)
-    log_file = log_dir / "worker_wor-10.log"
-    # Write a log with redundant reads to produce a non-zero waste score.
-    log_file.write_text(
-        json.dumps(
-            {
-                "type": "result",
-                "usage": {"input_tokens": 1000, "output_tokens": 200},
-            }
-        )
-        + "\n",
-        encoding="utf-8",
-    )
-    # Add redundant Read tool_use entries.
-    for _ in range(3):
-        with open(log_file, "a", encoding="utf-8") as f:
-            f.write(
-                json.dumps(
-                    {
-                        "type": "tool_use",
-                        "name": "Read",
-                        "input": {"path": "a.py"},
-                    }
-                )
-                + "\n"
-            )
-
-    worker = ActiveWorker(
-        ticket_id="WOR-10",
-        linear_id="fake-linear-id",
-        manifest=manifest,
-        worktree_path=tmp_path,
-        process=MagicMock(spec=subprocess.Popen),
-    )
-
-    with (
-        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(True, [])),
-        patch(
-            "app.core.watcher.watcher_finalize.create_pr",
-            return_value="https://github.com/example/pr/1",
-        ),
-        patch("app.core.watcher.watcher_finalize.cleanup_worktree"),
-    ):
-        _call_finalize(worker, metrics=metrics_mock)
-
-    m = metrics_mock.record.call_args[0][0]
-    assert m.waste_score is not None
-    assert m.waste_score > 0
-    assert m.waste_breakdown_json is not None
-
-
-def test_finalize_worker_waste_score_none_when_no_log(
-    tmp_path: Path,
-) -> None:
-    """When no worker log exists, waste_score is None."""
-    manifest = make_manifest(ticket_id="WOR-10", worker_branch="wor-10-test-ticket")
-    metrics_mock = MagicMock()
-
-    worker = ActiveWorker(
-        ticket_id="WOR-10",
-        linear_id="fake-linear-id",
-        manifest=manifest,
-        worktree_path=tmp_path,
-        process=MagicMock(spec=subprocess.Popen),
-    )
-
-    with (
-        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(True, [])),
-        patch(
-            "app.core.watcher.watcher_finalize.create_pr",
-            return_value="https://github.com/example/pr/1",
-        ),
-        patch("app.core.watcher.watcher_finalize.cleanup_worktree"),
-    ):
-        _call_finalize(worker, metrics=metrics_mock)
-
-    m = metrics_mock.record.call_args[0][0]
-    assert m.waste_score is None
-    assert m.waste_breakdown_json is None
-
-
-def test_finalize_worker_waste_warning_logged(
-    tmp_path: Path,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """WARNING is logged when waste score exceeds threshold."""
-    manifest = make_manifest(ticket_id="WOR-10", worker_branch="wor-10-test-ticket")
-    metrics_mock = MagicMock()
-
-    log_dir = tmp_path / ".claude"
-    log_dir.mkdir(parents=True, exist_ok=True)
-    log_file = log_dir / "worker_wor-10.log"
-    # Write a log with many redundant reads to produce a high waste score.
-    log_file.write_text(
-        json.dumps(
-            {
-                "type": "result",
-                "usage": {"input_tokens": 1000, "output_tokens": 200},
-            }
-        )
-        + "\n",
-        encoding="utf-8",
-    )
-    # 20 redundant reads → 20 * 2 = 40, well above threshold of 60 with other signals.
-    for _ in range(25):
-        with open(log_file, "a", encoding="utf-8") as f:
-            f.write(
-                json.dumps(
-                    {
-                        "type": "tool_use",
-                        "name": "Read",
-                        "input": {"path": "a.py"},
-                    }
-                )
-                + "\n"
-            )
-
-    worker = ActiveWorker(
-        ticket_id="WOR-10",
-        linear_id="fake-linear-id",
-        manifest=manifest,
-        worktree_path=tmp_path,
-        process=MagicMock(spec=subprocess.Popen),
-    )
-
-    with (
-        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(True, [])),
-        patch(
-            "app.core.watcher.watcher_finalize.create_pr",
-            return_value="https://github.com/example/pr/1",
-        ),
-        patch("app.core.watcher.watcher_finalize.cleanup_worktree"),
-        caplog.at_level(logging.WARNING, logger="app.core.watcher.watcher_finalize"),
-    ):
-        _call_finalize(worker, metrics=metrics_mock)
-
-    # Should log a WARNING with the ticket ID and waste score.
-    assert any("WOR-10" in msg and "waste" in msg.lower() for msg in caplog.messages)
-
-
-# ---------------------------------------------------------------------------
-# WOR-332 — tags auto-populated from result.json flags
-# ---------------------------------------------------------------------------
-
-
-def test_finalize_worker_auto_populates_tags_from_flags(tmp_path: Path) -> None:
-    """When result.json has scope_drift, compute_tags fires and set_tags is called."""
-    manifest = make_manifest(ticket_id="WOR-10", worker_branch="wor-10-test-ticket")
-    linear_mock = MagicMock()
-    metrics_mock = MagicMock()
-
-    result_path = tmp_path / ".claude" / "artifacts" / "wor_10" / "result.json"
-    result_path.parent.mkdir(parents=True, exist_ok=True)
-    result_path.write_text(
-        json.dumps({"status": "success", "scope_drift": True}),
-        encoding="utf-8",
-    )
-
-    # Real TicketMetrics so compute_tags can read fields without MagicMock errors.
-    row = TicketMetrics(
-        ticket_id="WOR-10",
-        project_id=_DEFAULT_PROJECT,
-        implementation_mode="local",
-        outcome="success",
-        retry_count=0,
-        lines_changed=5,
-    )
-    metrics_mock.get_by_ticket.return_value = row
-
-    worker = ActiveWorker(
-        ticket_id="WOR-10",
-        linear_id="fake-linear-id",
-        manifest=manifest,
-        worktree_path=tmp_path,
-        process=MagicMock(spec=subprocess.Popen),
-    )
-
-    with (
-        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(True, [])),
-        patch(
-            "app.core.watcher.watcher_finalize.preserve_worker_artifacts",
-        ),
-        patch(
-            "app.core.watcher.watcher_finalize.create_pr",
-            return_value="https://github.com/example/pr/1",
-        ),
-        patch("app.core.watcher.watcher_finalize.cleanup_worktree"),
-    ):
-        _call_finalize(
-            worker,
-            linear=linear_mock,
-            metrics=metrics_mock,
-            repo_root=tmp_path,
-            compute_tags_fn=MagicMock(return_value=["scope_drift"]),
-        )
-
-    # set_tags should be called because compute_tags returns non-empty list
-    metrics_mock.set_tags.assert_called_once()
-    call_args = metrics_mock.set_tags.call_args[0]
-    assert call_args[0] == "WOR-10"
-    assert call_args[1] == _DEFAULT_PROJECT
-    assert "scope_drift" in call_args[2]
-
-
-def test_finalize_worker_no_set_tags_when_compute_tags_empty(
-    tmp_path: Path,
-) -> None:
-    """When compute_tags returns [], set_tags is NOT called."""
-    manifest = make_manifest(ticket_id="WOR-10", worker_branch="wor-10-test-ticket")
-    linear_mock = MagicMock()
-    metrics_mock = MagicMock()
-
-    result_path = tmp_path / ".claude" / "artifacts" / "wor_10" / "result.json"
-    result_path.parent.mkdir(parents=True, exist_ok=True)
-    result_path.write_text(json.dumps({"status": "success"}), encoding="utf-8")
-
-    # Real TicketMetrics so compute_tags doesn't crash on MagicMock comparisons.
-    row = TicketMetrics(
-        ticket_id="WOR-10",
-        project_id=_DEFAULT_PROJECT,
-        implementation_mode="local",
-        outcome="success",
-        retry_count=0,
-        lines_changed=5,
-    )
-    metrics_mock.get_by_ticket.return_value = row
-
-    worker = ActiveWorker(
-        ticket_id="WOR-10",
-        linear_id="fake-linear-id",
-        manifest=manifest,
-        worktree_path=tmp_path,
-        process=MagicMock(spec=subprocess.Popen),
-    )
-
-    with (
-        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(True, [])),
-        patch(
-            "app.core.watcher.watcher_finalize.preserve_worker_artifacts",
-        ),
-        patch(
-            "app.core.watcher.watcher_finalize.create_pr",
-            return_value="https://github.com/example/pr/1",
-        ),
-        patch("app.core.watcher.watcher_finalize.cleanup_worktree"),
-    ):
-        _call_finalize(
-            worker, linear=linear_mock, metrics=metrics_mock, repo_root=tmp_path
-        )
-
-    metrics_mock.set_tags.assert_not_called()
-
-
-# ---------------------------------------------------------------------------
-# WOR-343 — branch-aware state setter on PR success path
-# ---------------------------------------------------------------------------
-
-
-def test_finalize_main_target_sets_in_review(tmp_path: Path) -> None:
-    """When base_branch == 'main', finalize_worker sets state to 'In Review'."""
-    manifest = make_manifest(
-        ticket_id="WOR-10",
-        worker_branch="wor-10-test-ticket",
-        base_branch="main",
-    )
-    linear_mock = MagicMock()
-    metrics_mock = MagicMock()
-
-    worker = ActiveWorker(
-        ticket_id="WOR-10",
-        linear_id="fake-linear-id",
-        manifest=manifest,
-        worktree_path=tmp_path,
-        process=MagicMock(spec=subprocess.Popen),
-    )
-
-    with (
-        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(True, [])),
-        patch("app.core.watcher.watcher_finalize.preserve_worker_artifacts"),
-        patch(
-            "app.core.watcher.watcher_finalize.create_pr",
-            return_value="https://github.com/example/pr/1",
-        ),
-        patch("app.core.watcher.watcher_finalize.cleanup_worktree"),
-    ):
-        _call_finalize(
-            worker, linear=linear_mock, metrics=metrics_mock, repo_root=tmp_path
-        )
-
-    linear_mock.set_state.assert_called_once_with("fake-linear-id", "In Review")
-
-
-def test_finalize_epic_target_sets_merged_to_epic(tmp_path: Path) -> None:
-    """When base_branch != 'main', finalize_worker sets state to 'MergedToEpic'."""
-    manifest = make_manifest(
-        ticket_id="WOR-10",
-        worker_branch="wor-10-test-ticket",
-        base_branch="epic/wor-10-test",
-    )
-    linear_mock = MagicMock()
-    metrics_mock = MagicMock()
-
-    worker = ActiveWorker(
-        ticket_id="WOR-10",
-        linear_id="fake-linear-id",
-        manifest=manifest,
-        worktree_path=tmp_path,
-        process=MagicMock(spec=subprocess.Popen),
-    )
-
-    with (
-        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(True, [])),
-        patch("app.core.watcher.watcher_finalize.preserve_worker_artifacts"),
-        patch(
-            "app.core.watcher.watcher_finalize.create_pr",
-            return_value="https://github.com/example/pr/1",
-        ),
-        patch("app.core.watcher.watcher_finalize.cleanup_worktree"),
-    ):
-        _call_finalize(
-            worker, linear=linear_mock, metrics=metrics_mock, repo_root=tmp_path
-        )
-
-    linear_mock.set_state.assert_called_once_with("fake-linear-id", "MergedToEpic")

--- a/tests/test_watcher_finalize_helpers.py
+++ b/tests/test_watcher_finalize_helpers.py
@@ -1,0 +1,348 @@
+"""Tests for app.core.watcher_finalize_helpers — internal finalization helpers."""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.core.escalation_policy import EscalationPolicy
+from app.core.manifest import FailurePolicy
+from app.core.watcher.watcher_finalize_helpers import (
+    _execute_finalization,
+    _handle_policy_outcome,
+    _sonar_requires_escalation,
+    _try_post_comment,
+)
+from app.core.watcher.watcher_types import ActiveWorker
+from tests.conftest import make_manifest
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+_DEFAULT_PROJECT = "repo-scaffold-desktop"
+
+
+def _make_worker_with_result(
+    tmp_path: Path, flags: dict[str, bool]
+) -> tuple[MagicMock, ActiveWorker]:
+    manifest = make_manifest(ticket_id="WOR-10", worker_branch="wor-10-test-ticket")
+    linear_mock = MagicMock()
+
+    result_path = tmp_path / ".claude" / "artifacts" / "wor_10" / "result.json"
+    result_path.parent.mkdir(parents=True, exist_ok=True)
+    result_path.write_text(json.dumps({"status": "success", **flags}), encoding="utf-8")
+
+    worker = ActiveWorker(
+        ticket_id="WOR-10",
+        linear_id="fake-linear-id",
+        manifest=manifest,
+        worktree_path=tmp_path,
+        process=MagicMock(spec=__import__("subprocess").Popen),
+    )
+    return linear_mock, worker
+
+
+# ---------------------------------------------------------------------------
+# _sonar_requires_escalation — boundary cases
+# ---------------------------------------------------------------------------
+
+
+def test_sonar_requires_escalation_empty_list(tmp_path: Path) -> None:
+    """returns False for empty findings list."""
+    assert (
+        _sonar_requires_escalation([], "WOR-10", EscalationPolicy.from_toml()) is False
+    )
+
+
+def test_sonar_requires_escalation_severity_triggers_true() -> None:
+    """returns True when escalation_policy maps severity to 'escalate'."""
+    # Default policy: BLOCKER -> escalate
+    assert (
+        _sonar_requires_escalation(["BLOCKER"], "WOR-10", EscalationPolicy.from_toml())
+        is True
+    )
+    assert (
+        _sonar_requires_escalation(["CRITICAL"], "WOR-10", EscalationPolicy.from_toml())
+        is True
+    )
+
+
+def test_sonar_requires_escalation_no_triggers_false() -> None:
+    """returns False when no severity maps to 'escalate'."""
+    # Default policy: MAJOR, MINOR, INFO -> fix_locally (not escalate)
+    assert (
+        _sonar_requires_escalation(
+            ["MAJOR", "MINOR", "INFO"],
+            "WOR-10",
+            EscalationPolicy.from_toml(),
+        )
+        is False
+    )
+
+
+# ---------------------------------------------------------------------------
+# _execute_finalization — explicit return-value assertions
+# ---------------------------------------------------------------------------
+
+
+def test_execute_finalization_nonzero_returncode_returns_failure(
+    tmp_path: Path,
+) -> None:
+    """non-zero returncode -> 'failure' returned (not just logged)."""
+    manifest = make_manifest(ticket_id="WOR-10", worker_branch="wor-10-test-ticket")
+    linear_mock = MagicMock()
+    worker = ActiveWorker(
+        ticket_id="WOR-10",
+        linear_id="fake-linear-id",
+        manifest=manifest,
+        worktree_path=tmp_path,
+        process=MagicMock(spec=__import__("subprocess").Popen),
+    )
+
+    outcome, escalated, preserved, findings, _, _ = _execute_finalization(
+        worker, 1, linear_mock, EscalationPolicy.from_toml(), tmp_path
+    )
+
+    assert outcome == "failure"
+    assert escalated is False
+    assert preserved is False
+    assert findings is None
+
+
+def test_execute_finalization_check_failure_abort_returns_failure(
+    tmp_path: Path,
+) -> None:
+    """checks fail with on_check_failure='abort' -> 'failure' returned."""
+    manifest = make_manifest(
+        ticket_id="WOR-10",
+        worker_branch="wor-10-test-ticket",
+        failure_policy=FailurePolicy(on_check_failure="abort"),
+    )
+    linear_mock = MagicMock()
+    worker = ActiveWorker(
+        ticket_id="WOR-10",
+        linear_id="fake-linear-id",
+        manifest=manifest,
+        worktree_path=tmp_path,
+        process=MagicMock(spec=__import__("subprocess").Popen),
+    )
+    with patch(
+        "app.core.watcher.watcher_finalize_helpers.run_checks",
+        return_value=(False, []),
+    ):
+        outcome, escalated, preserved, findings, _, _ = _execute_finalization(
+            worker, 0, linear_mock, EscalationPolicy.from_toml(), tmp_path
+        )
+
+    assert outcome == "failure"
+    assert escalated is False
+    assert preserved is False
+    assert findings is None
+
+
+# ---------------------------------------------------------------------------
+# escalate_to_cloud branching in _execute_finalization
+# ---------------------------------------------------------------------------
+
+
+def test_execute_finalization_check_failure_escalates_to_cloud(tmp_path: Path) -> None:
+    manifest = make_manifest(
+        ticket_id="WOR-10",
+        worker_branch="wor-10-test-ticket",
+        failure_policy=FailurePolicy(on_check_failure="abort", escalate_to_cloud=True),
+    )
+    linear_mock = MagicMock()
+    worker = ActiveWorker(
+        ticket_id="WOR-10",
+        linear_id="fake-linear-id",
+        manifest=manifest,
+        worktree_path=tmp_path,
+        process=MagicMock(spec=__import__("subprocess").Popen),
+    )
+    with (
+        patch(
+            "app.core.watcher.watcher_finalize_helpers.run_checks",
+            return_value=(False, []),
+        ),
+        patch("app.core.watcher.watcher_worktrees.cleanup_worktree"),
+    ):
+        _execute_finalization(
+            worker, 0, linear_mock, EscalationPolicy.from_toml(), tmp_path
+        )
+
+    linear_mock.set_state.assert_called_with("fake-linear-id", "In Progress")
+    linear_mock.post_comment.assert_called_once()
+
+
+def test_execute_finalization_check_failure_blocked_when_no_escalate(
+    tmp_path: Path,
+) -> None:
+    manifest = make_manifest(
+        ticket_id="WOR-10",
+        worker_branch="wor-10-test-ticket",
+    )
+    linear_mock = MagicMock()
+    worker = ActiveWorker(
+        ticket_id="WOR-10",
+        linear_id="fake-linear-id",
+        manifest=manifest,
+        worktree_path=tmp_path,
+        process=MagicMock(spec=__import__("subprocess").Popen),
+    )
+    with (
+        patch(
+            "app.core.watcher.watcher_finalize_helpers.run_checks",
+            return_value=(False, []),
+        ),
+        patch("app.core.watcher.watcher_worktrees.cleanup_worktree"),
+    ):
+        _execute_finalization(
+            worker, 0, linear_mock, EscalationPolicy.from_toml(), tmp_path
+        )
+
+    linear_mock.set_state.assert_called_with("fake-linear-id", "Blocked")
+
+
+def test_execute_finalization_nonzero_exit_escalates_to_cloud(tmp_path: Path) -> None:
+    manifest = make_manifest(
+        ticket_id="WOR-10",
+        worker_branch="wor-10-test-ticket",
+        failure_policy=FailurePolicy(escalate_to_cloud=True),
+    )
+    linear_mock = MagicMock()
+    worker = ActiveWorker(
+        ticket_id="WOR-10",
+        linear_id="fake-linear-id",
+        manifest=manifest,
+        worktree_path=tmp_path,
+        process=MagicMock(spec=__import__("subprocess").Popen),
+    )
+    with patch("app.core.watcher.watcher_worktrees.cleanup_worktree"):
+        _execute_finalization(
+            worker, 1, linear_mock, EscalationPolicy.from_toml(), tmp_path
+        )
+
+    linear_mock.set_state.assert_called_with("fake-linear-id", "In Progress")
+    linear_mock.post_comment.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# _handle_policy_outcome — explicit return-value assertions
+# ---------------------------------------------------------------------------
+
+
+def test_handle_policy_outcome_escalate_returns_escalated(
+    tmp_path: Path,
+) -> None:
+    """action='escalate' -> returns 'escalated'."""
+    linear_mock = MagicMock()
+    manifest = make_manifest(ticket_id="WOR-10", worker_branch="wor-10-test-ticket")
+    worker = ActiveWorker(
+        ticket_id="WOR-10",
+        linear_id="fake-linear-id",
+        manifest=manifest,
+        worktree_path=tmp_path,
+        process=MagicMock(spec=__import__("subprocess").Popen),
+    )
+
+    outcome, escalated, findings, pr_url = _handle_policy_outcome(
+        "escalate",
+        {"scope_drift": True},
+        worker,
+        linear_mock,
+        EscalationPolicy.from_toml(),
+    )
+
+    assert outcome == "escalated"
+    assert escalated is True
+    assert findings is None
+    assert pr_url is None
+
+
+def test_handle_policy_outcome_human_returns_aborted(tmp_path: Path) -> None:
+    """action='human' -> returns 'aborted'."""
+    linear_mock = MagicMock()
+    manifest = make_manifest(ticket_id="WOR-10", worker_branch="wor-10-test-ticket")
+    worker = ActiveWorker(
+        ticket_id="WOR-10",
+        linear_id="fake-linear-id",
+        manifest=manifest,
+        worktree_path=tmp_path,
+        process=MagicMock(spec=__import__("subprocess").Popen),
+    )
+
+    outcome, escalated, findings, pr_url = _handle_policy_outcome(
+        "human",
+        {"scope_drift": True},
+        worker,
+        linear_mock,
+        EscalationPolicy.from_toml(),
+    )
+
+    assert outcome == "aborted"
+    assert escalated is False
+    assert findings is None
+    assert pr_url is None
+
+
+# ---------------------------------------------------------------------------
+# Human policy action — _handle_policy_outcome 'human' branch
+# ---------------------------------------------------------------------------
+
+
+def test_finalize_worker_human_policy_posts_comment_and_aborts(
+    tmp_path: Path,
+) -> None:
+    linear_mock, worker = _make_worker_with_result(tmp_path, {})
+    with (
+        patch(
+            "app.core.watcher.watcher_finalize_helpers.run_checks",
+            return_value=(True, []),
+        ),
+        patch("app.core.watcher.watcher_finalize_helpers.preserve_worker_artifacts"),
+        patch("app.core.watcher.watcher_subprocess.create_pr") as mock_create_pr,
+        patch("app.core.watcher.watcher_worktrees.cleanup_worktree"),
+        patch.object(EscalationPolicy, "classify_result", return_value="human"),
+    ):
+        from app.core.watcher.watcher_finalize import finalize_worker
+
+        finalize_worker(
+            worker,
+            returncode=0,
+            wall_time=1.0,
+            linear=linear_mock,
+            metrics=MagicMock(),
+            escalation_policy=EscalationPolicy.from_toml(),
+            repo_root=tmp_path,
+            mode="default",
+            project_id=_DEFAULT_PROJECT,
+        )
+
+    mock_create_pr.assert_not_called()
+    linear_mock.set_state.assert_not_called()
+    linear_mock.post_comment.assert_called_once()
+    comment_body: str = linear_mock.post_comment.call_args[0][1]
+    assert "Human review required" in comment_body
+    assert "WOR-10" in comment_body
+
+
+# ---------------------------------------------------------------------------
+# _try_post_comment exception guard
+# ---------------------------------------------------------------------------
+
+
+def test_try_post_comment_swallows_exception(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    linear_mock = MagicMock()
+    linear_mock.post_comment.side_effect = Exception("connection reset by peer")
+
+    with caplog.at_level(logging.WARNING, logger="app.core.watcher.watcher_finalize"):
+        _try_post_comment(linear_mock, "lin-id", "WOR-10", "some comment body")
+
+    assert any("Could not post comment" in msg for msg in caplog.messages)

--- a/tests/test_watcher_finalize_metrics.py
+++ b/tests/test_watcher_finalize_metrics.py
@@ -75,7 +75,7 @@ def test_finalize_worker_check_failures_populated_on_check_failure(
     )
     with (
         patch(
-            "app.core.watcher.watcher_finalize.run_checks",
+            "app.core.watcher.watcher_finalize_helpers.run_checks",
             return_value=(
                 False,
                 [{"check": "mypy app/", "exit_code": 1}],
@@ -111,7 +111,7 @@ def test_finalize_worker_check_failures_empty_on_success(
     )
     with (
         patch(
-            "app.core.watcher.watcher_finalize.run_checks",
+            "app.core.watcher.watcher_finalize_helpers.run_checks",
             return_value=(True, []),
         ),
         patch(
@@ -149,7 +149,7 @@ def test_finalize_worker_sonar_count_zero_on_empty_findings(
     )
     with (
         patch(
-            "app.core.watcher.watcher_finalize.run_checks",
+            "app.core.watcher.watcher_finalize_helpers.run_checks",
             return_value=(True, []),
         ),
         patch(
@@ -158,7 +158,7 @@ def test_finalize_worker_sonar_count_zero_on_empty_findings(
         ),
         patch("app.core.watcher.watcher_finalize.cleanup_worktree"),
         patch(
-            "app.core.watcher.watcher_finalize.fetch_sonar_findings",
+            "app.core.watcher.watcher_finalize_helpers.fetch_sonar_findings",
             return_value=[],
         ),
     ):
@@ -188,7 +188,7 @@ def test_finalize_worker_failed_check_in_run_log_on_failure(
     )
     with (
         patch(
-            "app.core.watcher.watcher_finalize.run_checks",
+            "app.core.watcher.watcher_finalize_helpers.run_checks",
             return_value=(
                 False,
                 [
@@ -244,7 +244,10 @@ def test_finalize_worker_cloud_metrics_populated_for_cloud_run(
     )
 
     with (
-        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(True, [])),
+        patch(
+            "app.core.watcher.watcher_finalize_helpers.run_checks",
+            return_value=(True, []),
+        ),
         patch(
             "app.core.watcher.watcher_finalize.create_pr",
             return_value="https://github.com/example/pr/1",
@@ -305,7 +308,10 @@ def test_finalize_worker_cloud_model_from_env(
     )
 
     with (
-        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(True, [])),
+        patch(
+            "app.core.watcher.watcher_finalize_helpers.run_checks",
+            return_value=(True, []),
+        ),
         patch(
             "app.core.watcher.watcher_finalize.create_pr",
             return_value="https://github.com/example/pr/1",
@@ -340,7 +346,10 @@ def test_finalize_worker_cloud_no_token_log(
     )
 
     with (
-        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(True, [])),
+        patch(
+            "app.core.watcher.watcher_finalize_helpers.run_checks",
+            return_value=(True, []),
+        ),
         patch(
             "app.core.watcher.watcher_finalize.create_pr",
             return_value="https://github.com/example/pr/1",
@@ -391,7 +400,10 @@ def test_finalize_worker_local_run_keeps_local_fields(
     )
 
     with (
-        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(True, [])),
+        patch(
+            "app.core.watcher.watcher_finalize_helpers.run_checks",
+            return_value=(True, []),
+        ),
         patch(
             "app.core.watcher.watcher_finalize.create_pr",
             return_value="https://github.com/example/pr/1",
@@ -451,7 +463,10 @@ def test_finalize_worker_local_model_non_null_for_local_run(
     )
 
     with (
-        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(True, [])),
+        patch(
+            "app.core.watcher.watcher_finalize_helpers.run_checks",
+            return_value=(True, []),
+        ),
         patch(
             "app.core.watcher.watcher_finalize.create_pr",
             return_value="https://github.com/example/pr/1",
@@ -487,7 +502,10 @@ def test_finalize_worker_local_model_is_none_for_cloud_run(
     )
 
     with (
-        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(True, [])),
+        patch(
+            "app.core.watcher.watcher_finalize_helpers.run_checks",
+            return_value=(True, []),
+        ),
         patch(
             "app.core.watcher.watcher_finalize.create_pr",
             return_value="https://github.com/example/pr/1",
@@ -643,7 +661,7 @@ def _finalize_with_real_diff(repo: Path, ticket_id: str = "WOR-354") -> object:
     )
     with (
         patch(
-            "app.core.watcher.watcher_finalize.run_checks",
+            "app.core.watcher.watcher_finalize_helpers.run_checks",
             return_value=(True, []),
         ),
         patch(
@@ -652,7 +670,7 @@ def _finalize_with_real_diff(repo: Path, ticket_id: str = "WOR-354") -> object:
         ),
         patch("app.core.watcher.watcher_finalize.cleanup_worktree"),
         patch(
-            "app.core.watcher.watcher_finalize.fetch_sonar_findings",
+            "app.core.watcher.watcher_finalize_helpers.fetch_sonar_findings",
             return_value=[],
         ),
     ):

--- a/tests/test_watcher_finalize_recovery.py
+++ b/tests/test_watcher_finalize_recovery.py
@@ -76,7 +76,10 @@ def test_finalize_worker_calls_commit_wip_state_on_check_failure(
     )
 
     with (
-        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(False, [])),
+        patch(
+            "app.core.watcher.watcher_finalize_helpers.run_checks",
+            return_value=(False, []),
+        ),
         patch(
             "app.core.watcher.watcher_finalize.commit_wip_state",
             return_value=WipPreservationResult(
@@ -120,7 +123,10 @@ def test_finalize_worker_writes_last_failure_json_on_wip_commit(
     failure_file.write_text('{"failed_at": "2026-01-01"}', encoding="utf-8")
 
     with (
-        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(False, [])),
+        patch(
+            "app.core.watcher.watcher_finalize_helpers.run_checks",
+            return_value=(False, []),
+        ),
         patch(
             "app.core.watcher.watcher_finalize.commit_wip_state",
             return_value=WipPreservationResult(
@@ -159,7 +165,10 @@ def test_finalize_worker_last_failure_json_created_when_absent(
     # No last_failure.json exists
 
     with (
-        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(False, [])),
+        patch(
+            "app.core.watcher.watcher_finalize_helpers.run_checks",
+            return_value=(False, []),
+        ),
         patch(
             "app.core.watcher.watcher_finalize.commit_wip_state",
             return_value=WipPreservationResult(
@@ -193,7 +202,10 @@ def test_finalize_worker_skips_commit_wip_when_no_sha(tmp_path: Path) -> None:
     )
 
     with (
-        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(False, [])),
+        patch(
+            "app.core.watcher.watcher_finalize_helpers.run_checks",
+            return_value=(False, []),
+        ),
         patch(
             "app.core.watcher.watcher_finalize.commit_wip_state",
             return_value=WipPreservationResult(
@@ -252,7 +264,10 @@ def test_finalize_worker_success_resultjson_overrides_nonzero_exit(
     )
 
     with (
-        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(True, [])),
+        patch(
+            "app.core.watcher.watcher_finalize_helpers.run_checks",
+            return_value=(True, []),
+        ),
         patch(
             "app.core.watcher.watcher_finalize.create_pr",
             return_value="https://github.com/example/pr/1",
@@ -388,7 +403,10 @@ def test_finalize_worker_success_resultjson_but_checks_fail_routes_failure(
     )
 
     with (
-        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(False, [])),
+        patch(
+            "app.core.watcher.watcher_finalize_helpers.run_checks",
+            return_value=(False, []),
+        ),
         patch(
             "app.core.watcher.watcher_finalize.commit_wip_state",
             return_value=WipPreservationResult(
@@ -435,7 +453,10 @@ def test_finalize_worker_failure_path_cleanup_skipped_when_wip_failed(
     )
 
     with (
-        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(False, [])),
+        patch(
+            "app.core.watcher.watcher_finalize_helpers.run_checks",
+            return_value=(False, []),
+        ),
         patch(
             "app.core.watcher.watcher_finalize.commit_wip_state",
             return_value=WipPreservationResult(
@@ -477,7 +498,10 @@ def test_finalize_worker_failure_path_cleanup_runs_when_wip_pushed(
     )
 
     with (
-        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(False, [])),
+        patch(
+            "app.core.watcher.watcher_finalize_helpers.run_checks",
+            return_value=(False, []),
+        ),
         patch(
             "app.core.watcher.watcher_finalize.commit_wip_state",
             return_value=WipPreservationResult(
@@ -510,7 +534,10 @@ def test_finalize_worker_failure_path_cleanup_runs_when_wip_backup(
     )
 
     with (
-        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(False, [])),
+        patch(
+            "app.core.watcher.watcher_finalize_helpers.run_checks",
+            return_value=(False, []),
+        ),
         patch(
             "app.core.watcher.watcher_finalize.commit_wip_state",
             return_value=WipPreservationResult(
@@ -546,7 +573,10 @@ def test_finalize_worker_failure_path_cleanup_runs_when_wip_clean(
     )
 
     with (
-        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(False, [])),
+        patch(
+            "app.core.watcher.watcher_finalize_helpers.run_checks",
+            return_value=(False, []),
+        ),
         patch(
             "app.core.watcher.watcher_finalize.commit_wip_state",
             return_value=WipPreservationResult(
@@ -582,7 +612,10 @@ def test_finalize_worker_passes_backup_root_to_commit_wip_state(
     repo_root.mkdir()
 
     with (
-        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(False, [])),
+        patch(
+            "app.core.watcher.watcher_finalize_helpers.run_checks",
+            return_value=(False, []),
+        ),
         patch(
             "app.core.watcher.watcher_finalize.commit_wip_state",
             return_value=WipPreservationResult(
@@ -629,7 +662,10 @@ def test_finalize_worker_success_path_runs_commit_wip_state(
     )
 
     with (
-        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(True, [])),
+        patch(
+            "app.core.watcher.watcher_finalize_helpers.run_checks",
+            return_value=(True, []),
+        ),
         patch(
             "app.core.watcher.watcher_finalize.create_pr",
             return_value="https://github.com/example/pr/1",
@@ -678,7 +714,10 @@ def test_finalize_worker_success_path_skips_cleanup_when_wip_preservation_fails(
     )
 
     with (
-        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(True, [])),
+        patch(
+            "app.core.watcher.watcher_finalize_helpers.run_checks",
+            return_value=(True, []),
+        ),
         patch(
             "app.core.watcher.watcher_finalize.create_pr",
             return_value="https://github.com/example/pr/1",

--- a/tests/test_watcher_integration.py
+++ b/tests/test_watcher_integration.py
@@ -115,18 +115,21 @@ def test_finalize_worker_happy_path_all_enriched_fields(
 
     # Patch the three functions the manifest calls out plus generic helpers.
     with (
-        patch("app.core.watcher.watcher_finalize.run_checks", return_value=(True, [])),
+        patch(
+            "app.core.watcher.watcher_finalize_helpers.run_checks",
+            return_value=(True, []),
+        ),
         patch(
             "app.core.watcher.watcher_finalize.create_pr",
             return_value="https://github.com/example/repo/pull/130",
         ),
         patch(
-            "app.core.watcher.watcher_finalize.fetch_sonar_findings",
+            "app.core.watcher.watcher_finalize_helpers.fetch_sonar_findings",
             return_value=["MAJOR", "MINOR", "MINOR", "INFO"],
         ),
         patch("app.core.watcher.watcher_finalize.cleanup_worktree"),
-        patch("app.core.watcher.watcher_finalize.compute_tags", return_value=[]),
-        patch("app.core.watcher.watcher_finalize.preserve_worker_artifacts"),
+        patch("app.core.metrics.compute_tags", return_value=[]),
+        patch("app.core.watcher.watcher_finalize_helpers.preserve_worker_artifacts"),
     ):
         finalize_worker(
             worker,


### PR DESCRIPTION
Closes WOR-404

Reduce app/core/watcher/watcher_finalize.py from 804 LOC under 700 LOC AND tests/test_watcher_finalize.py from 1569 LOC under 1200 LOC. Production split: extract internal helpers cluster (_read_result