### PR TITLE
WOR-337 Watcher: ticket-status CLI subcommand + /ticket-status skill (eliminate ad-hoc bash scripting for status checks)

### DIFF
--- a/.claude/commands/ticket-status.md
+++ b/.claude/commands/ticket-status.md
@@ -1,0 +1,43 @@
+Show a structured snapshot of a Linear ticket's current state.
+
+### 1. Run the CLI subcommand
+
+```bash
+python -m app.cli ticket-status $1
+```
+
+Replace `$1` with the ticket ID (e.g. WOR-123). The command requires `LINEAR_API_KEY` in the environment.
+
+Optional flags:
+- `--json` — machine-readable JSON output
+- `--brief` — single-line summary for status bars
+- `--watch` — re-poll every 30s until the ticket reaches a terminal state (Done, MergedToEpic, Cancelled, Duplicate, Blocked)
+
+### 2. Summarise for the user
+
+Read the output and summarise in 2-3 sentences:
+- Ticket title and current Linear state
+- Whether the ticket has an active worker log, and the last tool calls seen
+- Artifact status (manifest/result present or missing)
+- Worktree existence
+- Any health flags (API retries, subagent spawns, missing artifacts)
+
+If `--json` was requested, parse the JSON and present the key fields in prose.
+
+### Manual setup
+
+This subcommand requires a Bash permission entry in `.claude/settings.json`. The operator must add the following manually — the skill file cannot write to settings files:
+
+```json
+{
+  "settings.json": {
+    "permissions": {
+      "allow": ["Bash(python -m app.cli ticket-status*)"]
+    }
+  }
+}
+```
+
+Or add the `Bash(python -m app.cli ticket-status*)` entry to the existing allowlist if one is present.
+
+Without this entry, the first invocation will trigger a permission prompt; subsequent invocations will be silent once the allowlist is in place.

--- a/app/cli.py
+++ b/app/cli.py
@@ -264,6 +264,31 @@ def _build_parser() -> argparse.ArgumentParser:
         ),
     )
 
+    # WOR-337: ticket-status subcommand — structured ticket snapshot.
+    ts = sub.add_parser(
+        "ticket-status",
+        help="Show a structured snapshot of a ticket's state.",
+    )
+    ts.add_argument("ticket_id", help="Linear ticket ID, e.g. WOR-123")
+    ts.add_argument(
+        "--watch",
+        action="store_true",
+        default=False,
+        help="Re-poll every 30s until the ticket reaches a terminal state.",
+    )
+    ts.add_argument(
+        "--json",
+        action="store_true",
+        default=False,
+        help="Emit machine-readable JSON output.",
+    )
+    ts.add_argument(
+        "--brief",
+        action="store_true",
+        default=False,
+        help="Emit a single-line summary suitable for status bars.",
+    )
+
     return parser
 
 
@@ -728,6 +753,176 @@ def _run_waste_score(args: argparse.Namespace) -> int:
     return 0
 
 
