### PR TITLE
WOR-419 Watcher dispatch: cross-epic ticket selection + multi-dispatch-per-cycle for fast ramp

### DIFF
--- a/.claude/commands/start-ticket.md
+++ b/.claude/commands/start-ticket.md
@@ -79,7 +79,80 @@ Check whether this ticket has a parent epic (`parentId` from `get_issue` relatio
 - Warn: "This ticket has no parent epic — branch will target main instead of an epic branch."
 - Continue with the normal main-targeting flow (step 3 will branch off main)
 
-### 0.55. Epic-size charter check (run when parent epic exists)
+### 0.56. Cross-epic branch detection (WOR-419)
+
+The principle: **Linear parentId describes the ticket; git base_branch describes
+the shipping unit. They can diverge.** (WOR-419)
+
+Detect the active epic branch in flight and prefer it for the current ticket.
+This lets sub-tickets target whichever epic branch is active rather than always
+using their own Linear-parent epic branch — which may be a different epic in
+flight.
+
+Step — list all epic branches and check their Linear-parent status:
+```bash
+# 1. List epic branches on origin
+epic_branches=$(git ls-remote --heads origin 'epic/*' | sed 's|.*refs/heads/||' | sort)
+
+# 2. Determine which epic branches are "active"
+active_epics=""
+for branch in $epic_branches; do
+  # Extract the epic ticket ID from the branch (epic/wor-NNN-slug → WOR-NNN)
+  epic_id=$(echo "$branch" | sed 's|epic/wor-\([0-9]*\)-.*|\WOR-\1|')
+  # Fetch the parent epic issue via Linear MCP
+  parent_issue=$(get_issue "$epic_id")
+  # Check if parent is "In Review" → if so, this epic is NOT active
+  parent_state=$(echo "$parent_issue" | jq -r '.state.name')
+  if [ "$parent_state" = "In Review" ]; then
+    continue
+  fi
+  # Check if any direct child is InProgressLocal or MergedToEpic
+  children_count=$(list_issues(parentId: "$epic_id") | jq '[.[] | select(.state.type == "InProgressLocal" or .state.type == "MergedToEpic")] | length')
+  if [ "$children_count" -gt 0 ]; then
+    active_epics="$active_epics $branch"
+  fi
+done
+
+# 3. Apply the rule:
+#    - If exactly ONE active epic exists AND current ticket's Linear-parent
+#      epic is NOT itself active → default base_branch to the active epic
+#    - If MULTIPLE active epics exist → fall back to current behavior (use
+#      Linear-parent epic branch), surface note to architect
+#    - If NO active epic exists → use default branch resolution
+
+# Check if the current ticket's Linear-parent epic is in the active list
+parent_epic_base="${manifest.base_branch:-}"
+is_parent_active=false
+for active in $active_epics; do
+  if [ "$active" = "$parent_epic_base" ]; then
+    is_parent_active=true
+    break
+  fi
+done
+
+if [ "$is_parent_active" = "false" ] && [ -n "$active_epics" ]; then
+  active_count=$(echo "$active_epics" | wc -w)
+  if [ "$active_count" -eq 1 ]; then
+    echo "Preferring active epic branch $active_epics (parent epic $parent_epic_base is not in-flight)"
+    # Use this branch as base_branch instead of the Linear-parent epic
+    base_branch="$active_epics"
+  elif [ "$active_count" -gt 1 ]; then
+    echo "WARNING: Multiple active epic branches detected ($active_epics). Using Linear-parent epic branch. Manual intervention may be needed."
+  fi
+fi
+```
+
+Architect-facing: if `is_parent_active` is false and `active_count == 1`, explain:
+*"This ticket's Linear parent is epic <parent> but the active epic branch in-flight
+is <active>. Defaulting base_branch to <active> — the shipping unit diverges from
+the Linear-parent (WOR-419 principle)."*
+
+**Edge cases:**
+- If MULTIPLE active epic branches exist → fall back to current behavior; surface note
+- If NO active epic branch exists → use default branch resolution (Linear-parent)
+- If the ticket has no parent epic → skip this check entirely
+
+### 0.57. Epic-size charter check (run when parent epic exists)
 
 When the ticket has a parent epic, count the parent's sub-tickets via `list_issues(parentId: <epicId>)` and inspect the parent description for a `**Charter:** <sentence>` line and a `**Sub-ticket budget:** <N>` line.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,7 @@ Module responsibilities:
   - `watcher_types.py` — constants, `LinearClientProtocol`, `ActiveWorker` dataclass, `is_watcher_running`, `_to_metrics_mode`
   - `watcher_worktrees.py` — git worktree lifecycle: `create_worktree`, `rebase_worktree_from_base`, `copy_manifest_to_worktree`, `preserve_worker_artifacts`, `cleanup_worktree`, `cleanup_orphaned_worktrees`, `backup_plan_files`, `restore_plan_files`, `write_worker_pytest_config`
   - `worker_waste.py` — post-hoc waste-score analysis on worker JSONL logs; `compute_waste_score` flags redundant reads, suppressed loops, and tool-gap patterns; surfaced in `ticket_metrics.waste_score` for retro analysis
+- `watcher.py` dispatch loop: multi-dispatch-per-cycle — on each poll cycle the watcher dispatches up to `MAX_DISPATCHES_PER_CYCLE=4` eligible tickets with a `DISPATCH_DELAY_SECONDS=2.5` inter-dispatch gap, saturating the local pool faster than the prior single-dispatch model. Epic-branch overlap gate (WOR-419) blocks dispatch to a new epic/* branch when another is already in-flight.
 - `bench_store.py` — `BenchRun` Pydantic model + `BenchStore`: SQLite-backed append-only store for benchmark run records; shares the same `app.db` file as `metrics.py` (separate `bench_run` table); stores hardware/timing/quality columns per run
 - `main.py` — PySide6 `QApplication` entry point
 
@@ -245,6 +246,12 @@ main
     ├── wor-45-add-yaml-preset      ← sub-ticket branch → auto-merges to epic when CI passes
     └── wor-47-jinja-context-fix    ← parallel sub-ticket → its own worktree, isolated
 ```
+
+**Cross-epic principle:** Linear parentId describes the ticket; git base_branch
+describes the shipping unit. They can diverge (WOR-419). A ticket whose Linear
+parent is epic A can ship on epic B's branch when epic B is the one currently
+active in-flight. The `/start-ticket` architect detects this via Linear status
+queries and defaults base_branch to the active epic branch.
 
 ### Parallel work
 

--- a/app/core/watcher/dispatch.py
+++ b/app/core/watcher/dispatch.py
@@ -59,6 +59,41 @@ def start_ticket(
     # Prerequisite checks (open_blockers + overlap) are handled by
     # Watcher._start_ticket before calling this function.
 
+    # WOR-419: defense-in-depth — refuse to spawn a worker on a new epic/*
+    # branch when another epic/* branch is already in flight. This prevents
+    # overlapping epic work from competing for the same shared files
+    # (CLAUDE.md, templates/, etc.) and keeps the epic branch topology clean.
+    # Gate fires ONLY when this ticket's base_branch is epic/* AND another
+    # active worker is already on a different epic/* branch. Sub-ticket
+    # branches under the same epic are unaffected — those are the normal
+    # dispatch path and handled by the overlap check above.
+    if manifest.base_branch.startswith("epic/"):
+        for worker in _local_active:
+            if hasattr(worker, "manifest") and worker.manifest.base_branch.startswith(
+                "epic/"
+            ):
+                if worker.manifest.base_branch != manifest.base_branch:
+                    logger.warning(
+                        "Deferring %s — epic branch %s already in-flight "
+                        "(worker on %s)",
+                        ticket_id,
+                        manifest.base_branch,
+                        worker.manifest.base_branch,
+                    )
+                    linear.post_comment(
+                        linear_id,
+                        (
+                            f"Dispatch deferred: another worker is already "
+                            f"in-flight on epic branch "
+                            f"`{worker.manifest.base_branch}`. "
+                            f"Cannot dispatch to a new epic branch "
+                            f"`{manifest.base_branch}` until the in-flight "
+                            f"worker completes (one-active-epic-branch "
+                            f"principle, WOR-419)."
+                        ),
+                    )
+                    return
+
     # Manifest quality gates (WOR-378) — Pydantic validation accepts these as
     # legal but they are almost certainly authoring mistakes. Refuse early
     # with a clear Linear comment so the operator knows to re-author.

--- a/app/core/watcher/watcher.py
+++ b/app/core/watcher/watcher.py
@@ -100,6 +100,16 @@ _WORKER_KILL_GRACE_SECONDS = 5 * 60
 # S1192: extracted from literal used in 3 glob() calls (lines ~256, ~371, ~850)
 _MANIFEST_GLOB = "*/manifest.json"
 
+# WOR-419: multi-dispatch-per-cycle — bounds on how many eligible tickets the
+# watcher dispatches in a single poll cycle. Prevents a thundering-herd of
+# subprocess spawns when many tickets are queued. The loop iterates eligible
+# tickets, dispatches each, then sleeps DISPATCH_DELAY_SECONDS between
+# successive dispatches (gives Linear's state-change API and vLLM a breathing
+# moment). Stops when the pool is full, no more eligible tickets remain, or
+# MAX_DISPATCHES_PER_CYCLE is reached as a safety valve.
+MAX_DISPATCHES_PER_CYCLE = 4
+DISPATCH_DELAY_SECONDS = 2.5
+
 
 class _ProcessedTicket(NamedTuple):
     ticket_id: str
@@ -522,6 +532,7 @@ class Watcher:
     # ------------------------------------------------------------------
 
     def _dispatch_next_ticket(self) -> None:
+        dispatch_count = 0
         try:
             tickets = self._linear.list_ready_for_local()
         except Exception as exc:
@@ -544,7 +555,10 @@ class Watcher:
                 continue
             try:
                 self._start_ticket(ticket_id, ticket["id"])
-                return  # one ticket per dispatch cycle
+                dispatch_count += 1
+                if dispatch_count >= MAX_DISPATCHES_PER_CYCLE:
+                    break
+                time.sleep(DISPATCH_DELAY_SECONDS)
             except Exception as exc:
                 logger.error("Failed to start %s: %s", ticket_id, exc)
 
@@ -569,6 +583,44 @@ class Watcher:
                     state_type,
                 )
                 return
