### PR TITLE
chore: allowlist read-only MCP tools + lint-imports/bandit

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -117,8 +117,11 @@
       "mcp__linear-server__list_issue_statuses",
       "mcp__linear-server__list_teams",
       "mcp__linear-server__list_comments",
+      "mcp__sonarqube__issues",
       "Bash(ruff check *)",
-      "Bash(mypy app/)"
+      "Bash(mypy app/)",
+      "Bash(lint-imports*)",
+      "Bash(bandit *)"
     ]
   }
 }


### PR DESCRIPTION
## Summary

- Allowlist three high-frequency read-only operations to reduce permission prompts
- Based on scan of 50 most-recent transcripts under `~/.claude/projects/`

## What's added

- `mcp__sonarqube__issues` (12 calls observed) — Sonar issue lookup, read-only
- `Bash(lint-imports*)` (10 calls) — covers both `lint-imports` and `lint-imports.exe`, with or without redirects
- `Bash(bandit *)` (3 calls) — security scan, read-only

## What's intentionally skipped

- Built-in auto-allow already covers `git status/log/diff/branch`, `gh pr view/list/diff/checks`, `gh run view/list`, `gh api` GET, plus `cat`/`ls`/`grep`/`find`/`echo`/`wc`/`tail`/`head`/`printf`/`sleep`/`file`/`jq`
- Mutations skipped: `git checkout/add/push/fetch/pull/commit/worktree/merge/restore`, `rm`, `ruff format`, `pytest`, `pre-commit run`, `mkdir`, `chmod`, `cp`, `kill`
- Arbitrary code execution skipped per skill guidance: `python`, `python.exe`, `python3`, `wsl`, `curl`, `sed`
- Linear MCP write tools skipped: `save_issue`, `save_comment`, `save_project`

## Test plan

- [ ] Confirm Claude Code reads new entries on next session start
- [ ] Trigger one `bandit -r app/` and one `lint-imports.exe` from the watcher path; verify no permission prompt
- [ ] Trigger one `mcp__sonarqube__issues` call from `/groom-ticket`; verify no prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)
