### PR TITLE
Sonar quick wins: 7 findings + shallow-clone CI fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0  # full history for SonarCloud SCM auto-assignment
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/app/core/manifest_builder.py
+++ b/app/core/manifest_builder.py
@@ -9,6 +9,7 @@ write_manifest(path, manifest_dict)    -- write + validate to disk
 from __future__ import annotations
 
 import json
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
@@ -49,6 +50,21 @@ class TaxonomyFields:
         self.ac_specificity = ac_specificity
 
 
+@dataclass
+class ManifestOptions:
+    """Optional/defaulted kwargs for ``build_manifest`` (WOR-Sonar S107).
+
+    Bundles the rarely-set knobs so the main builder signature stays under
+    the 13-parameter Sonar threshold.
+    """
+
+    tech_stack: str = ""
+    raw_extensions: list[str] = field(default_factory=list)
+    forbidden_paths_extra: list[str] = field(default_factory=list)
+    risk_level: str = "low"
+    priority: int = 3
+
+
 class ManifestBuilder:
     """Builder for ExecutionManifest dicts."""
 
@@ -79,21 +95,14 @@ class ManifestBuilder:
         objective: str,
         acceptance_criteria: list[str],
         implementation_constraints: list[str],
-        tech_stack: str = "",
-        raw_extensions: list[str] | None = None,
-        forbidden_paths_extra: list[str] | None = None,
-        risk_level: str = "low",
-        priority: int = 3,
+        options: ManifestOptions | None = None,
     ) -> dict[str, Any]:
         """Return a dict matching ExecutionManifest schema."""
-        if raw_extensions is None:
-            raw_extensions = []
-        if forbidden_paths_extra is None:
-            forbidden_paths_extra = []
+        opts = options if options is not None else ManifestOptions()
 
         forbidden_paths = self._compute_forbidden_paths(
             allowed_paths,
-            forbidden_paths_extra,
+            opts.forbidden_paths_extra,
         )
         artifact_id = self._artifact_id(ticket_id)
 
@@ -102,12 +111,12 @@ class ManifestBuilder:
             "ticket_id": ticket_id,
             "epic_id": epic_id,
             "title": title,
-            "priority": priority,
+            "priority": opts.priority,
             "status": "ReadyForLocal",
             "linear_id": None,
             "blocked_by_tickets": [],
             "parallel_safe": True,
-            "risk_level": risk_level,
+            "risk_level": opts.risk_level,
             "risk_flags": [],
             "implementation_mode": "local",
             "effort": effort,
@@ -117,8 +126,8 @@ class ManifestBuilder:
             "scope_clarity": taxonomy.scope_clarity,
             "constraint_density": taxonomy.constraint_density,
             "ac_specificity": taxonomy.ac_specificity,
-            "tech_stack": tech_stack,
-            "raw_extensions": json.dumps(raw_extensions),
+            "tech_stack": opts.tech_stack,
+            "raw_extensions": json.dumps(opts.raw_extensions),
             "base_branch": "epic/wor-313-mega-overnight-hardening",
             "worker_branch": branch,
             "worktree_name": None,
