### PR TITLE
WOR-426 Block test-spawned claude subprocess leaks

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,12 +4,59 @@ from __future__ import annotations
 
 import subprocess
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
 
 from app.core.manifest import ArtifactPaths, ExecutionManifest
 from app.core.watcher.watcher_types import ActiveWorker
+
+# WOR-426: Block any test from spawning a real `claude` subprocess.
+#
+# WOR-312's retry-loop tests in tests/test_watcher_finalize.py mock run_checks
+# but several forgot to mock launch_worker too — the retry path fires for real,
+# spawning a real claude binary against vLLM and writing to production
+# .claude/artifacts/wor_*/ paths. CI passes because the claude binary doesn't
+# exist in CI runners; local devs paid the cost silently.
+#
+# Patch Popen.__init__ rather than the class itself so MagicMock(spec=...) still
+# resolves the real attribute list.
+_REAL_POPEN_INIT = subprocess.Popen.__init__
+
+
+def _extract_first_arg(args: Any) -> str:
+    if isinstance(args, (list, tuple)) and args:
+        return str(args[0])
+    if isinstance(args, str) and args:
+        return args.split()[0]
+    return ""
+
+
+@pytest.fixture(autouse=True)
+def _block_real_claude_subprocess(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Refuse to spawn a real `claude` binary from any test."""
+
+    def _guarded_init(
+        self: subprocess.Popen[Any],
+        args: Any,
+        *rest: Any,
+        **kwargs: Any,
+    ) -> None:
+        first = _extract_first_arg(args)
+        binary = Path(first).name.lower() if first else ""
+        if binary in ("claude", "claude.exe"):
+            raise AssertionError(
+                "Test attempted to spawn real `claude` binary "
+                f"(argv[0]={first!r}). Mock launch_worker via "
+                "patch('app.core.watcher.watcher_finalize.launch_worker', "
+                "return_value=MagicMock()) inside the test's with-block."
+            )
+        _REAL_POPEN_INIT(self, args, *rest, **kwargs)
+
+    monkeypatch.setattr(subprocess.Popen, "__init__", _guarded_init)
 
 
 # Session-scoped QApplication fixture (pytest-qt)

--- a/tests/test_subprocess_guard.py
+++ b/tests/test_subprocess_guard.py
@@ -1,0 +1,65 @@
+"""WOR-426 regression guard: tests must never spawn a real `claude` binary.
+
+Defense-in-depth verification for the autouse fixture in `tests/conftest.py`.
+The fixture wraps `subprocess.Popen` to raise `AssertionError` when invoked
+with `claude` as argv[0]. This file confirms the guard fires for claude and
+does not interfere with legitimate subprocess calls (git, pytest, etc.).
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import pytest
+
+
+def test_guard_rejects_bare_claude_command() -> None:
+    """argv=['claude', ...] is rejected with a clear assertion."""
+    with pytest.raises(AssertionError, match="real `claude` binary"):
+        subprocess.Popen(["claude", "--version"])
+
+
+def test_guard_rejects_claude_exe_on_windows() -> None:
+    """argv=['claude.exe', ...] is also rejected (Windows binary suffix)."""
+    with pytest.raises(AssertionError, match="real `claude` binary"):
+        subprocess.Popen(["claude.exe", "--version"])
+
+
+def test_guard_rejects_claude_with_full_path() -> None:
+    """An absolute path to claude is rejected — guard inspects argv[0] basename."""
+    with pytest.raises(AssertionError, match="real `claude` binary"):
+        subprocess.Popen(["/usr/local/bin/claude", "--version"])
+
+
+def test_guard_allows_git_subprocess() -> None:
+    """Legitimate git subprocess calls pass through unaffected."""
+    proc = subprocess.Popen(
+        ["git", "--version"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    stdout, _ = proc.communicate(timeout=5)
+    assert proc.returncode == 0
+    assert b"git version" in stdout
+
+
+def test_guard_allows_python_subprocess() -> None:
+    """Python subprocess calls (used by the test suite itself) pass through."""
+    proc = subprocess.Popen(
+        [sys.executable, "-c", "print('ok')"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    stdout, _ = proc.communicate(timeout=5)
+    assert proc.returncode == 0
+    assert stdout.strip() == b"ok"
+
+
+def test_guard_allows_command_containing_claude_substring() -> None:
+    """`git clone claude-something` is allowed — guard checks argv[0] basename only."""
+    # Use a fake non-claude binary to verify substring matching doesn't false-positive.
+    # This test does NOT actually run the command; it asserts no AssertionError raised
+    # at Popen-construction time (the real OS lookup will then fail naturally).
+    with pytest.raises((FileNotFoundError, OSError)):
+        subprocess.Popen(["definitely-not-a-real-binary-claude-suffix"])

--- a/tests/test_watcher_finalize.py
+++ b/tests/test_watcher_finalize.py
@@ -142,6 +142,10 @@ def test_finalize_worker_retry_count_increments_on_check_failure(
             return_value=(False, []),
         ),
         patch("app.core.watcher.watcher_finalize.cleanup_worktree"),
+        patch(
+            "app.core.watcher.watcher_finalize.launch_worker",
+            return_value=MagicMock(),
+        ),
     ):
         _call_finalize(worker)
         _call_finalize(worker)
@@ -172,6 +176,10 @@ def test_finalize_worker_retry_count_two_failures_then_success(
             return_value="https://github.com/example/pr/1",
         ),
         patch("app.core.watcher.watcher_finalize.cleanup_worktree"),
+        patch(
+            "app.core.watcher.watcher_finalize.launch_worker",
+            return_value=MagicMock(),
+        ),
     ):
         _call_finalize(worker, metrics=metrics_mock)
         _call_finalize(worker, metrics=metrics_mock)


### PR DESCRIPTION
## Summary

Fixes the test-isolation bug discovered during `/close-epic WOR-335` on 2026-05-11 — two tests in `tests/test_watcher_finalize.py` were spawning real `claude` binaries against vLLM despite mocking `run_checks`.

- **Targeted fix**: `test_finalize_worker_retry_count_increments_on_check_failure` (line 128) and `test_finalize_worker_retry_count_two_failures_then_success` (line 152) now mock `launch_worker` alongside `run_checks`, matching the pattern in five sibling tests in the same file.
- **Defense in depth**: new autouse fixture in `tests/conftest.py` patches `subprocess.Popen.__init__` to raise `AssertionError` if argv[0] is `claude` / `claude.exe`. Any future test that forgets to mock the chain will fail loudly here rather than silently burning vLLM cycles + polluting production paths.
- **Regression guard**: `tests/test_subprocess_guard.py` exercises the fixture across the bare command, `.exe` suffix, absolute-path, and substring-false-positive cases.

## Why it matters

CI passed for these tests in PR #862 (WOR-312's merge) because the `claude` binary isn't installed in CI runners — `subprocess.Popen(["claude", ...])` raised `FileNotFoundError` and the test moved on. Locally, the binary exists and resolves; the tests spawned real claude sessions that:

- Wrote to production `.claude/artifacts/wor_10/worker_wor-10.log` (a real `result.json` line was captured during investigation)
- Burned thousands of input + output tokens per leak against vLLM
- Were invisible to operators — never logged, never tracked

## Implementation note

The fixture patches `subprocess.Popen.__init__` rather than replacing `subprocess.Popen` itself. Replacing the class breaks `MagicMock(spec=subprocess.Popen)` usage in `tests/test_watcher_worker_lifecycle.py` because the mock then specs against a function (no `.wait`, `.terminate`, etc). Patching `__init__` intercepts real instantiations while leaving the class object intact for mock spec lookups.

## Test plan

- [x] `tests/test_subprocess_guard.py` — 6 new tests, all pass
- [x] `tests/test_watcher_finalize.py` — 2 fixed tests + 24 unchanged sibling tests pass; no real claude binary spawned
- [x] `tests/test_watcher_worker_lifecycle.py` — 28 tests still pass (MagicMock spec preserved)
- [x] Full suite: **1574 passed, 1 failed** (pre-existing WOR-427 unrelated bug); coverage 87.52%
- [x] ruff, mypy, lint-imports, bandit, detect-secrets all pass

Closes WOR-426
