### PR TITLE
WOR-415 fix: script-file approach for vLLM auto-start preserve_thinking

### DIFF
--- a/app/core/watcher/watcher_services.py
+++ b/app/core/watcher/watcher_services.py
@@ -23,19 +23,10 @@ from .watcher_types import _VLLM_HOST, _VLLM_PORT, _VLLM_SERVED_MODEL
 
 logger = logging.getLogger(__name__)
 
-# WOR-415: preserve_thinking via per-user-cache indirection. WOR-408 tried
-# to add --default-chat-template-kwargs '{"preserve_thinking": true}' directly
-# to the auto-start command but the JSON literal was mangled by the
-# multi-shell quoting chain (subprocess.list2cmdline → wt.exe → wsl → bash).
-# We now write the kwargs JSON inside WSL via `bash -c "tee …"` (stdin-piped,
-# no shell quoting of the JSON content), and have the inner-most bash read
-# it via $(cat …) at vLLM startup. The cat substitution happens inside the
-# spawned bash where it's safe. Path is under WSL ~/.cache/ rather than /tmp
-# to avoid shared-tmpdir hazards (bandit B108) — no symlink-attack surface
-# on a per-user XDG cache path.
-_VLLM_KWARGS_PATH = "~/.cache/repo-scaffold/qwen3_chat_template_kwargs.json"
-_VLLM_KWARGS_JSON = '{"preserve_thinking": true}'
-
+# Full canonical vLLM serve command — matches the operator-facing version
+# in CLAUDE.md / README.md / start-{ticket,epic}.md. Used for the warning
+# log line so operators can copy-paste it. NOT used directly by the
+# auto-start path — see _VLLM_AUTOSTART_CMD below.
 _VLLM_FP8_CMD = (
     "/home/antti/vllm-env/bin/vllm serve /home/antti/models/Qwen3.6-35B-A3B-NVFP4"
     " --served-model-name qwen3-coder"
@@ -44,44 +35,77 @@ _VLLM_FP8_CMD = (
     " --reasoning-parser qwen3 --enable-prefix-caching"
     " --language-model-only --safetensors-load-strategy prefetch"
     " --enable-auto-tool-choice --tool-call-parser qwen3_coder"
-    f' --default-chat-template-kwargs "$(cat {_VLLM_KWARGS_PATH})"'
+    " --default-chat-template-kwargs '{\"preserve_thinking\": true}'"
 )
 
+# WOR-415 (script-file rewrite): WOR-408 and the first WOR-415 attempt both
+# tried to pass the JSON literal through the multi-shell auto-start chain
+# (subprocess.list2cmdline → wt.exe → wsl → bash) — both failed because
+# successive shells strip or mis-escape the inner quotes. We now write the
+# entire vLLM invocation to a bash script inside WSL and have the auto-start
+# tab simply run that script. Bash reads the script directly from disk, so
+# its single-quoted JSON survives — no multi-shell argv ever touches the
+# JSON content. Path under ~/.cache/ rather than /tmp to satisfy bandit
+# B108 (per-user XDG cache, no symlink-attack surface).
+_VLLM_SCRIPT_PATH = "~/.cache/repo-scaffold/start_vllm.sh"
 
-def _write_vllm_kwargs_file() -> None:
-    """Write ``_VLLM_KWARGS_JSON`` to ``_VLLM_KWARGS_PATH`` inside WSL.
+# Bash script body. Mirrors _VLLM_FP8_CMD but as a script with backslash
+# line continuations. Bash parses single-quoted strings literally, so the
+# JSON survives intact when bash reads the script from disk.
+_VLLM_SCRIPT_BODY = (
+    "#!/bin/bash\n"
+    "exec /home/antti/vllm-env/bin/vllm serve"
+    " /home/antti/models/Qwen3.6-35B-A3B-NVFP4 \\\n"
+    "  --served-model-name qwen3-coder \\\n"
+    "  --max-model-len 262144 --max-num-seqs 16 \\\n"
+    "  --kv-cache-dtype fp8 --max-num-batched-tokens 4096 \\\n"
+    "  --reasoning-parser qwen3 --enable-prefix-caching \\\n"
+    "  --language-model-only --safetensors-load-strategy prefetch \\\n"
+    "  --enable-auto-tool-choice --tool-call-parser qwen3_coder \\\n"
+    "  --default-chat-template-kwargs '{\"preserve_thinking\": true}'\n"
+)
 
-    Pipes the JSON via stdin into a `bash -c "mkdir -p … && tee …"` invocation
-    so (a) the cache directory is created if missing and (b) the JSON content
-    never appears in any shell command line — only the path does, and that
-    has no special characters. Avoids the quoting chain that defeated
-    WOR-408. The auto-start command's ``$(cat …)`` substitution reads this
-    file at vLLM startup.
+# What the spawned terminal actually runs — just invokes the script. No
+# JSON in argv at any layer of the multi-shell chain.
+_VLLM_AUTOSTART_CMD = f"bash {_VLLM_SCRIPT_PATH}"
 
-    On failure (wsl.exe missing, tee error, timeout) we log a warning and
-    continue — the terminal will still open and vLLM will fail with a clear
-    "no such file" error from cat, which the operator can fix manually.
+
+def _write_vllm_script_file() -> None:
+    """Write ``_VLLM_SCRIPT_BODY`` to ``_VLLM_SCRIPT_PATH`` inside WSL.
+
+    Pipes the script body via stdin into a `bash -c "mkdir -p … && tee … &&
+    chmod +x …"` invocation. The script content travels via stdin (never as
+    an argv string), so no multi-shell argv ever touches the JSON literal.
+
+    On failure (wsl.exe missing, tee error, timeout) log a warning and
+    continue — the auto-start terminal will then fail with a clearer
+    "no such file" error than a Python exception, and the operator can
+    fall back to the canonical command in CLAUDE.md.
     """
-    bash_cmd = f"mkdir -p $(dirname {_VLLM_KWARGS_PATH}) && tee {_VLLM_KWARGS_PATH}"
+    bash_cmd = (
+        f"mkdir -p $(dirname {_VLLM_SCRIPT_PATH}) && "
+        f"tee {_VLLM_SCRIPT_PATH} > /dev/null && "
+        f"chmod +x {_VLLM_SCRIPT_PATH}"
+    )
     try:
         subprocess.run(  # nosec B603 B607
             ["wsl", "bash", "-c", bash_cmd],
-            input=_VLLM_KWARGS_JSON.encode("utf-8"),
+            input=_VLLM_SCRIPT_BODY.encode("utf-8"),
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
             check=True,
             timeout=10,
         )
         logger.debug(
-            "Wrote vLLM chat-template kwargs to %s (preserve_thinking=true)",
-            _VLLM_KWARGS_PATH,
+            "Wrote vLLM auto-start script to %s (preserve_thinking=true)",
+            _VLLM_SCRIPT_PATH,
         )
     except FileNotFoundError:
         logger.warning("wsl.exe not found — vLLM will start without preserve_thinking")
     except (OSError, subprocess.SubprocessError) as exc:
         logger.warning(
             "Could not write %s — vLLM may start without preserve_thinking: %s",
-            _VLLM_KWARGS_PATH,
+            _VLLM_SCRIPT_PATH,
             exc,
         )
 
@@ -140,13 +164,13 @@ class ServiceManager:
     def _open_vllm_terminal(self) -> None:
         """Open a new Windows Terminal tab running the vLLM FP8 command in WSL2.
 
-        Writes the chat-template kwargs JSON to ``_VLLM_KWARGS_PATH`` first so
-        the auto-start command's ``$(cat …)`` substitution finds it (WOR-415).
-        If the kwargs write fails the terminal still opens — vLLM will then
-        fail to start with a clear "no such file" error from cat, which the
-        operator can fix manually.
+        Writes the auto-start script to ``_VLLM_SCRIPT_PATH`` first so the
+        terminal can simply ``bash <script>`` it. The script-file approach
+        bypasses the multi-shell quoting chain that defeated WOR-408 and the
+        first WOR-415 attempt — bash reads the script directly from disk, so
+        single-quoted JSON survives intact (WOR-415 follow-up).
         """
-        _write_vllm_kwargs_file()
+        _write_vllm_script_file()
         try:
             subprocess.Popen(  # nosec B603 B607
                 [
@@ -159,7 +183,7 @@ class ServiceManager:
                     "bash",
                     "-i",
                     "-c",
-                    _VLLM_FP8_CMD,
+                    _VLLM_AUTOSTART_CMD,
                 ],
                 creationflags=(
                     getattr(subprocess, "DETACHED_PROCESS", 0)

--- a/tests/test_watcher_services.py
+++ b/tests/test_watcher_services.py
@@ -16,11 +16,12 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from app.core.watcher.watcher_services import (
+    _VLLM_AUTOSTART_CMD,
     _VLLM_FP8_CMD,
-    _VLLM_KWARGS_JSON,
-    _VLLM_KWARGS_PATH,
+    _VLLM_SCRIPT_BODY,
+    _VLLM_SCRIPT_PATH,
     ServiceManager,
-    _write_vllm_kwargs_file,
+    _write_vllm_script_file,
 )
 
 # ---------------------------------------------------------------------------
@@ -100,7 +101,7 @@ def test_probe_vllm_health_opens_terminal_on_windows(tmp_path: Path) -> None:
         patch("sys.platform", "win32"),
         patch("subprocess.Popen") as mock_popen,
         patch(
-            "app.core.watcher.watcher_services._write_vllm_kwargs_file"
+            "app.core.watcher.watcher_services._write_vllm_script_file"
         ) as mock_write,
     ):
         mock_conn_cls.return_value.request.side_effect = OSError("connection refused")
@@ -110,7 +111,7 @@ def test_probe_vllm_health_opens_terminal_on_windows(tmp_path: Path) -> None:
     cmd = mock_popen.call_args[0][0]
     assert "wt.exe" in cmd
     assert "wsl" in cmd
-    # WOR-415: kwargs file must be written before the terminal spawns
+    # WOR-415: script file must be written before the terminal spawns
     mock_write.assert_called_once()
 
 
@@ -120,7 +121,7 @@ def test_probe_vllm_health_opens_terminal_only_once(tmp_path: Path) -> None:
         patch("http.client.HTTPConnection") as mock_conn_cls,
         patch("sys.platform", "win32"),
         patch("subprocess.Popen") as mock_popen,
-        patch("app.core.watcher.watcher_services._write_vllm_kwargs_file"),
+        patch("app.core.watcher.watcher_services._write_vllm_script_file"),
     ):
         mock_conn_cls.return_value.request.side_effect = OSError("connection refused")
         mgr.probe_vllm_health()
@@ -135,91 +136,111 @@ def test_probe_vllm_health_handles_missing_wt_exe(tmp_path: Path) -> None:
         patch("http.client.HTTPConnection") as mock_conn_cls,
         patch("sys.platform", "win32"),
         patch("subprocess.Popen", side_effect=FileNotFoundError("wt.exe not found")),
-        patch("app.core.watcher.watcher_services._write_vllm_kwargs_file"),
+        patch("app.core.watcher.watcher_services._write_vllm_script_file"),
     ):
         mock_conn_cls.return_value.request.side_effect = OSError("connection refused")
         mgr.probe_vllm_health()  # must not raise
 
 
 # ---------------------------------------------------------------------------
-# WOR-415: preserve_thinking via temp-file indirection
+# WOR-415 (script-file approach): preserve_thinking via on-disk bash script
 # ---------------------------------------------------------------------------
 
 
-def test_vllm_fp8_cmd_references_kwargs_file() -> None:
-    """The auto-start command must use $(cat <path>) substitution rather than
-    inlining the JSON literal — WOR-408 proved JSON literals don't survive the
-    multi-shell quoting chain (subprocess → wt.exe → wsl → bash)."""
-    assert _VLLM_KWARGS_PATH in _VLLM_FP8_CMD
-    assert f"$(cat {_VLLM_KWARGS_PATH})" in _VLLM_FP8_CMD
-    assert "--default-chat-template-kwargs" in _VLLM_FP8_CMD
-    # The literal JSON string must NOT appear in the command — that's the
-    # exact thing that broke in WOR-408.
-    assert _VLLM_KWARGS_JSON not in _VLLM_FP8_CMD
+def test_vllm_autostart_cmd_invokes_script_only() -> None:
+    """The auto-start command passed to wt.exe → wsl → bash must be JUST
+    `bash <script>` — no JSON literal anywhere in the multi-shell argv chain.
+    This is the entire point of the script-file approach: the JSON travels
+    only via the on-disk script that bash reads directly."""
+    assert _VLLM_AUTOSTART_CMD == f"bash {_VLLM_SCRIPT_PATH}"
+    # Sanity: no JSON, no quoting tricks
+    assert "preserve_thinking" not in _VLLM_AUTOSTART_CMD
+    assert "$(" not in _VLLM_AUTOSTART_CMD
 
 
-def test_vllm_kwargs_json_is_valid_and_enables_preserve_thinking() -> None:
-    """The kwargs JSON must parse and set preserve_thinking=true — anything
-    else would silently disable WOR-400's main feature on the auto-start path."""
-    payload = json.loads(_VLLM_KWARGS_JSON)
-    assert payload == {"preserve_thinking": True}
+def test_vllm_script_body_contains_full_invocation_with_preserve_thinking() -> None:
+    """The script body must be a complete vLLM serve command including the
+    preserve_thinking kwarg as a single-quoted JSON literal. Bash parses
+    single-quoted strings literally, so the JSON survives intact when bash
+    reads the script from disk."""
+    assert _VLLM_SCRIPT_BODY.startswith("#!/bin/bash\n")
+    assert "vllm serve" in _VLLM_SCRIPT_BODY
+    assert "qwen3-coder" in _VLLM_SCRIPT_BODY
+    # Critical: JSON literal must be single-quoted in the script
+    assert "--default-chat-template-kwargs '{\"preserve_thinking\": true}'" in (
+        _VLLM_SCRIPT_BODY
+    )
 
 
-def test_write_vllm_kwargs_file_pipes_json_via_stdin() -> None:
-    """Writing must pipe JSON via stdin to `wsl bash -c '... tee ...'` — never
-    a shell command interpolating the JSON content, which would re-introduce
-    WOR-408's quoting bug."""
+def test_vllm_fp8_cmd_is_canonical_full_command() -> None:
+    """_VLLM_FP8_CMD remains the canonical full command (used in operator-
+    facing warning logs and matches the version in CLAUDE.md). It is NOT
+    the auto-start command — that is _VLLM_AUTOSTART_CMD."""
+    assert "vllm serve" in _VLLM_FP8_CMD
+    # The canonical command DOES include the JSON literal — it's meant for
+    # operators to copy-paste into a single bash shell where JSON quoting
+    # works fine.
+    assert "preserve_thinking" in _VLLM_FP8_CMD
+    # And it is NOT the auto-start command
+    assert _VLLM_FP8_CMD != _VLLM_AUTOSTART_CMD
+
+
+def test_write_vllm_script_file_pipes_body_via_stdin() -> None:
+    """Writing must pipe the script body via stdin to `wsl bash -c '... tee
+    ...'` — never a shell command interpolating the script content. This is
+    what makes the JSON content survive: tee writes stdin bytes literally to
+    the file."""
     with patch("subprocess.run") as mock_run:
-        _write_vllm_kwargs_file()
+        _write_vllm_script_file()
 
     mock_run.assert_called_once()
     call = mock_run.call_args
     argv = call[0][0]
     assert argv[:3] == ["wsl", "bash", "-c"]
-    # The bash command references the path but NOT the JSON content
     bash_cmd = argv[3]
-    assert _VLLM_KWARGS_PATH in bash_cmd
+    # The bash command references the path and uses tee + chmod, but the
+    # script content (with JSON) does NOT appear in the command string.
+    assert _VLLM_SCRIPT_PATH in bash_cmd
     assert "tee" in bash_cmd
-    assert "mkdir -p" in bash_cmd  # ensure cache dir exists
-    assert _VLLM_KWARGS_JSON not in bash_cmd  # JSON travels via stdin, not argv
-    # JSON arrives via stdin
-    assert call.kwargs["input"] == _VLLM_KWARGS_JSON.encode("utf-8")
-    # check=True so a tee failure raises CalledProcessError, which we catch
+    assert "chmod +x" in bash_cmd  # script must be executable
+    assert "mkdir -p" in bash_cmd  # cache dir auto-created
+    assert "preserve_thinking" not in bash_cmd  # JSON travels via stdin only
+    # Script body arrives via stdin
+    assert call.kwargs["input"] == _VLLM_SCRIPT_BODY.encode("utf-8")
     assert call.kwargs.get("check") is True
 
 
-def test_write_vllm_kwargs_file_handles_missing_wsl(caplog: Any) -> None:
-    """If wsl.exe is not installed, log a warning and continue — vLLM will
-    fail with a clearer error from cat than from a Python exception."""
+def test_write_vllm_script_file_handles_missing_wsl(caplog: Any) -> None:
+    """If wsl.exe is not installed, log a warning and continue."""
     import logging
 
     with (
         patch("subprocess.run", side_effect=FileNotFoundError("wsl.exe missing")),
         caplog.at_level(logging.WARNING, logger="app.core.watcher.watcher_services"),
     ):
-        _write_vllm_kwargs_file()  # must not raise
+        _write_vllm_script_file()  # must not raise
 
     assert "wsl.exe not found" in caplog.text
 
 
-def test_write_vllm_kwargs_file_handles_tee_failure(caplog: Any) -> None:
-    """If `wsl tee` fails (CalledProcessError), log and continue."""
+def test_write_vllm_script_file_handles_tee_failure(caplog: Any) -> None:
+    """If the bash command fails (CalledProcessError), log and continue."""
     import logging
 
-    err = subprocess.CalledProcessError(1, ["wsl", "tee", _VLLM_KWARGS_PATH])
+    err = subprocess.CalledProcessError(1, ["wsl", "bash", "-c", "..."])
     with (
         patch("subprocess.run", side_effect=err),
         caplog.at_level(logging.WARNING, logger="app.core.watcher.watcher_services"),
     ):
-        _write_vllm_kwargs_file()  # must not raise
+        _write_vllm_script_file()  # must not raise
 
     assert "Could not write" in caplog.text
 
 
-def test_open_vllm_terminal_writes_kwargs_before_spawning(tmp_path: Path) -> None:
-    """Order of operations must be: write kwargs file FIRST, then spawn the
-    terminal. If we spawn first, the terminal could try to cat the file before
-    it's written (race), and vLLM would fail at startup."""
+def test_open_vllm_terminal_writes_script_before_spawning(tmp_path: Path) -> None:
+    """Order of operations must be: write script file FIRST, then spawn the
+    terminal. If we spawn first, the terminal could try to invoke the script
+    before it's written (race), and bash would fail at startup."""
     mgr = ServiceManager(tmp_path)
     call_order: list[str] = []
 
@@ -232,7 +253,7 @@ def test_open_vllm_terminal_writes_kwargs_before_spawning(tmp_path: Path) -> Non
 
     with (
         patch(
-            "app.core.watcher.watcher_services._write_vllm_kwargs_file",
+            "app.core.watcher.watcher_services._write_vllm_script_file",
             side_effect=record_write,
         ),
         patch("subprocess.Popen", side_effect=record_popen),
@@ -242,6 +263,24 @@ def test_open_vllm_terminal_writes_kwargs_before_spawning(tmp_path: Path) -> Non
     assert call_order == ["write", "popen"], (
         f"expected write before popen, got {call_order}"
     )
+
+
+def test_open_vllm_terminal_spawn_uses_script_invocation(tmp_path: Path) -> None:
+    """The argv passed to wt.exe → wsl → bash must invoke the script — not
+    pass any JSON content as an argument. This is the contract the script-
+    file approach restores after WOR-408 / first-WOR-415 failed."""
+    mgr = ServiceManager(tmp_path)
+    with (
+        patch("app.core.watcher.watcher_services._write_vllm_script_file"),
+        patch("subprocess.Popen") as mock_popen,
+    ):
+        mgr._open_vllm_terminal()
+
+    argv = mock_popen.call_args[0][0]
+    # The last arg is the bash -c body — must be the autostart cmd, NOT
+    # the full vLLM command with JSON.
+    assert argv[-1] == _VLLM_AUTOSTART_CMD
+    assert "preserve_thinking" not in argv[-1]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why this is a follow-up

PR #843 (the original WOR-415 fix) shipped a kwargs-JSON-file with `$(cat ...)` substitution in the auto-start command. **It didn't work in production** — vLLM received `'{preserve_thinking:'` (word-split, inner quotes stripped) and refused to start. Same WOR-408 bug, different surface.

Root cause: even with the JSON content moved to a file, the *outer* quoting around `"$(cat ~/.cache/...)"` still has to traverse `subprocess.list2cmdline → wt.exe → wsl → bash`, and that chain still strips/mangles the quotes before bash performs the substitution.

## The actual fix

Write the **entire vLLM invocation** (including the JSON kwarg as a literal) to a bash script on disk, then have the auto-spawn just run `bash <script>`. Bash reads the script directly from the filesystem — no multi-shell argv touches the JSON content at any point.

```
_VLLM_FP8_CMD        # canonical full command (operator copy-paste, warning logs)
_VLLM_SCRIPT_PATH    # ~/.cache/repo-scaffold/start_vllm.sh
_VLLM_SCRIPT_BODY    # bash script body — single-quoted JSON survives bash parsing
_VLLM_AUTOSTART_CMD  # what wt.exe runs: just `bash <SCRIPT_PATH>` (no JSON in argv)

_write_vllm_script_file()  # stdin-piped tee writes the script atomically
```

The script body includes `--default-chat-template-kwargs '{"preserve_thinking": true}'` as a literal — exactly as it appears in the canonical operator command. Bash parses single-quoted strings literally, so the JSON arrives at vLLM intact.

## Why this works where #843 didn't

| Approach | JSON in argv? | Survives multi-shell? |
|---|---|---|
| WOR-408 (inline literal) | yes | ❌ |
| #843 (cat substitution) | yes (the `"$(cat ...)"` quoting) | ❌ |
| **This PR (script file)** | **no** — bash reads from disk | **✅** |

The whole point: the multi-shell chain is fundamentally hostile to inline quoting. Sidestep it by having bash read the command from disk where only one shell parses it.

## Test plan

- [x] `pytest tests/test_watcher_services.py` — 22 passed (replaces the 7 obsolete kwargs-file tests with 8 new script-file tests)
- [x] Full unscoped `pytest -q` — 1461 passed
- [x] ruff / ruff format / mypy / lint-imports / bandit (Medium: 0, High: 0) — all clean
- [ ] Manual end-to-end: post-merge, kill vLLM, run `python -m app.cli watcher --no-epic-shutdown`, observe the auto-spawned terminal runs `bash ~/.cache/repo-scaffold/start_vllm.sh` and vLLM starts with preserve_thinking active

## Failure modes (graceful)

- `wsl.exe` missing: writer logs warning and continues. Terminal opens, bash fails with `cannot find script` — clearer than a Python crash.
- `tee` / `chmod` fails (e.g. `~/.cache/` not writable): logged, continues.
- Auto-start spawn itself fails: existing FileNotFoundError / OSError handlers stay intact.

Closes WOR-415

🤖 Generated with [Claude Code](https://claude.com/claude-code)