@@ -162,11 +171,7 @@ def build_manifest(
     objective: str,
     acceptance_criteria: list[str],
     implementation_constraints: list[str],
-    tech_stack: str = "",
-    raw_extensions: list[str] | None = None,
-    forbidden_paths_extra: list[str] | None = None,
-    risk_level: str = "low",
-    priority: int = 3,
+    options: ManifestOptions | None = None,
 ) -> dict[str, Any]:
     """Convenience function -- delegates to a singleton builder."""
     return ManifestBuilder().build_manifest(
@@ -182,11 +187,7 @@ def build_manifest(
         objective=objective,
         acceptance_criteria=acceptance_criteria,
         implementation_constraints=implementation_constraints,
-        tech_stack=tech_stack,
-        raw_extensions=raw_extensions,
-        forbidden_paths_extra=forbidden_paths_extra,
-        risk_level=risk_level,
-        priority=priority,
+        options=options,
     )
 
 

--- a/app/core/watcher/dispatch.py
+++ b/app/core/watcher/dispatch.py
@@ -69,30 +69,30 @@ def start_ticket(
     # dispatch path and handled by the overlap check above.
     if manifest.base_branch.startswith("epic/"):
         for worker in _local_active:
-            if hasattr(worker, "manifest") and worker.manifest.base_branch.startswith(
-                "epic/"
+            if (
+                hasattr(worker, "manifest")
+                and worker.manifest.base_branch.startswith("epic/")
+                and worker.manifest.base_branch != manifest.base_branch
             ):
-                if worker.manifest.base_branch != manifest.base_branch:
-                    logger.warning(
-                        "Deferring %s — epic branch %s already in-flight "
-                        "(worker on %s)",
-                        ticket_id,
-                        manifest.base_branch,
-                        worker.manifest.base_branch,
-                    )
-                    linear.post_comment(
-                        linear_id,
-                        (
-                            f"Dispatch deferred: another worker is already "
-                            f"in-flight on epic branch "
-                            f"`{worker.manifest.base_branch}`. "
-                            f"Cannot dispatch to a new epic branch "
-                            f"`{manifest.base_branch}` until the in-flight "
-                            f"worker completes (one-active-epic-branch "
-                            f"principle, WOR-419)."
-                        ),
-                    )
-                    return
+                logger.warning(
+                    "Deferring %s — epic branch %s already in-flight (worker on %s)",
+                    ticket_id,
+                    manifest.base_branch,
+                    worker.manifest.base_branch,
+                )
+                linear.post_comment(
+                    linear_id,
+                    (
+                        f"Dispatch deferred: another worker is already "
+                        f"in-flight on epic branch "
+                        f"`{worker.manifest.base_branch}`. "
+                        f"Cannot dispatch to a new epic branch "
+                        f"`{manifest.base_branch}` until the in-flight "
+                        f"worker completes (one-active-epic-branch "
+                        f"principle, WOR-419)."
+                    ),
+                )
+                return
 
     # Manifest quality gates (WOR-378) — Pydantic validation accepts these as
     # legal but they are almost certainly authoring mistakes. Refuse early

--- a/app/core/watcher/watcher.py
+++ b/app/core/watcher/watcher.py
@@ -183,7 +183,7 @@ class Watcher:
 
     def run(self) -> None:
         """Start the poll loop. Blocks until SIGINT/SIGTERM."""
-        write_pid_file(self._repo_root)
+        write_pid_file()
         handler = make_signal_handler(self._services, self)
         signal.signal(signal.SIGINT, handler)
         if hasattr(signal, "SIGTERM"):
@@ -695,7 +695,7 @@ class Watcher:
         elapsed_str = format_elapsed(elapsed)
         log_path = (
             worker.worktree_path
-            / ".claude"
+            / _CLAUDE_DIR
             / "logs"
             / f"{worker.ticket_id.replace('-', '_')}.jsonl"
         )
@@ -758,7 +758,7 @@ class Watcher:
         for worker in (*self._local_active, *self._cloud_active):
             log_path = (
                 worker.worktree_path
-                / ".claude"
+                / _CLAUDE_DIR
                 / f"worker_{worker.ticket_id.lower()}.log"
             )
             try:
@@ -838,7 +838,7 @@ class Watcher:
             return
         if ready:
             return
-        artifacts = self._repo_root / ".claude" / "artifacts"
+        artifacts = self._repo_root / _CLAUDE_DIR / "artifacts"
         if artifacts.exists():
             for mp in artifacts.glob("manifest.json"):
                 try:

--- a/app/core/watcher/watcher_finalize.py
+++ b/app/core/watcher/watcher_finalize.py
@@ -542,7 +542,7 @@ def finalize_worker(
                         worker.ticket_id,
                         exc,
                     )
-    except (OSError, ValueError, json.JSONDecodeError) as exc:
+    except (OSError, ValueError) as exc:
         logger.warning(
             "Could not read result.json for improvement-log harvest: %s", exc
         )

--- a/app/core/watcher/watcher_signals.py
+++ b/app/core/watcher/watcher_signals.py
@@ -34,7 +34,6 @@ def _handle_signal_impl(
     services: Any,
     running_ref: Any,
     signum: int,
-    frame: Any,
 ) -> None:
     """Actual signal handler logic — called with (signum, frame) by the signal
     module. ``services`` and ``running_ref`` are captured by the closure in
@@ -49,9 +48,7 @@ def make_signal_handler(
     running_ref: object,
 ) -> Callable[[int, Any], None]:
     """Factory that creates a ``(signum, frame)`` handler bound to ``self``."""
-    return lambda signum, frame: _handle_signal_impl(
-        services, running_ref, signum, frame
-    )
+    return lambda signum, _frame: _handle_signal_impl(services, running_ref, signum)
 
 
 # ---------------------------------------------------------------------------
@@ -59,7 +56,7 @@ def make_signal_handler(
 # ---------------------------------------------------------------------------
 
 
-def write_pid_file(repo_root: Path) -> None:
+def write_pid_file() -> None:
     """Write the watcher PID to ``<repo>/.claude/watcher.pid``."""
     _PID_FILE.parent.mkdir(parents=True, exist_ok=True)
     _PID_FILE.write_text(str(os.getpid()), encoding="utf-8")

--- a/app/core/watcher/watcher_subprocess.py
+++ b/app/core/watcher/watcher_subprocess.py
@@ -398,7 +398,7 @@ def fetch_sonar_findings(branch: str) -> list[str] | None:
             with urllib.request.urlopen(  # nosec B310  # nosemgrep
                 req, timeout=10, context=ctx
             ) as resp:
-                all_severities, total, should_break = _parse_sonar_response(
+                all_severities, _total, should_break = _parse_sonar_response(
                     resp.read(), all_severities, page
                 )
             if should_break:

--- a/scripts/generate_overnight_manifests.py
+++ b/scripts/generate_overnight_manifests.py
@@ -22,6 +22,7 @@ except ImportError:  # pragma: no cover
     sys.exit(1)
 
 from app.core.manifest_builder import (  # noqa: E402
+    ManifestOptions,
     TaxonomyFields,
     build_manifest,
     write_manifest,
@@ -65,9 +66,11 @@ def main() -> int:
                 objective=t["objective"],
                 acceptance_criteria=t["acceptance_criteria"],
                 implementation_constraints=t["implementation_constraints"],
-                tech_stack=t["tech_stack"],
-                raw_extensions=t["raw_extensions"],
-                forbidden_paths_extra=t.get("forbidden_paths_extra", []),
+                options=ManifestOptions(
+                    tech_stack=t["tech_stack"],
+                    raw_extensions=t["raw_extensions"],
+                    forbidden_paths_extra=t.get("forbidden_paths_extra", []),
+                ),
             )
         except Exception as exc:  # noqa: BLE001
             failures.append(f"{ticket_id}: {exc}")

--- a/tests/test_manifest_builder.py
+++ b/tests/test_manifest_builder.py
@@ -18,6 +18,7 @@ import pytest
 
 from app.core.manifest import ExecutionManifest
 from app.core.manifest_builder import (
+    ManifestOptions,
     TaxonomyFields,
     build_manifest,
     write_manifest,
@@ -27,7 +28,28 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 
 
 def _minimal_kwargs(**overrides: object) -> dict[str, object]:
-    """Smallest valid build_manifest call; used by several tests."""
+    """Smallest valid build_manifest call; used by several tests.
+
+    ``options`` kwargs (tech_stack, raw_extensions, forbidden_paths_extra,
+    risk_level, priority) can be supplied via the special ``_options`` key
+    and will be folded into a ``ManifestOptions`` instance.
+    """
+    opt_kwargs: dict[str, object] = {
+        "tech_stack": "python",
+        "raw_extensions": [".py"],
+    }
+    # Lift any option-bound override from `overrides` into opt_kwargs so callers
+    # can keep their previous flat-kwarg ergonomics.
+    for key in (
+        "tech_stack",
+        "raw_extensions",
+        "forbidden_paths_extra",
+        "risk_level",
+        "priority",
+    ):
+        if key in overrides:
+            opt_kwargs[key] = overrides.pop(key)
+
     base: dict[str, object] = {
         "ticket_id": "WOR-999",
         "epic_id": "WOR-313",
@@ -46,8 +68,7 @@ def _minimal_kwargs(**overrides: object) -> dict[str, object]:
         "objective": "Test that build_manifest works.",
         "acceptance_criteria": ["AC 1", "AC 2"],
         "implementation_constraints": ["Do the thing"],
-        "tech_stack": "python",
-        "raw_extensions": [".py"],
+        "options": ManifestOptions(**opt_kwargs),  # type: ignore[arg-type]
     }
     base.update(overrides)
     return base

--- a/tests/test_watcher_types.py
+++ b/tests/test_watcher_types.py
@@ -50,7 +50,7 @@ def test_write_and_remove_pid_file(
     monkeypatch.setattr("app.core.watcher.watcher_types._PID_FILE", pid_file)
     monkeypatch.setattr("app.core.watcher.watcher_signals._PID_FILE", pid_file)
 
-    write_pid_file(tmp_path)
+    write_pid_file()
     assert pid_file.exists()
     assert pid_file.read_text(encoding="utf-8") == str(os.getpid())
 


### PR DESCRIPTION
## Summary

Bundle of SonarCloud quick-wins identified in the 2026-05-11 inventory sweep + the shallow-clone warning shown in the SonarCloud analysis dialog.

**CI hygiene:**
- `.github/workflows/ci.yml` — `actions/checkout` now uses `fetch-depth: 0` so SonarCloud has full git history. Eliminates the "Shallow clone detected" warning and unblocks SCM-based auto-assignment of issues.

**Sonar code smells fixed (7 findings):**

| Rule | File:Line | Fix |
|---|---|---|
| S1172 | `watcher_signals.py:33` | Drop unused `frame` param from `_handle_signal_impl`; lambda still matches signal-API `(signum, frame)` but discards frame |
| S1172 | `watcher_signals.py:62` | Drop unused `repo_root` param from `write_pid_file` (`_PID_FILE` is module-level) |
| S1481 | `watcher_subprocess.py:401` | Rename unused `total` to `_total` |
| S1066 | `dispatch.py:72-76` | Merge nested ifs into single compound condition |
| S1192 | `watcher.py:698,761,841` | Use existing `_CLAUDE_DIR` constant instead of `".claude"` literal x3 |
| S5713 | `watcher_finalize.py:545` | Remove redundant `json.JSONDecodeError` from except tuple (subclass of `ValueError`) |
| S107 | `manifest_builder.py:67,151` | Bundle 5 optional kwargs into new `ManifestOptions` dataclass; 17 → 13 params (at Sonar threshold) |

The `ManifestOptions` refactor reduces `build_manifest`'s 17-param signature down to 13 by extracting `tech_stack`, `raw_extensions`, `forbidden_paths_extra`, `risk_level`, `priority` into a dataclass:

```python
build_manifest(
    ticket_id=..., epic_id=..., branch=..., title=...,
    allowed_paths=..., related_files_hint=..., effort=..., change_type=...,
    taxonomy=...,
    objective=..., acceptance_criteria=..., implementation_constraints=...,
    options=ManifestOptions(tech_stack="python", raw_extensions=[".py"]),
)
```

The **WOR-313 round-trip regression test** verifies the refactor produces byte-identical manifests — confirms zero behavior change.

## Caller updates

- `scripts/generate_overnight_manifests.py` — pass `ManifestOptions(...)` instead of individual kwargs
- `tests/test_manifest_builder.py` — `_minimal_kwargs` helper folds caller-side opt-kwargs into a `ManifestOptions` instance
- `tests/test_watcher_types.py` — drop `tmp_path` arg from `write_pid_file()` call

## Test plan

- [x] **1578 passed, 0 failed** (full pytest)
- [x] ruff, ruff format, mypy (36 files), lint-imports, bandit all pass
- [x] WOR-313 byte-identical round-trip test passes (validates ManifestOptions refactor)

## Out of scope (filed later)

- 22 remaining cognitive-complexity findings (S3776) — separate epic to be filed; each is its own bounded ticket
- `watcher_finalize.py` ↔ `watcher_finalize_helpers.py` architectural tangle surfaced in the SonarCloud Architecture view — separate refactor ticket