+
+        # WOR-419: defense-in-depth — refuse to spawn on a new epic/* branch
+        # when another epic/* is already in flight. Sub-ticket branches under
+        # the same epic are unaffected.
+        if manifest.base_branch.startswith("epic/"):
+            for worker in self._local_active:
+                if not hasattr(worker, "manifest"):
+                    continue
+                if not worker.manifest.base_branch.startswith("epic/"):
+                    continue
+                if worker.manifest.base_branch != manifest.base_branch:
+                    logger.warning(
+                        "Deferring %s — epic branch %s already in-flight "
+                        "(worker on %s)",
+                        ticket_id,
+                        manifest.base_branch,
+                        worker.manifest.base_branch,
+                    )
+                    try:
+                        self._linear.post_comment(
+                            linear_id,
+                            (
+                                f"Dispatch deferred: another worker is already "
+                                f"in-flight on epic branch "
+                                f"`{worker.manifest.base_branch}`. "
+                                f"Cannot dispatch to a new epic branch "
+                                f"`{manifest.base_branch}` until the in-flight "
+                                f"worker completes (one-active-epic-branch "
+                                f"principle, WOR-419)."
+                            ),
+                        )
+                    except Exception as exc:
+                        logger.warning(
+                            "Could not post epic-branch conflict comment for %s: %s",
+                            ticket_id,
+                            exc,
+                        )
+                    return
 
         all_active = self._local_active + self._cloud_active
         conflicts = check_allowed_paths_overlap(all_active, manifest)
