### PR TITLE
Break watcher_finalize tangle via DI + importlinter contract

### DIFF
--- a/.importlinter
+++ b/.importlinter
@@ -78,3 +78,18 @@ source_modules =
     app.core.watcher.watcher_types
 forbidden_modules =
     app.core.bench_store
+
+[importlinter:contract:finalize-helpers-below-finalize]
+name = watcher_finalize_helpers must not import watcher_finalize (no tangle)
+type = forbidden
+# watcher_finalize_helpers contains internal helpers extracted from
+# watcher_finalize.py. By definition it sits BELOW finalize in the layer
+# graph — if it imports back into finalize, we get a cycle that has to be
+# worked around with lazy in-function imports (SonarCloud's Architecture
+# view flagged exactly this on 2026-05-11).
+# Inject dependencies via callback parameters instead.
+# CONTRACT OWNER: cloud LLM only — do not modify without explicit approval.
+source_modules =
+    app.core.watcher.watcher_finalize_helpers
+forbidden_modules =
+    app.core.watcher.watcher_finalize

--- a/app/core/watcher/watcher_finalize.py
+++ b/app/core/watcher/watcher_finalize.py
@@ -248,6 +248,7 @@ def finalize_worker(
                 linear,
                 escalation_policy,
                 repo_root,
+                attempt_pr,
                 tracked_prs=tracked_prs,
                 metrics=metrics,
                 project_id=project_id,

--- a/app/core/watcher/watcher_finalize_helpers.py
+++ b/app/core/watcher/watcher_finalize_helpers.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import json
 import logging
 from pathlib import Path
+from typing import Callable
 
 from app.core.escalation_policy import EscalationPolicy
 from app.core.linear_client import LinearError
@@ -33,6 +34,11 @@ from app.core.watcher.watcher_worktrees import (
     preserve_worker_artifacts,
     squash_wip_commits,
 )
+
+# WOR-Sonar-tangle: callback type for `attempt_pr` injected by watcher_finalize.
+# Using Callable[..., ...] (not a Protocol) keeps the type loose enough to accept
+# the existing function without forcing a public-API change.
+AttemptPrFn = Callable[..., "tuple[Outcome, str | None]"]
 
 logger = logging.getLogger(__name__)
 
@@ -85,6 +91,7 @@ def _execute_finalization(
     linear: LinearClientProtocol,
     escalation_policy: EscalationPolicy,
     repo_root: Path,
+    attempt_pr_fn: AttemptPrFn,
     tracked_prs: list[TrackedPR] | None = None,
     metrics: MetricsStore | None = None,
     project_id: str = "",
@@ -179,6 +186,7 @@ def _execute_finalization(
         worker,
         linear,
         escalation_policy,
+        attempt_pr_fn,
         manifest.objective,
         tracked_prs=tracked_prs,
     )
@@ -191,6 +199,7 @@ def _handle_policy_outcome(
     worker: ActiveWorker,
     linear: LinearClientProtocol,
     escalation_policy: EscalationPolicy,
+    attempt_pr_fn: AttemptPrFn,
     final_message: str = "Implementation complete",
     tracked_prs: list[TrackedPR] | None = None,
 ) -> tuple[Outcome, bool, list[str] | None, str | None]:
@@ -250,9 +259,7 @@ def _handle_policy_outcome(
         final_message,
     )
 
-    from .watcher_finalize import attempt_pr
-
-    outcome, pr_url = attempt_pr(manifest, worker, linear, tracked_prs=tracked_prs)
+    outcome, pr_url = attempt_pr_fn(manifest, worker, linear, tracked_prs=tracked_prs)
     if outcome == "success":
         if manifest.base_branch == "main":
             safe_set_state(linear, linear_id, "In Review", ticket_id)

--- a/tests/test_watcher_finalize_helpers.py
+++ b/tests/test_watcher_finalize_helpers.py
@@ -105,7 +105,7 @@ def test_execute_finalization_nonzero_returncode_returns_failure(
     )
 
     outcome, escalated, preserved, findings, _, _ = _execute_finalization(
-        worker, 1, linear_mock, EscalationPolicy.from_toml(), tmp_path
+        worker, 1, linear_mock, EscalationPolicy.from_toml(), tmp_path, MagicMock()
     )
 
     assert outcome == "failure"
@@ -136,7 +136,7 @@ def test_execute_finalization_check_failure_abort_returns_failure(
         return_value=(False, []),
     ):
         outcome, escalated, preserved, findings, _, _ = _execute_finalization(
-            worker, 0, linear_mock, EscalationPolicy.from_toml(), tmp_path
+            worker, 0, linear_mock, EscalationPolicy.from_toml(), tmp_path, MagicMock()
         )
 
     assert outcome == "failure"
@@ -172,7 +172,7 @@ def test_execute_finalization_check_failure_escalates_to_cloud(tmp_path: Path) -
         patch("app.core.watcher.watcher_worktrees.cleanup_worktree"),
     ):
         _execute_finalization(
-            worker, 0, linear_mock, EscalationPolicy.from_toml(), tmp_path
+            worker, 0, linear_mock, EscalationPolicy.from_toml(), tmp_path, MagicMock()
         )
 
     linear_mock.set_state.assert_called_with("fake-linear-id", "In Progress")
@@ -202,7 +202,7 @@ def test_execute_finalization_check_failure_blocked_when_no_escalate(
         patch("app.core.watcher.watcher_worktrees.cleanup_worktree"),
     ):
         _execute_finalization(
-            worker, 0, linear_mock, EscalationPolicy.from_toml(), tmp_path
+            worker, 0, linear_mock, EscalationPolicy.from_toml(), tmp_path, MagicMock()
         )
 
     linear_mock.set_state.assert_called_with("fake-linear-id", "Blocked")
@@ -224,7 +224,7 @@ def test_execute_finalization_nonzero_exit_escalates_to_cloud(tmp_path: Path) ->
     )
     with patch("app.core.watcher.watcher_worktrees.cleanup_worktree"):
         _execute_finalization(
-            worker, 1, linear_mock, EscalationPolicy.from_toml(), tmp_path
+            worker, 1, linear_mock, EscalationPolicy.from_toml(), tmp_path, MagicMock()
         )
 
     linear_mock.set_state.assert_called_with("fake-linear-id", "In Progress")
