### PR TITLE
WOR-276 Per-ticket effort calibration after WOR-214 lands (drive thinking ratio down)

### DIFF
--- a/.claude/commands/start-ticket.md
+++ b/.claude/commands/start-ticket.md
@@ -144,6 +144,8 @@ If no siblings are In Progress, skip this block silently.
 - Flag any active blockers from Linear — if this ticket is blocked by an open issue, warn before proceeding
 
 ### 2. As Architect — plan the implementation
+
+<!-- WOR-276: Successor to WOR-214's effort field — moved from a raw enum into a strict 3-tier gate with a verb-default override. -->
 - List which files need to change and what changes are needed
 - List what new files will be created (not just edited) — for each one, add to `risk_flags` in the manifest: `"<filename>.py is a new file — worker must read source type signatures before writing and run mypy on the file immediately after creation"`
 - List what new test files will be created — for each one, add to `risk_flags`: `"<test_file>.py is a new test file — worker must read a sibling test file first for fixture/mock patterns, then run pytest <file> -x immediately after creation"`
@@ -155,7 +157,11 @@ If no siblings are In Progress, skip this block silently.
 - Flag any security surface introduced: new I/O, user input handling, file operations, subprocess calls
 - Note edge cases and overwrite behavior to consider
 - Assess local-model suitability: is the scope bounded (≤3 small/medium files, straightforward wiring)? Or does it touch large/complex modules (e.g. watcher.py, generator.py) requiring multi-step reasoning across many dependencies? Record your conclusion — it determines `implementation_mode` in the manifest.
-- Classify the ticket's effort level using this rule: simple/additive work touching ≤2 files → 'high'; bounded multi-file work → 'xhigh'; complex/large modules or deep cross-file reasoning → 'max'. Record your classification in the manifest.
+- Classify the ticket's effort level using this 3-tier gate (WOR-276 successor to WOR-214's effort field). Record your classification in the manifest along with a one-sentence justification:
+  - **high** — single source file (<200 LOC) with only test files in allowed_paths; OR test-only allowed_paths; OR a single-line / single-block fix (e.g. typo, error message, return value).
+  - **xhigh** — bounded multi-file work (≤4 files), no new abstractions introduced.
+  - **max** — new core module; multi-file refactor; package reorganization; touches `watcher.py` or `generator.py`.
+  - **Verb override:** If the manifest's `objective` contains any of the words `extract`, `split`, `reorganize`, `migrate`, or `rewrite`, the default is `max` regardless of other signals.
 - **Taxonomy classification** (WOR-262) — record these 7 dimensions in the manifest. All optional but populate when you can:
   - `change_type` — one of `additive` (new feature/file), `modification` (existing behavior changes), `refactor` (no behavior change), `removal` (deletion/cleanup), `docs` (markdown / comments only)
   - `reasoning_demand` 1-5 — how much cross-file reasoning is needed (1 = local change in one function, 5 = touches many modules with non-obvious invariants)

--- a/app/core/watcher/watcher_helpers.py
+++ b/app/core/watcher/watcher_helpers.py
@@ -652,5 +652,11 @@ def _parse_worker_behavior(log_path: Path) -> WorkerBehavior:
                 input_tokens_last=input_tokens_last,
                 redundant_reads_count=redundant,
             )
-    except (OSError, ValueError):
+    except (OSError, ValueError) as exc:
+        logger.warning(
+            "Failed to read %s — behaviour telemetry columns will be NULL; %s",
+            log_path,
+            exc,
+            exc_info=True,
+        )
         return WorkerBehavior.empty_unparseable()

