### PR TITLE
WOR-423 Add `.claude/tmp_commit_msg.txt` to `.gitignore` — workers spend 25min recovering when it leaks into commits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,9 @@ litellm-local.yaml
 # Claude Code local worker artifacts (ephemeral, machine-generated)
 .claude/artifacts/
 
+# Bash discipline workaround (WOR-376): tmp file for commit messages, see WOR-423
+.claude/tmp_commit_msg.txt
+
 # Claude Code watcher logs
 .claude/*.log
 .claude/*.pid


### PR DESCRIPTION
Closes WOR-423

.gitignore matches .claude/tmp_commit_msg.txt verified via git check-ignore. Worker_*.log entry from WOR-418 remains untouched. Worker's own commit does NOT include the tmp file. All 4 required_checks pass.