### PR TITLE
WOR-303 Watcher: auto-post worker side-discoveries from result.json notes to WOR-254 improvement log

### DIFF
--- a/.claude/commands/implement-ticket.md
+++ b/.claude/commands/implement-ticket.md
@@ -322,6 +322,12 @@ If the commit is rejected by a pre-commit hook, fix the issue and retry the comm
 
 Write a JSON result file to `artifact_paths.result_json`. Create parent dirs as needed.
 
+**Field semantics:** `summary` holds the ticket-scope summary (what was implemented).
+`notes` holds side-discoveries — bugs, quirks, or improvements observed during this
+worker session that fall outside this ticket's scope. The watcher auto-posts `notes`
+to the WOR-254 improvement log when it exceeds ~50 characters. Do not duplicate the
+ticket summary in `notes`; keep it focused on unexpected findings.
+
 **On success:**
 ```json
 {
@@ -330,7 +336,7 @@ Write a JSON result file to `artifact_paths.result_json`. Create parent dirs as 
   "summary": "<one-paragraph description of what was implemented>",
   "checks_passed": ["<check1>", "<check2>"],
   "checks_failed": [],
-  "notes": "<any surprising findings or edge cases encountered>"
+  "notes": "<side-discoveries (bugs/quirks/improvements outside this ticket's scope); auto-posted to WOR-254 if >50 chars — do not duplicate ticket-scope summary here>"
 }
 ```
 

--- a/.claude/commands/start-ticket.md
+++ b/.claude/commands/start-ticket.md
@@ -79,7 +79,80 @@ Check whether this ticket has a parent epic (`parentId` from `get_issue` relatio
 - Warn: "This ticket has no parent epic — branch will target main instead of an epic branch."
 - Continue with the normal main-targeting flow (step 3 will branch off main)
 
-### 0.55. Epic-size charter check (run when parent epic exists)
+### 0.56. Cross-epic branch detection (WOR-419)
+
+The principle: **Linear parentId describes the ticket; git base_branch describes
+the shipping unit. They can diverge.** (WOR-419)
+
+Detect the active epic branch in flight and prefer it for the current ticket.
+This lets sub-tickets target whichever epic branch is active rather than always
+using their own Linear-parent epic branch — which may be a different epic in
+flight.
+
+Step — list all epic branches and check their Linear-parent status:
+```bash
+# 1. List epic branches on origin
+epic_branches=$(git ls-remote --heads origin 'epic/*' | sed 's|.*refs/heads/||' | sort)
+
+# 2. Determine which epic branches are "active"
+active_epics=""
+for branch in $epic_branches; do
+  # Extract the epic ticket ID from the branch (epic/wor-NNN-slug → WOR-NNN)
+  epic_id=$(echo "$branch" | sed 's|epic/wor-\([0-9]*\)-.*|\WOR-\1|')
+  # Fetch the parent epic issue via Linear MCP
+  parent_issue=$(get_issue "$epic_id")
+  # Check if parent is "In Review" → if so, this epic is NOT active
+  parent_state=$(echo "$parent_issue" | jq -r '.state.name')
+  if [ "$parent_state" = "In Review" ]; then
+    continue
+  fi
+  # Check if any direct child is InProgressLocal or MergedToEpic
+  children_count=$(list_issues(parentId: "$epic_id") | jq '[.[] | select(.state.type == "InProgressLocal" or .state.type == "MergedToEpic")] | length')
+  if [ "$children_count" -gt 0 ]; then
+    active_epics="$active_epics $branch"
+  fi
+done
+
+# 3. Apply the rule:
+#    - If exactly ONE active epic exists AND current ticket's Linear-parent
+#      epic is NOT itself active → default base_branch to the active epic
+#    - If MULTIPLE active epics exist → fall back to current behavior (use
+#      Linear-parent epic branch), surface note to architect
+#    - If NO active epic exists → use default branch resolution
+
+# Check if the current ticket's Linear-parent epic is in the active list
+parent_epic_base="${manifest.base_branch:-}"
+is_parent_active=false
+for active in $active_epics; do
+  if [ "$active" = "$parent_epic_base" ]; then
+    is_parent_active=true
+    break
+  fi
+done
+
+if [ "$is_parent_active" = "false" ] && [ -n "$active_epics" ]; then
+  active_count=$(echo "$active_epics" | wc -w)
+  if [ "$active_count" -eq 1 ]; then
+    echo "Preferring active epic branch $active_epics (parent epic $parent_epic_base is not in-flight)"
+    # Use this branch as base_branch instead of the Linear-parent epic
+    base_branch="$active_epics"
+  elif [ "$active_count" -gt 1 ]; then
+    echo "WARNING: Multiple active epic branches detected ($active_epics). Using Linear-parent epic branch. Manual intervention may be needed."
+  fi
+fi
+```
+
+Architect-facing: if `is_parent_active` is false and `active_count == 1`, explain:
+*"This ticket's Linear parent is epic <parent> but the active epic branch in-flight
+is <active>. Defaulting base_branch to <active> — the shipping unit diverges from
+the Linear-parent (WOR-419 principle)."*
+
+**Edge cases:**
+- If MULTIPLE active epic branches exist → fall back to current behavior; surface note
+- If NO active epic branch exists → use default branch resolution (Linear-parent)
+- If the ticket has no parent epic → skip this check entirely
+
+### 0.57. Epic-size charter check (run when parent epic exists)
 
 When the ticket has a parent epic, count the parent's sub-tickets via `list_issues(parentId: <epicId>)` and inspect the parent description for a `**Charter:** <sentence>` line and a `**Sub-ticket budget:** <N>` line.
 

--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,9 @@ litellm-local.yaml
 # Claude Code local worker artifacts (ephemeral, machine-generated)
 .claude/artifacts/
 
+# Bash discipline workaround (WOR-376): tmp file for commit messages, see WOR-423
+.claude/tmp_commit_msg.txt
+
 # Claude Code watcher logs
 .claude/*.log
 .claude/*.pid

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,7 @@ Module responsibilities:
   - `watcher_types.py` — constants, `LinearClientProtocol`, `ActiveWorker` dataclass, `is_watcher_running`, `_to_metrics_mode`
   - `watcher_worktrees.py` — git worktree lifecycle: `create_worktree`, `rebase_worktree_from_base`, `copy_manifest_to_worktree`, `preserve_worker_artifacts`, `cleanup_worktree`, `cleanup_orphaned_worktrees`, `backup_plan_files`, `restore_plan_files`, `write_worker_pytest_config`
   - `worker_waste.py` — post-hoc waste-score analysis on worker JSONL logs; `compute_waste_score` flags redundant reads, suppressed loops, and tool-gap patterns; surfaced in `ticket_metrics.waste_score` for retro analysis
+- `watcher.py` dispatch loop: multi-dispatch-per-cycle — on each poll cycle the watcher dispatches up to `MAX_DISPATCHES_PER_CYCLE=4` eligible tickets with a `DISPATCH_DELAY_SECONDS=2.5` inter-dispatch gap, saturating the local pool faster than the prior single-dispatch model. Epic-branch overlap gate (WOR-419) blocks dispatch to a new epic/* branch when another is already in-flight.
 - `bench_store.py` — `BenchRun` Pydantic model + `BenchStore`: SQLite-backed append-only store for benchmark run records; shares the same `app.db` file as `metrics.py` (separate `bench_run` table); stores hardware/timing/quality columns per run
 - `main.py` — PySide6 `QApplication` entry point
 
@@ -245,6 +246,12 @@ main
     ├── wor-45-add-yaml-preset      ← sub-ticket branch → auto-merges to epic when CI passes
     └── wor-47-jinja-context-fix    ← parallel sub-ticket → its own worktree, isolated
 ```
+
+**Cross-epic principle:** Linear parentId describes the ticket; git base_branch
+describes the shipping unit. They can diverge (WOR-419). A ticket whose Linear
+parent is epic A can ship on epic B's branch when epic B is the one currently
+active in-flight. The `/start-ticket` architect detects this via Linear status
+queries and defaults base_branch to the active epic branch.
 
 ### Parallel work
 

--- a/app/core/metrics.py
+++ b/app/core/metrics.py
@@ -659,7 +659,12 @@ class MetricsStore:
                     constraint_density, ac_specificity, tech_stack, raw_extensions,
                     waste_score, waste_breakdown_json, tags, notes, effort,
                     compact_duration_ms, api_retry_count, subagent_spawns,
-                    hook_trust_violations, dispatch_concurrency
+                    hook_trust_violations, dispatch_concurrency,
+                    -- WOR-380: per-worker behavior telemetry
+                    turn_count, tool_calls_total, tool_calls_breakdown,
+                    thinking_blocks, thinking_chars_total,
+                    input_tokens_max, input_tokens_first, input_tokens_last,
+                    redundant_reads_count
                 ) VALUES (
                     :ticket_id, :project_id, :epic_id, :implementation_mode,
                     :cloud_used, :cloud_model, :cloud_tokens, :cloud_cost_estimate,
@@ -675,7 +680,11 @@ class MetricsStore:
                     :constraint_density, :ac_specificity, :tech_stack, :raw_extensions,
                     :waste_score, :waste_breakdown_json, :tags, :notes, :effort,
                     :compact_duration_ms, :api_retry_count, :subagent_spawns,
-                    :hook_trust_violations, :dispatch_concurrency
+                    :hook_trust_violations, :dispatch_concurrency,
+                    :turn_count, :tool_calls_total, :tool_calls_breakdown,
+                    :thinking_blocks, :thinking_chars_total,
+                    :input_tokens_max, :input_tokens_first, :input_tokens_last,
+                    :redundant_reads_count
                 )
                 """,
                 {

--- a/app/core/watcher/dispatch.py
+++ b/app/core/watcher/dispatch.py
@@ -59,6 +59,41 @@ def start_ticket(
     # Prerequisite checks (open_blockers + overlap) are handled by
     # Watcher._start_ticket before calling this function.
 
+    # WOR-419: defense-in-depth — refuse to spawn a worker on a new epic/*
+    # branch when another epic/* branch is already in flight. This prevents
+    # overlapping epic work from competing for the same shared files
+    # (CLAUDE.md, templates/, etc.) and keeps the epic branch topology clean.
+    # Gate fires ONLY when this ticket's base_branch is epic/* AND another
+    # active worker is already on a different epic/* branch. Sub-ticket
+    # branches under the same epic are unaffected — those are the normal
+    # dispatch path and handled by the overlap check above.
+    if manifest.base_branch.startswith("epic/"):
+        for worker in _local_active:
+            if hasattr(worker, "manifest") and worker.manifest.base_branch.startswith(
+                "epic/"
+            ):
+                if worker.manifest.base_branch != manifest.base_branch:
+                    logger.warning(
+                        "Deferring %s — epic branch %s already in-flight "
+                        "(worker on %s)",
+                        ticket_id,
+                        manifest.base_branch,
+                        worker.manifest.base_branch,
+                    )
+                    linear.post_comment(
+                        linear_id,
+                        (
+                            f"Dispatch deferred: another worker is already "
+                            f"in-flight on epic branch "
+                            f"`{worker.manifest.base_branch}`. "
+                            f"Cannot dispatch to a new epic branch "
+                            f"`{manifest.base_branch}` until the in-flight "
+                            f"worker completes (one-active-epic-branch "
+                            f"principle, WOR-419)."
+                        ),
+                    )
+                    return
+
     # Manifest quality gates (WOR-378) — Pydantic validation accepts these as
     # legal but they are almost certainly authoring mistakes. Refuse early
     # with a clear Linear comment so the operator knows to re-author.

--- a/app/core/watcher/watcher.py
+++ b/app/core/watcher/watcher.py
@@ -100,6 +100,16 @@ _WORKER_KILL_GRACE_SECONDS = 5 * 60
 # S1192: extracted from literal used in 3 glob() calls (lines ~256, ~371, ~850)
 _MANIFEST_GLOB = "*/manifest.json"
 
+# WOR-419: multi-dispatch-per-cycle — bounds on how many eligible tickets the
+# watcher dispatches in a single poll cycle. Prevents a thundering-herd of
+# subprocess spawns when many tickets are queued. The loop iterates eligible
+# tickets, dispatches each, then sleeps DISPATCH_DELAY_SECONDS between
+# successive dispatches (gives Linear's state-change API and vLLM a breathing
+# moment). Stops when the pool is full, no more eligible tickets remain, or
+# MAX_DISPATCHES_PER_CYCLE is reached as a safety valve.
+MAX_DISPATCHES_PER_CYCLE = 4
+DISPATCH_DELAY_SECONDS = 2.5
+
 
 class _ProcessedTicket(NamedTuple):
     ticket_id: str
@@ -522,6 +532,7 @@ class Watcher:
     # ------------------------------------------------------------------
 
     def _dispatch_next_ticket(self) -> None:
+        dispatch_count = 0
         try:
             tickets = self._linear.list_ready_for_local()
         except Exception as exc:
@@ -544,7 +555,10 @@ class Watcher:
                 continue
             try:
                 self._start_ticket(ticket_id, ticket["id"])
-                return  # one ticket per dispatch cycle
+                dispatch_count += 1
+                if dispatch_count >= MAX_DISPATCHES_PER_CYCLE:
+                    break
+                time.sleep(DISPATCH_DELAY_SECONDS)
             except Exception as exc:
                 logger.error("Failed to start %s: %s", ticket_id, exc)
 
@@ -569,6 +583,44 @@ class Watcher:
                     state_type,
                 )
                 return
