### PR TITLE
WOR-410 Carve out __init__.py from allowed_paths overlap gate

### DIFF
--- a/app/core/watcher/watcher_helpers.py
+++ b/app/core/watcher/watcher_helpers.py
@@ -279,13 +279,28 @@ def _read_result_flags(result_path: Path) -> dict[str, bool]:
 # ---------------------------------------------------------------------------
 
 
+def _is_append_only_path(path: str) -> bool:
+    """Return True for path entries treated as append-only re-export barrels.
+
+    Two workers editing the same ``__init__.py`` typically only add a new
+    import + ``__all__`` entry for their respective new module — commutative
+    edits whose only conflict surface is the auto-merge at sub-ticket → epic
+    time, which is recoverable. Treating ``__init__.py`` as append-only lets
+    package-split tickets dispatch concurrently (WOR-410). If a real conflict
+    materialises, one sub-ticket PR will fail to auto-merge and need a manual
+    rebase — same outcome as any other late-stage merge collision.
+    """
+    return path == "__init__.py" or path.endswith("/__init__.py")
+
+
 def check_allowed_paths_overlap(
     active: list[ActiveWorker], candidate: ExecutionManifest
 ) -> list[str]:
     """Return identifiers of active workers whose allowed_paths overlap with candidate.
 
-    Two manifests overlap when they share at least one allowed_path pattern.
-    An empty allowed_paths list means "no restriction" — treated as overlap with
+    Two manifests overlap when they share at least one allowed_path pattern,
+    excluding append-only barrel files (see ``_is_append_only_path``). An empty
+    allowed_paths list means "no restriction" — treated as overlap with
     everything to be safe.
     """
     if not candidate.allowed_paths:
@@ -294,9 +309,11 @@ def check_allowed_paths_overlap(
     conflicts: list[str] = []
     candidate_set = set(candidate.allowed_paths)
     for worker in active:
-        if not worker.manifest.allowed_paths or candidate_set & set(
-            worker.manifest.allowed_paths
-        ):
+        if not worker.manifest.allowed_paths:
+            conflicts.append(worker.manifest.ticket_id)
+            continue
+        intersection = candidate_set & set(worker.manifest.allowed_paths)
+        if any(not _is_append_only_path(p) for p in intersection):
             conflicts.append(worker.manifest.ticket_id)
     return conflicts
 

--- a/tests/test_watcher_helpers.py
+++ b/tests/test_watcher_helpers.py
@@ -55,6 +55,72 @@ def test_multiple_active_partial_overlap() -> None:
     assert check_allowed_paths_overlap(active, candidate) == ["WOR-11"]
 
 
+# WOR-410: __init__.py overlap carve-out
+
+
+def test_init_py_only_overlap_does_not_block() -> None:
+    """Two manifests whose only shared path is __init__.py may dispatch concurrently.
+
+    Append-only barrel files (re-export __init__.py) admit commutative edits
+    in the typical case — each worker registers its own new module name. The
+    overlap gate skips them so package-split waves don't serialize.
+    """
+    active = [
+        make_active_worker(
+            "WOR-11",
+            allowed_paths=[
+                "app/core/watcher/watcher_signals.py",
+                "app/core/watcher/__init__.py",
+            ],
+        )
+    ]
+    candidate = make_manifest(
+        allowed_paths=[
+            "app/core/watcher/watcher_promotion.py",
+            "app/core/watcher/__init__.py",
+        ]
+    )
+    assert check_allowed_paths_overlap(active, candidate) == []
+
+
+def test_non_init_overlap_still_blocks() -> None:
+    """The carve-out is __init__.py only — every other shared file still conflicts."""
+    active = [
+        make_active_worker("WOR-11", allowed_paths=["app/core/watcher/watcher.py"])
+    ]
+    candidate = make_manifest(allowed_paths=["app/core/watcher/watcher.py"])
+    assert check_allowed_paths_overlap(active, candidate) == ["WOR-11"]
+
+
+def test_overlap_on_init_plus_real_file_still_blocks() -> None:
+    """If the intersection contains __init__.py *and* a regular file, it still
+    blocks — the regular file is the real conflict surface, not the barrel."""
+    active = [
+        make_active_worker(
+            "WOR-11",
+            allowed_paths=[
+                "app/core/watcher/watcher.py",
+                "app/core/watcher/__init__.py",
+            ],
+        )
+    ]
+    candidate = make_manifest(
+        allowed_paths=[
+            "app/core/watcher/watcher.py",
+            "app/core/watcher/__init__.py",
+        ]
+    )
+    assert check_allowed_paths_overlap(active, candidate) == ["WOR-11"]
+
+
+def test_root_level_init_py_treated_as_append_only() -> None:
+    """A bare 'app/__init__.py' entry should also count as the barrel — the
+    helper checks for the literal name and any '/__init__.py' suffix."""
+    active = [make_active_worker("WOR-11", allowed_paths=["app/__init__.py"])]
+    candidate = make_manifest(allowed_paths=["app/__init__.py"])
+    assert check_allowed_paths_overlap(active, candidate) == []
+
+
 # ---------------------------------------------------------------------------
 # build_worker_env
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Two manifests whose only shared `allowed_path` is an `__init__.py` file may now dispatch concurrently. Package-split tickets that only touch the barrel to add re-exports no longer serialize.
- Carve-out is narrow: any non-`__init__.py` overlap still blocks; mixed overlap (init + regular file) still blocks.
- New helper `_is_append_only_path` matches literal `__init__.py` and any `/__init__.py` suffix.

## Why

WOR-402 wave-3 tonight had 5 sub-tickets, 8 free worker slots, all `parallel_safe: true`. Three of them listed `app/core/watcher/__init__.py` in `allowed_paths` and serialized — adding ~30-45 min of avoidable wall time despite no actual edit conflict (WOR-404 didn't even touch `__init__.py`, having chosen a facade-style split).

If a real conflict materializes despite the carve-out, the second sub-ticket PR fails to auto-merge to the epic — same recovery path as any late-stage collision, no new failure mode.

## Test plan

- [x] `pytest -k "overlap or init_py"` — 7/7 pass (3 existing + 4 new carve-out cases)
- [x] Full unscoped `pytest` — 1459 passed
- [x] `ruff check`, `ruff format --check`, `mypy app/`, `lint-imports` all clean
- [x] Pre-commit (bandit, semgrep, detect-secrets, check-patch-paths, check-file-sizes) all pass

## Out of scope

- Per-path mode declaration in the manifest schema (approach 2 in WOR-410 description) — larger redesign, deferred.
- Diff-based post-hoc merge resolution (approach 3) — larger blast radius, deferred.

Closes WOR-410

🤖 Generated with [Claude Code](https://claude.com/claude-code)