+def _run_ticket_status(args: argparse.Namespace) -> int:
+    """Show a structured snapshot of a Linear ticket's state."""
+    import os
+    import time
+
+    ticket_id = args.ticket_id.upper()
+
+    # Require LINEAR_API_KEY for the Linear client.
+    api_key = os.environ.get("LINEAR_API_KEY")
+    if not api_key:
+        print(
+            "Error: LINEAR_API_KEY environment variable not set.",
+            file=sys.stderr,
+        )
+        return 1
+
+    from app.core.linear_client import LinearClient
+
+    client = LinearClient(api_key=api_key)
+
+    from app.core.watcher.ticket_status import (
+        _format_age,
+        _format_size,
+        fetch_ticket_status,
+    )
+
+    status = fetch_ticket_status(client, ticket_id)
+
+    if args.json:
+        import json as json_mod
+
+        print(json_mod.dumps(status.to_dict(), indent=2))
+        return 0
+
+    if args.brief:
+        # One-line: WOR-NNN — Title (State) — age
+        ts = status.ticket_id
+        title = status.title
+        st = status.state
+        age_str = (
+            _format_age(status.state_age_seconds) if status.state_age_seconds else "?"
+        )
+        print(f"{ts} — {title} ({st}) — {age_str}")
+        return 0
+
+    # Default: human-readable structured output.
+    print(f"Ticket: {status.ticket_id} — {status.title}")
+    age_str = _format_age(status.state_age_seconds) if status.state_age_seconds else "?"
+    print(f"State (Linear): {status.state} (age: {age_str})")
+
+    # Worker process info
+    if status.worker_log is not None:
+        wl = status.worker_log
+        size_str = _format_size(wl.size_bytes)
+        last_ago = (
+            _format_age(wl.last_activity_ago_seconds)
+            if wl.last_activity_ago_seconds
+            else "?"
+        )
+        print("Worker process:")
+        print(f"  Log: {size_str}, last activity {last_ago}")
+        if wl.last_tool_calls:
+            print(f"  Recent actions (last {min(3, len(wl.last_tool_calls))}):")
+            for tc in wl.last_tool_calls[:3]:
+                print(f"    {tc.name} {tc.display}")
+        else:
+            print("  Recent actions: ?")
+    else:
+        print("Worker process: no log file found")
+
+    # Artifacts
+    if status.artifacts is not None:
+        print(f"Artifacts ({status.artifacts.path}):")
+        for name, info in status.artifacts.entries.items():
+            print(f"  {name}    {info}")
+    else:
+        print("Artifacts: none")
+
+    # Worktree
+    if status.worktree_exists is True:
+        print(f"Worktree: {status.worktree_path}  exists")
+    elif status.worktree_exists is False:
+        print("Worktree: none")
+    else:
+        print("Worktree: ?")
+
+    # Health flags
+    if status.health_flags:
+        parts = []
+        if "api_retries" in status.health_flags:
+            retries = status.health_flags["api_retries"]
+            parts.append(f"{retries} api_retry events")
+        if "subagent_spawns" in status.health_flags:
+            spawns = status.health_flags["subagent_spawns"]
+            parts.append(f"{spawns} subagent spawns")
+        if "no_result_artifact" in status.health_flags:
+            parts.append("no result artifact yet")
+        print(f"Health flags: {'; '.join(parts)}")
+
+    # Watch mode: keep polling until terminal state or Ctrl+C
+    if args.watch:
+        terminal_states = {
+            "Done",
+            "MergedToEpic",
+            "Cancelled",
+            "Duplicate",
+            "Blocked",
+        }
+        while status.state not in terminal_states:
+            print(f"\n── polled {_format_age(status.state_age_seconds)} ──")
+            try:
+                time.sleep(30)
+            except KeyboardInterrupt:
+                return 0
+            status = fetch_ticket_status(client, ticket_id)
+            # Re-render output (strip ANSI from above)
+            print(f"\nTicket: {status.ticket_id} — {status.title}")
+            age_str = (
+                _format_age(status.state_age_seconds)
+                if status.state_age_seconds
+                else "?"
+            )
+            print(f"State (Linear): {status.state} (age: {age_str})")
+            if status.worker_log is not None:
+                wl = status.worker_log
+                size_str = _format_size(wl.size_bytes)
+                last_ago = (
+                    _format_age(wl.last_activity_ago_seconds)
+                    if wl.last_activity_ago_seconds
+                    else "?"
+                )
+                print("Worker process:")
+                print(f"  Log: {size_str}, last activity {last_ago}")
+                if wl.last_tool_calls:
+                    print(f"  Recent actions (last {min(3, len(wl.last_tool_calls))}):")
+                    for tc in wl.last_tool_calls[:3]:
+                        print(f"    {tc.name} {tc.display}")
+                else:
+                    print("  Recent actions: ?")
+            else:
+                print("Worker process: no log file found")
+            if status.artifacts is not None:
+                print(f"Artifacts ({status.artifacts.path}):")
+                for name, info in status.artifacts.entries.items():
+                    print(f"  {name}    {info}")
+            else:
+                print("Artifacts: none")
+            if status.worktree_exists is True:
+                print(f"Worktree: {status.worktree_path}  exists")
+            elif status.worktree_exists is False:
+                print("Worktree: none")
+            else:
+                print("Worktree: ?")
+            if status.health_flags:
+                parts = []
+                if "api_retries" in status.health_flags:
+                    retries = status.health_flags["api_retries"]
+                    parts.append(f"{retries} api_retry events")
+                if "subagent_spawns" in status.health_flags:
+                    spawns = status.health_flags["subagent_spawns"]
+                    parts.append(f"{spawns} subagent spawns")
+                if "no_result_artifact" in status.health_flags:
+                    parts.append("no result artifact yet")
+                print(f"Health flags: {'; '.join(parts)}")
+        print(f"\nTicket reached terminal state: {status.state}")
+        return 0
+
+    return 0
+
+
 def _dispatch_command(args: argparse.Namespace) -> int:
     """Route parsed args to the appropriate command handler.
 
@@ -743,6 +938,8 @@ def _dispatch_command(args: argparse.Namespace) -> int:
         return _run_watcher_softstop(args)
     if args.command == "waste-score":
         return _run_waste_score(args)
+    if args.command == "ticket-status":
+        return _run_ticket_status(args)
     if args.command == "generate":
         return _run_generate(args)
     return 1

--- a/app/core/watcher/ticket_status.py
+++ b/app/core/watcher/ticket_status.py
@@ -1,0 +1,378 @@
+"""Pure functions for assembling a structured ticket-status snapshot.
+
+Reads only: Linear issue data (via LinearClient), worker log files,
+artifact directory contents, and worktree existence. No writes, no
+subprocess calls.
+
+Designed to be trivially unit-testable with mocks and tmp_path.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from app.core.manifest import ArtifactPaths
+
+# Terminal state names that indicate a ticket is no longer in-flight.
+_TERMINAL_STATES = frozenset(
+    {"Done", "MergedToEpic", "Cancelled", "Duplicate", "Blocked"},
+)
+
+# Tokens in a stream-json assistant content block that indicate a tool_use
+# with a Bash/Command name. We show the target (first argument) or the
+# command name itself.
+_TOOL_USE_NAME_RE = re.compile(r'"name"\s*:\s*"(\w+)"')
+_TOOL_USE_INPUT_RE = re.compile(r'"input"\s*:\s*\{([^}]*)\}', re.DOTALL)
+
+
+@dataclass
+class ToolCallInfo:
+    """A single tool call extracted from a worker log."""
+
+    name: str  # e.g. "Edit", "Bash", "Read", "Grep", "Write", "Task"
+    display: str  # human-friendly short description, truncated to ~40 chars
+
+
+@dataclass
+class LogInfo:
+    """Worker log file metadata + extracted info."""
+
+    size_bytes: int
+    last_activity_ago_seconds: int | None
+    last_tool_calls: list[ToolCallInfo] = field(default_factory=list)
+    api_retries: int | None = None
+    subagent_spawns: int | None = None
+
+
+@dataclass
+class ArtifactInfo:
+    """Contents of the artifact directory for a ticket."""
+
+    path: str
+    entries: dict[str, int]  # filename -> byte size (int) or None if missing
+
+
+@dataclass
+class TicketStatus:
+    """Structured snapshot of a single Linear ticket's state."""
+
+    ticket_id: str
+    title: str
+    state: str
+    state_age_seconds: int | None
+    worker_log: LogInfo | None
+    artifacts: ArtifactInfo | None
+    worktree_exists: bool | None
+    worktree_path: str | None
+    health_flags: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def is_terminal(self) -> bool:
+        """True when the ticket is in a terminal (closed) state."""
+        return self.state in _TERMINAL_STATES
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a plain dict (JSON-compatible)."""
+        result: dict[str, Any] = {
+            "ticket_id": self.ticket_id,
+            "title": self.title,
+            "state": self.state,
+            "state_age_seconds": self.state_age_seconds,
+            "is_terminal": self.state in _TERMINAL_STATES,
+        }
+        if self.worker_log is not None:
+            result["worker_log"] = self._log_to_dict()
+        if self.artifacts is not None:
+            result["artifacts"] = self._artifacts_to_dict()
+        result["worktree_exists"] = self.worktree_exists
+        if self.worktree_path is not None:
+            result["worktree_path"] = self.worktree_path
+        if self.health_flags:
+            result["health_flags"] = self.health_flags
+        return result
+
+    def _log_to_dict(self) -> dict[str, Any]:
+        log = self.worker_log
+        if log is None:
+            return {}
+        result: dict[str, Any] = {
+            "size_bytes": log.size_bytes,
+            "last_activity_ago_seconds": log.last_activity_ago_seconds,
+        }
+        if log.last_tool_calls:
+            result["last_tool_calls"] = [
+                {"name": tc.name, "display": tc.display} for tc in log.last_tool_calls
+            ]
+        if log.api_retries is not None:
+            result["api_retries"] = log.api_retries
+        if log.subagent_spawns is not None:
+            result["subagent_spawns"] = log.subagent_spawns
+        return result
+
+    def _artifacts_to_dict(self) -> dict[str, Any]:
+        if self.artifacts is None:
+            return {}
+        entries: dict[str, Any] = {}
+        for name, size in self.artifacts.entries.items():
+            if size is None:
+                entries[name] = "missing"
+            else:
+                entries[name] = f"{size} bytes"
+        return entries
+
+
+def _format_age(seconds: int | None) -> str:
+    """Format seconds into a human-readable age string."""
+    if seconds is None:
+        return "?"
+    if seconds < 60:
+        return f"{seconds}s"
+    if seconds < 3600:
+        mins = seconds // 60
+        secs = seconds % 60
+        return f"{mins}m{secs:02d}s" if secs else f"{mins}m"
+    hours = seconds // 3600
+    mins = (seconds % 3600) // 60
+    return f"{hours}h{mins:02d}m" if mins else f"{hours}h"
+
+
+def _format_size(n: int | None) -> str:
+    """Format byte count to human-readable size."""
+    if n is None:
+        return "?"
+    if n < 1024:
+        return f"{n}B"
+    if n < 1024 * 1024:
+        k = n / 1024
+        return f"{k:.1f}KB" if k != int(k) else f"{int(k)}KB"
+    return f"{n / (1024 * 1024):.1f}MB"
+
+
+def _truncate(s: str, max_len: int = 40) -> str:
+    """Truncate a string to max_len, adding ellipsis if needed."""
+    if len(s) <= max_len:
+        return s
+    return s[: max_len - 3] + "..."
+
+
+def _parse_last_tool_calls(log_path: Path) -> list[ToolCallInfo]:
+    """Tail the last ~10 lines of the log and extract tool_use events.
+
+    Returns up to 3 most recent tool calls as ToolCallInfo objects.
+    Returns [] when the log is empty or has no tool_use events.
+    """
+    try:
+        lines = log_path.read_text(encoding="utf-8").splitlines()
+        tail = lines[-30:] if len(lines) > 30 else lines
+    except Exception:
+        return []
+
+    calls: list[ToolCallInfo] = []
+    for line in tail:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if obj.get("type") != "assistant":
+            continue
+        msg = obj.get("message", {}) or {}
+        for block in msg.get("content") or []:
+            if not isinstance(block, dict):
+                continue
+            if block.get("type") != "tool_use":
+                continue
+            name = block.get("name", "")
+            if not name:
+                continue
+            input_data = block.get("input") or {}
+            display = _build_display(name, input_data)
+            calls.append(ToolCallInfo(name=name, display=_truncate(display)))
+            if len(calls) >= 3:
+                return list(reversed(calls))
+    return list(reversed(calls))
+
+
+def _build_display(name: str, input_data: dict[str, Any]) -> str:
+    """Build a short display string for a tool_use call."""
+    if name == "Bash":
+        cmd = input_data.get("command", "")
+        if isinstance(cmd, str):
+            first_token = cmd.strip().split()[0] if cmd.strip() else ""
+            return f"Bash {first_token}"
+        return "Bash <command>"
+    if name == "Task":
+        prompt = input_data.get("prompt", "")
+        if isinstance(prompt, str):
+            return f"Task {prompt[:40]}"
+        return "Task"
+    # For Edit/Read/Grep/Write/etc., show first arg if present.
+    for key in ("path", "file_path", "file", "filepath"):
+        val = input_data.get(key)
+        if isinstance(val, str) and val:
+            return f"{name} {val}"
+    return name
+
+
+def _parse_log_path(ticket_id_lower: str) -> Path:
+    """Derive the canonical worker log path for a ticket ID."""
+    slug = ticket_id_lower
+    log_name = f"worker_{slug}.log"
+    return Path(".claude") / "artifacts" / slug / log_name
+
+
+def fetch_ticket_status(
+    linear_client: Any,
+    ticket_id: str,
+    *,
+    artifact_dir: Path | None = None,
+    worktree_dir: Path | None = None,
+) -> TicketStatus:
+    """Assemble a structured status snapshot for *ticket_id*.
+
+    Parameters
+    ----------
+    linear_client : LinearClient
+        An instantiated LinearClient — only read methods are called.
+    ticket_id : str
+        Linear ticket identifier, e.g. "WOR-277".
+    artifact_dir : Path | None
+        Override artifact directory. Defaults to
+        ``.claude/artifacts/<ticket_id_lower>``.
+    worktree_dir : Path | None
+        Override worktree directory. Defaults to
+        ``.claude/worktrees/<ticket_id_slug>``.
+
+    Returns
+    -------
+    TicketStatus
+        A dataclass with all extracted fields.
+    """
+    ticket_id_lower = ticket_id.lower()
+
+    # ---- Linear data ----
+    try:
+        issue = linear_client.get_issue(ticket_id)
+    except Exception as exc:
+        # Fallback: return minimal info when Linear is unreachable.
+        return TicketStatus(
+            ticket_id=ticket_id,
+            title=f"(error fetching: {exc})",
+            state="Unknown",
+            state_age_seconds=None,
+            worker_log=None,
+            artifacts=None,
+            worktree_exists=None,
+            worktree_path=None,
+        )
+
+    title = issue.get("title", "")
+    state_data = issue.get("state") or {}
+    state = state_data.get("name", state_data.get("type", "Unknown"))
+    state_created = state_data.get("createdAt") or state_data.get("created_at")
+
+    state_age_seconds: int | None = None
+    if state_created:
+        try:
+            # Linear returns ISO-8601 strings like "2026-05-10T06:19:32.000Z"
+            created_dt = time.mktime(
+                time.strptime(state_created[:19], "%Y-%m-%dT%H:%M:%S")
+            )
+            state_age_seconds = max(0, int(time.time() - created_dt))
+        except (ValueError, TypeError):
+            state_age_seconds = None
+
+    # ---- Log file ----
+    log_path = _parse_log_path(ticket_id_lower)
+    log_info: LogInfo | None = None
+    if log_path.exists():
+        stat = log_path.stat()
+        size_bytes = stat.st_size
+        mtime = stat.st_mtime
+        last_activity = max(0, int(time.time() - mtime))
+
+        # Last 3 tool calls
+        last_tool_calls = _parse_last_tool_calls(log_path)
+
+        # API retries and subagent spawns from existing helpers
+        from app.core.watcher.watcher_log_parsing import (
+            _parse_worker_api_retries,
+            _parse_worker_subagent_spawns,
+        )
+
+        api_retries = _parse_worker_api_retries(log_path)
+        subagent_spawns = _parse_worker_subagent_spawns(log_path)
+
+        log_info = LogInfo(
+            size_bytes=size_bytes,
+            last_activity_ago_seconds=last_activity,
+            last_tool_calls=last_tool_calls,
+            api_retries=api_retries,
+            subagent_spawns=subagent_spawns,
+        )
+
+    # ---- Artifacts ----
+    if artifact_dir is None:
+        artifact_paths = ArtifactPaths.from_ticket_id(ticket_id)
+        artifact_dir = Path(artifact_paths.result_json).parent
+
+    entries: dict[str, int] = {}
+    if artifact_dir.exists():
+        for child in sorted(artifact_dir.iterdir()):
+            if child.is_file():
+                entries[child.name] = child.stat().st_size
+
+    if entries:
+        artifacts = ArtifactInfo(path=str(artifact_dir), entries=entries)
+    else:
+        artifacts = None
+
+    # ---- Worktree ----
+    worktree_path = None
+    if worktree_dir is None:
+        slug = ticket_id_lower.replace("-", "_")
+        worktree_dir = Path(".claude") / "worktrees" / slug
+    else:
+        worktree_path = str(worktree_dir)
+
+    worktree_exists = worktree_dir.exists() if worktree_dir else None
+    if worktree_path is None and worktree_dir is not None:
+        worktree_path = str(worktree_dir)
+
+    # ---- Health flags ----
+    health_flags: dict[str, Any] = {}
+    if log_info is not None:
+        if log_info.api_retries is not None:
+            health_flags["api_retries"] = log_info.api_retries
+        if log_info.subagent_spawns is not None:
+            health_flags["subagent_spawns"] = log_info.subagent_spawns
+
+    # If there are no artifacts beyond what's expected, flag it
+    result_json_path = artifact_dir / "result.json"
+    if not result_json_path.exists() and state not in (
+        "Done",
+        "MergedToEpic",
+        "Cancelled",
+        "Duplicate",
+        "Blocked",
+    ):
+        health_flags["no_result_artifact"] = True
+
+    return TicketStatus(
+        ticket_id=ticket_id,
+        title=title,
+        state=state,
+        state_age_seconds=state_age_seconds,
+        worker_log=log_info,
+        artifacts=artifacts,
+        worktree_exists=worktree_exists,
+        worktree_path=worktree_path,
+        health_flags=health_flags,
+    )

--- a/tests/test_cli_ticket_status.py
+++ b/tests/test_cli_ticket_status.py
@@ -1,0 +1,155 @@
+"""CLI integration tests for the ticket-status subcommand."""
+
+import json
+import os
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.cli import main
+
+if TYPE_CHECKING:
+    from _pytest.capture import CaptureFixture as CapSys
+else:
+    CapSys = pytest.CaptureFixture  # type: ignore[misc,assignment]
+
+# ── Environment setup ──────────────────────────────────────────────────────────
+
+FAKE_API_KEY = "fake_linear_key_for_tests"  # pragma: allowlist secret
+
+
+def _clear_linear_key(env: dict[str, str]) -> dict[str, str]:
+    """Return a copy of env without LINEAR_API_KEY."""
+    result = dict(env)
+    result.pop("LINEAR_API_KEY", None)
+    return result
+
+
+# ── Missing env tests ──────────────────────────────────────────────────────────
+
+
+class TestTicketStatusMissingEnv:
+    def test_missing_api_key_exits_with_error(self, capsys: CapSys) -> None:
+        env = _clear_linear_key(os.environ)
+        with patch.dict("os.environ", env, clear=True):
+            rc = main(["ticket-status", "WOR-999"])
+
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "LINEAR_API_KEY" in err
+
+
+# ── Linear error tests ─────────────────────────────────────────────────────────
+
+
+def _mock_linear_client() -> MagicMock:
+    """Create a LinearClient mock that returns a standard issue dict."""
+    client = MagicMock()
+    client.get_issue.return_value = {
+        "title": "Test ticket",
+        "state": {"name": "InProgressLocal", "createdAt": "2026-05-10T06:19:32.000Z"},
+    }
+    return client
+
+
+class TestTicketStatusNotFound:
+    def test_linear_error_shows_message(self, capsys: CapSys) -> None:
+        client = MagicMock()
+        client.get_issue.side_effect = Exception("issue not found")
+        with (
+            patch.dict("os.environ", {"LINEAR_API_KEY": FAKE_API_KEY}, clear=True),
+            patch("app.core.linear_client.LinearClient", return_value=client),
+        ):
+            rc = main(["ticket-status", "WOR-999"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "issue not found" in out
+
+
+# ── --json flag tests ──────────────────────────────────────────────────────────
+
+
+class TestTicketStatusJson:
+    def test_json_output_is_valid(self, capsys: CapSys) -> None:
+        client = _mock_linear_client()
+        with (
+            patch.dict("os.environ", {"LINEAR_API_KEY": FAKE_API_KEY}, clear=True),
+            patch("app.core.linear_client.LinearClient", return_value=client),
+        ):
+            rc = main(["ticket-status", "--json", "WOR-123"])
+
+        assert rc == 0
+        data = json.loads(capsys.readouterr().out)
+        assert data["ticket_id"] == "WOR-123"
+        assert data["state"] == "InProgressLocal"
+        assert data["is_terminal"] is False
+
+    def test_json_output_parsing(self, capsys: CapSys) -> None:
+        client = _mock_linear_client()
+        with (
+            patch.dict("os.environ", {"LINEAR_API_KEY": FAKE_API_KEY}, clear=True),
+            patch("app.core.linear_client.LinearClient", return_value=client),
+        ):
+            rc = main(["ticket-status", "--json", "WOR-123"])
+
+        assert rc == 0
+        data = json.loads(capsys.readouterr().out)
+        assert data["ticket_id"] == "WOR-123"
+        assert data["state"] == "InProgressLocal"
+
+
+# ── --brief flag tests ─────────────────────────────────────────────────────────
+
+
+class TestTicketStatusBrief:
+    def test_brief_is_single_line(self, capsys: CapSys) -> None:
+        client = _mock_linear_client()
+        with (
+            patch.dict("os.environ", {"LINEAR_API_KEY": FAKE_API_KEY}, clear=True),
+            patch("app.core.linear_client.LinearClient", return_value=client),
+        ):
+            rc = main(["ticket-status", "--brief", "WOR-123"])
+
+        assert rc == 0
+        out = capsys.readouterr().out.strip()
+        assert out.count("\n") == 0
+        assert "WOR-123" in out
+        assert "InProgressLocal" in out
+
+
+# ── Normal output tests ────────────────────────────────────────────────────────
+
+
+class TestTicketStatusNormalOutput:
+    def test_normal_output_structure(self, capsys: CapSys) -> None:
+        client = _mock_linear_client()
+        with (
+            patch.dict("os.environ", {"LINEAR_API_KEY": FAKE_API_KEY}, clear=True),
+            patch("app.core.linear_client.LinearClient", return_value=client),
+        ):
+            rc = main(["ticket-status", "WOR-123"])
+
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "Ticket: WOR-123" in out
+        assert "Test ticket" in out
+        assert "InProgressLocal" in out
+
+
+# ── Subparser registration tests ───────────────────────────────────────────────
+
+
+class TestTicketStatusSubparser:
+    def test_flag_parsing(self, capsys: CapSys) -> None:
+        """All flags should be accepted without error."""
+        client = _mock_linear_client()
+        with (
+            patch.dict("os.environ", {"LINEAR_API_KEY": FAKE_API_KEY}, clear=True),
+            patch("app.core.linear_client.LinearClient", return_value=client),
+        ):
+            rc = main(["ticket-status", "--json", "--brief", "WOR-123"])
+        assert rc == 0
+        # --json takes precedence over --brief: JSON is emitted.
+        data = json.loads(capsys.readouterr().out)
+        assert data["ticket_id"] == "WOR-123"

--- a/tests/test_ticket_status.py
+++ b/tests/test_ticket_status.py
@@ -1,0 +1,260 @@
+"""Tests for the pure ticket-status assembler (app/core/watcher/ticket_status.py)."""
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from app.core.watcher.ticket_status import (
+    _format_age,
+    _format_size,
+    _parse_last_tool_calls,
+    fetch_ticket_status,
+)
+
+# ── Helper tests ───────────────────────────────────────────────────────────────
+
+
+class TestFormatAge:
+    def test_zero_seconds(self) -> None:
+        assert _format_age(0) == "0s"
+
+    def test_seconds(self) -> None:
+        assert _format_age(45) == "45s"
+
+    def test_minutes(self) -> None:
+        assert _format_age(120) == "2m"
+
+    def test_minutes_with_remainder(self) -> None:
+        assert _format_age(125) == "2m05s"
+
+    def test_hours(self) -> None:
+        assert _format_age(7200) == "2h"
+
+    def test_hours_with_minutes(self) -> None:
+        assert _format_age(7500) == "2h05m"
+
+    def test_none(self) -> None:
+        assert _format_age(None) == "?"
+
+
+class TestFormatSize:
+    def test_bytes(self) -> None:
+        assert _format_size(500) == "500B"
+
+    def test_kilobytes_exact(self) -> None:
+        assert _format_size(2048) == "2KB"
+
+    def test_kilobytes_fractional(self) -> None:
+        assert _format_size(2560) == "2.5KB"
+
+    def test_megabytes(self) -> None:
+        assert _format_size(1_048_576) == "1.0MB"
+
+    def test_none(self) -> None:
+        assert _format_size(None) == "?"
+
+
+# ── Log parsing tests ──────────────────────────────────────────────────────────
+
+
+class TestParseLastToolCalls:
+    def test_empty_log(self, tmp_path: Path) -> None:
+        log_path = tmp_path / "worker_wor_99.log"
+        log_path.write_text("", encoding="utf-8")
+        result = _parse_last_tool_calls(log_path)
+        assert result == []
+
+    def test_no_assistant_events(self, tmp_path: Path) -> None:
+        log_path = tmp_path / "worker_wor_99.log"
+        system_event = '{"type":"system","subtype":"api_retry"}\n'
+        log_path.write_text(system_event, encoding="utf-8")
+        result = _parse_last_tool_calls(log_path)
+        assert result == []
+
+    def test_extracts_single_tool_call(self, tmp_path: Path) -> None:
+        log_path = tmp_path / "worker_wor_99.log"
+        path_arg = "app/core/X.py"
+        payload = json.dumps(
+            {
+                "type": "assistant",
+                "message": {
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "name": "Edit",
+                            "input": {
+                                "path": path_arg,
+                                "old_string": "a",
+                                "new_string": "b",
+                            },
+                        }
+                    ]
+                },
+            }
+        )
+        log_path.write_text(payload + "\n", encoding="utf-8")
+        result = _parse_last_tool_calls(log_path)
+        assert len(result) == 1
+        assert result[0].name == "Edit"
+        assert "app/core/X.py" in result[0].display
+
+    def test_truncates_long_display(self, tmp_path: Path) -> None:
+        log_path = tmp_path / "worker_wor_99.log"
+        payload = json.dumps(
+            {
+                "type": "assistant",
+                "message": {
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "name": "Task",
+                            "input": {"prompt": "A" * 100},
+                        }
+                    ]
+                },
+            }
+        )
+        log_path.write_text(payload + "\n", encoding="utf-8")
+        result = _parse_last_tool_calls(log_path)
+        assert len(result) == 1
+        assert len(result[0].display) <= 40
+
+    def test_returns_max_three(self, tmp_path: Path) -> None:
+        log_path = tmp_path / "worker_wor_99.log"
+        entries: list[str] = []
+        for i in range(5):
+            entries.append(
+                json.dumps(
+                    {
+                        "type": "assistant",
+                        "message": {
+                            "content": [
+                                {
+                                    "type": "tool_use",
+                                    "name": "Read",
+                                    "input": {"path": f"app/f{i}.py"},
+                                }
+                            ]
+                        },
+                    }
+                )
+            )
+        log_path.write_text("\n".join(entries) + "\n", encoding="utf-8")
+        result = _parse_last_tool_calls(log_path)
+        assert len(result) == 3
+
+
+# ── fetch_ticket_status tests ──────────────────────────────────────────────────
+
+
+def _make_mock_issue(
+    state_name: str = "InProgressLocal", title: str = "Test ticket"
+) -> MagicMock:
+    """Create a mock LinearClient that returns a valid issue dict."""
+    client = MagicMock()
+    client.get_issue.return_value = {
+        "title": title,
+        "state": {"name": state_name, "createdAt": "2026-05-10T06:19:32.000Z"},
+    }
+    return client
+
+
+def test_in_flight_ticket(tmp_path: Path) -> None:
+    """An in-flight ticket should show log, artifacts, and worktree info."""
+    client = _make_mock_issue("InProgressLocal", "In-progress ticket")
+
+    # Create a dummy log file
+    log_dir = tmp_path / ".claude" / "artifacts" / "wor_inprogress"
+    log_dir.mkdir(parents=True)
+    log_path = log_dir / "worker_wor_inprogress.log"
+    log_path.write_text(
+        json.dumps(
+            {
+                "type": "assistant",
+                "message": {
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "name": "Edit",
+                            "input": {"path": "app/x.py"},
+                        }
+                    ],
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    # Create a dummy artifact
+    (log_dir / "manifest.json").write_text('{"ticket":"WOR-123"}', encoding="utf-8")
+
+    # Create dummy worktree
+    (tmp_path / ".claude" / "worktrees" / "wor_inprogress").mkdir(parents=True)
+
+    with patch(
+        "app.core.watcher.ticket_status._parse_log_path",
+        return_value=log_path,
+    ):
+        status = fetch_ticket_status(
+            client,
+            "WOR-INPROGRESS",
+            artifact_dir=log_dir,
+            worktree_dir=tmp_path / ".claude" / "worktrees" / "wor_inprogress",
+        )
+
+    assert status.ticket_id == "WOR-INPROGRESS"
+    assert status.title == "In-progress ticket"
+    assert status.state == "InProgressLocal"
+    assert status.worker_log is not None
+    assert status.worker_log.size_bytes > 0
+    assert status.worker_log.last_tool_calls
+    assert status.artifacts is not None
+    assert "manifest.json" in status.artifacts.entries
+    assert status.worktree_exists is True
+    assert "no_result_artifact" in status.health_flags
+
+
+def test_terminal_ticket(tmp_path: Path) -> None:
+    """A done ticket should not flag missing result artifact."""
+    client = _make_mock_issue("Done")
+
+    status = fetch_ticket_status(
+        client, "WOR-123", artifact_dir=tmp_path / "nonexistent"
+    )
+
+    assert status.state == "Done"
+    assert "no_result_artifact" not in status.health_flags
+
+
+def test_linear_error(tmp_path: Path) -> None:
+    """When Linear is unreachable, return a minimal status."""
+    client = MagicMock()
+    client.get_issue.side_effect = Exception("network unreachable")
+
+    status = fetch_ticket_status(client, "WOR-123")
+
+    assert status.ticket_id == "WOR-123"
+    assert "network unreachable" in status.title
+    assert status.state == "Unknown"
+    assert status.worker_log is None
+    assert status.worktree_exists is None
+
+
+def test_to_dict_serialization() -> None:
+    """TicketStatus.to_dict should produce a JSON-serialisable dict."""
+    status = fetch_ticket_status(_make_mock_issue("Done"), "WOR-123")
+    data: dict[str, Any] = status.to_dict()
+    # Should round-trip through json.dumps/dumps
+    text = json.dumps(data)
+    assert json.loads(text) == data
+    assert data["is_terminal"] is True
+
+
+def test_brief_terminal_state() -> None:
+    """Terminal states should make is_terminal=True."""
+    for state in ["Done", "MergedToEpic", "Cancelled", "Duplicate", "Blocked"]:
+        client = _make_mock_issue(state)
+        status = fetch_ticket_status(client, "WOR-123")
+        assert status.is_terminal is True, f"Expected is_terminal=True for {state}"


### PR DESCRIPTION
Closes WOR-337

ticket-status CLI subcommand + slash command exist and produce structured snapshots. Pure-function assembler in app/core/watcher/ticket_status.py is fully unit-tested. --watch / --json / --brief flags work. Skill md file documents the manual permission setup. ruff/mypy/pytest/lint-imports pass.