@@ -779,7 +831,7 @@ class Watcher:
            Linear comment with the timeout context. The natural reap path
            handles the eventual exit code.
 
-        If the log file does not exist yet (worker just dispatched), the
+        If the log file does not exist yet (worker just dispatch_count), the
         check is skipped â€” natural process reap handles the case where the
         worker died before writing anything.
         """

--- a/tests/test_start_ticket_routing.py
+++ b/tests/test_start_ticket_routing.py
@@ -125,3 +125,62 @@ class TestCanonicalCases:
         text = _read_skill()
         # modification should be mentioned as a cell with low failure rate
         assert "modification" in text
+
+
+# ---------------------------------------------------------------------------
+# WOR-419 — cross-epic branch detection in start-ticket.md
+# ---------------------------------------------------------------------------
+
+
+class TestCrossEpicBranchDetection:
+    """File-content assertions for cross-epic detection logic in start-ticket.md."""
+
+    def test_cross_epic_section_header_exists(self):
+        text = _read_skill()
+        assert "Cross-epic branch detection" in text or "cross-epic" in text.lower()
+
+    def test_principle_prose_present(self):
+        """The cross-epic principle is stated: Linear parentId describes,
+        base_branch is the shipping unit; they can diverge."""
+        text = _read_skill()
+        assert "parentId" in text
+        assert "base_branch" in text
+        assert "diverge" in text or "diverges" in text
+
+    def test_epic_branch_listing_present(self):
+        """Cross-epic detection includes listing epic branches via git."""
+        text = _read_skill()
+        assert "epic/*" in text or "epic/" in text
+        assert "ls-remote" in text
+
+    def test_active_epic_check_logic_present(self):
+        """Detection checks: parent NOT 'In Review' AND at least one child
+        in InProgressLocal or MergedToEpic."""
+        text = _read_skill()
+        assert "InProgressLocal" in text or "In Progress" in text
+        assert "In Review" in text
+        assert "MergedToEpic" in text
+
+    def test_single_active_epic_rule(self):
+        """Exactly one active epic → default to it."""
+        text = _read_skill()
+        assert (
+            "exactly one" in text
+            or "active_count" in text
+            or "active epic" in text.lower()
+        )
+
+    def test_multiple_active_fallback(self):
+        """Multiple active epics → fall back to current behavior."""
+        text = _read_skill()
+        assert (
+            "multiple" in text
+            or "MULTIPLE" in text
+            or "fallback" in text
+            or "fall back" in text
+        )
+
+    def test_no_active_fallback(self):
+        """No active epic → use default resolution."""
+        text = _read_skill()
+        assert "default" in text or "default resolution" in text.lower()

--- a/tests/test_watcher_dispatch.py
+++ b/tests/test_watcher_dispatch.py
@@ -10,6 +10,7 @@ plus the dedup-on-repeat-defer edge case.
 from __future__ import annotations
 
 import logging
+import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -496,3 +497,170 @@ def test_start_ticket_vllm_not_ready_dedup_logs_warning_once(
 
     vllm_warnings = [r for r in caplog.records if "vLLM not ready" in r.message]
     assert len(vllm_warnings) == 1  # second call is suppressed
+
+
+# ---------------------------------------------------------------------------
+# WOR-419 — epic-branch overlap defense gate at dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_start_ticket_defers_when_another_epic_branch_already_in_flight(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Dispatch to a new epic/* branch is refused when another epic/* branch
+    is already in-flight on a local worker."""
+    manifest = make_manifest(
+        implementation_mode="local",
+        base_branch="epic/wor-419-new-epic",
+    )
+    # Create an active worker on a different epic branch
+    active_epic_manifest = make_manifest(
+        implementation_mode="local",
+        base_branch="epic/wor-335-active",
+    )
+    from app.core.watcher.watcher_types import ActiveWorker
+
+    local_active: list[ActiveWorker] = [
+        ActiveWorker(
+            ticket_id="WOR-335-A",
+            linear_id="fake-linear-id-335",
+            manifest=active_epic_manifest,
+            worktree_path=tmp_path / "worktree_335",
+            process=MagicMock(spec=subprocess.Popen),
+        )
+    ]
+    linear = MagicMock()
+    services = _services()
+    cloud_active: list = []
+
+    with (
+        patch("app.core.watcher.dispatch.create_worktree") as mock_create,
+        caplog.at_level(logging.WARNING, logger="app.core.watcher.dispatch"),
+    ):
+        start_ticket(
+            manifest=manifest,
+            linear=linear,
+            services=services,
+            worker_verbose=False,
+            _local_active=local_active,
+            _cloud_active=cloud_active,
+            max_cloud_workers=3,
+            _repo_root=tmp_path,
+            _processed_tickets=[],
+            linear_id="fake-linear-id-419",
+            ticket_id="WOR-419",
+            _escalation_policy=MagicMock(),
+            _dedup_state={},
+        )
+
+    mock_create.assert_not_called()
+    assert len(local_active) == 1  # no worker appended, original preserved
+    # Linear comment should have been posted
+    linear.post_comment.assert_called_once()
+    body = linear.post_comment.call_args[0][1]
+    assert "epic branch" in body.lower()
+    assert "epic/wor-335-active" in body
+    assert "epic/wor-419-new-epic" in body
+    assert any("epic branch" in r.message for r in caplog.records)
+
+
+def test_start_ticket_proceeds_for_same_epic_branch(
+    tmp_path: Path,
+) -> None:
+    """Dispatch within the SAME epic branch is unaffected — normal dispatch path."""
+    epic_manifest = make_manifest(
+        implementation_mode="local",
+        base_branch="epic/wor-335-active",
+    )
+    from app.core.watcher.watcher_types import ActiveWorker
+
+    existing_worker_manifest = make_manifest(
+        implementation_mode="local",
+        base_branch="epic/wor-335-active",
+    )
+    local_active: list[ActiveWorker] = [
+        ActiveWorker(
+            ticket_id="WOR-335-A",
+            linear_id="fake-linear-id-335",
+            manifest=existing_worker_manifest,
+            worktree_path=tmp_path / "worktree_335",
+            process=MagicMock(spec=subprocess.Popen),
+        )
+    ]
+    linear = MagicMock()
+    services = _services()
+    cloud_active: list = []
+
+    with (
+        patch(
+            "app.core.watcher.dispatch.create_worktree",
+            return_value=tmp_path / "worktree",
+        ),
+        patch("app.core.watcher.dispatch.copy_manifest_to_worktree"),
+        patch("app.core.watcher.dispatch.write_worker_pytest_config"),
+        patch("app.core.watcher.dispatch.backup_plan_files", return_value=[]),
+        patch("app.core.watcher.dispatch.launch_worker", return_value=MagicMock()),
+        patch("app.core.watcher.dispatch.safe_set_state"),
+    ):
+        start_ticket(
+            manifest=epic_manifest,
+            linear=linear,
+            services=services,
+            worker_verbose=False,
+            _local_active=local_active,
+            _cloud_active=cloud_active,
+            max_cloud_workers=3,
+            _repo_root=tmp_path,
+            _processed_tickets=[],
+            linear_id="fake-linear-id-419",
+            ticket_id="WOR-419",
+            _escalation_policy=MagicMock(),
+            _dedup_state={},
+        )
+
+    assert len(local_active) == 2  # both the existing and new worker
+    linear.post_comment.assert_not_called()
+
+
+def test_start_ticket_unaffected_when_no_epic_workers_active(
+    tmp_path: Path,
+) -> None:
+    """A non-epic base_branch dispatches normally when no epic workers are active."""
+    manifest = make_manifest(
+        implementation_mode="local",
+        base_branch="main",
+    )
+    local_active: list = []  # no active workers at all
+    cloud_active: list = []
+    linear = MagicMock()
+    services = _services()
+
+    with (
+        patch(
+            "app.core.watcher.dispatch.create_worktree",
+            return_value=tmp_path / "worktree",
+        ),
+        patch("app.core.watcher.dispatch.copy_manifest_to_worktree"),
+        patch("app.core.watcher.dispatch.write_worker_pytest_config"),
+        patch("app.core.watcher.dispatch.backup_plan_files", return_value=[]),
+        patch("app.core.watcher.dispatch.launch_worker", return_value=MagicMock()),
+        patch("app.core.watcher.dispatch.safe_set_state"),
+    ):
+        start_ticket(
+            manifest=manifest,
+            linear=linear,
+            services=services,
+            worker_verbose=False,
+            _local_active=local_active,
+            _cloud_active=cloud_active,
+            max_cloud_workers=3,
+            _repo_root=tmp_path,
+            _processed_tickets=[],
+            linear_id="fake-linear-id",
+            ticket_id="WOR-10",
+            _escalation_policy=MagicMock(),
+            _dedup_state={},
+        )
+
+    assert len(local_active) == 1
+    linear.post_comment.assert_not_called()

