### PR TITLE
Extend watcher-layers contract to enforce full 16-module stack

### DIFF
--- a/.importlinter
+++ b/.importlinter
@@ -29,20 +29,30 @@ forbidden_modules =
 [importlinter:contract:watcher-layers]
 name = watcher sub-modules form a strict dependency layer
 type = layers
-# watcher (orchestrator) imports all sub-modules.
-# watcher_finalize sits between watcher and the subprocess/worktrees/services tier
-# because it imports from all three of those modules.
-# watcher_subprocess, watcher_worktrees, watcher_services may import from
-# watcher_types and watcher_helpers — not from each other or from watcher.
-# watcher_helpers may import from watcher_types only.
-# watcher_types is a leaf: imports nothing from watcher siblings.
+# Layered dependency stack for the watcher subpackage (16 modules).
+# Higher layers may import from lower layers; siblings at the same level
+# (separated by `:`) are independent — they may NOT import each other.
+# Verified against the actual import graph on 2026-05-11; structure prevents
+# tangles like the watcher_finalize ↔ watcher_finalize_helpers cycle that
+# SonarCloud's Architecture view flagged.
+#
+# Layer rationale:
+#  6 (top): entry points — imported only externally, not by any sibling.
+#  5: the single orchestration chokepoint (watcher_finalize).
+#  4: internal helpers extracted from L6/L5 modules to keep file sizes small.
+#  3: side-effect services (subprocess, git worktrees, vLLM lifecycle).
+#  2: pure utility functions consumed by L3+.
+#  1: leaves — types, parsers, TUI primitives, log formatting. Import nothing
+#     from siblings.
+#
 # CONTRACT OWNER: cloud LLM only — do not modify without explicit approval.
 layers =
-    app.core.watcher.watcher
+    app.core.watcher.watcher : app.core.watcher.dispatch : app.core.watcher.ticket_status
     app.core.watcher.watcher_finalize
+    app.core.watcher.watcher_finalize_helpers : app.core.watcher.watcher_heartbeat : app.core.watcher.watcher_signals
     app.core.watcher.watcher_subprocess : app.core.watcher.watcher_worktrees : app.core.watcher.watcher_services
     app.core.watcher.watcher_helpers
-    app.core.watcher.watcher_types
+    app.core.watcher.watcher_types : app.core.watcher.watcher_log_parsing : app.core.watcher.watcher_tui : app.core.watcher.worker_waste : app.core.watcher.log_format
 
 [importlinter:contract:watcher-types-is-leaf]
 name = watcher_types must not import from sibling watcher modules


### PR DESCRIPTION
## Summary

Surveyed the actual import graph in `app/core/watcher/` on 2026-05-11 and codified it as a 6-layer `layers` contract.

The previous `watcher-layers` contract knew about **6 of the 16** watcher modules. The newer modules (`watcher_finalize_helpers`, `watcher_heartbeat`, `watcher_signals`, `watcher_log_parsing`, `watcher_tui`, `worker_waste`, `dispatch`, `ticket_status`, `log_format`) had no architectural rule constraining them — which is exactly how the `watcher_finalize ↔ watcher_finalize_helpers` tangle slipped past lint-imports until SonarCloud's Architecture view flagged it.

## The 6 layers (top → bottom)

| Layer | Modules | Rationale |
|---|---|---|
| 6 (entry points) | `watcher`, `dispatch`, `ticket_status` | Imported only externally; no sibling imports them |
| 5 (orchestration) | `watcher_finalize` | The single chokepoint between entry points and services |
| 4 (internal helpers) | `watcher_finalize_helpers`, `watcher_heartbeat`, `watcher_signals` | Private companions of L5/L6 modules; isolated from each other |
| 3 (services) | `watcher_subprocess`, `watcher_worktrees`, `watcher_services` | Side-effect modules: workers, git, vLLM lifecycle |
| 2 (utilities) | `watcher_helpers` | Pure stateless functions consumed by L3+ |
| 1 (leaves) | `watcher_types`, `watcher_log_parsing`, `watcher_tui`, `worker_waste`, `log_format` | Import no siblings |

Modules at the same level (`:` separator in the config) are **independent — they may NOT import each other**. Higher layers may import from any lower layer.

## What this enforces

- Any new tangle between the 16 watcher modules fails at `lint-imports` in CI, not when SonarCloud's Architecture view re-discovers it days later
- `dispatch` cannot grow a coupling to `watcher` (or vice versa) — they're peer entry points
- The three Layer 4 helpers stay isolated from each other (`watcher_signals` can't sneak in a call to `watcher_finalize_helpers`)
- The three Layer 3 services stay peers (subprocess can't depend on worktrees or vice versa)

## Redundancy with PR #884

The `finalize-helpers-below-finalize` contract added in PR #884 is now subsumed by this layered contract — L4 → L5 imports are impossible by construction. **Keeping it as belt-and-suspenders** rather than removing in this PR; can be removed in a future cleanup if desired.

## Test plan

- [x] `lint-imports`: **6 contracts kept, 0 broken** — the codebase already conforms to the proposed structure (no code changes needed)
- [x] Full pytest: **1578 passed, 0 failed**
- [x] All pre-commit hooks pass

## Note for reviewers

This is an architecture decision per the `CONTRACT OWNER: cloud LLM only` notes in `.importlinter`. The structure was derived from an actual import-graph analysis (not invention) — the survey output is in the commit message's first paragraph.