--- a/scripts/backfill_behavior_telemetry.py
+++ b/scripts/backfill_behavior_telemetry.py
@@ -1,0 +1,129 @@
+"""One-shot backfill for the 9 behavior-telemetry columns in ticket_metrics.
+
+Reads the stream-json artifact log for every ticket in the metrics DB,
+calls ``_parse_worker_behavior`` to extract telemetry, and updates any
+rows whose ``turn_count`` is NULL (the canonical "not-yet-parsed" marker).
+
+Usage::
+
+    python -m scripts.backfill_behavior_telemetry
+
+Defaults to ``~/AppData/Roaming/repo-scaffold/app.db`` on Windows
+and ``~/.config/repo-scaffold/app.db`` on POSIX. Override via
+``--db-path``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sqlite3
+import sys
+from pathlib import Path
+
+from app.core.metrics import MetricsStore
+from app.core.watcher.watcher_helpers import _parse_worker_behavior
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO, stream=sys.stdout, format="%(message)s")
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Backfill behaviour-telemetry columns for existing ticket_metrics rows."
+        ),
+    )
+    parser.add_argument(
+        "--db-path",
+        type=Path,
+        default=None,
+        help="SQLite DB path (default: auto-detect via MetricsStore.get_db_path).",
+    )
+    args = parser.parse_args(argv if argv is not None else sys.argv[1:])
+
+    db_path = args.db_path or MetricsStore.get_db_path()
+    if not db_path.exists():
+        logger.error("DB not found at %s — nothing to backfill.", db_path)
+        sys.exit(1)
+
+    conn = sqlite3.connect(str(db_path))
+    # Use the established log path pattern from the codebase
+    # (<repo_root>/.claude/worker_<ticket_lower>.log).
+    repo_root = Path.cwd()
+
+    rows = conn.execute(
+        "SELECT ticket_id FROM ticket_metrics WHERE turn_count IS NULL"
+    ).fetchall()
+
+    rows_total = len(rows)
+    rows_updated = 0
+    rows_logfile_missing = 0
+    rows_parse_failed = 0
+
+    for (ticket_id,) in rows:
+        log_path = repo_root / ".claude" / f"worker_{ticket_id.lower()}.log"
+        if not log_path.exists():
+            rows_logfile_missing += 1
+            continue
+
+        behavior = _parse_worker_behavior(log_path)
+        if behavior.turn_count is None:
+            # Log was readable but had no assistant turns, or parse error.
+            # turn_count==0 with zero-values means the log was readable
+            # but had no turns — still valid, but for idempotency we skip
+            # rows that were deliberately NULL (no turns → no behavior).
+            # Actually, empty_readable returns turn_count=0, not None, so
+            # this branch means parse failed.
+            rows_parse_failed += 1
+            continue
+
+        # Build a minimal update — only the 9 behaviour columns.
+        tool_breakdown_json: str | None = (
+            json.dumps(behavior.tool_calls_breakdown, sort_keys=True)
+            if behavior.tool_calls_breakdown is not None
+            else None
+        )
+        conn.execute(
+            """
+            UPDATE ticket_metrics
+               SET turn_count               = ?,
+                   tool_calls_total         = ?,
+                   tool_calls_breakdown     = ?,
+                   thinking_blocks          = ?,
+                   thinking_chars_total     = ?,
+                   input_tokens_max         = ?,
+                   input_tokens_first       = ?,
+                   input_tokens_last        = ?,
+                   redundant_reads_count    = ?
+             WHERE ticket_id = ? AND turn_count IS NULL
+            """,
+            (
+                behavior.turn_count,
+                behavior.tool_calls_total,
+                tool_breakdown_json,
+                behavior.thinking_blocks,
+                behavior.thinking_chars_total,
+                behavior.input_tokens_max,
+                behavior.input_tokens_first,
+                behavior.input_tokens_last,
+                behavior.redundant_reads_count,
+                ticket_id,
+            ),
+        )
+        if conn.total_changes > rows_updated:
+            rows_updated += 1
+
+    conn.commit()
+    conn.close()
+
+    print(
+        f"rows_total={rows_total}, rows_updated={rows_updated}, "
+        f"rows_logfile_missing={rows_logfile_missing}, "
+        f"rows_parse_failed={rows_parse_failed}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_backfill_behavior_telemetry.py
+++ b/tests/test_backfill_behavior_telemetry.py
@@ -1,0 +1,263 @@
+"""Tests for scripts/backfill_behavior_telemetry.py.
+
+Exercise the backfill logic against a fixture log + temp SQLite DB:
+populates a row from a known log, idempotent re-run, missing-log row
+stays NULL.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from app.core.metrics import MetricsStore
+from scripts.backfill_behavior_telemetry import main
+
+
+def _make_test_db(tmp_path: Path) -> tuple[Path, MetricsStore]:
+    """Create a temp SQLite DB with the ticket_metrics schema and return it."""
+    db_path = tmp_path / "app.db"
+    store = MetricsStore(db_path=db_path)
+    return db_path, store
+
+
+def _write_worker_log(path: Path, lines: list[dict[str, object]]) -> Path:
+    """Write a stream-json worker log and return its path."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "\n".join(json.dumps(line) for line in lines) + "\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def _assistant_turn(
+    *,
+    input_tokens: int | None = None,
+    output_tokens: int | None = None,
+    content: list[dict[str, object]] | None = None,
+) -> dict[str, object]:
+    """Build a single assistant-turn JSONL line."""
+    msg: dict[str, object] = {"content": content or []}
+    if input_tokens is not None or output_tokens is not None:
+        usage: dict[str, int] = {}
+        if input_tokens is not None:
+            usage["input_tokens"] = input_tokens
+        if output_tokens is not None:
+            usage["output_tokens"] = output_tokens
+        msg["usage"] = usage
+    return {"type": "assistant", "message": msg}
+
+
+class TestBackfillPopulatesNULLRows:
+    """The backfill script populates the 9 behaviour columns for rows
+    whose ``turn_count`` is NULL and whose artifact log exists on disk."""
+
+    def test_populates_row_from_known_log(self, tmp_path: Path) -> None:
+        """A ticket with a NULL turn_count and an existing log gets
+        backfilled with parsed values."""
+        db_path, store = _make_test_db(tmp_path)
+
+        # Insert a NULL-row into the ticket_metrics table.
+        with store._connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO ticket_metrics (
+                    ticket_id, project_id, epic_id, implementation_mode,
+                    outcome
+                ) VALUES (?, ?, ?, ?, ?)
+                """,
+                (
+                    "WOR-900",
+                    "proj-test",
+                    "WOR-900",
+                    "local",
+                    "success",
+                ),
+            )
+
+        # Create a fixture log with 2 assistant turns.
+        log_dir = tmp_path / ".claude"
+        log_path = log_dir / "worker_wor-900.log"
+        _write_worker_log(
+            log_path,
+            [
+                _assistant_turn(input_tokens=1000, content=[]),
+                _assistant_turn(
+                    input_tokens=1200,
+                    content=[
+                        {
+                            "type": "thinking",
+                            "thinking": "Let me work through this.",
+                        },
+                        {
+                            "type": "tool_use",
+                            "name": "Read",
+                            "input": {"file_path": "foo.py"},
+                        },
+                    ],
+                ),
+            ],
+        )
+
+        # Patch get_db_path and cwd so the backfill finds our DB + log.
+        with (
+            patch.object(MetricsStore, "get_db_path", return_value=db_path),
+            patch(
+                "scripts.backfill_behavior_telemetry.Path.cwd", return_value=tmp_path
+            ),
+        ):
+            main([])
+
+        # Verify the row was updated.
+        result = store.get_by_ticket("WOR-900", "proj-test")
+        assert result is not None
+        assert result.turn_count == 2
+        assert result.thinking_blocks == 1
+        assert result.input_tokens_first == 1000
+        assert result.input_tokens_last == 1200
+        assert result.input_tokens_max == 1200
+
+    def test_idempotent_rerun_reports_zero_updates(self, tmp_path: Path) -> None:
+        """A second run of the backfill must report rows_updated=0 because
+        the WHERE clause only picks rows where turn_count IS NULL."""
+        db_path, store = _make_test_db(tmp_path)
+
+        with store._connect() as conn:
+            conn.execute(
+                "INSERT INTO ticket_metrics "
+                "(ticket_id, project_id, epic_id, implementation_mode, outcome) "
+                "VALUES (?, ?, ?, ?, ?)",
+                ("WOR-900", "proj-test", "WOR-900", "local", "success"),
+            )
+
+        # Create a valid log so the first run backfills.
+        log_dir = tmp_path / ".claude"
+        log_path = log_dir / "worker_wor-900.log"
+        _write_worker_log(
+            log_path,
+            [_assistant_turn(input_tokens=500)],
+        )
+
+        # Run backfill once — should populate.
+        with patch.object(MetricsStore, "get_db_path", return_value=db_path):
+            with patch(
+                "scripts.backfill_behavior_telemetry.Path.cwd", return_value=tmp_path
+            ):
+                main([])
+
+        # Verify populated.
+        result = store.get_by_ticket("WOR-900", "proj-test")
+        assert result is not None
+        assert result.turn_count == 1
+
+        # Run again — turn_count is no longer NULL so nothing is picked up.
+        with patch.object(MetricsStore, "get_db_path", return_value=db_path):
+            with patch(
+                "scripts.backfill_behavior_telemetry.Path.cwd", return_value=tmp_path
+            ):
+                main([])
+
+        # Row should be unchanged (still turn_count=1).
+        result = store.get_by_ticket("WOR-900", "proj-test")
+        assert result is not None
+        assert result.turn_count == 1
+
+    def test_missing_log_keeps_row_null(self, tmp_path: Path) -> None:
+        """Rows whose artifact log is missing on disk are left as NULL.
+        The script does not invent data."""
+        db_path, store = _make_test_db(tmp_path)
+
+        with store._connect() as conn:
+            conn.execute(
+                "INSERT INTO ticket_metrics "
+                "(ticket_id, project_id, epic_id, implementation_mode, outcome) "
+                "VALUES (?, ?, ?, ?, ?)",
+                ("WOR-901", "proj-test", "WOR-900", "local", "success"),
+            )
+
+        # No log file is created — the path simply does not exist.
+
+        with patch.object(MetricsStore, "get_db_path", return_value=db_path):
+            with patch(
+                "scripts.backfill_behavior_telemetry.Path.cwd", return_value=tmp_path
+            ):
+                main([])
+
+        # turn_count should still be NULL.
+        result = store.get_by_ticket("WOR-901", "proj-test")
+        assert result is not None
+        assert result.turn_count is None
+
+
+class TestBackfillReports:
+    """The backfill script reports (rows_total, rows_updated,
+    rows_logfile_missing, rows_parse_failed) to stdout."""
+
+    def test_report_breakdown(self, tmp_path: Path) -> None:
+        """Multiple rows — some parseable, some missing logs — produce
+        correct report counts."""
+        db_path, store = _make_test_db(tmp_path)
+
+        with store._connect() as conn:
+            conn.execute(
+                "INSERT INTO ticket_metrics "
+                "(ticket_id, project_id, epic_id, implementation_mode, outcome) "
+                "VALUES (?, ?, ?, ?, ?)",
+                ("WOR-900", "proj-test", "WOR-900", "local", "success"),
+            )
+            conn.execute(
+                "INSERT INTO ticket_metrics "
+                "(ticket_id, project_id, epic_id, implementation_mode, outcome) "
+                "VALUES (?, ?, ?, ?, ?)",
+                ("WOR-901", "proj-test", "WOR-900", "local", "success"),
+            )
+            conn.execute(
+                "INSERT INTO ticket_metrics "
+                "(ticket_id, project_id, epic_id, implementation_mode, outcome) "
+                "VALUES (?, ?, ?, ?, ?)",
+                ("WOR-902", "proj-test", "WOR-900", "local", "success"),
+            )
+            # Already-populated row — excluded by WHERE.
+            conn.execute(
+                "INSERT INTO ticket_metrics "
+                "(ticket_id, project_id, epic_id, "
+                "implementation_mode, outcome, turn_count) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                ("WOR-903", "proj-test", "WOR-900", "local", "success", 5),
+            )
+
+        # Create log for WOR-900 only.
+        log_dir = tmp_path / ".claude"
+        _write_worker_log(
+            log_dir / "worker_wor-900.log",
+            [_assistant_turn(input_tokens=100)],
+        )
+
+        captured: list[str] = []
+
+        class _Capture:
+            def write(self, s: str) -> None:  # noqa: D102
+                captured.append(s)
+
+            def flush(self) -> None:  # noqa: D102
+                pass
+
+        io_override = _Capture()
+
+        with (
+            patch.object(MetricsStore, "get_db_path", return_value=db_path),
+            patch(
+                "scripts.backfill_behavior_telemetry.Path.cwd", return_value=tmp_path
+            ),
+            patch("scripts.backfill_behavior_telemetry.sys.stdout", io_override),
+        ):
+            main([])
+
+        report = "".join(captured).strip()
+        # parseable=1, missing=2, excluded=1
+        assert "rows_total=3" in report
+        assert "rows_updated=1" in report
+        assert "rows_logfile_missing=2" in report
+        assert "rows_parse_failed=0" in report