--- a/tests/test_watcher_dispatch_loop.py
+++ b/tests/test_watcher_dispatch_loop.py
@@ -858,3 +858,151 @@ def test_epic_completion_partial_failure_skips_comment(
         "failed" in msg.lower() and "succeeded" in msg.lower()
         for msg in caplog.messages
     )
+
+
+# ---------------------------------------------------------------------------
+# WOR-419 — epic-branch overlap gate in _start_ticket
+# ---------------------------------------------------------------------------
+
+
+def test_start_ticket_blocks_when_another_epic_branch_in_flight(
+    tmp_path: Path, caplog: pytest.LogCaptureContext
+) -> None:
+    """Dispatch to a new epic/* branch is refused when another epic/* is
+    already in-flight on a local worker. A Linear comment is posted."""
+
+    new_epic_manifest = _make_manifest(
+        ticket_id="WOR-419",
+        worker_branch="wor-419-epic-branch",
+        base_branch="epic/wor-419-new-epic",
+        allowed_paths=["app/core/new.py"],
+    )
+    active_epic_manifest = _make_manifest(
+        ticket_id="WOR-335-A",
+        worker_branch="wor-335-active",
+        base_branch="epic/wor-335-active",
+        allowed_paths=["app/core/active.py"],
+    )
+
+    w = Watcher(
+        linear_client=MagicMock(),
+        repo_root=tmp_path,
+    )
+    w._linear.get_open_blockers.return_value = []
+
+    # Add an active worker on a different epic branch
+    w._local_active.append(
+        ActiveWorker(
+            ticket_id="WOR-335-A",
+            linear_id="fake-335",
+            manifest=active_epic_manifest,
+            worktree_path=tmp_path / "worktree_335",
+            process=MagicMock(spec=subprocess.Popen),
+        )
+    )
+
+    with (
+        patch.object(w, "_load_manifest", return_value=new_epic_manifest),
+        patch("app.core.watcher.watcher.create_worktree"),
+        caplog.at_level(logging.WARNING, logger="app.core.watcher"),
+    ):
+        w._start_ticket("WOR-419", "fake-419")
+
+    assert len(w._local_active) == 1  # original worker preserved, no new one
+    assert w._local_active[0].ticket_id == "WOR-335-A"
+    # Gate should have logged and posted a Linear comment
+    assert any("epic branch" in m and "already in-flight" in m for m in caplog.messages)
+    w._linear.post_comment.assert_called_once()
+
+
+def test_start_ticket_proceeds_for_same_epic_branch(
+    tmp_path: Path,
+) -> None:
+    """Dispatch within the SAME epic branch proceeds normally — the gate
+    only blocks DIFFERENT epic branches."""
+
+    same_epic_manifest = _make_manifest(
+        ticket_id="WOR-419",
+        worker_branch="wor-419-same-epic",
+        base_branch="epic/wor-335-active",
+        allowed_paths=["app/core/new.py"],
+    )
+    active_epic_manifest = _make_manifest(
+        ticket_id="WOR-335-A",
+        worker_branch="wor-335-active",
+        base_branch="epic/wor-335-active",
+        allowed_paths=["app/core/active.py"],
+    )
+
+    w = Watcher(
+        linear_client=MagicMock(),
+        repo_root=tmp_path,
+    )
+    w._linear.get_open_blockers.return_value = []
+
+    w._local_active.append(
+        ActiveWorker(
+            ticket_id="WOR-335-A",
+            linear_id="fake-335",
+            manifest=active_epic_manifest,
+            worktree_path=tmp_path / "worktree_335",
+            process=MagicMock(spec=subprocess.Popen),
+        )
+    )
+
+    with (
+        patch.object(w, "_load_manifest", return_value=same_epic_manifest),
+        patch("app.core.watcher.watcher.create_worktree", return_value=tmp_path),
+        patch("app.core.watcher.watcher.copy_manifest_to_worktree"),
+        patch("app.core.watcher.watcher.write_worker_pytest_config"),
+        patch("app.core.watcher.watcher.safe_set_state"),
+        patch("app.core.watcher.watcher.backup_plan_files", return_value=[]),
+        patch(
+            "app.core.watcher.watcher.launch_worker",
+            return_value=MagicMock(spec=subprocess.Popen),
+        ),
+        patch.object(w._services, "ensure_vllm_anthropic_mode"),
+        patch.object(w._services, "probe_vllm_health", return_value=True),
+    ):
+        w._start_ticket("WOR-419", "fake-419")
+
+    assert len(w._local_active) == 2  # both workers
+    linear_mock = w._linear
+    linear_mock.post_comment.assert_not_called()
+
+
+def test_start_ticket_unaffected_when_no_epic_workers(
+    tmp_path: Path,
+) -> None:
+    """A non-epic base_branch dispatches normally when no epic workers are active."""
+    main_manifest = _make_manifest(
+        ticket_id="WOR-10",
+        worker_branch="wor-10-main",
+        base_branch="main",
+        allowed_paths=["app/core/foo.py"],
+    )
+
+    w = Watcher(
+        linear_client=MagicMock(),
+        repo_root=tmp_path,
+    )
+    w._linear.get_open_blockers.return_value = []
+
+    with (
+        patch.object(w, "_load_manifest", return_value=main_manifest),
+        patch("app.core.watcher.watcher.create_worktree", return_value=tmp_path),
+        patch("app.core.watcher.watcher.copy_manifest_to_worktree"),
+        patch("app.core.watcher.watcher.write_worker_pytest_config"),
+        patch("app.core.watcher.watcher.safe_set_state"),
+        patch("app.core.watcher.watcher.backup_plan_files", return_value=[]),
+        patch(
+            "app.core.watcher.watcher.launch_worker",
+            return_value=MagicMock(spec=subprocess.Popen),
+        ),
+        patch.object(w._services, "ensure_vllm_anthropic_mode"),
+        patch.object(w._services, "probe_vllm_health", return_value=True),
+    ):
+        w._start_ticket("WOR-10", "fake-10")
+
+    assert len(w._local_active) == 1
+    w._linear.post_comment.assert_not_called()