+
+        # WOR-419: defense-in-depth — refuse to spawn on a new epic/* branch
+        # when another epic/* is already in flight. Sub-ticket branches under
+        # the same epic are unaffected.
+        if manifest.base_branch.startswith("epic/"):
+            for worker in self._local_active:
+                if not hasattr(worker, "manifest"):
+                    continue
+                if not worker.manifest.base_branch.startswith("epic/"):
+                    continue
+                if worker.manifest.base_branch != manifest.base_branch:
+                    logger.warning(
+                        "Deferring %s — epic branch %s already in-flight "
+                        "(worker on %s)",
+                        ticket_id,
+                        manifest.base_branch,
+                        worker.manifest.base_branch,
+                    )
+                    try:
+                        self._linear.post_comment(
+                            linear_id,
+                            (
+                                f"Dispatch deferred: another worker is already "
+                                f"in-flight on epic branch "
+                                f"`{worker.manifest.base_branch}`. "
+                                f"Cannot dispatch to a new epic branch "
+                                f"`{manifest.base_branch}` until the in-flight "
+                                f"worker completes (one-active-epic-branch "
+                                f"principle, WOR-419)."
+                            ),
+                        )
+                    except Exception as exc:
+                        logger.warning(
+                            "Could not post epic-branch conflict comment for %s: %s",
+                            ticket_id,
+                            exc,
+                        )
+                    return
 
         all_active = self._local_active + self._cloud_active
         conflicts = check_allowed_paths_overlap(all_active, manifest)
@@ -779,7 +831,7 @@ class Watcher:
            Linear comment with the timeout context. The natural reap path
            handles the eventual exit code.
 
