### PR TITLE
WOR-413 Instruct workers to run the four checks in parallel

### DIFF
--- a/.claude/commands/implement-ticket.md
+++ b/.claude/commands/implement-ticket.md
@@ -176,16 +176,43 @@ the PR is created, giving fine-grained retry resume.
 
 ### 4. Run required checks
 
-After implementation, run each command in `required_checks` in order. Run them
+After implementation, run each command in `required_checks`. Run them
 **verbatim** as written in the manifest — do NOT scope them down to specific
 files for "speed", because the watcher will run them at the manifest's full
 scope and any regression you missed will fail the ticket (WOR-353).
 
-```bash
-<check command 1>
-<check command 2>
-...
+**Run the four checks in parallel — they have no data dependencies (WOR-413).**
+`ruff check .`, `mypy app/`, `pytest`, `lint-imports` each read source files
+independently and produce their own findings. Emit all four as separate
+`tool_use` blocks in the **same assistant message** rather than as four
+sequential Bash calls. The runtime executes them concurrently and returns all
+four `tool_result` blocks in one user turn. Wall-time of the check phase
+becomes `max(individual durations)` instead of `sum`, typically halving it.
+
 ```
+# CORRECT: one assistant message with four parallel Bash tool_use blocks
+[Bash] ruff check .
+[Bash] mypy app/
+[Bash] lint-imports
+[Bash] pytest
+```
+
+```
+# WRONG: four sequential Bash calls across four assistant messages
+turn 1: [Bash] ruff check .  →  tool_result
+turn 2: [Bash] mypy app/     →  tool_result
+turn 3: [Bash] lint-imports  →  tool_result
+turn 4: [Bash] pytest        →  tool_result
+```
+
+WOR-412 measured the parallel-tool-use rate at 9-25% across observed worker
+sessions, with the check sweep being the largest reliably-parallel phase per
+ticket. Aim for 100% parallel here. Top observed parallel combos are
+`Bash + Bash`, `Read + Read`, `Bash + Read` — the same pattern applied to
+`Read + Read + Read` during the investigation phase before the first edit.
+
+If a check fails, fix it and re-run only the failing one (no need to re-run
+the whole sweep until you're declaring success).
 
 **Pytest scope rule (WOR-353):** When `required_checks` contains `pytest`
 without arguments, run the **full** test suite — not just the test files

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -338,6 +338,8 @@ Rules for local worker sessions (watcher-spawned `claude` processes). Each tool 
 
 **Emit independent tool calls in parallel (WOR-387).** When multiple tool calls don't depend on each other's results, emit ALL the `tool_use` blocks in ONE assistant message. The runtime executes them in parallel and returns all `tool_result` blocks in one user turn. A serial 4-Read sequence pays the turn-boundary cost (prefill + decode warmup, 10-30s on long context) 4 times; one parallel 4-Read pays it once. Only serialize when a later call's input genuinely depends on an earlier result (e.g. "Read the file we just located via Glob"). The investigation phase before the first edit is the highest-leverage place to apply this — replace 5-15 single-Read turns with 1-3 multi-Read turns.
 
+**The four required checks specifically should always be parallel (WOR-413).** `ruff check .`, `mypy app/`, `pytest`, `lint-imports` have no data dependencies on each other. Emit all four as `tool_use` blocks in one assistant message. WOR-412 measured the per-session parallel-tool-use rate at 9-25%; the check sweep is the easiest 100% target. Halves wall-time of the pre-finalize phase.
+
 **No standalone `cd` commands.** Every `cd` is a wasted round-trip. Use absolute paths or chain with the actual command:
 ```bash
 # bad  — two round-trips


### PR DESCRIPTION
## Summary

- `.claude/commands/implement-ticket.md` section 4: explicit instruction to emit all four required checks as parallel `tool_use` blocks in one assistant message, with a CORRECT/WRONG pair showing the difference.
- `CLAUDE.md` "Worker efficiency": one-line addition pointing at the same rule scoped to the four checks specifically.

## Why

Tonight's WOR-412 measurement showed parallel-tool-use rate at 9-25% across observed sessions. The check sweep is the largest reliably-parallelizable phase per ticket (no data dependencies between ruff/mypy/pytest/lint-imports). Today most workers run them serially as four separate Bash calls — turning ~140s of check work into ~70s when run as four parallel `tool_use` blocks.

Compounds with WOR-410 (concurrent dispatch): every wall-second saved on per-worker check phase becomes additional aggregate throughput on multi-worker waves.

## Test plan

- [x] Markdown-only changes; ruff/mypy/pytest/lint-imports untouched
- [x] Pre-commit hooks passed (other Python file hooks skipped — no Python changes)
- [ ] Post-merge verification: re-run `scripts/metrics_analysis/measure_parallel_tool_use.py` after a wave runs against this prompt; rate should climb above 25% baseline

## Out of scope

- Hooking parallelization at the watcher level (e.g. dispatching the four checks ourselves) — would work but breaks per-check error transparency the LLM relies on for fix loops.
- Watcher-side enforcement — this is a wall-time optimization, not a correctness gate.

Closes WOR-413

🤖 Generated with [Claude Code](https://claude.com/claude-code)