--- a/tests/test_watcher_multidispatch.py
+++ b/tests/test_watcher_multidispatch.py
@@ -1,0 +1,395 @@
+"""Tests for multi-dispatch-per-cycle and inter-dispatch delay (WOR-419).
+
+Tests the _dispatch_next_ticket loop change: instead of returning after one
+successful dispatch, the watcher iterates eligible tickets and dispatches up
+to MAX_DISPATCHES_PER_CYCLE per poll cycle, with DISPATCH_DELAY_SECONDS sleep
+between successive dispatches.
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.core.manifest import ArtifactPaths, ExecutionManifest
+from app.core.watcher.watcher import Watcher
+
+
+def _make_manifest(**overrides: Any) -> ExecutionManifest:
+    defaults: dict[str, Any] = {
+        "ticket_id": "WOR-10",
+        "epic_id": "WOR-96",
+        "title": "Test ticket",
+        "priority": 2,
+        "status": "ReadyForLocal",
+        "parallel_safe": True,
+        "risk_level": "low",
+        "implementation_mode": "local",
+        "review_mode": "auto",
+        "base_branch": "wor-96-local-worker-engine",
+        "worker_branch": "wor-10-test-ticket",
+        "objective": "Do the thing.",
+        "artifact_paths": ArtifactPaths.from_ticket_id("WOR-10"),
+        "allowed_paths": ["app/core/foo.py"],
+        "required_checks": ["pytest"],
+    }
+    defaults.update(overrides)
+    return ExecutionManifest(**defaults)
+
+
+def _regular_ticket(identifier: str = "WOR-99") -> dict[str, Any]:
+    return {
+        "id": "fake-linear-id",
+        "identifier": identifier,
+        "title": "Regular ticket",
+        "labels": {"nodes": [{"name": "local-ready"}]},
+    }
+
+
+class TestMultiDispatchPerCycle:
+    """_dispatch_next_ticket dispatches multiple eligible tickets per cycle."""
+
+    def test_dispatches_multiple_eligible_tickets_in_one_cycle(
+        self, tmp_path: Path, caplog: pytest.LogCaptureContext
+    ) -> None:
+        """Given 4 eligible tickets and an empty pool, watcher dispatches all 4
+        in one cycle instead of just 1."""
+        manifest1 = _make_manifest(
+            ticket_id="WOR-10",
+            worker_branch="wor-10-test-ticket",
+            allowed_paths=["app/core/a.py"],
+        )
+        manifest2 = _make_manifest(
+            ticket_id="WOR-11",
+            worker_branch="wor-11-test-ticket",
+            allowed_paths=["app/core/b.py"],
+        )
+        manifest3 = _make_manifest(
+            ticket_id="WOR-12",
+            worker_branch="wor-12-test-ticket",
+            allowed_paths=["app/core/c.py"],
+        )
+        manifest4 = _make_manifest(
+            ticket_id="WOR-13",
+            worker_branch="wor-13-test-ticket",
+            allowed_paths=["app/core/d.py"],
+        )
+
+        linear_mock = MagicMock()
+        linear_mock.get_open_blockers.return_value = []
+        linear_mock.list_ready_for_local.return_value = [
+            _regular_ticket("WOR-10"),
+            _regular_ticket("WOR-11"),
+            _regular_ticket("WOR-12"),
+            _regular_ticket("WOR-13"),
+        ]
+
+        w = Watcher(
+            linear_client=linear_mock,
+            repo_root=tmp_path,
+            max_local_workers=8,
+        )
+
+        load_counts: dict[str, int] = {}
+
+        def capture_load(ticket_id: str):
+            load_counts[ticket_id] = load_counts.get(ticket_id, 0) + 1
+            manifest_map = {
+                "WOR-10": manifest1,
+                "WOR-11": manifest2,
+                "WOR-12": manifest3,
+                "WOR-13": manifest4,
+            }
+            return manifest_map[ticket_id]
+
+        fake_process = MagicMock(spec=subprocess.Popen)
+
+        with (
+            patch.object(w, "_load_manifest", side_effect=capture_load),
+            patch("app.core.watcher.watcher.create_worktree", return_value=tmp_path),
+            patch("app.core.watcher.watcher.copy_manifest_to_worktree"),
+            patch("app.core.watcher.watcher.write_worker_pytest_config"),
+            patch("app.core.watcher.watcher.safe_set_state"),
+            patch("app.core.watcher.watcher.backup_plan_files", return_value=[]),
+            patch(
+                "app.core.watcher.watcher.launch_worker",
+                return_value=fake_process,
+            ),
+            patch.object(w._services, "ensure_vllm_anthropic_mode"),
+            patch.object(w._services, "probe_vllm_health", return_value=True),
+            caplog.at_level(logging.INFO, logger="app.core.watcher"),
+        ):
+            w._dispatch_next_ticket()
+
+        # All 4 tickets should have been dispatch_count
+        for tid in ("WOR-10", "WOR-11", "WOR-12", "WOR-13"):
+            assert load_counts.get(tid, 0) == 1, f"{tid} was not dispatch_count"
+
+        assert len(w._local_active) == 4
+        for tid in ("WOR-10", "WOR-11", "WOR-12", "WOR-13"):
+            assert any(w._local_active[i].ticket_id == tid for i in range(4)), (
+                f"{tid} not in local_active"
+            )
+
+    def test_respects_max_dispatches_per_cycle(self, tmp_path: Path) -> None:
+        """Given 8 eligible tickets but MAX_DISPATCHES_PER_CYCLE=4,
+        only 4 are dispatch_count."""
+        from app.core.watcher.watcher import MAX_DISPATCHES_PER_CYCLE
+
+        manifests = [
+            _make_manifest(
+                ticket_id=f"WOR-{i}",
+                worker_branch=f"wor-{i}-test-ticket",
+                allowed_paths=[f"app/core/{chr(97 + i)}.py"],
+            )
+            for i in range(8)
+        ]
+
+        linear_mock = MagicMock()
+        linear_mock.get_open_blockers.return_value = []
+        linear_mock.list_ready_for_local.return_value = [
+            _regular_ticket(f"WOR-{i}") for i in range(8)
+        ]
+
+        w = Watcher(
+            linear_client=linear_mock,
+            repo_root=tmp_path,
+            max_local_workers=8,
+        )
+
+        load_counts: dict[str, int] = {}
+
+        def load_for(ticket_id: str):
+            load_counts[ticket_id] = load_counts.get(ticket_id, 0) + 1
+            return manifests[int(ticket_id[4:])]
+
+        fake_process = MagicMock(spec=subprocess.Popen)
+
+        with (
+            patch.object(w, "_load_manifest", side_effect=load_for),
+            patch("app.core.watcher.watcher.create_worktree", return_value=tmp_path),
+            patch("app.core.watcher.watcher.copy_manifest_to_worktree"),
+            patch("app.core.watcher.watcher.write_worker_pytest_config"),
+            patch("app.core.watcher.watcher.safe_set_state"),
+            patch("app.core.watcher.watcher.backup_plan_files", return_value=[]),
+            patch(
+                "app.core.watcher.watcher.launch_worker",
+                return_value=fake_process,
+            ),
+            patch.object(w._services, "ensure_vllm_anthropic_mode"),
+            patch.object(w._services, "probe_vllm_health", return_value=True),
+        ):
+            w._dispatch_next_ticket()
+
+        dispatch_count = {k: v for k, v in load_counts.items() if v > 0}
+        assert len(dispatch_count) == MAX_DISPATCHES_PER_CYCLE
+
+    def test_skips_spiked_tickets_does_not_count_toward_limit(
+        self, tmp_path: Path
+    ) -> None:
+        """Spike-labelled tickets are skipped (continue) and do not count
+        toward the MAX_DISPATCHES_PER_CYCLE limit — eligible non-spike tickets
+        still get dispatch_count."""
+
+        spike_ticket: dict[str, Any] = {
+            "id": "fake-linear-id",
+            "identifier": "WOR-SPIKE",
+            "title": "Spike ticket",
+            "labels": {"nodes": [{"name": "Spike"}]},
+        }
+
+        manifests = [
+            _make_manifest(
+                ticket_id=f"WOR-{i}",
+                worker_branch=f"wor-{i}-test-ticket",
+                allowed_paths=[f"app/core/{chr(97 + i)}.py"],
+            )
+            for i in range(3)
+        ]
+
+        linear_mock = MagicMock()
+        linear_mock.get_open_blockers.return_value = []
+        linear_mock.list_ready_for_local.return_value = [
+            spike_ticket,  # spike — should be skipped
+            _regular_ticket("WOR-10"),
+            _regular_ticket("WOR-11"),
+            _regular_ticket("WOR-12"),
+        ]
+
+        w = Watcher(
+            linear_client=linear_mock,
+            repo_root=tmp_path,
+            max_local_workers=8,
+        )
+
+        load_counts: dict[str, int] = {}
+
+        def capture_load(ticket_id: str):
+            load_counts[ticket_id] = load_counts.get(ticket_id, 0) + 1
+            idx = int(ticket_id[4:]) - 10
+            if 0 <= idx < len(manifests):
+                return manifests[idx]
+            return manifests[0]
+
+        fake_process = MagicMock(spec=subprocess.Popen)
+
+        with (
+            patch.object(w, "_load_manifest", side_effect=capture_load),
+            patch("app.core.watcher.watcher.create_worktree", return_value=tmp_path),
+            patch("app.core.watcher.watcher.copy_manifest_to_worktree"),
+            patch("app.core.watcher.watcher.write_worker_pytest_config"),
+            patch("app.core.watcher.watcher.safe_set_state"),
+            patch("app.core.watcher.watcher.backup_plan_files", return_value=[]),
+            patch(
+                "app.core.watcher.watcher.launch_worker",
+                return_value=fake_process,
+            ),
+            patch.object(w._services, "ensure_vllm_anthropic_mode"),
+            patch.object(w._services, "probe_vllm_health", return_value=True),
+        ):
+            w._dispatch_next_ticket()
+
+        # All 3 eligible tickets should be dispatch_count (spike skipped, doesn't
+        # consume the dispatch limit)
+        for tid in ("WOR-10", "WOR-11", "WOR-12"):
+            assert load_counts.get(tid, 0) == 1, f"{tid} was not dispatch_count"
+        assert load_counts.get("WOR-SPIKE", 0) == 0
+
+
+class TestInterDispatchDelay:
+    """Inter-dispatch delay constants and behavior."""
+
+    def test_delay_constant_is_module_level(self) -> None:
+        """DISPATCH_DELAY_SECONDS is defined as a module-level constant."""
+        from app.core.watcher.watcher import DISPATCH_DELAY_SECONDS
+
+        assert isinstance(DISPATCH_DELAY_SECONDS, float)
+        assert DISPATCH_DELAY_SECONDS == 2.5
+
+    def test_max_dispatches_constant_is_module_level(self) -> None:
+        """MAX_DISPATCHES_PER_CYCLE is defined as a module-level constant."""
+        from app.core.watcher.watcher import MAX_DISPATCHES_PER_CYCLE
+
+        assert isinstance(MAX_DISPATCHES_PER_CYCLE, int)
+        assert MAX_DISPATCHES_PER_CYCLE == 4
+
+    def test_delay_is_called_between_dispatches(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """time.sleep is called between each dispatch to avoid Linear API spike."""
+        sleep_calls: list[float] = []
+
+        def record_sleep(seconds: float) -> None:
+            sleep_calls.append(seconds)
+
+        manifest = _make_manifest(
+            ticket_id="WOR-10",
+            worker_branch="wor-10-test-ticket",
+            allowed_paths=["app/core/a.py"],
+        )
+        manifest2 = _make_manifest(
+            ticket_id="WOR-11",
+            worker_branch="wor-11-test-ticket",
+            allowed_paths=["app/core/b.py"],
+        )
+
+        linear_mock = MagicMock()
+        linear_mock.get_open_blockers.return_value = []
+        linear_mock.list_ready_for_local.return_value = [
+            _regular_ticket("WOR-10"),
+            _regular_ticket("WOR-11"),
+        ]
+
+        w = Watcher(
+            linear_client=linear_mock,
+            repo_root=tmp_path,
+            max_local_workers=8,
+        )
+
+        load_index = [0]
+
+        def capture_load(ticket_id: str):
+            idx = load_index[0]
+            load_index[0] += 1
+            return manifest if idx == 0 else manifest2
+
+        fake_process = MagicMock(spec=subprocess.Popen)
+
+        with (
+            patch.object(w, "_load_manifest", side_effect=capture_load),
+            patch("app.core.watcher.watcher.create_worktree", return_value=tmp_path),
+            patch("app.core.watcher.watcher.copy_manifest_to_worktree"),
+            patch("app.core.watcher.watcher.write_worker_pytest_config"),
+            patch("app.core.watcher.watcher.safe_set_state"),
+            patch("app.core.watcher.watcher.backup_plan_files", return_value=[]),
+            patch(
+                "app.core.watcher.watcher.launch_worker",
+                return_value=fake_process,
+            ),
+            patch.object(w._services, "ensure_vllm_anthropic_mode"),
+            patch.object(w._services, "probe_vllm_health", return_value=True),
+            patch("app.core.watcher.watcher.time.sleep", record_sleep),
+            patch("app.core.watcher.watcher.MAX_DISPATCHES_PER_CYCLE", 2),
+        ):
+            w._dispatch_next_ticket()
+
+        # Exactly one sleep call between two dispatches; break after 2 hits
+        # so no sleep after the final dispatch.
+        assert len(sleep_calls) == 1
+        assert sleep_calls[0] == 2.5
+
+
+class TestFailureDoesNotConsumeLimit:
+    """A failed _start_ticket (exception) does not consume the dispatch limit."""
+
+    def test_exception_does_not_break_loop(self, tmp_path: Path) -> None:
+        """When _start_ticket raises, the loop continues to the next ticket."""
+
+        manifests = [
+            _make_manifest(
+                ticket_id="WOR-FAIL",
+                worker_branch="wor-fail-ticket",
+                allowed_paths=["app/core/evil.py"],
+            ),
+            _make_manifest(
+                ticket_id="WOR-10",
+                worker_branch="wor-10-test-ticket",
+                allowed_paths=["app/core/a.py"],
+            ),
+        ]
+
+        linear_mock = MagicMock()
+        linear_mock.get_open_blockers.return_value = []
+        linear_mock.list_ready_for_local.return_value = [
+            {"identifier": "WOR-FAIL", "id": "fake", "labels": {"nodes": []}},
+            _regular_ticket("WOR-10"),
+        ]
+
+        w = Watcher(
+            linear_client=linear_mock,
+            repo_root=tmp_path,
+            max_local_workers=8,
+        )
+
+        with (
+            patch.object(w, "_load_manifest") as mock_load,
+            patch("app.core.watcher.watcher.create_worktree"),
+        ):
+            mock_load.side_effect = [
+                RuntimeError("boom"),  # First ticket fails
+                manifests[1],  # Second ticket succeeds
+            ]
+            # Patch safe_set_state to avoid actual Linear call
+            with patch("app.core.watcher.watcher.safe_set_state"):
+                w._dispatch_next_ticket()
+
+        # Second ticket should have been loaded despite first failure
+        calls = mock_load.call_args_list
+        assert len(calls) == 2
+        assert calls[0][0][0] == "WOR-FAIL"
+        assert calls[1][0][0] == "WOR-10"


### PR DESCRIPTION
Closes WOR-419

start-ticket.md step 0.5 detects the active epic branch and prefers it. dispatch.py refuses to spawn workers on new epic/* branches when another is in flight. watcher.py dispatches up to MAX_DISPATCHES_PER_CYCLE=4 eligible tickets per poll cycle with a 2.5s inter-dispatch delay. CLAUDE.md documents both principles. Tests cover all three changes. All required_checks pass.