@@ -256,6 +256,7 @@ def test_handle_policy_outcome_escalate_returns_escalated(
         worker,
         linear_mock,
         EscalationPolicy.from_toml(),
+        MagicMock(),
     )
 
     assert outcome == "escalated"
@@ -282,6 +283,7 @@ def test_handle_policy_outcome_human_returns_aborted(tmp_path: Path) -> None:
         worker,
         linear_mock,
         EscalationPolicy.from_toml(),
+        MagicMock(),
     )
 
     assert outcome == "aborted"


### PR DESCRIPTION
## Summary

Fixes the `watcher_finalize.py ↔ watcher_finalize_helpers.py` architectural tangle surfaced in the SonarCloud Architecture view on 2026-05-11.

**Before:**
```
watcher_finalize.py:25            from .watcher_finalize_helpers import ...    (module-load)
watcher_finalize_helpers.py:253   from .watcher_finalize import attempt_pr     (lazy, in-function)
```

The lazy in-function import was the classic workaround for the cycle — `_handle_policy_outcome` (in helpers, below) needs `attempt_pr` (in finalize, above) at the end of the `fix_locally` path.

**Fix:** dependency injection. Pass `attempt_pr` as a callback parameter through `_execute_finalization` → `_handle_policy_outcome`. The cycle is gone.

## Changes

- `watcher_finalize_helpers.py`
  - New `AttemptPrFn = Callable[..., tuple[Outcome, str | None]]` type alias
  - `_execute_finalization` and `_handle_policy_outcome` gain an `attempt_pr_fn` parameter
  - The lazy `from .watcher_finalize import attempt_pr` is deleted
- `watcher_finalize.py`
  - `_execute_finalization(...)` call site passes `attempt_pr` as the new positional arg
- `tests/test_watcher_finalize_helpers.py`
  - 6 call sites updated to pass `MagicMock()` for the new param

## Architecture contract — prevent future tangles

`.importlinter` gains a sixth contract:

```ini
[importlinter:contract:finalize-helpers-below-finalize]
name = watcher_finalize_helpers must not import watcher_finalize (no tangle)
type = forbidden
source_modules =
    app.core.watcher.watcher_finalize_helpers
forbidden_modules =
    app.core.watcher.watcher_finalize
```

If anyone re-introduces the cycle (or a similar one with lazy imports), `lint-imports` catches it at CI rather than SonarCloud noticing days later.

## Test plan

- [x] Full pytest: **1578 passed, 0 failed**
- [x] `lint-imports`: **6 contracts kept, 0 broken** (new contract included)
- [x] ruff, mypy, lint-imports, bandit all pass