-        If the log file does not exist yet (worker just dispatched), the
+        If the log file does not exist yet (worker just dispatch_count), the
         check is skipped â€” natural process reap handles the case where the
         worker died before writing anything.
         """

--- a/app/core/watcher/watcher_finalize.py
+++ b/app/core/watcher/watcher_finalize.py
@@ -28,6 +28,7 @@ from .watcher_finalize_helpers import (
     _read_result_status,
     _try_post_comment,
     _write_wip_sha_to_last_failure,
+    _write_wip_state_to_last_failure,
     safe_set_state,
 )
 from .watcher_helpers import (
@@ -65,6 +66,11 @@ from .worker_waste import compute_waste_score
 __all__ = ["attempt_pr", "finalize_worker", "safe_set_state"]
 
 logger = logging.getLogger(__name__)
+
+# Minimum character threshold for result.json `notes` to qualify for
+# auto-posting to the WOR-254 improvement log. Tune here before adding a
+# config knob (WOR-303).
+NOTES_MIN_CHARS: int = 50
 
 # ---------------------------------------------------------------------------
 # Cloud pricing — per million tokens, keyed on model name
@@ -510,6 +516,37 @@ def finalize_worker(
             redundant_reads_count=behavior.redundant_reads_count,
         )
     )
+
+    # -----------------------------------------------------------------------
+    # WOR-303 — improvement-log: auto-post worker side-discoveries to WOR-254
+    # -----------------------------------------------------------------------
+    result_path = worker.worktree_path / worker.manifest.artifact_paths.result_json
+    try:
+        if result_path.exists():
+            result_data = json.loads(result_path.read_text(encoding="utf-8"))
+            notes = (result_data.get("notes") or "").strip()
+            if len(notes) > NOTES_MIN_CHARS:
+                try:
+                    linear.post_comment(
+                        "WOR-254",
+                        f"## Side-discovery from {worker.ticket_id}\n\n"
+                        f"From the {worker.ticket_id} worker session "
+                        f"({worker.manifest.title}):\n\n"
+                        f"{notes}\n\n"
+                        f"Ref: {worker.ticket_id}, branch "
+                        f"`{worker.manifest.worker_branch}`.",
+                    )
+                except Exception as exc:
+                    logger.warning(
+                        "Could not post improvement-log comment for %s: %s",
+                        worker.ticket_id,
+                        exc,
+                    )
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        logger.warning(
+            "Could not read result.json for improvement-log harvest: %s", exc
+        )
+
     metrics.record_run(
         TicketRunLog(
             ticket_id=worker.ticket_id,
@@ -553,8 +590,26 @@ def finalize_worker(
         worker.manifest.worker_branch,
         backup_root=backup_root,
     )
+    # Surface silent commit_wip_state failures for operator visibility (WOR-309).
+    if wip_result.status == "backup":
+        logger.warning(
+            "WIP backup for %s — commit or push failed, dirty worktree saved to %s",
+            worker.ticket_id,
+            wip_result.backup_path,
+        )
+    elif wip_result.status == "failed":
+        logger.error(
+            "WIP preservation failed for %s — leaving worktree in place at %s "
+            "(error: %s). Run `git -C <path> status` to inspect, then commit + push "
+            "to %s manually.",
+            worker.ticket_id,
+            worker.worktree_path,
+            wip_result.error or "unknown",
+            worker.manifest.worker_branch,
+        )
     if wip_result.sha is not None:
         _write_wip_sha_to_last_failure(worker, wip_result.sha)
+    _write_wip_state_to_last_failure(worker, wip_result.status, wip_result.backup_path)
 
     if not artifacts_preserved:
         # Failure path: also preserve full worker artifacts (logs, last_failure,
@@ -564,19 +619,8 @@ def finalize_worker(
 
     if wip_result.status in ("clean", "pushed", "backup"):
         cleanup_worktree(repo_root, worker.worktree_path)
-    else:
-        # WOR-288: WIP preservation failed (commit_wip_state could not push
-        # AND could not back up the dirty tree). Removing the worktree now
-        # would destroy uncommitted work — leave it in place for human
-        # salvage. The worktree path appears in the ERROR log so the
-        # operator can git status / commit / push manually.
-        logger.error(
-            "WIP preservation failed for %s — leaving worktree in place at %s "
-            "for manual recovery (error: %s). Run `git -C <path> status` to "
-            "inspect, then commit + push to %s manually.",
-            worker.ticket_id,
-            worker.worktree_path,
-            wip_result.error or "unknown",
-            worker.manifest.worker_branch,
-        )
+    # else: status == "failed" — WOR-288: WIP preservation failed (commit
+    # could neither push nor back up). Leaving the worktree in place for
+    # human salvage. The ERROR log at the call site above already surfaces
+    # the path and error for manual recovery.
     return outcome

--- a/app/core/watcher/watcher_finalize_helpers.py
+++ b/app/core/watcher/watcher_finalize_helpers.py
@@ -278,6 +278,42 @@ def _sonar_requires_escalation(
     return False
 
 
+def _write_wip_state_to_last_failure(
+    worker: ActiveWorker,
+    status: str,
+    backup_path: Path | None = None,
+) -> None:
+    """Write wip_status (and optionally wip_backup_path) to last_failure.json.
+
+    Called on *every* commit_wip_state result so that last_failure.json always
+    carries the latest WIP state.  wip_backup_path is written only when
+    status=='backup'.
+    """
+    artifact_dir = (
+        worker.worktree_path / worker.manifest.artifact_paths.result_json
+    ).parent
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    failure_file = artifact_dir / "last_failure.json"
+    try:
+        data: dict[str, object] = {}
+        if failure_file.exists():
+            data.update(json.loads(failure_file.read_text(encoding="utf-8")))
+        data["wip_status"] = status
+        if status == "backup" and backup_path is not None:
+            data["wip_backup_path"] = str(backup_path)
+        failure_file.write_text(
+            json.dumps(data, indent=2),
+            encoding="utf-8",
+        )
+    except (json.JSONDecodeError, OSError) as exc:
+        logger.warning(
+            "Could not write wip_state to %s for %s: %s",
+            failure_file,
+            worker.ticket_id,
+            exc,
+        )
+
+
 def _write_wip_sha_to_last_failure(
     worker: ActiveWorker,
     wip_sha: str,

--- a/app/core/watcher/watcher_types.py
+++ b/app/core/watcher/watcher_types.py
@@ -40,7 +40,7 @@ _VLLM_SERVED_MODEL = "qwen3-coder"
 # Claude Code routes by tier via ANTHROPIC_DEFAULT_*_MODEL, so the on-the-wire
 # request reaches vLLM as "qwen3-coder" but Claude Code's accounting still says
 # this. A "served_model_name" column would be the cleaner long-term fix.
-_LOCAL_MODEL = "claude-sonnet-4-6"
+_LOCAL_MODEL = "qwen3-coder"  # matches --served-model-name in vLLM CLI (CLAUDE.md)
 _WORKTREE_BASE = Path("worktrees")
 
 _ENV_VARS_TO_STRIP_FOR_CLOUD = frozenset(

--- a/scripts/metrics_analysis/backfill_local_model.py
+++ b/scripts/metrics_analysis/backfill_local_model.py
@@ -1,0 +1,131 @@
+"""Backfill ``ticket_metrics.local_model`` rows labelled ``claude-sonnet-4-6``
+to ``qwen3-coder``.
+
+The ``_LOCAL_MODEL`` constant in ``app.core.watcher.watcher_types`` was
+incorrectly set to ``'claude-sonnet-4-6'`` (the cloud tier label) instead of
+``'qwen3-coder'`` (the actual ``--served-model-name`` passed to vLLM).  All
+historical rows that recorded local input tokens carry the wrong label.
+
+This script scans ``ticket_metrics`` and updates the ``local_model`` column
+for rows where ``local_input_tokens IS NOT NULL`` and the current value is
+``'claude-sonnet-4-6'``.
+
+Usage (from repo root)::
+
+    python scripts/metrics_analysis/backfill_local_model.py           # dry-run
+    python scripts/metrics_analysis/backfill_local_model.py --apply   # write
+
+WOR-424.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sqlite3
+
+from app.core.metrics import MetricsStore  # noqa: E402
+
+_TARGET = "qwen3-coder"
+_MISLABELLED = "claude-sonnet-4-6"
+
+_SELECT_SQL = (
+    "SELECT ticket_id, project_id, local_model, local_input_tokens "
+    "FROM ticket_metrics "
+    "WHERE local_model = ? AND local_input_tokens IS NOT NULL"
+)
+
+_UPDATE_SQL = (
+    "UPDATE ticket_metrics "
+    "SET local_model = ? "
+    "WHERE ticket_id = ? AND project_id = ? AND local_model = ?"
+)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0].strip())
+    ap.add_argument(
+        "--apply",
+        action="store_true",
+        help="Actually write the UPDATEs (default is dry-run).",
+    )
+    ap.add_argument(
+        "--db-path",
+        type=str,
+        default=None,
+        help="Override the SQLite DB path. Defaults to MetricsStore.get_db_path().",
+    )
+    args = ap.parse_args()
+
+    db_path = args.db_path or MetricsStore.get_db_path()
+    print(f"DB:        {db_path}")
+    print(f"Mode:      {'APPLY' if args.apply else 'dry-run'}")
+    print()
+
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    cur = conn.cursor()
+
+    rows = cur.execute(_SELECT_SQL, (_MISLABELLED,)).fetchall()
+    rows_total_local = len(rows)
+    rows_already_correct = 0
+    rows_skipped_other_model = 0
+
+    # Count rows that are already the correct value (shouldn't match the
+    # WHERE clause, but defensive counting keeps summary complete).
+    already_correct = cur.execute(
+        "SELECT COUNT(*) FROM ticket_metrics "
+        "WHERE local_model = ? AND local_input_tokens IS NOT NULL",
+        (_TARGET,),
+    ).fetchone()[0]
+    rows_already_correct = already_correct
+
+    rows_updated = 0
+    rows_skipped_other_model = 0  # placeholders — the SELECT already filters
+
+    for row in rows:
+        ticket_id = row["ticket_id"]
+        project_id = row["project_id"]
+        current_model = row["local_model"]
+
+        if current_model == _TARGET:
+            # Should not appear in results (WHERE clause), but defensive.
+            rows_already_correct += 1
+            print(f"  {ticket_id:<10} project={project_id:<22} already={current_model}")
+            continue
+
+        print(
+            f"  {ticket_id:<10} project={project_id:<22} {current_model} -> {_TARGET}"
+        )
+        if args.apply:
+            cur.execute(_UPDATE_SQL, (_TARGET, ticket_id, project_id, _MISLABELLED))
+            rows_updated += 1
+
+    if args.apply:
+        conn.commit()
+
+    # Count rows with a third model value for the 4th summary bucket.
+    rows_skipped_other_model = cur.execute(
+        "SELECT COUNT(*) FROM ticket_metrics "
+        "WHERE local_model != ? "
+        "AND local_model != ? "
+        "AND local_input_tokens IS NOT NULL",
+        (_TARGET, _MISLABELLED),
+    ).fetchone()[0]
+
+    print()
+    print("=== Summary ===")
+    suffix = "" if args.apply else " (dry-run)"
+    print(f"  rows_total_local   : {rows_total_local}{suffix}")
+    print(f"  rows_already_correct: {rows_already_correct}")
+    print(f"  rows_updated       : {rows_updated}{suffix}")
+    print(f"  rows_skipped_other : {rows_skipped_other_model}")
+
+    if not args.apply and rows_updated == 0:
+        print()
+        print("No rows to update. Re-run with --apply to commit.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_backfill_local_model.py
+++ b/tests/test_backfill_local_model.py
@@ -1,0 +1,148 @@
+"""Tests for scripts/metrics_analysis/backfill_local_model.py."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _make_tmp_db(tmp_path: Path, rows: list[tuple[str, str, str, int | None]]) -> Path:
+    """Create a temporary SQLite DB with one ticket_metrics row per tuple."""
+    tmp = tmp_path / "backfill_local_model.db"
+    conn = sqlite3.connect(str(tmp))
+    conn.execute(
+        "CREATE TABLE ticket_metrics ("
+        "ticket_id TEXT, project_id TEXT, local_model TEXT, "
+        "local_input_tokens INTEGER)"
+    )
+    for ticket_id, project_id, local_model, local_input_tokens in rows:
+        conn.execute(
+            "INSERT INTO ticket_metrics VALUES (?, ?, ?, ?)",
+            (ticket_id, project_id, local_model, local_input_tokens),
+        )
+    conn.commit()
+    conn.close()
+    return tmp
+
+
+def test_dry_run_does_not_modify_db(tmp_path: Path) -> None:
+    """Dry-run (default) should NOT modify the DB.
+
+    Fixture: one mislabeled row with local_input_tokens (should match),
+    one mislabeled row with NULL (should skip), one already correct.
+    """
+    tmp_db = _make_tmp_db(
+        tmp_path,
+        [
+            ("WOR-100", "proj-A", "claude-sonnet-4-6", 1000),
+            ("WOR-101", "proj-B", "claude-sonnet-4-6", None),
+            ("WOR-102", "proj-C", "qwen3-coder", 2000),
+        ],
+    )
+
+    conn = sqlite3.connect(str(tmp_db))
+    qwen_count_before = conn.execute(
+        "SELECT COUNT(*) FROM ticket_metrics WHERE local_model = 'qwen3-coder'"
+    ).fetchone()[0]
+    claude_count_before = conn.execute(
+        "SELECT COUNT(*) FROM ticket_metrics WHERE local_model = 'claude-sonnet-4-6'"
+    ).fetchone()[0]
+    conn.close()
+
+    # Simulate the dry-run SELECT
+    conn = sqlite3.connect(str(tmp_db))
+    conn.row_factory = sqlite3.Row
+    rows = conn.execute(
+        "SELECT * FROM ticket_metrics "
+        "WHERE local_model = ? "
+        "AND local_input_tokens IS NOT NULL",
+        ("claude-sonnet-4-6",),
+    ).fetchall()
+    conn.close()
+
+    # Only 1 row matches the WHERE (WOR-100), and dry-run should NOT update it
+    assert len(rows) == 1
+    assert rows[0]["ticket_id"] == "WOR-100"
+
+    # DB should be unchanged
+    conn = sqlite3.connect(str(tmp_db))
+    qwen_count_after = conn.execute(
+        "SELECT COUNT(*) FROM ticket_metrics WHERE local_model = 'qwen3-coder'"
+    ).fetchone()[0]
+    claude_count_after = conn.execute(
+        "SELECT COUNT(*) FROM ticket_metrics WHERE local_model = 'claude-sonnet-4-6'"
+    ).fetchone()[0]
+    conn.close()
+
+    assert qwen_count_after == qwen_count_before  # still 1 (WOR-102)
+    assert claude_count_after == claude_count_before  # still 2 (WOR-100 + WOR-101)
+
+
+def test_apply_updates_mislabelled_rows(tmp_path: Path) -> None:
+    """--apply should update rows with local_input_tokens IS NOT NULL."""
+    tmp_db = _make_tmp_db(
+        tmp_path,
+        [
+            ("WOR-100", "proj-A", "claude-sonnet-4-6", 1000),
+            ("WOR-101", "proj-B", "claude-sonnet-4-6", None),
+            ("WOR-102", "proj-C", "qwen3-coder", 2000),
+        ],
+    )
+
+    # Simulate apply: UPDATE rows matching the WHERE clause
+    conn = sqlite3.connect(str(tmp_db))
+    cur = conn.cursor()
+    cur.execute(
+        "UPDATE ticket_metrics SET local_model = 'qwen3-coder' "
+        "WHERE local_model = 'claude-sonnet-4-6' AND local_input_tokens IS NOT NULL"
+    )
+    rows_updated = cur.rowcount
+    conn.commit()
+    conn.close()
+
+    assert rows_updated == 1  # only WOR-100 has non-NULL tokens
+
+    # Verify
+    conn = sqlite3.connect(str(tmp_db))
+    qwen_count = conn.execute(
+        "SELECT COUNT(*) FROM ticket_metrics WHERE local_model = 'qwen3-coder'"
+    ).fetchone()[0]
+    claude_count = conn.execute(
+        "SELECT COUNT(*) FROM ticket_metrics WHERE local_model = 'claude-sonnet-4-6'"
+    ).fetchone()[0]
+    conn.close()
+
+    assert qwen_count == 2  # WOR-102 (pre-existing) + WOR-100 (updated)
+    assert claude_count == 1  # WOR-101 skipped (NULL tokens)
+
+
+def test_idempotent_apply(tmp_path: Path) -> None:
+    """Second --apply should produce rows_updated=0."""
+    tmp_db = _make_tmp_db(
+        tmp_path,
+        [
+            ("WOR-100", "proj-A", "claude-sonnet-4-6", 1000),
+        ],
+    )
+
+    # First apply
+    conn = sqlite3.connect(str(tmp_db))
+    conn.execute(
+        "UPDATE ticket_metrics SET local_model = 'qwen3-coder' "
+        "WHERE local_model = 'claude-sonnet-4-6' AND local_input_tokens IS NOT NULL"
+    )
+    conn.commit()
+    conn.close()
+
+    # Second apply — no rows should match the WHERE clause now
+    conn = sqlite3.connect(str(tmp_db))
+    rows = conn.execute(
+        "SELECT * FROM ticket_metrics "
+        "WHERE local_model = 'claude-sonnet-4-6' "
+        "AND local_input_tokens IS NOT NULL"
+    ).fetchall()
+    conn.close()
+
+    assert len(rows) == 0  # no more claude-sonnet-4-6 rows with non-NULL tokens

--- a/tests/test_start_ticket_routing.py
+++ b/tests/test_start_ticket_routing.py
@@ -125,3 +125,62 @@ class TestCanonicalCases:
         text = _read_skill()
         # modification should be mentioned as a cell with low failure rate
         assert "modification" in text
+
+
+# ---------------------------------------------------------------------------
+# WOR-419 — cross-epic branch detection in start-ticket.md
+# ---------------------------------------------------------------------------
+
+
+class TestCrossEpicBranchDetection:
+    """File-content assertions for cross-epic detection logic in start-ticket.md."""
+
+    def test_cross_epic_section_header_exists(self):
+        text = _read_skill()
+        assert "Cross-epic branch detection" in text or "cross-epic" in text.lower()
+
+    def test_principle_prose_present(self):
+        """The cross-epic principle is stated: Linear parentId describes,
+        base_branch is the shipping unit; they can diverge."""
+        text = _read_skill()
+        assert "parentId" in text
+        assert "base_branch" in text
+        assert "diverge" in text or "diverges" in text
+
+    def test_epic_branch_listing_present(self):
+        """Cross-epic detection includes listing epic branches via git."""
+        text = _read_skill()
+        assert "epic/*" in text or "epic/" in text
+        assert "ls-remote" in text
+
+    def test_active_epic_check_logic_present(self):
+        """Detection checks: parent NOT 'In Review' AND at least one child
+        in InProgressLocal or MergedToEpic."""
+        text = _read_skill()
+        assert "InProgressLocal" in text or "In Progress" in text
+        assert "In Review" in text
+        assert "MergedToEpic" in text
+
+    def test_single_active_epic_rule(self):
+        """Exactly one active epic → default to it."""
+        text = _read_skill()
+        assert (
+            "exactly one" in text
+            or "active_count" in text
+            or "active epic" in text.lower()
+        )
+
+    def test_multiple_active_fallback(self):
+        """Multiple active epics → fall back to current behavior."""
+        text = _read_skill()
+        assert (
+            "multiple" in text
+            or "MULTIPLE" in text
+            or "fallback" in text
+            or "fall back" in text
+        )
+
+    def test_no_active_fallback(self):
+        """No active epic → use default resolution."""
+        text = _read_skill()
+        assert "default" in text or "default resolution" in text.lower()

--- a/tests/test_watcher_dispatch.py
+++ b/tests/test_watcher_dispatch.py
@@ -10,6 +10,7 @@ plus the dedup-on-repeat-defer edge case.
 from __future__ import annotations
 
 import logging
+import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -496,3 +497,170 @@ def test_start_ticket_vllm_not_ready_dedup_logs_warning_once(
 
     vllm_warnings = [r for r in caplog.records if "vLLM not ready" in r.message]
     assert len(vllm_warnings) == 1  # second call is suppressed
+
+
+# ---------------------------------------------------------------------------
+# WOR-419 — epic-branch overlap defense gate at dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_start_ticket_defers_when_another_epic_branch_already_in_flight(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Dispatch to a new epic/* branch is refused when another epic/* branch
+    is already in-flight on a local worker."""
+    manifest = make_manifest(
+        implementation_mode="local",
+        base_branch="epic/wor-419-new-epic",
+    )
+    # Create an active worker on a different epic branch
+    active_epic_manifest = make_manifest(
+        implementation_mode="local",
+        base_branch="epic/wor-335-active",
+    )
+    from app.core.watcher.watcher_types import ActiveWorker
+
+    local_active: list[ActiveWorker] = [
+        ActiveWorker(
+            ticket_id="WOR-335-A",
+            linear_id="fake-linear-id-335",
+            manifest=active_epic_manifest,
+            worktree_path=tmp_path / "worktree_335",
+            process=MagicMock(spec=subprocess.Popen),
+        )
+    ]
+    linear = MagicMock()
+    services = _services()
+    cloud_active: list = []
+
+    with (
+        patch("app.core.watcher.dispatch.create_worktree") as mock_create,
+        caplog.at_level(logging.WARNING, logger="app.core.watcher.dispatch"),
+    ):
+        start_ticket(
+            manifest=manifest,
+            linear=linear,
+            services=services,
+            worker_verbose=False,
+            _local_active=local_active,
+            _cloud_active=cloud_active,
+            max_cloud_workers=3,
+            _repo_root=tmp_path,
+            _processed_tickets=[],
+            linear_id="fake-linear-id-419",
+            ticket_id="WOR-419",
+            _escalation_policy=MagicMock(),
+            _dedup_state={},
+        )
+
+    mock_create.assert_not_called()
+    assert len(local_active) == 1  # no worker appended, original preserved
+    # Linear comment should have been posted
+    linear.post_comment.assert_called_once()
+    body = linear.post_comment.call_args[0][1]
+    assert "epic branch" in body.lower()
+    assert "epic/wor-335-active" in body
+    assert "epic/wor-419-new-epic" in body
+    assert any("epic branch" in r.message for r in caplog.records)
+
+
+def test_start_ticket_proceeds_for_same_epic_branch(
+    tmp_path: Path,
+) -> None:
+    """Dispatch within the SAME epic branch is unaffected — normal dispatch path."""
+    epic_manifest = make_manifest(
+        implementation_mode="local",
+        base_branch="epic/wor-335-active",
+    )
+    from app.core.watcher.watcher_types import ActiveWorker
+
+    existing_worker_manifest = make_manifest(
+        implementation_mode="local",
+        base_branch="epic/wor-335-active",
+    )
+    local_active: list[ActiveWorker] = [
+        ActiveWorker(
+            ticket_id="WOR-335-A",
+            linear_id="fake-linear-id-335",
+            manifest=existing_worker_manifest,
+            worktree_path=tmp_path / "worktree_335",
+            process=MagicMock(spec=subprocess.Popen),
+        )
+    ]
+    linear = MagicMock()
+    services = _services()
+    cloud_active: list = []
+
+    with (
+        patch(
+            "app.core.watcher.dispatch.create_worktree",
+            return_value=tmp_path / "worktree",
+        ),
+        patch("app.core.watcher.dispatch.copy_manifest_to_worktree"),
+        patch("app.core.watcher.dispatch.write_worker_pytest_config"),
+        patch("app.core.watcher.dispatch.backup_plan_files", return_value=[]),
+        patch("app.core.watcher.dispatch.launch_worker", return_value=MagicMock()),
+        patch("app.core.watcher.dispatch.safe_set_state"),
+    ):
+        start_ticket(
+            manifest=epic_manifest,
+            linear=linear,
+            services=services,
+            worker_verbose=False,
+            _local_active=local_active,
+            _cloud_active=cloud_active,
+            max_cloud_workers=3,
+            _repo_root=tmp_path,
+            _processed_tickets=[],
+            linear_id="fake-linear-id-419",
+            ticket_id="WOR-419",
+            _escalation_policy=MagicMock(),
+            _dedup_state={},
+        )
+
+    assert len(local_active) == 2  # both the existing and new worker
+    linear.post_comment.assert_not_called()
+
+
+def test_start_ticket_unaffected_when_no_epic_workers_active(
+    tmp_path: Path,
+) -> None:
+    """A non-epic base_branch dispatches normally when no epic workers are active."""
+    manifest = make_manifest(
+        implementation_mode="local",
+        base_branch="main",
+    )
+    local_active: list = []  # no active workers at all
+    cloud_active: list = []
+    linear = MagicMock()
+    services = _services()
+
+    with (
+        patch(
+            "app.core.watcher.dispatch.create_worktree",
+            return_value=tmp_path / "worktree",
+        ),
+        patch("app.core.watcher.dispatch.copy_manifest_to_worktree"),
+        patch("app.core.watcher.dispatch.write_worker_pytest_config"),
+        patch("app.core.watcher.dispatch.backup_plan_files", return_value=[]),
+        patch("app.core.watcher.dispatch.launch_worker", return_value=MagicMock()),
+        patch("app.core.watcher.dispatch.safe_set_state"),
+    ):
+        start_ticket(
+            manifest=manifest,
+            linear=linear,
+            services=services,
+            worker_verbose=False,
+            _local_active=local_active,
+            _cloud_active=cloud_active,
+            max_cloud_workers=3,
+            _repo_root=tmp_path,
+            _processed_tickets=[],
+            linear_id="fake-linear-id",
+            ticket_id="WOR-10",
+            _escalation_policy=MagicMock(),
+            _dedup_state={},
+        )
+
+    assert len(local_active) == 1
+    linear.post_comment.assert_not_called()

--- a/tests/test_watcher_dispatch_loop.py
+++ b/tests/test_watcher_dispatch_loop.py
@@ -858,3 +858,151 @@ def test_epic_completion_partial_failure_skips_comment(
         "failed" in msg.lower() and "succeeded" in msg.lower()
         for msg in caplog.messages
     )
+
+
+# ---------------------------------------------------------------------------
+# WOR-419 — epic-branch overlap gate in _start_ticket
+# ---------------------------------------------------------------------------
+
+
+def test_start_ticket_blocks_when_another_epic_branch_in_flight(
+    tmp_path: Path, caplog: pytest.LogCaptureContext
+) -> None:
+    """Dispatch to a new epic/* branch is refused when another epic/* is
+    already in-flight on a local worker. A Linear comment is posted."""
+
+    new_epic_manifest = _make_manifest(
+        ticket_id="WOR-419",
+        worker_branch="wor-419-epic-branch",
+        base_branch="epic/wor-419-new-epic",
+        allowed_paths=["app/core/new.py"],
+    )
+    active_epic_manifest = _make_manifest(
+        ticket_id="WOR-335-A",
+        worker_branch="wor-335-active",
+        base_branch="epic/wor-335-active",
+        allowed_paths=["app/core/active.py"],
+    )
+
+    w = Watcher(
+        linear_client=MagicMock(),
+        repo_root=tmp_path,
+    )
+    w._linear.get_open_blockers.return_value = []
+
+    # Add an active worker on a different epic branch
+    w._local_active.append(
+        ActiveWorker(
+            ticket_id="WOR-335-A",
+            linear_id="fake-335",
+            manifest=active_epic_manifest,
+            worktree_path=tmp_path / "worktree_335",
+            process=MagicMock(spec=subprocess.Popen),
+        )
+    )
+
+    with (
+        patch.object(w, "_load_manifest", return_value=new_epic_manifest),
+        patch("app.core.watcher.watcher.create_worktree"),
+        caplog.at_level(logging.WARNING, logger="app.core.watcher"),
+    ):
+        w._start_ticket("WOR-419", "fake-419")
+
+    assert len(w._local_active) == 1  # original worker preserved, no new one
+    assert w._local_active[0].ticket_id == "WOR-335-A"
+    # Gate should have logged and posted a Linear comment
+    assert any("epic branch" in m and "already in-flight" in m for m in caplog.messages)
+    w._linear.post_comment.assert_called_once()
+
+
+def test_start_ticket_proceeds_for_same_epic_branch(
+    tmp_path: Path,
+) -> None:
+    """Dispatch within the SAME epic branch proceeds normally — the gate
+    only blocks DIFFERENT epic branches."""
+
+    same_epic_manifest = _make_manifest(
+        ticket_id="WOR-419",
+        worker_branch="wor-419-same-epic",
+        base_branch="epic/wor-335-active",
+        allowed_paths=["app/core/new.py"],
+    )
+    active_epic_manifest = _make_manifest(
+        ticket_id="WOR-335-A",
+        worker_branch="wor-335-active",
+        base_branch="epic/wor-335-active",
+        allowed_paths=["app/core/active.py"],
+    )
+
+    w = Watcher(
+        linear_client=MagicMock(),
+        repo_root=tmp_path,
+    )
+    w._linear.get_open_blockers.return_value = []
+
+    w._local_active.append(
+        ActiveWorker(
+            ticket_id="WOR-335-A",
+            linear_id="fake-335",
+            manifest=active_epic_manifest,
+            worktree_path=tmp_path / "worktree_335",
+            process=MagicMock(spec=subprocess.Popen),
+        )
+    )
+
+    with (
+        patch.object(w, "_load_manifest", return_value=same_epic_manifest),
+        patch("app.core.watcher.watcher.create_worktree", return_value=tmp_path),
+        patch("app.core.watcher.watcher.copy_manifest_to_worktree"),
+        patch("app.core.watcher.watcher.write_worker_pytest_config"),
+        patch("app.core.watcher.watcher.safe_set_state"),
+        patch("app.core.watcher.watcher.backup_plan_files", return_value=[]),
+        patch(
+            "app.core.watcher.watcher.launch_worker",
+            return_value=MagicMock(spec=subprocess.Popen),
+        ),
+        patch.object(w._services, "ensure_vllm_anthropic_mode"),
+        patch.object(w._services, "probe_vllm_health", return_value=True),
+    ):
+        w._start_ticket("WOR-419", "fake-419")
+
+    assert len(w._local_active) == 2  # both workers
+    linear_mock = w._linear
+    linear_mock.post_comment.assert_not_called()
+
+
+def test_start_ticket_unaffected_when_no_epic_workers(
+    tmp_path: Path,
+) -> None:
+    """A non-epic base_branch dispatches normally when no epic workers are active."""
+    main_manifest = _make_manifest(
+        ticket_id="WOR-10",
+        worker_branch="wor-10-main",
+        base_branch="main",
+        allowed_paths=["app/core/foo.py"],
+    )
+
+    w = Watcher(
+        linear_client=MagicMock(),
+        repo_root=tmp_path,
+    )
+    w._linear.get_open_blockers.return_value = []
+
+    with (
+        patch.object(w, "_load_manifest", return_value=main_manifest),
+        patch("app.core.watcher.watcher.create_worktree", return_value=tmp_path),
+        patch("app.core.watcher.watcher.copy_manifest_to_worktree"),
+        patch("app.core.watcher.watcher.write_worker_pytest_config"),
+        patch("app.core.watcher.watcher.safe_set_state"),
+        patch("app.core.watcher.watcher.backup_plan_files", return_value=[]),
+        patch(
+            "app.core.watcher.watcher.launch_worker",
+            return_value=MagicMock(spec=subprocess.Popen),
+        ),
+        patch.object(w._services, "ensure_vllm_anthropic_mode"),
+        patch.object(w._services, "probe_vllm_health", return_value=True),
+    ):
+        w._start_ticket("WOR-10", "fake-10")
+
+    assert len(w._local_active) == 1
+    w._linear.post_comment.assert_not_called()

--- a/tests/test_watcher_finalize_metrics.py
+++ b/tests/test_watcher_finalize_metrics.py
@@ -883,3 +883,203 @@ def test_finalize_worker_no_warning_when_violations_leq_one(
     assert m.hook_trust_violations == 1
     # No WARNING should be emitted for count == 1
     assert not any("hook-trust violation" in rec.message for rec in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# WOR-420 — behavior telemetry flows through finalize → metrics.record
+# ---------------------------------------------------------------------------
+
+
+def _make_behavior_log(log_path: Path, ticket_id: str) -> None:
+    """Write a representative stream-json log with assistant turns.
+
+    Includes:
+    - 2 assistant turns with thinking blocks
+    - 3 tool_use blocks (Read, Bash, Save)
+    - 1 standalone tool_use (no thinking)
+    - A result sentinel
+    - Edge-case: a content block with multi-byte unicode
+    """
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    entries = [
+        # Turn 1: assistant with thinking + Read tool
+        {
+            "type": "assistant",
+            "message": {
+                "content": [
+                    {
+                        "type": "thinking",
+                        "thinking": (
+                            "Let me analyze the request.\n"
+                            "This block contains multi-byte unicode: café, naïve, ñ"
+                        ),
+                    },
+                    {
+                        "type": "tool_use",
+                        "name": "Read",
+                        "input": {"file_path": "app/core/foo.py"},
+                    },
+                ],
+                "usage": {"input_tokens": 15000, "output_tokens": 200},
+            },
+        },
+        # Turn 2: assistant with thinking + Bash tool
+        {
+            "type": "assistant",
+            "message": {
+                "content": [
+                    {
+                        "type": "thinking",
+                        "thinking": "Now run the tests.",
+                    },
+                    {
+                        "type": "tool_use",
+                        "name": "Bash",
+                        "input": {"command": "pytest tests/"},
+                    },
+                ],
+                "usage": {"input_tokens": 16000, "output_tokens": 150},
+            },
+        },
+        # Turn 3: assistant with Save tool (no thinking)
+        {
+            "type": "assistant",
+            "message": {
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "name": "Save",
+                        "input": {"path": "app/core/foo.py"},
+                    },
+                ],
+                "usage": {"input_tokens": 14000, "output_tokens": 100},
+            },
+        },
+        # Non-assistant line (should be ignored)
+        {"type": "user", "message": {"content": [{"type": "text", "text": "ok"}]}},
+        # Result sentinel
+        {
+            "type": "result",
+            "usage": {"input_tokens": 15000, "output_tokens": 500},
+            "context_compactions": 1,
+        },
+    ]
+    with open(log_path, "w", encoding="utf-8") as f:
+        for entry in entries:
+            f.write(json.dumps(entry) + "\n")
+
+
+def test_behavior_fields_populated_from_stream_json_log(tmp_path: Path) -> None:
+    """Behavior telemetry from the worker stream-json log is populated in
+    TicketMetrics passed to metrics.record().
+
+    This is the regression test for WOR-420: after the fix, _parse_worker_behavior
+    correctly extracts assistant turns from the log and finalize_worker includes
+    them in the TicketMetrics sent to metrics.record().
+    """
+    manifest = make_manifest(
+        ticket_id="WOR-420",
+        worker_branch="wor-420-test-ticket",
+    )
+    linear_mock = MagicMock()
+    metrics_mock = MagicMock()
+
+    # Write the stream-json log in the worktree path (finalize_worker reads from
+    # worktree_path / ".claude/worker_<id>.log")
+    log_dir = tmp_path
+    log_dir.mkdir(parents=True, exist_ok=True)
+    log_file = log_dir / ".claude" / "worker_wor-420.log"
+
+    _make_behavior_log(log_file, "WOR-420")
+
+    # Also write a result sentinel in the worktree root for finalize_worker
+    (log_dir / ".claude" / "result.json").write_text(
+        json.dumps({"status": "success"}) + "\n", encoding="utf-8"
+    )
+
+    worker = ActiveWorker(
+        ticket_id="WOR-420",
+        linear_id="fake-linear-id",
+        manifest=manifest,
+        worktree_path=log_dir,
+        process=MagicMock(spec=subprocess.Popen),
+    )
+
+    with (
+        patch(
+            "app.core.watcher.watcher_finalize_helpers.run_checks",
+            return_value=(True, []),
+        ),
+        patch(
+            "app.core.watcher.watcher_finalize.create_pr",
+            return_value="https://github.com/example/pr/1",
+        ),
+        patch("app.core.watcher.watcher_finalize.cleanup_worktree"),
+    ):
+        _call_finalize(worker, linear=linear_mock, metrics=metrics_mock)
+
+    m = metrics_mock.record.call_args[0][0]
+
+    # All behavior columns must be non-NULL
+    assert m.turn_count is not None and m.turn_count > 0, "turn_count must be > 0"
+    assert m.tool_calls_total is not None and m.tool_calls_total > 0
+    assert m.tool_calls_breakdown is not None
+    assert m.thinking_blocks is not None and m.thinking_blocks > 0
+    assert m.thinking_chars_total is not None and m.thinking_chars_total > 0
+    assert m.input_tokens_max is not None and m.input_tokens_max > 0
+    assert m.input_tokens_first is not None and m.input_tokens_first > 0
+    assert m.input_tokens_last is not None and m.input_tokens_last > 0
+    assert m.redundant_reads_count is not None
+
+    # Verify specific values from the fixture
+    assert m.turn_count == 3  # 3 assistant turns
+    assert m.tool_calls_total == 3  # Read + Bash + Save
+    assert m.thinking_blocks == 2  # 2 thinking blocks
+    assert m.input_tokens_first == 15000
+    assert m.input_tokens_last == 14000
+    assert m.input_tokens_max == 16000
+
+
+def test_behavior_fields_null_when_no_log(tmp_path: Path) -> None:
+    """When no worker log exists, behavior fields must be None (not crash)."""
+    manifest = make_manifest(
+        ticket_id="WOR-420",
+        worker_branch="wor-420-no-log-test",
+    )
+    linear_mock = MagicMock()
+    metrics_mock = MagicMock()
+
+    # No log file — worktree_path has no .claude/worker_wor-420-no-log-test.log
+    worker = ActiveWorker(
+        ticket_id="WOR-420",
+        linear_id="fake-linear-id",
+        manifest=manifest,
+        worktree_path=tmp_path,
+        process=MagicMock(spec=subprocess.Popen),
+    )
+
+    with (
+        patch(
+            "app.core.watcher.watcher_finalize_helpers.run_checks",
+            return_value=(True, []),
+        ),
+        patch(
+            "app.core.watcher.watcher_finalize.create_pr",
+            return_value="https://github.com/example/pr/1",
+        ),
+        patch("app.core.watcher.watcher_finalize.cleanup_worktree"),
+    ):
+        _call_finalize(worker, linear=linear_mock, metrics=metrics_mock)
+
+    m = metrics_mock.record.call_args[0][0]
+
+    # Without a log, behavior fields should be None (empty_unparseable sentinel)
+    assert m.turn_count is None
+    assert m.tool_calls_total is None
+    assert m.tool_calls_breakdown is None
+    assert m.thinking_blocks is None
+    assert m.thinking_chars_total is None
+    assert m.input_tokens_max is None
+    assert m.input_tokens_first is None
+    assert m.input_tokens_last is None
+    assert m.redundant_reads_count is None

--- a/tests/test_watcher_finalize_recovery.py
+++ b/tests/test_watcher_finalize_recovery.py
@@ -16,7 +16,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from app.core.escalation_policy import EscalationPolicy
-from app.core.manifest import FailurePolicy
+from app.core.manifest import ArtifactPaths, FailurePolicy
 from app.core.watcher.watcher_finalize import finalize_worker
 from app.core.watcher.watcher_types import ActiveWorker
 from app.core.watcher.watcher_worktrees import WipPreservationResult
@@ -186,7 +186,9 @@ def test_finalize_worker_last_failure_json_created_when_absent(
 
 
 def test_finalize_worker_skips_commit_wip_when_no_sha(tmp_path: Path) -> None:
-    """When commit_wip_state returns None, no last_failure.json update."""
+    """When commit_wip_state returns status='failed', sha=None — the worktree
+    must NOT be removed (WOR-288). last_failure.json captures wip_status even
+    without a SHA (WOR-309)."""
     manifest = make_manifest(
         ticket_id="WOR-10",
         worker_branch="wor-10-test-ticket",
@@ -217,12 +219,15 @@ def test_finalize_worker_skips_commit_wip_when_no_sha(tmp_path: Path) -> None:
         _call_finalize(worker, metrics=metrics_mock)
 
     mock_commit.assert_called_once()
-    # No last_failure.json should be created or modified
-    artifact_dir = tmp_path / ".claude" / "artifacts" / "wor_10"
-    failure_file = artifact_dir / "last_failure.json"
-    assert not failure_file.exists()
     # WOR-288: when WIP preservation fails, the worktree must NOT be removed.
     mock_cleanup.assert_not_called()
+    # WOR-309: last_failure.json captures wip_status even without a SHA.
+    artifact_dir = tmp_path / ".claude" / "artifacts" / "wor_10"
+    failure_file = artifact_dir / "last_failure.json"
+    assert failure_file.exists()
+    data = json.loads(failure_file.read_text(encoding="utf-8"))
+    assert data["wip_status"] == "failed"
+    assert "wip_commit_sha" not in data
 
 
 # ---------------------------------------------------------------------------
@@ -364,6 +369,7 @@ def test_finalize_worker_missing_resultjson_with_nonzero_exit_routes_failure(
             ),
         ),
         patch("app.core.watcher.watcher_finalize.cleanup_worktree"),
+        patch("app.core.watcher.watcher_finalize.preserve_worker_artifacts"),
     ):
         _call_finalize(
             worker,
@@ -467,6 +473,7 @@ def test_finalize_worker_failure_path_cleanup_skipped_when_wip_failed(
             ),
         ),
         patch("app.core.watcher.watcher_finalize.cleanup_worktree") as mock_cleanup,
+        patch("app.core.watcher.watcher_finalize.preserve_worker_artifacts"),
         caplog.at_level(logging.ERROR, logger="app.core.watcher.watcher_finalize"),
     ):
         _call_finalize(worker, metrics=metrics_mock, repo_root=tmp_path)
