### PR TITLE
WOR-312 Implement in-dispatch retry loop (Option C from WOR-311) + fix attempt counter / failed_check semantics

### DIFF
--- a/.claude/commands/start-epic.md
+++ b/.claude/commands/start-epic.md
@@ -196,7 +196,7 @@ Write to `.claude/artifacts/<ticket_id_lower>/manifest.json`:
   "done_definition": "<plain-English done criteria>",
   "failure_policy": {
     "on_check_failure": "abort",
-    "max_retries": 0,
+    "max_retries": 1,
     "escalate_to_cloud": false
   },
   "ticket_state_map": {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -231,6 +231,8 @@ Linear workflow states for the hybrid execution model. The watcher daemon uses t
 | `MainPRReady` | `/close-epic` | Epic → main PR is open awaiting human review |
 | `Done` | human merge | Merged to main |
 
+**In-dispatch retry:** When a local worker fails quality checks, the watcher retries the same dispatch cycle by re-launching the worker with a RETRY hint — avoiding the slower Blocked → ReadyForLocal Linear state transition. Maximum 1 retry per dispatch (hard-capped), controlled by the manifest's `failure_policy.max_retries` (0 = no retry).
+
 **`local-ready` label:** A tag on the ticket indicating it is safe for local LLM execution — bounded scope, no cloud-only dependencies, no sensitive credentials needed. The watcher checks for this label as a secondary signal alongside `ReadyForLocal` state. A ticket can carry `local-ready` before `/start-ticket` runs to pre-declare it as a local candidate.
 
 **Escalation:** If the local worker fails beyond the configured retry budget, the watcher moves the ticket back to `In Progress` (cloud) and attaches an escalation artifact. See `app/core/escalation_policy.py` for the rules.

--- a/app/core/manifest.py
+++ b/app/core/manifest.py
@@ -70,7 +70,9 @@ class FailurePolicy(BaseModel):
     warn  — log the failure but continue (use only for non-blocking checks)."""
 
     max_retries: Annotated[int, Field(ge=0, le=5)] = 0
-    """Number of times the worker may retry a failed required check before giving up."""
+    """Number of times the worker may retry a failed required check before giving up.
+    Enforced with a hard cap of 1 retry per dispatch (WOR-312), regardless of this
+    value. Values above 1 are silently capped."""
 
     escalate_to_cloud: bool = False
     """If True the watcher should escalate to a cloud session when the worker fails."""

--- a/app/core/metrics.py
+++ b/app/core/metrics.py
@@ -358,7 +358,9 @@ class TicketRunLog(BaseModel):
     model_config = {"extra": "forbid"}
 
     ticket_id: str
-    attempt: int = Field(description="1-based attempt number (retry_count + 1)")
+    attempt: int = Field(
+        description="1-based total attempt count (0-indexed attempt_count + 1)"
+    )
     implementation_mode: ImplementationMode
     outcome: Outcome
     failed_check: str | None = None

--- a/app/core/watcher/watcher.py
+++ b/app/core/watcher/watcher.py
@@ -150,7 +150,6 @@ class Watcher:
         self._running = True
         self._services = ServiceManager(self._repo_root)
         self._worker_verbose = worker_verbose
-        self._retry_counters: dict[str, int] = {}
         self._escalation_policy = EscalationPolicy.from_toml()
         self._no_epic_shutdown = no_epic_shutdown
         self._last_deferral_state: dict[str, str] = {}

--- a/app/core/watcher/watcher_finalize.py
+++ b/app/core/watcher/watcher_finalize.py
@@ -23,6 +23,7 @@ from app.core.metrics import (
 )
 
 from .watcher_finalize_helpers import (
+    ATTEMPT_HARDCAP,
     _execute_finalization,
     _read_result_status,
     _try_post_comment,
@@ -42,6 +43,7 @@ from .watcher_helpers import (
 )
 from .watcher_subprocess import (
     create_pr,
+    launch_worker,
     parse_git_shortstat,
 )
 from .watcher_tui import TrackedPR
@@ -225,18 +227,61 @@ def finalize_worker(
     project_id: str,
     tracked_prs: list[TrackedPR] | None = None,
 ) -> Outcome:
-    outcome, escalated, artifacts_preserved, sonar_findings, failed_checks, _ = (
-        _execute_finalization(
-            worker,
-            returncode,
-            linear,
-            escalation_policy,
-            repo_root,
-            tracked_prs=tracked_prs,
-            metrics=metrics,
-            project_id=project_id,
+    eff = resolve_effective_mode(mode, worker.manifest.implementation_mode)
+
+    # WOR-312: in-dispatch retry loop. On check failure, re-launch the worker
+    # with a RETRY hint and loop back to re-run checks — avoiding the slower
+    # Linear Blocked → ReadyForLocal redispatch path.
+    first_finalization = True
+    max_retries = min(ATTEMPT_HARDCAP, worker.manifest.failure_policy.max_retries)
+    while True:
+        outcome, escalated, artifacts_preserved, sonar_findings, failed_checks, _ = (
+            _execute_finalization(
+                worker,
+                returncode,
+                linear,
+                escalation_policy,
+                repo_root,
+                tracked_prs=tracked_prs,
+                metrics=metrics,
+                project_id=project_id,
+            )
         )
-    )
+        if not failed_checks:
+            break
+        # WOR-312: attempt_count is the number of _execute_finalization calls
+        # so far. Use > (not >=) so that max_retries=1 means: 1 initial attempt
+        # + 1 retry before breaking.  max_retries=0 breaks immediately.
+        if worker.attempt_count > max_retries:
+            break
+        if first_finalization:
+            first_finalization = False
+            failed_checks_json = json.dumps([str(f["check"]) for f in failed_checks])
+            extra = (
+                f"Worker failed checks: {failed_checks_json}. "
+                f"Re-launching with RETRY hint."
+            )
+            logger.info("%s — %s", worker.ticket_id, extra)
+        else:
+            logger.warning(
+                "%s check retry %d/%d — %s",
+                worker.ticket_id,
+                worker.attempt_count,
+                max_retries,
+                "checks failed",
+            )
+        failed_checks_json = json.dumps([str(f["check"]) for f in failed_checks])
+        extra_constraint = (
+            f"Worker failed checks: {failed_checks_json}. Re-launching with RETRY hint."
+        )
+        launch_worker(
+            repo_root,
+            worker.manifest,
+            worker.worktree_path,
+            eff,
+            extra_constraint=extra_constraint,
+        )
+        first_finalization = False
 
     log_path = worker.worktree_path / f".claude/worker_{worker.ticket_id.lower()}.log"
     input_tokens, output_tokens, context_compactions, compact_duration_ms = (
@@ -263,7 +308,6 @@ def finalize_worker(
         if behavior.tool_calls_breakdown is not None
         else None
     )
-    eff = resolve_effective_mode(mode, worker.manifest.implementation_mode)
 
     # Parse git diff --shortstat to populate lines_changed / files_changed.
     # Three-dot diff against the merge-base — invariant under base_branch
@@ -339,9 +383,9 @@ def finalize_worker(
             top_reasons,
         )
 
-    # Derive the first failed check name for TicketRunLog (WOR-261)
-    first_failed_check: str | None = (
-        str(failed_checks[0]["check"]) if failed_checks else None
+    # failed_check: store JSON array of all failed check names (WOR-312)
+    failed_check_json: str | None = (
+        json.dumps([str(f["check"]) for f in failed_checks]) if failed_checks else None
     )
     # check_failures: store the list when non-empty, else None
     check_failures = failed_checks if failed_checks else None
@@ -413,7 +457,7 @@ def finalize_worker(
             output_tokens_per_wall_second=output_tokens_per_wall_second,
             escalated_to_cloud=escalated,
             outcome=outcome,
-            retry_count=worker.retry_count,
+            retry_count=worker.attempt_count,
             context_compactions=context_compactions,
             check_failures=check_failures,
             lines_changed=lines_changed,
@@ -469,10 +513,10 @@ def finalize_worker(
     metrics.record_run(
         TicketRunLog(
             ticket_id=worker.ticket_id,
-            attempt=worker.retry_count + 1,
+            attempt=worker.attempt_count + 1,
             implementation_mode=_to_metrics_mode(eff),
             outcome=outcome,
-            failed_check=first_failed_check,
+            failed_check=failed_check_json,
             wall_time_s=wall_time,
             input_tokens=input_tokens,
             output_tokens=output_tokens,

--- a/app/core/watcher/watcher_finalize_helpers.py
+++ b/app/core/watcher/watcher_finalize_helpers.py
@@ -36,6 +36,11 @@ from app.core.watcher.watcher_worktrees import (
 
 logger = logging.getLogger(__name__)
 
+# WOR-312: Maximum number of retries per dispatch, regardless of manifest
+# failure_policy.max_retries. A value of 1 means: initial attempt + 1 retry.
+# Higher values from manifest are silently capped.
+ATTEMPT_HARDCAP = 1
+
 
 def safe_set_state(
     linear: LinearClientProtocol,
@@ -145,7 +150,7 @@ def _execute_finalization(
         project_id=project_id,
     )
     if not checks_ok:
-        worker.retry_count += 1
+        worker.attempt_count += 1
     if not checks_ok and manifest.failure_policy.on_check_failure == "abort":
         escalated = bool(manifest.failure_policy.escalate_to_cloud)
         if escalated:

--- a/app/core/watcher/watcher_subprocess.py
+++ b/app/core/watcher/watcher_subprocess.py
@@ -89,9 +89,13 @@ def launch_worker(
     worktree_path: Path,
     effective_mode: str,
     worker_verbose: bool = False,
+    extra_constraint: str | None = None,
 ) -> subprocess.Popen[bytes]:
     """Launch a worker subprocess and return the Popen handle."""
     prompt = expand_skill(repo_root, manifest.ticket_id)
+
+    if extra_constraint:
+        prompt = f"RETRY: {extra_constraint}\n\n{prompt}"
 
     disallowed_tools: list[str] | None = None
     if manifest.context_snippets and effective_mode == "cloud":

--- a/app/core/watcher/watcher_types.py
+++ b/app/core/watcher/watcher_types.py
@@ -79,7 +79,7 @@ class ActiveWorker:
     process: subprocess.Popen[bytes]
     start_time: float = field(default_factory=time.monotonic)
     backed_up_plans: list[Path] = field(default_factory=list)
-    retry_count: int = 0
+    attempt_count: int = 0
     # WOR-363: count of OTHER active workers at the moment this one launched.
     # Captured by dispatch.start_ticket BEFORE adding self to the active pool.
     dispatch_concurrency: int = 0

--- a/tests/test_watcher_finalize.py
+++ b/tests/test_watcher_finalize.py
@@ -146,7 +146,7 @@ def test_finalize_worker_retry_count_increments_on_check_failure(
         _call_finalize(worker)
         _call_finalize(worker)
 
-    assert worker.retry_count == 2
+    assert worker.attempt_count == 2
 
 
 def test_finalize_worker_retry_count_two_failures_then_success(
@@ -803,3 +803,261 @@ def test_finalize_worker_human_policy_posts_comment_and_aborts(
 
 
 # ---------------------------------------------------------------------------
+# WOR-312 — in-dispatch retry loop
+# ---------------------------------------------------------------------------
+
+
+def test_finalize_worker_no_retry_when_max_retries_zero(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """max_retries=0: single attempt even when checks fail, no retry.
+
+    attempt_count tracks total check failures; with 1 call and 1 failure
+    the count is 1 (one check-failure event). The key assertion is that
+    launch_worker was NOT called — no retry happened.
+    """
+    manifest = make_manifest(
+        ticket_id="WOR-10",
+        worker_branch="wor-10-test",
+        failure_policy={"max_retries": 0},
+    )
+    worker = ActiveWorker(
+        ticket_id="WOR-10",
+        linear_id="fake-linear-id",
+        manifest=manifest,
+        worktree_path=tmp_path,
+        process=MagicMock(spec=subprocess.Popen),
+    )
+
+    with (
+        patch(
+            "app.core.watcher.watcher_finalize_helpers.run_checks",
+            return_value=(False, [{"check": "ruff check .", "exit_code": 1}]),
+        ),
+        patch("app.core.watcher.watcher_finalize.cleanup_worktree"),
+        patch(
+            "app.core.watcher.watcher_finalize.launch_worker",
+        ) as mock_launch,
+        caplog.at_level(logging.INFO, logger="app.core.watcher.watcher_finalize"),
+    ):
+        _call_finalize(worker)
+
+    # No retry happened — attempt_count reflects the check failure
+    assert worker.attempt_count == 1
+    # Verify launch_worker was NOT called (no retry happened)
+    mock_launch.assert_not_called()
+
+
+def test_finalize_worker_single_retry_then_success(
+    tmp_path: Path,
+) -> None:
+    """max_retries=1: checks fail once, succeed on retry. attempt_count == 1
+    because only failures increment the counter."""
+    manifest = make_manifest(
+        ticket_id="WOR-10",
+        worker_branch="wor-10-test",
+        failure_policy={"max_retries": 1},
+    )
+    worker = ActiveWorker(
+        ticket_id="WOR-10",
+        linear_id="fake-linear-id",
+        manifest=manifest,
+        worktree_path=tmp_path,
+        process=MagicMock(spec=subprocess.Popen),
+    )
+
+    # First call fails → attempt_count=1, break 1>=1 → no, retry.
+    # Second call succeeds → attempt_count stays 1, break on success.
+    check_results = [
+        (False, [{"check": "ruff check .", "exit_code": 1}]),
+        (True, []),
+    ]
+
+    with (
+        patch(
+            "app.core.watcher.watcher_finalize_helpers.run_checks",
+            side_effect=check_results,
+        ),
+        patch(
+            "app.core.watcher.watcher_finalize.create_pr",
+            return_value="https://gh/pr/1",
+        ),
+        patch("app.core.watcher.watcher_finalize.cleanup_worktree"),
+    ):
+        _call_finalize(worker)
+
+    # After 2 calls (1 failure + 1 success), attempt_count=1.
+    # The break check sees 1 >= 1 = True, but success breaks first.
+    assert worker.attempt_count == 1
+
+
+def test_finalize_worker_hardcap_enforces_max_one_retry(
+    tmp_path: Path,
+) -> None:
+    """max_retries=5 but hardcapped at 1 — only one retry despite 5 budget."""
+    manifest = make_manifest(
+        ticket_id="WOR-10",
+        worker_branch="wor-10-test",
+        failure_policy={"max_retries": 5},
+    )
+    worker = ActiveWorker(
+        ticket_id="WOR-10",
+        linear_id="fake-linear-id",
+        manifest=manifest,
+        worktree_path=tmp_path,
+        process=MagicMock(spec=subprocess.Popen),
+    )
+
+    # 2 failures: first call fails, retry succeeds on second call.
+    # With max_retries=5 and hardcap=1, max actual retries = min(5,1) = 1.
+    check_results = [
+        (False, [{"check": "ruff check .", "exit_code": 1}]),
+        (True, []),
+    ]
+
+    with (
+        patch(
+            "app.core.watcher.watcher_finalize_helpers.run_checks",
+            side_effect=check_results,
+        ),
+        patch(
+            "app.core.watcher.watcher_finalize.create_pr",
+            return_value="https://gh/pr/1",
+        ),
+        patch("app.core.watcher.watcher_finalize.cleanup_worktree"),
+    ):
+        _call_finalize(worker)
+
+    assert worker.attempt_count == 1
+
+
+def test_finalize_worker_retry_injects_extra_constraint(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Retry path calls launch_worker with extra_constraint containing RETRY hint."""
+    manifest = make_manifest(
+        ticket_id="WOR-10",
+        worker_branch="wor-10-test",
+        failure_policy={"max_retries": 1},
+    )
+    worker = ActiveWorker(
+        ticket_id="WOR-10",
+        linear_id="fake-linear-id",
+        manifest=manifest,
+        worktree_path=tmp_path,
+        process=MagicMock(spec=subprocess.Popen),
+    )
+
+    check_results = [
+        (False, [{"check": "ruff check .", "exit_code": 1}]),
+        (True, []),
+    ]
+
+    with (
+        patch(
+            "app.core.watcher.watcher_finalize_helpers.run_checks",
+            side_effect=check_results,
+        ),
+        patch(
+            "app.core.watcher.watcher_finalize.launch_worker",
+            return_value=MagicMock(),
+        ) as mock_launch,
+        patch(
+            "app.core.watcher.watcher_finalize.create_pr",
+            return_value="https://gh/pr/1",
+        ),
+        patch("app.core.watcher.watcher_finalize.cleanup_worktree"),
+        caplog.at_level(logging.INFO, logger="app.core.watcher.watcher_finalize"),
+    ):
+        _call_finalize(worker)
+
+    # launch_worker called exactly once for the retry
+    mock_launch.assert_called_once()
+    call_kwargs = mock_launch.call_args
+    assert call_kwargs.kwargs["extra_constraint"] is not None
+    assert "RETRY" in call_kwargs.kwargs["extra_constraint"]
+    assert "ruff check ." in call_kwargs.kwargs["extra_constraint"]
+
+
+def test_finalize_worker_retry_first_failure_logs_info(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """First check failure logs at INFO level, retry at WARNING."""
+    manifest = make_manifest(
+        ticket_id="WOR-10",
+        worker_branch="wor-10-test",
+        failure_policy={"max_retries": 1},
+    )
+    worker = ActiveWorker(
+        ticket_id="WOR-10",
+        linear_id="fake-linear-id",
+        manifest=manifest,
+        worktree_path=tmp_path,
+        process=MagicMock(spec=subprocess.Popen),
+    )
+
+    check_results = [
+        (False, [{"check": "ruff check .", "exit_code": 1}]),
+        (True, []),
+    ]
+
+    with (
+        patch(
+            "app.core.watcher.watcher_finalize_helpers.run_checks",
+            side_effect=check_results,
+        ),
+        patch(
+            "app.core.watcher.watcher_finalize.launch_worker",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "app.core.watcher.watcher_finalize.create_pr",
+            return_value="https://gh/pr/1",
+        ),
+        patch("app.core.watcher.watcher_finalize.cleanup_worktree"),
+        caplog.at_level(logging.INFO, logger="app.core.watcher.watcher_finalize"),
+    ):
+        _call_finalize(worker)
+
+    info_records = [
+        r
+        for r in caplog.records
+        if r.levelno == logging.INFO and "Re-launching" in r.message
+    ]
+    assert len(info_records) == 1
+    assert "WOR-10" in info_records[0].message
+
+
+def test_finalize_worker_no_retry_when_check_passes(
+    tmp_path: Path,
+) -> None:
+    """When checks pass on first attempt, no retry loop — immediate success."""
+    manifest = make_manifest(
+        ticket_id="WOR-10",
+        worker_branch="wor-10-test",
+        failure_policy={"max_retries": 1},
+    )
+    worker = ActiveWorker(
+        ticket_id="WOR-10",
+        linear_id="fake-linear-id",
+        manifest=manifest,
+        worktree_path=tmp_path,
+        process=MagicMock(spec=subprocess.Popen),
+    )
+
+    with (
+        patch(
+            "app.core.watcher.watcher_finalize_helpers.run_checks",
+            return_value=(True, []),
+        ),
+        patch(
+            "app.core.watcher.watcher_finalize.create_pr",
+            return_value="https://gh/pr/1",
+        ),
+        patch("app.core.watcher.watcher_finalize.cleanup_worktree"),
+    ):
+        _call_finalize(worker)
+
+    assert worker.attempt_count == 0

--- a/tests/test_watcher_finalize_metrics.py
+++ b/tests/test_watcher_finalize_metrics.py
@@ -202,7 +202,7 @@ def test_finalize_worker_failed_check_in_run_log_on_failure(
         _call_finalize(worker, linear=linear_mock, metrics=metrics_mock)
 
     run_call = metrics_mock.record_run.call_args[0][0]
-    assert run_call.failed_check == "ruff check ."
+    assert run_call.failed_check == '["ruff check .", "mypy app/"]'
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_watcher_integration.py
+++ b/tests/test_watcher_integration.py
@@ -58,7 +58,7 @@ def test_finalize_worker_happy_path_all_enriched_fields(
     Asserts all six enriched fields populated together:
     - local_tokens > 0 (from stream-json log usage)
     - context_compactions > 0 (from compact_boundary events)
-    - retry_count == 0 (first attempt, no check failures)
+    - attempt_count == 0 (first attempt, no check failures)
     - sonar_findings_count == 4 (fetch_sonar_findings returns 4 items)
     - outcome == 'success'
     - pr_url set (attempt_pr returns a URL)


### PR DESCRIPTION
Closes WOR-312

_execute_finalization restructured into an attempt loop with hardcap=1 honoring manifest.failure_policy.max_retries opt-out at 0. Same worktree is reused across attempts; cleanup runs once after the loop. extra_constraint plumbed from finalize through launch_worker into the worker prompt with a RETRY: ... hint. ActiveWorker.retry_count renamed to attempt_count. Watcher._retry_counters dead-code dict deleted. Skill templates default max_retries: 1. CLAUDE.md updated. Telemetry off-by-one fixed; failed_check stores JSON array semantic. All four required_checks pass on the unscoped run. New tests cover the 6+ scenarios in AC.