### PR TITLE
WOR-427 Fix ticket-status CLI: load_dotenv test isolation + LinearClient.get_issue

### DIFF
--- a/app/core/linear_client.py
+++ b/app/core/linear_client.py
@@ -162,6 +162,35 @@ class LinearClient:
             return None
         return cast(str, issue["state"]["type"])
 
+    def get_issue(self, identifier: str) -> dict[str, Any]:
+        """Return full issue data for a ticket by its human identifier.
+
+        Returns a dict with `id`, `identifier`, `title`, and `state` (with
+        nested `name`, `type`, `createdAt`). Raises LinearError if the
+        issue is not found.
+        """
+        data = self._query(
+            """
+            query GetIssueByIdentifier($identifier: String!) {
+              issue(id: $identifier) {
+                id
+                identifier
+                title
+                state {
+                  name
+                  type
+                  createdAt
+                }
+              }
+            }
+            """,
+            {"identifier": identifier},
+        )
+        issue = data.get("issue")
+        if issue is None:
+            raise LinearError(f"Issue {identifier!r} not found")
+        return cast(dict[str, Any], issue)
+
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------

--- a/tests/test_cli_ticket_status.py
+++ b/tests/test_cli_ticket_status.py
@@ -32,7 +32,13 @@ def _clear_linear_key(env: dict[str, str]) -> dict[str, str]:
 class TestTicketStatusMissingEnv:
     def test_missing_api_key_exits_with_error(self, capsys: CapSys) -> None:
         env = _clear_linear_key(os.environ)
-        with patch.dict("os.environ", env, clear=True):
+        # WOR-427: main() calls load_dotenv() which re-populates LINEAR_API_KEY
+        # from .env if the file exists locally — defeating the env clearing.
+        # Patch load_dotenv to a no-op so the test isolates the env state.
+        with (
+            patch.dict("os.environ", env, clear=True),
+            patch("app.cli.load_dotenv"),
+        ):
             rc = main(["ticket-status", "WOR-999"])
 
         assert rc == 1

--- a/tests/test_linear_client.py
+++ b/tests/test_linear_client.py
@@ -292,6 +292,42 @@ def test_get_issue_state_type_raises_on_api_error() -> None:
 
 
 # ---------------------------------------------------------------------------
+# get_issue (WOR-427)
+# ---------------------------------------------------------------------------
+
+
+def test_get_issue_returns_full_issue_dict() -> None:
+    issue_data = {
+        "id": "uuid-123",
+        "identifier": "WOR-45",
+        "title": "Test ticket",
+        "state": {
+            "name": "InProgressLocal",
+            "type": "started",
+            "createdAt": "2026-05-10T06:19:32.000Z",
+        },
+    }
+    response = {"data": {"issue": issue_data}}
+    with patch("urllib.request.urlopen", return_value=_mock_response(response)):
+        result = _client().get_issue("WOR-45")
+    assert result == issue_data
+
+
+def test_get_issue_raises_on_missing_issue() -> None:
+    response = {"data": {"issue": None}}
+    with patch("urllib.request.urlopen", return_value=_mock_response(response)):
+        with pytest.raises(LinearError, match="WOR-99"):
+            _client().get_issue("WOR-99")
+
+
+def test_get_issue_propagates_api_errors() -> None:
+    response = {"errors": [{"message": "unauthorized"}]}
+    with patch("urllib.request.urlopen", return_value=_mock_response(response)):
+        with pytest.raises(LinearError, match="unauthorized"):
+            _client().get_issue("WOR-45")
+
+
+# ---------------------------------------------------------------------------
 # _query retry and safe access
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Two pre-existing bugs in WOR-337's ticket-status CLI, surfaced by `/close-epic WOR-335` on 2026-05-11.

### Bug 1 — `LinearClient.get_issue` doesn't exist

`app/core/watcher/ticket_status.py:262` calls `linear_client.get_issue(ticket_id)` but the class exposes only `list_ready_for_local`, `get_open_blockers`, `set_state`, `post_comment`, `get_issue_state_type`. No `get_issue`.

The CLI silently masked this — `fetch_ticket_status` wraps the call in `except Exception` and falls back to a "Unknown" status with the AttributeError as the title. So the CLI "worked" cosmetically but never actually fetched ticket data from Linear.

**Fix:** added `get_issue(identifier)` to `LinearClient`. Returns a dict matching what `ticket_status.py` expects: `{id, identifier, title, state: {name, type, createdAt}}`. Raises `LinearError` if not found.

### Bug 2 — `load_dotenv()` defeats test isolation

`tests/test_cli_ticket_status.py::TestTicketStatusMissingEnv::test_missing_api_key_exits_with_error` passed `patch.dict("os.environ", env, clear=True)` then called `main(["ticket-status", "WOR-999"])`. But `app/cli.py:949 load_dotenv()` re-populated `LINEAR_API_KEY` from the local `.env` file, defeating the clearing. Test passed in CI (no `.env`) but failed locally.

**Fix:** patch `app.cli.load_dotenv` to a no-op in the test's with-block. Surgical — no production code change.

## Effect

```
$ python -m app.cli ticket-status WOR-NNN   # was:
Ticket: WOR-999 — (error fetching: 'LinearClient' object has no attribute 'get_issue')
State (Linear): Unknown (age: ?)

# now:
Ticket: WOR-999 — <actual title from Linear>
State (Linear): <actual state> (age: <actual age>)
...
```

## Test plan

- [x] `tests/test_cli_ticket_status.py` — previously-failing test passes both locally (with `.env` present) and in CI
- [x] `tests/test_linear_client.py` — three new tests cover `get_issue` happy path, missing-issue, API-error
- [x] Full suite: **1578 passed, 0 failed**
- [x] ruff, mypy (36 files), lint-imports, bandit all pass

Closes WOR-427