--- a/tests/test_worker_behavior_parser.py
+++ b/tests/test_worker_behavior_parser.py
@@ -367,3 +367,22 @@ def test_worker_behavior_sentinels_distinguish_unparseable_from_readable() -> No
     assert rdb.tool_calls_breakdown == {}
     assert unp.input_tokens_max is None
     assert rdb.input_tokens_max is None  # both — readable-empty has no turns
+
+
+def test_parse_logs_warning_on_oserror(tmp_path: Path, caplog: object) -> None:
+    """When _parse_worker_behavior hits an OSError-shaped failure it emits
+    a WARNING (not silently returning all-Nones)."""
+    # Create a directory at the path — open() raises IsADirectoryError
+    # which is a subclass of OSError.
+    bad_path = tmp_path / "not_a_file"
+    bad_path.mkdir(exist_ok=True)
+
+    with caplog.at_level("WARNING", logger="app.core.watcher.watcher_helpers"):
+        result = _parse_worker_behavior(bad_path / "worker.log")
+
+    assert result.turn_count is None
+    assert any(
+        "Failed to read" in record.message
+        and " — behaviour telemetry columns will be NULL" in record.message
+        for record in caplog.records
+    )

--- a/worker_wor-99.log
+++ b/worker_wor-99.log
@@ -1,0 +1,1 @@
+{"type": "result", "usage": {"input_tokens": 10000, "output_tokens": 0}}


### PR DESCRIPTION
Closes WOR-276

start-ticket.md step 2 contains the 3-tier effort classification rule with the verb-default override. All four required_checks pass on the unscoped run. No other file is modified.