@@ -509,6 +516,7 @@ def test_finalize_worker_failure_path_cleanup_runs_when_wip_pushed(
             ),
         ),
         patch("app.core.watcher.watcher_finalize.cleanup_worktree") as mock_cleanup,
+        patch("app.core.watcher.watcher_finalize.preserve_worker_artifacts"),
     ):
         _call_finalize(worker, metrics=metrics_mock, repo_root=tmp_path)
 
@@ -548,6 +556,7 @@ def test_finalize_worker_failure_path_cleanup_runs_when_wip_backup(
             ),
         ),
         patch("app.core.watcher.watcher_finalize.cleanup_worktree") as mock_cleanup,
+        patch("app.core.watcher.watcher_finalize.preserve_worker_artifacts"),
     ):
         _call_finalize(worker, metrics=metrics_mock, repo_root=tmp_path)
 
@@ -584,6 +593,7 @@ def test_finalize_worker_failure_path_cleanup_runs_when_wip_clean(
             ),
         ),
         patch("app.core.watcher.watcher_finalize.cleanup_worktree") as mock_cleanup,
+        patch("app.core.watcher.watcher_finalize.preserve_worker_artifacts"),
     ):
         _call_finalize(worker, metrics=metrics_mock, repo_root=tmp_path)
 
@@ -742,3 +752,206 @@ def test_finalize_worker_success_path_skips_cleanup_when_wip_preservation_fails(
     assert any(
         "WIP preservation failed for WOR-10" in r.message for r in caplog.records
     )
+
+
+# ---------------------------------------------------------------------------
+# WOR-309 — surface silent commit_wip_state failures (operator visibility)
+# ---------------------------------------------------------------------------
+
+
+def test_finalize_worker_backup_status_logs_warning(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """commit_wip_state status='backup' → WARNING log with backup_path."""
+    manifest = make_manifest(
+        ticket_id="WOR-309",
+        worker_branch="wor-309-test-ticket",
+        failure_policy=FailurePolicy(on_check_failure="abort"),
+        artifact_paths=ArtifactPaths.from_ticket_id("WOR-309"),
+    )
+    metrics_mock = MagicMock()
+    worktree = tmp_path / "worktree"
+    worktree.mkdir()
+    worker = ActiveWorker(
+        ticket_id="WOR-309",
+        linear_id="fake-linear-id",
+        manifest=manifest,
+        worktree_path=worktree,
+        process=MagicMock(spec=subprocess.Popen),
+    )
+    backup_path = worktree / ".claude" / "artifacts" / "wor_309" / "wip"
+
+    with (
+        patch(
+            "app.core.watcher.watcher_finalize_helpers.run_checks",
+            return_value=(False, []),
+        ),
+        patch(
+            "app.core.watcher.watcher_finalize.commit_wip_state",
+            return_value=WipPreservationResult(
+                status="backup",
+                sha=None,
+                backup_path=backup_path,
+                error="push rejected",
+            ),
+        ),
+        patch("app.core.watcher.watcher_finalize.cleanup_worktree"),
+        patch("app.core.watcher.watcher_finalize.preserve_worker_artifacts"),
+        caplog.at_level(logging.WARNING, logger="app.core.watcher.watcher_finalize"),
+    ):
+        _call_finalize(worker, metrics=metrics_mock, repo_root=tmp_path)
+
+    assert any(
+        "WIP backup for WOR-309" in r.message and str(backup_path) in r.message
+        for r in caplog.records
+    )
+
+
+def test_finalize_worker_failed_status_logs_error(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """commit_wip_state status='failed' → ERROR log with error + worktree_path."""
+    manifest = make_manifest(
+        ticket_id="WOR-309",
+        worker_branch="wor-309-test-ticket",
+        failure_policy=FailurePolicy(on_check_failure="abort"),
+        artifact_paths=ArtifactPaths.from_ticket_id("WOR-309"),
+    )
+    metrics_mock = MagicMock()
+    worktree = tmp_path / "worktree"
+    worktree.mkdir()
+    worker = ActiveWorker(
+        ticket_id="WOR-309",
+        linear_id="fake-linear-id",
+        manifest=manifest,
+        worktree_path=worktree,
+        process=MagicMock(spec=subprocess.Popen),
+    )
+
+    with (
+        patch(
+            "app.core.watcher.watcher_finalize_helpers.run_checks",
+            return_value=(False, []),
+        ),
+        patch(
+            "app.core.watcher.watcher_finalize.commit_wip_state",
+            return_value=WipPreservationResult(
+                status="failed",
+                sha=None,
+                backup_path=None,
+                error="git push rejected: branch protection",
+            ),
+        ),
+        patch("app.core.watcher.watcher_finalize.cleanup_worktree") as mock_cleanup,
+        patch("app.core.watcher.watcher_finalize.preserve_worker_artifacts"),
+        caplog.at_level(logging.ERROR, logger="app.core.watcher.watcher_finalize"),
+    ):
+        _call_finalize(worker, metrics=metrics_mock, repo_root=tmp_path)
+
+    mock_cleanup.assert_not_called()
+    assert any(
+        "WIP preservation failed for WOR-309" in r.message
+        and str(worktree) in r.message
+        for r in caplog.records
+    )
+
+
+def test_finalize_worker_writes_wip_status_to_last_failure(
+    tmp_path: Path,
+) -> None:
+    """last_failure.json includes wip_status on every commit_wip_state call."""
+    manifest = make_manifest(
+        ticket_id="WOR-309",
+        worker_branch="wor-309-test-ticket",
+        failure_policy=FailurePolicy(on_check_failure="abort"),
+        artifact_paths=ArtifactPaths.from_ticket_id("WOR-309"),
+    )
+    metrics_mock = MagicMock()
+    worktree = tmp_path / "worktree"
+    worktree.mkdir()
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    worker = ActiveWorker(
+        ticket_id="WOR-309",
+        linear_id="fake-linear-id",
+        manifest=manifest,
+        worktree_path=worktree,
+        process=MagicMock(spec=subprocess.Popen),
+    )
+
+    with (
+        patch(
+            "app.core.watcher.watcher_finalize_helpers.run_checks",
+            return_value=(False, []),
+        ),
+        patch(
+            "app.core.watcher.watcher_finalize.commit_wip_state",
+            return_value=WipPreservationResult(
+                status="backup",
+                sha=None,
+                backup_path=worktree / "backup",
+                error="push failed",
+            ),
+        ),
+        patch("app.core.watcher.watcher_finalize.cleanup_worktree"),
+    ):
+        _call_finalize(worker, metrics=metrics_mock, repo_root=repo_root)
+
+    artifact_dir = worktree / ".claude" / "artifacts" / "wor_309"
+    failure_file = artifact_dir / "last_failure.json"
+    assert failure_file.exists()
+    data = json.loads(failure_file.read_text(encoding="utf-8"))
+    assert data["wip_status"] == "backup"
+    assert data["wip_backup_path"] == str(worktree / "backup")
+
+
+def test_finalize_worker_wip_status_failed_no_backup_path(
+    tmp_path: Path,
+) -> None:
+    """When wip_status='failed', last_failure.json has wip_status but no
+    wip_backup_path."""
+    manifest = make_manifest(
+        ticket_id="WOR-309",
+        worker_branch="wor-309-test-ticket",
+        failure_policy=FailurePolicy(on_check_failure="abort"),
+        artifact_paths=ArtifactPaths.from_ticket_id("WOR-309"),
+    )
+    metrics_mock = MagicMock()
+    worktree = tmp_path / "worktree"
+    worktree.mkdir()
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    worker = ActiveWorker(
+        ticket_id="WOR-309",
+        linear_id="fake-linear-id",
+        manifest=manifest,
+        worktree_path=worktree,
+        process=MagicMock(spec=subprocess.Popen),
+    )
+
+    with (
+        patch(
+            "app.core.watcher.watcher_finalize_helpers.run_checks",
+            return_value=(False, []),
+        ),
+        patch(
+            "app.core.watcher.watcher_finalize.commit_wip_state",
+            return_value=WipPreservationResult(
+                status="failed",
+                sha=None,
+                backup_path=None,
+                error="git push rejected",
+            ),
+        ),
+        patch("app.core.watcher.watcher_finalize.cleanup_worktree"),
+    ):
+        _call_finalize(worker, metrics=metrics_mock, repo_root=repo_root)
+
+    artifact_dir = worktree / ".claude" / "artifacts" / "wor_309"
+    failure_file = artifact_dir / "last_failure.json"
+    assert failure_file.exists()
+    data = json.loads(failure_file.read_text(encoding="utf-8"))
+    assert data["wip_status"] == "failed"
+    assert "wip_backup_path" not in data

--- a/tests/test_watcher_multidispatch.py
+++ b/tests/test_watcher_multidispatch.py
@@ -1,0 +1,395 @@
+"""Tests for multi-dispatch-per-cycle and inter-dispatch delay (WOR-419).
+
+Tests the _dispatch_next_ticket loop change: instead of returning after one
+successful dispatch, the watcher iterates eligible tickets and dispatches up
+to MAX_DISPATCHES_PER_CYCLE per poll cycle, with DISPATCH_DELAY_SECONDS sleep
+between successive dispatches.
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.core.manifest import ArtifactPaths, ExecutionManifest
+from app.core.watcher.watcher import Watcher
+
+
+def _make_manifest(**overrides: Any) -> ExecutionManifest:
+    defaults: dict[str, Any] = {
+        "ticket_id": "WOR-10",
+        "epic_id": "WOR-96",
+        "title": "Test ticket",
+        "priority": 2,
+        "status": "ReadyForLocal",
+        "parallel_safe": True,
+        "risk_level": "low",
+        "implementation_mode": "local",
+        "review_mode": "auto",
+        "base_branch": "wor-96-local-worker-engine",
+        "worker_branch": "wor-10-test-ticket",
+        "objective": "Do the thing.",
+        "artifact_paths": ArtifactPaths.from_ticket_id("WOR-10"),
+        "allowed_paths": ["app/core/foo.py"],
+        "required_checks": ["pytest"],
+    }
+    defaults.update(overrides)
+    return ExecutionManifest(**defaults)
+
+
+def _regular_ticket(identifier: str = "WOR-99") -> dict[str, Any]:
+    return {
+        "id": "fake-linear-id",
+        "identifier": identifier,
+        "title": "Regular ticket",
+        "labels": {"nodes": [{"name": "local-ready"}]},
+    }
+
+
+class TestMultiDispatchPerCycle:
+    """_dispatch_next_ticket dispatches multiple eligible tickets per cycle."""
+
+    def test_dispatches_multiple_eligible_tickets_in_one_cycle(
+        self, tmp_path: Path, caplog: pytest.LogCaptureContext
+    ) -> None:
+        """Given 4 eligible tickets and an empty pool, watcher dispatches all 4
+        in one cycle instead of just 1."""
+        manifest1 = _make_manifest(
+            ticket_id="WOR-10",
+            worker_branch="wor-10-test-ticket",
+            allowed_paths=["app/core/a.py"],
+        )
+        manifest2 = _make_manifest(
+            ticket_id="WOR-11",
+            worker_branch="wor-11-test-ticket",
+            allowed_paths=["app/core/b.py"],
+        )
+        manifest3 = _make_manifest(
+            ticket_id="WOR-12",
+            worker_branch="wor-12-test-ticket",
+            allowed_paths=["app/core/c.py"],
+        )
+        manifest4 = _make_manifest(
+            ticket_id="WOR-13",
+            worker_branch="wor-13-test-ticket",
+            allowed_paths=["app/core/d.py"],
+        )
+
+        linear_mock = MagicMock()
+        linear_mock.get_open_blockers.return_value = []
+        linear_mock.list_ready_for_local.return_value = [
+            _regular_ticket("WOR-10"),
+            _regular_ticket("WOR-11"),
+            _regular_ticket("WOR-12"),
+            _regular_ticket("WOR-13"),
+        ]
+
+        w = Watcher(
+            linear_client=linear_mock,
+            repo_root=tmp_path,
+            max_local_workers=8,
+        )
+
+        load_counts: dict[str, int] = {}
+
+        def capture_load(ticket_id: str):
+            load_counts[ticket_id] = load_counts.get(ticket_id, 0) + 1
+            manifest_map = {
+                "WOR-10": manifest1,
+                "WOR-11": manifest2,
+                "WOR-12": manifest3,
+                "WOR-13": manifest4,
+            }
+            return manifest_map[ticket_id]
+
+        fake_process = MagicMock(spec=subprocess.Popen)
+
+        with (
+            patch.object(w, "_load_manifest", side_effect=capture_load),
+            patch("app.core.watcher.watcher.create_worktree", return_value=tmp_path),
+            patch("app.core.watcher.watcher.copy_manifest_to_worktree"),
+            patch("app.core.watcher.watcher.write_worker_pytest_config"),
+            patch("app.core.watcher.watcher.safe_set_state"),
+            patch("app.core.watcher.watcher.backup_plan_files", return_value=[]),
+            patch(
+                "app.core.watcher.watcher.launch_worker",
+                return_value=fake_process,
+            ),
+            patch.object(w._services, "ensure_vllm_anthropic_mode"),
+            patch.object(w._services, "probe_vllm_health", return_value=True),
+            caplog.at_level(logging.INFO, logger="app.core.watcher"),
+        ):
+            w._dispatch_next_ticket()
+
+        # All 4 tickets should have been dispatch_count
+        for tid in ("WOR-10", "WOR-11", "WOR-12", "WOR-13"):
+            assert load_counts.get(tid, 0) == 1, f"{tid} was not dispatch_count"
+
+        assert len(w._local_active) == 4
+        for tid in ("WOR-10", "WOR-11", "WOR-12", "WOR-13"):
+            assert any(w._local_active[i].ticket_id == tid for i in range(4)), (
+                f"{tid} not in local_active"
+            )
+
+    def test_respects_max_dispatches_per_cycle(self, tmp_path: Path) -> None:
+        """Given 8 eligible tickets but MAX_DISPATCHES_PER_CYCLE=4,
+        only 4 are dispatch_count."""
+        from app.core.watcher.watcher import MAX_DISPATCHES_PER_CYCLE
+
+        manifests = [
+            _make_manifest(
+                ticket_id=f"WOR-{i}",
+                worker_branch=f"wor-{i}-test-ticket",
+                allowed_paths=[f"app/core/{chr(97 + i)}.py"],
+            )
+            for i in range(8)
+        ]
+
+        linear_mock = MagicMock()
+        linear_mock.get_open_blockers.return_value = []
+        linear_mock.list_ready_for_local.return_value = [
+            _regular_ticket(f"WOR-{i}") for i in range(8)
+        ]
+
+        w = Watcher(
+            linear_client=linear_mock,
+            repo_root=tmp_path,
+            max_local_workers=8,
+        )
+
+        load_counts: dict[str, int] = {}
+
+        def load_for(ticket_id: str):
+            load_counts[ticket_id] = load_counts.get(ticket_id, 0) + 1
+            return manifests[int(ticket_id[4:])]
+
+        fake_process = MagicMock(spec=subprocess.Popen)
+
+        with (
+            patch.object(w, "_load_manifest", side_effect=load_for),
+            patch("app.core.watcher.watcher.create_worktree", return_value=tmp_path),
+            patch("app.core.watcher.watcher.copy_manifest_to_worktree"),
+            patch("app.core.watcher.watcher.write_worker_pytest_config"),
+            patch("app.core.watcher.watcher.safe_set_state"),
+            patch("app.core.watcher.watcher.backup_plan_files", return_value=[]),
+            patch(
+                "app.core.watcher.watcher.launch_worker",
+                return_value=fake_process,
+            ),
+            patch.object(w._services, "ensure_vllm_anthropic_mode"),
+            patch.object(w._services, "probe_vllm_health", return_value=True),
+        ):
+            w._dispatch_next_ticket()
+
+        dispatch_count = {k: v for k, v in load_counts.items() if v > 0}
+        assert len(dispatch_count) == MAX_DISPATCHES_PER_CYCLE
+
+    def test_skips_spiked_tickets_does_not_count_toward_limit(
+        self, tmp_path: Path
+    ) -> None:
+        """Spike-labelled tickets are skipped (continue) and do not count
+        toward the MAX_DISPATCHES_PER_CYCLE limit — eligible non-spike tickets
+        still get dispatch_count."""
+
+        spike_ticket: dict[str, Any] = {
+            "id": "fake-linear-id",
+            "identifier": "WOR-SPIKE",
+            "title": "Spike ticket",
+            "labels": {"nodes": [{"name": "Spike"}]},
+        }
+
+        manifests = [
+            _make_manifest(
+                ticket_id=f"WOR-{i}",
+                worker_branch=f"wor-{i}-test-ticket",
+                allowed_paths=[f"app/core/{chr(97 + i)}.py"],
+            )
+            for i in range(3)
+        ]
+
+        linear_mock = MagicMock()
+        linear_mock.get_open_blockers.return_value = []
+        linear_mock.list_ready_for_local.return_value = [
+            spike_ticket,  # spike — should be skipped
+            _regular_ticket("WOR-10"),
+            _regular_ticket("WOR-11"),
+            _regular_ticket("WOR-12"),
+        ]
+
+        w = Watcher(
+            linear_client=linear_mock,
+            repo_root=tmp_path,
+            max_local_workers=8,
+        )
+
+        load_counts: dict[str, int] = {}
+
+        def capture_load(ticket_id: str):
+            load_counts[ticket_id] = load_counts.get(ticket_id, 0) + 1
+            idx = int(ticket_id[4:]) - 10
+            if 0 <= idx < len(manifests):
+                return manifests[idx]
+            return manifests[0]
+
+        fake_process = MagicMock(spec=subprocess.Popen)
+
+        with (
+            patch.object(w, "_load_manifest", side_effect=capture_load),
+            patch("app.core.watcher.watcher.create_worktree", return_value=tmp_path),
+            patch("app.core.watcher.watcher.copy_manifest_to_worktree"),
+            patch("app.core.watcher.watcher.write_worker_pytest_config"),
+            patch("app.core.watcher.watcher.safe_set_state"),
+            patch("app.core.watcher.watcher.backup_plan_files", return_value=[]),
+            patch(
+                "app.core.watcher.watcher.launch_worker",
+                return_value=fake_process,
+            ),
+            patch.object(w._services, "ensure_vllm_anthropic_mode"),
+            patch.object(w._services, "probe_vllm_health", return_value=True),
+        ):
+            w._dispatch_next_ticket()
+
+        # All 3 eligible tickets should be dispatch_count (spike skipped, doesn't
+        # consume the dispatch limit)
+        for tid in ("WOR-10", "WOR-11", "WOR-12"):
+            assert load_counts.get(tid, 0) == 1, f"{tid} was not dispatch_count"
+        assert load_counts.get("WOR-SPIKE", 0) == 0
+
+
+class TestInterDispatchDelay:
+    """Inter-dispatch delay constants and behavior."""
+
+    def test_delay_constant_is_module_level(self) -> None:
+        """DISPATCH_DELAY_SECONDS is defined as a module-level constant."""
+        from app.core.watcher.watcher import DISPATCH_DELAY_SECONDS
+
+        assert isinstance(DISPATCH_DELAY_SECONDS, float)
+        assert DISPATCH_DELAY_SECONDS == 2.5
+
+    def test_max_dispatches_constant_is_module_level(self) -> None:
+        """MAX_DISPATCHES_PER_CYCLE is defined as a module-level constant."""
+        from app.core.watcher.watcher import MAX_DISPATCHES_PER_CYCLE
+
+        assert isinstance(MAX_DISPATCHES_PER_CYCLE, int)
+        assert MAX_DISPATCHES_PER_CYCLE == 4
+
+    def test_delay_is_called_between_dispatches(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """time.sleep is called between each dispatch to avoid Linear API spike."""
+        sleep_calls: list[float] = []
+
+        def record_sleep(seconds: float) -> None:
+            sleep_calls.append(seconds)
+
+        manifest = _make_manifest(
+            ticket_id="WOR-10",
+            worker_branch="wor-10-test-ticket",
+            allowed_paths=["app/core/a.py"],
+        )
+        manifest2 = _make_manifest(
+            ticket_id="WOR-11",
+            worker_branch="wor-11-test-ticket",
+            allowed_paths=["app/core/b.py"],
+        )
+
+        linear_mock = MagicMock()
+        linear_mock.get_open_blockers.return_value = []
+        linear_mock.list_ready_for_local.return_value = [
+            _regular_ticket("WOR-10"),
+            _regular_ticket("WOR-11"),
+        ]
+
+        w = Watcher(
+            linear_client=linear_mock,
+            repo_root=tmp_path,
+            max_local_workers=8,
+        )
+
+        load_index = [0]
+
+        def capture_load(ticket_id: str):
+            idx = load_index[0]
+            load_index[0] += 1
+            return manifest if idx == 0 else manifest2
+
+        fake_process = MagicMock(spec=subprocess.Popen)
+
+        with (
+            patch.object(w, "_load_manifest", side_effect=capture_load),
+            patch("app.core.watcher.watcher.create_worktree", return_value=tmp_path),
+            patch("app.core.watcher.watcher.copy_manifest_to_worktree"),
+            patch("app.core.watcher.watcher.write_worker_pytest_config"),
+            patch("app.core.watcher.watcher.safe_set_state"),
+            patch("app.core.watcher.watcher.backup_plan_files", return_value=[]),
+            patch(
+                "app.core.watcher.watcher.launch_worker",
+                return_value=fake_process,
+            ),
+            patch.object(w._services, "ensure_vllm_anthropic_mode"),
+            patch.object(w._services, "probe_vllm_health", return_value=True),
+            patch("app.core.watcher.watcher.time.sleep", record_sleep),
+            patch("app.core.watcher.watcher.MAX_DISPATCHES_PER_CYCLE", 2),
+        ):
+            w._dispatch_next_ticket()
+
+        # Exactly one sleep call between two dispatches; break after 2 hits
+        # so no sleep after the final dispatch.
+        assert len(sleep_calls) == 1
+        assert sleep_calls[0] == 2.5
+
+
+class TestFailureDoesNotConsumeLimit:
+    """A failed _start_ticket (exception) does not consume the dispatch limit."""
+
+    def test_exception_does_not_break_loop(self, tmp_path: Path) -> None:
+        """When _start_ticket raises, the loop continues to the next ticket."""
+
+        manifests = [
+            _make_manifest(
+                ticket_id="WOR-FAIL",
+                worker_branch="wor-fail-ticket",
+                allowed_paths=["app/core/evil.py"],
+            ),
+            _make_manifest(
+                ticket_id="WOR-10",
+                worker_branch="wor-10-test-ticket",
+                allowed_paths=["app/core/a.py"],
+            ),
+        ]
+
+        linear_mock = MagicMock()
+        linear_mock.get_open_blockers.return_value = []
+        linear_mock.list_ready_for_local.return_value = [
+            {"identifier": "WOR-FAIL", "id": "fake", "labels": {"nodes": []}},
+            _regular_ticket("WOR-10"),
+        ]
+
+        w = Watcher(
+            linear_client=linear_mock,
+            repo_root=tmp_path,
+            max_local_workers=8,
+        )
+
+        with (
+            patch.object(w, "_load_manifest") as mock_load,
+            patch("app.core.watcher.watcher.create_worktree"),
+        ):
+            mock_load.side_effect = [
+                RuntimeError("boom"),  # First ticket fails
+                manifests[1],  # Second ticket succeeds
+            ]
+            # Patch safe_set_state to avoid actual Linear call
+            with patch("app.core.watcher.watcher.safe_set_state"):
+                w._dispatch_next_ticket()
+
+        # Second ticket should have been loaded despite first failure
+        calls = mock_load.call_args_list
+        assert len(calls) == 2
+        assert calls[0][0][0] == "WOR-FAIL"
+        assert calls[1][0][0] == "WOR-10"

--- a/tests/test_watcher_types.py
+++ b/tests/test_watcher_types.py
@@ -128,3 +128,17 @@ def test_vllm_host_derives_from_env_override(
 
     monkeypatch.delenv("WATCHER_VLLM_BASE_URL", raising=False)
     importlib.reload(wt)
+
+
+# ---------------------------------------------------------------------------
+# WOR-424: _LOCAL_MODEL constant
+# ---------------------------------------------------------------------------
+
+
+def test_local_model_is_qwen3_coder() -> None:
+    """The _LOCAL_MODEL constant must be 'qwen3-coder' to match the
+    --served-model-name flag passed to vLLM.  WOR-424."""
+
+    from app.core.watcher.watcher_types import _LOCAL_MODEL
+
+    assert _LOCAL_MODEL == "qwen3-coder"

--- a/tests/test_wor303_improvement_log.py
+++ b/tests/test_wor303_improvement_log.py
@@ -1,0 +1,298 @@
+"""WOR-303 — improvement-log: auto-post result.json notes to WOR-254.
+
+Verifies that finalize_worker reads the worker's result.json, extracts the
+`notes` field, and posts a structured Linear comment to the WOR-254
+improvement-log when the notes exceed the hardcoded 50-char threshold.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.core.escalation_policy import EscalationPolicy
+from app.core.manifest import ArtifactPaths
+from app.core.watcher.watcher_finalize import finalize_worker
+from app.core.watcher.watcher_types import ActiveWorker
+from app.core.watcher.watcher_worktrees import WipPreservationResult
+from tests.conftest import make_manifest
+
+_DEFAULT_PROJECT = "repo-scaffold-desktop"
+
+
+def _write_result_json(repo_root: Path, ticket_id: str, **fields: object) -> Path:
+    """Write a worker result.json under repo_root's artifact dir."""
+    slug = ticket_id.lower().replace("-", "_")
+    art = repo_root / ".claude" / "artifacts" / slug
+    art.mkdir(parents=True, exist_ok=True)
+    f = art / "result.json"
+    payload = {"ticket_id": ticket_id, "status": "success", "summary": "done"}
+    payload.update(fields)
+    f.write_text(json.dumps(payload), encoding="utf-8")
+    return f
+
+
+def _make_worker(tmp_path: Path, ticket_id: str) -> ActiveWorker:
+    """Build an ActiveWorker whose worktree_path lives under tmp_path."""
+    manifest = make_manifest(
+        ticket_id=ticket_id,
+        worker_branch=f"{ticket_id.lower().replace('-', '')}-test-branch",
+        artifact_paths=ArtifactPaths.from_ticket_id(ticket_id),
+    )
+    return ActiveWorker(
+        ticket_id=ticket_id,
+        linear_id="fake-linear-id",
+        manifest=manifest,
+        worktree_path=tmp_path / "worktree",
+        process=MagicMock(spec=subprocess.Popen),
+    )
+
+
+def test_post_comment_when_notes_exceed_50_chars(tmp_path: Path) -> None:
+    """result.json notes > 50 chars → post_comment called with WOR-254."""
+    long_notes = "x" * 51  # 51 chars > NOTES_MIN_CHARS
+    worktree = tmp_path / "worktree"
+    worktree.mkdir()
+    _write_result_json(worktree, "WOR-303", notes=long_notes)
+    worker = _make_worker(tmp_path, "WOR-303")
+    metrics_mock = MagicMock()
+    linear_mock = MagicMock()
+
+    with (
+        patch(
+            "app.core.watcher.watcher_finalize._execute_finalization",
+            return_value=("success", False, True, None, [], "success"),
+        ),
+        patch(
+            "app.core.watcher.watcher_finalize.commit_wip_state",
+            return_value=WipPreservationResult(
+                status="clean", sha=None, backup_path=None, error=None
+            ),
+        ),
+        patch("app.core.watcher.watcher_finalize.cleanup_worktree"),
+    ):
+        finalize_worker(
+            worker,
+            returncode=0,
+            wall_time=1.0,
+            linear=linear_mock,
+            metrics=metrics_mock,
+            escalation_policy=EscalationPolicy.from_toml(),
+            repo_root=worktree,
+            mode="default",
+            project_id=_DEFAULT_PROJECT,
+        )
+
+    linear_mock.post_comment.assert_called_once()
+    call_args = linear_mock.post_comment.call_args
+    assert call_args[0][0] == "WOR-254"
+    body = call_args[0][1]
+    assert "## Side-discovery from WOR-303" in body
+    assert "Test ticket" in body  # manifest title
+    assert long_notes in body
+    assert "wor303-test-branch" in body
+
+
+def test_no_post_when_notes_at_threshold(tmp_path: Path) -> None:
+    """notes == 50 chars → NOT > 50, so no post_comment call."""
+    at_threshold = "x" * 50  # exactly 50, NOT > 50
+    worktree = tmp_path / "worktree"
+    worktree.mkdir()
+    _write_result_json(worktree, "WOR-303", notes=at_threshold)
+    worker = _make_worker(tmp_path, "WOR-303")
+    linear_mock = MagicMock()
+
+    with (
+        patch(
+            "app.core.watcher.watcher_finalize._execute_finalization",
+            return_value=("success", False, True, None, [], "success"),
+        ),
+        patch(
+            "app.core.watcher.watcher_finalize.commit_wip_state",
+            return_value=WipPreservationResult(
+                status="clean", sha=None, backup_path=None, error=None
+            ),
+        ),
+        patch("app.core.watcher.watcher_finalize.cleanup_worktree"),
+    ):
+        finalize_worker(
+            worker,
+            returncode=0,
+            wall_time=1.0,
+            linear=linear_mock,
+            metrics=MagicMock(),
+            escalation_policy=EscalationPolicy.from_toml(),
+            repo_root=worktree,
+            mode="default",
+            project_id=_DEFAULT_PROJECT,
+        )
+
+    linear_mock.post_comment.assert_not_called()
+
+
+def test_no_post_when_notes_empty(tmp_path: Path) -> None:
+    """Empty notes → no post_comment call (len("") <= 50)."""
+    worktree = tmp_path / "worktree"
+    worktree.mkdir()
+    _write_result_json(worktree, "WOR-303", notes="")
+    worker = _make_worker(tmp_path, "WOR-303")
+    linear_mock = MagicMock()
+
+    with (
+        patch(
+            "app.core.watcher.watcher_finalize._execute_finalization",
+            return_value=("success", False, True, None, [], "success"),
+        ),
+        patch(
+            "app.core.watcher.watcher_finalize.commit_wip_state",
+            return_value=WipPreservationResult(
+                status="clean", sha=None, backup_path=None, error=None
+            ),
+        ),
+        patch("app.core.watcher.watcher_finalize.cleanup_worktree"),
+    ):
+        finalize_worker(
+            worker,
+            returncode=0,
+            wall_time=1.0,
+            linear=linear_mock,
+            metrics=MagicMock(),
+            escalation_policy=EscalationPolicy.from_toml(),
+            repo_root=worktree,
+            mode="default",
+            project_id=_DEFAULT_PROJECT,
+        )
+
+    linear_mock.post_comment.assert_not_called()
+
+
+def test_no_post_when_result_json_missing(tmp_path: Path) -> None:
+    """Missing result.json → no exception, no post_comment call."""
+    worktree = tmp_path / "worktree"
+    worktree.mkdir()
+    # No result.json — file does not exist.
+    worker = _make_worker(tmp_path, "WOR-303")
+    linear_mock = MagicMock()
+
+    with (
+        patch(
+            "app.core.watcher.watcher_finalize._execute_finalization",
+            return_value=("success", False, True, None, [], "success"),
+        ),
+        patch(
+            "app.core.watcher.watcher_finalize.commit_wip_state",
+            return_value=WipPreservationResult(
+                status="clean", sha=None, backup_path=None, error=None
+            ),
+        ),
+        patch("app.core.watcher.watcher_finalize.cleanup_worktree"),
+    ):
+        finalize_worker(
+            worker,
+            returncode=0,
+            wall_time=1.0,
+            linear=linear_mock,
+            metrics=MagicMock(),
+            escalation_policy=EscalationPolicy.from_toml(),
+            repo_root=worktree,
+            mode="default",
+            project_id=_DEFAULT_PROJECT,
+        )
+
+    linear_mock.post_comment.assert_not_called()
+
+
+def test_no_post_when_notes_field_absent(tmp_path: Path) -> None:
+    """result.json without a `notes` field → no exception, no post_comment."""
+    worktree = tmp_path / "worktree"
+    worktree.mkdir()
+    # Write result.json with no "notes" key.
+    slug = "wor_303"
+    art = worktree / ".claude" / "artifacts" / slug
+    art.mkdir(parents=True, exist_ok=True)
+    (art / "result.json").write_text(
+        json.dumps({"ticket_id": "WOR-303", "status": "success", "summary": "done"}),
+        encoding="utf-8",
+    )
+    worker = _make_worker(tmp_path, "WOR-303")
+    linear_mock = MagicMock()
+
+    with (
+        patch(
+            "app.core.watcher.watcher_finalize._execute_finalization",
+            return_value=("success", False, True, None, [], "success"),
+        ),
+        patch(
+            "app.core.watcher.watcher_finalize.commit_wip_state",
+            return_value=WipPreservationResult(
+                status="clean", sha=None, backup_path=None, error=None
+            ),
+        ),
+        patch("app.core.watcher.watcher_finalize.cleanup_worktree"),
+    ):
+        finalize_worker(
+            worker,
+            returncode=0,
+            wall_time=1.0,
+            linear=linear_mock,
+            metrics=MagicMock(),
+            escalation_policy=EscalationPolicy.from_toml(),
+            repo_root=worktree,
+            mode="default",
+            project_id=_DEFAULT_PROJECT,
+        )
+
+    linear_mock.post_comment.assert_not_called()
+
+
+def test_graceful_failure_when_linear_unreachable(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Linear unreachable → logger.warning fires, finalize continues."""
+    long_notes = "x" * 51
+    worktree = tmp_path / "worktree"
+    worktree.mkdir()
+    _write_result_json(worktree, "WOR-303", notes=long_notes)
+    worker = _make_worker(tmp_path, "WOR-303")
+    metrics_mock = MagicMock()
+    linear_mock = MagicMock()
+    linear_mock.post_comment.side_effect = ConnectionRefusedError("connection refused")
+
+    with (
+        patch(
+            "app.core.watcher.watcher_finalize._execute_finalization",
+            return_value=("success", False, True, None, [], "success"),
+        ),
+        patch(
+            "app.core.watcher.watcher_finalize.commit_wip_state",
+            return_value=WipPreservationResult(
+                status="clean", sha=None, backup_path=None, error=None
+            ),
+        ),
+        patch("app.core.watcher.watcher_finalize.cleanup_worktree"),
+        caplog.at_level(logging.WARNING, logger="app.core.watcher.watcher_finalize"),
+    ):
+        finalize_worker(
+            worker,
+            returncode=0,
+            wall_time=1.0,
+            linear=linear_mock,
+            metrics=metrics_mock,
+            escalation_policy=EscalationPolicy.from_toml(),
+            repo_root=worktree,
+            mode="default",
+            project_id=_DEFAULT_PROJECT,
+        )
+
+    # The hook warned but did not raise — finalize continued.
+    assert any(
+        "Could not post improvement-log comment" in r.message for r in caplog.records
+    )
+    # metrics still recorded — the failure didn't break the flow.
+    metrics_mock.record.assert_called_once()


### PR DESCRIPTION
Closes WOR-303

finalize_worker auto-posts a structured comment to WOR-254 when result.json notes exceed 50 chars; gracefully handles Linear unavailability; never raises into finalize_worker. implement-ticket.md prose clarifies notes vs summary semantics. Tests cover the 5+ cases. All required_checks pass.