### PR TITLE
WOR-431: Reconcile Watcher._start_ticket with dispatch.start_ticket

### DIFF
--- a/app/core/watcher/dispatch.py
+++ b/app/core/watcher/dispatch.py
@@ -11,11 +11,13 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 
+from app.core.linear_client import DONE_STATE_TYPES
 from app.core.manifest import ExecutionManifest
 
 from .watcher_finalize import safe_set_state
 from .watcher_helpers import (
     capture_vllm_metrics,
+    check_allowed_paths_overlap,
     count_main_ahead_of_epic,
     resolve_effective_mode,
     suppress_dedup,
@@ -55,9 +57,23 @@ def start_ticket(
     _escalation_policy: object,
     _dedup_state: dict[str, str],
 ) -> None:
-    """Execute the full ticket-start flow extracted from Watcher._start_ticket."""
-    # Prerequisite checks (open_blockers + overlap) are handled by
-    # Watcher._start_ticket before calling this function.
+    """Run the full ticket-start flow (WOR-431: prereqs + dispatch)."""
+    # Prerequisite checks (WOR-431: moved here from Watcher._start_ticket
+    # so dispatch.start_ticket is fully self-contained).
+    open_blockers = linear.get_open_blockers(linear_id)
+    if open_blockers:
+        logger.info("Skipping %s - open blockers: %s", ticket_id, open_blockers)
+        return
+    for blocker_id in manifest.blocked_by_tickets:
+        state_type = linear.get_issue_state_type(blocker_id)
+        if state_type not in DONE_STATE_TYPES:
+            logger.info(
+                "Skipping %s - manifest declares unmerged blocker %s (state=%s)",
+                ticket_id,
+                blocker_id,
+                state_type,
+            )
+            return
 
     # WOR-419: defense-in-depth — refuse to spawn a worker on a new epic/*
     # branch when another epic/* branch is already in flight. This prevents
@@ -155,6 +171,21 @@ def start_ticket(
                 f"  git push"
             ),
         )
+        return
+
+    # WOR-431: path-overlap check (was in Watcher._start_ticket pre-#886).
+    # Runs AFTER the WOR-419 epic-branch gate, WOR-378 manifest gates,
+    # and WOR-373 stale-epic check to preserve original ordering.
+    all_active = _local_active + _cloud_active
+    conflicts = check_allowed_paths_overlap(all_active, manifest)
+    if conflicts:
+        reason = f"overlap:{','.join(conflicts)}"
+        reason_msg = "Deferring %s - allowed_paths overlap with active workers: %s" % (
+            ticket_id,
+            conflicts,
+        )
+        if suppress_dedup(ticket_id, reason, reason_msg, _dedup_state):
+            logger.info(reason_msg)
         return
 
     effective_mode = resolve_effective_mode(

--- a/app/core/watcher/watcher.py
+++ b/app/core/watcher/watcher.py
@@ -29,14 +29,10 @@ from app.core.linear_client import DONE_STATE_TYPES
 from app.core.manifest import ExecutionManifest
 from app.core.metrics import MetricsStore
 
+from . import dispatch
 from .watcher_epic import check_epic_completion
 from .watcher_finalize import finalize_worker, safe_set_state
 from .watcher_heartbeat import build_tui_state, emit_heartbeat, emit_idle_line
-from .watcher_helpers import (
-    check_allowed_paths_overlap,
-    resolve_effective_mode,
-    suppress_dedup,
-)
 from .watcher_log_parsing import format_elapsed, format_worker_token_count
 from .watcher_services import ServiceManager
 from .watcher_signals import (
@@ -51,7 +47,6 @@ from .watcher_signals import (
     wait_for_active_workers,
     write_pid_file,
 )
-from .watcher_subprocess import launch_worker
 from .watcher_tui import TrackedPR, WatcherDisplay
 from .watcher_types import (
     _ARTIFACTS_DIR,
@@ -60,11 +55,7 @@ from .watcher_types import (
     LinearClientProtocol,
 )
 from .watcher_worktrees import (
-    backup_plan_files,
     cleanup_worktree,
-    copy_manifest_to_worktree,
-    create_worktree,
-    write_worker_pytest_config,
 )
 
 logger = logging.getLogger(__name__)
@@ -131,6 +122,9 @@ class Watcher:
         self._processed_tickets: list[_ProcessedTicket] = []
         self._running = True
         self._services = ServiceManager(self._repo_root)
+        # WOR-431: dispatch.start_ticket reads services._mode for
+        # effective_mode resolution. Forward the watcher's mode.
+        self._services._mode = worker_mode  # type: ignore[attr-defined]
         self._worker_verbose = worker_verbose
         self._escalation_policy = EscalationPolicy.from_toml()
         self._no_epic_shutdown = no_epic_shutdown
@@ -474,182 +468,31 @@ class Watcher:
             except Exception as exc:
                 logger.error("Failed to start %s: %s", ticket_id, exc)
 
-    def _has_open_blockers(
-        self, ticket_id: str, linear_id: str, manifest: ExecutionManifest
-    ) -> bool:
-        """Return True if ticket has open blockers (Linear or manifest)."""
-        open_blockers = self._linear.get_open_blockers(linear_id)
-        if open_blockers:
-            logger.info("Skipping %s - open blockers: %s", ticket_id, open_blockers)
-            return True
-        for blocker_id in manifest.blocked_by_tickets:
-            state_type = self._linear.get_issue_state_type(blocker_id)
-            if state_type not in DONE_STATE_TYPES:
-                logger.info(
-                    "Skipping %s - manifest declares unmerged blocker %s (state=%s)",
-                    ticket_id,
-                    blocker_id,
-                    state_type,
-                )
-                return True
-        return False
-
-    def _epic_branch_in_use(
-        self, ticket_id: str, linear_id: str, manifest: ExecutionManifest
-    ) -> bool:
-        """WOR-419: defer if another epic/* branch is already in flight."""
-        if not manifest.base_branch.startswith("epic/"):
-            return False
-        for worker in self._local_active:
-            if not hasattr(worker, "manifest"):
-                continue
-            if not worker.manifest.base_branch.startswith("epic/"):
-                continue
-            if worker.manifest.base_branch == manifest.base_branch:
-                continue
-            logger.warning(
-                "Deferring %s - epic branch %s already in-flight (worker on %s)",
-                ticket_id,
-                manifest.base_branch,
-                worker.manifest.base_branch,
-            )
-            try:
-                self._linear.post_comment(
-                    linear_id,
-                    (
-                        f"Dispatch deferred: another worker is already "
-                        f"in-flight on epic branch "
-                        f"`{worker.manifest.base_branch}`. "
-                        f"Cannot dispatch to a new epic branch "
-                        f"`{manifest.base_branch}` until the in-flight "
-                        f"worker completes (one-active-epic-branch "
-                        f"principle, WOR-419)."
-                    ),
-                )
-            except Exception as exc:
-                logger.warning(
-                    "Could not post epic-branch conflict comment for %s: %s",
-                    ticket_id,
-                    exc,
-                )
-            return True
-        return False
-
-    def _has_path_overlap(self, ticket_id: str, manifest: ExecutionManifest) -> bool:
-        """Return True if allowed_paths overlap with any active worker's."""
-        all_active = self._local_active + self._cloud_active
-        conflicts = check_allowed_paths_overlap(all_active, manifest)
-        if not conflicts:
-            return False
-        reason = f"overlap:{','.join(conflicts)}"
-        reason_msg = "Deferring %s - allowed_paths overlap with active workers: %s" % (
-            ticket_id,
-            conflicts,
-        )
-        if suppress_dedup(ticket_id, reason, reason_msg, self._last_deferral_state):
-            logger.info(reason_msg)
-        return True
-
-    def _pool_full_for_mode(self, ticket_id: str, effective_mode: str) -> bool:
-        """Return True if the pool for `effective_mode` has no capacity."""
-        if effective_mode == "local":
-            if len(self._local_active) >= self._max_local_workers:
-                reason_msg = "Deferring %s - local pool full (%d/%d)" % (
-                    ticket_id,
-                    len(self._local_active),
-                    self._max_local_workers,
-                )
-                if suppress_dedup(
-                    ticket_id, "local_pool_full", reason_msg, self._last_deferral_state
-                ):
-                    logger.info(reason_msg)
-                return True
-            return False
-        if len(self._cloud_active) >= self._max_cloud_workers:
-            reason_msg = "Deferring %s - cloud pool full (%d/%d)" % (
-                ticket_id,
-                len(self._cloud_active),
-                self._max_cloud_workers,
-            )
-            if suppress_dedup(
-                ticket_id, "cloud_pool_full", reason_msg, self._last_deferral_state
-            ):
-                logger.info(reason_msg)
-            return True
-        return False
-
-    def _vllm_not_ready(self, ticket_id: str) -> bool:
-        """Return True if local mode is selected but vLLM isn't reachable."""
-        if not self._services.probe_vllm_health():
-            reason_msg = "Deferring %s - vLLM not ready yet" % ticket_id
-            if suppress_dedup(
-                ticket_id, "vllm_not_ready", reason_msg, self._last_deferral_state
-            ):
-                logger.warning(reason_msg)
-            return True
-        self._services.ensure_vllm_anthropic_mode()
-        return False
-
-    def _spawn_worker(
-        self,
-        ticket_id: str,
-        linear_id: str,
-        manifest: ExecutionManifest,
-        effective_mode: str,
-    ) -> None:
-        """Create the worktree, launch the worker process, and append to pool."""
-        worktree_path = create_worktree(self._repo_root, manifest)
-        copy_manifest_to_worktree(self._repo_root, manifest, worktree_path)
-        write_worker_pytest_config(worktree_path)
-        safe_set_state(
-            self._linear,
-            linear_id,
-            manifest.ticket_state_map.in_progress_local,
-            ticket_id,
-        )
-        logger.info("Starting worker for %s - mode=%s", ticket_id, effective_mode)
-        backed_up_plans = backup_plan_files()
-        process = launch_worker(
-            self._repo_root,
-            manifest,
-            worktree_path,
-            effective_mode,
-            self._worker_verbose,
-        )
-        worker = ActiveWorker(
-            ticket_id=ticket_id,
-            linear_id=linear_id,
-            manifest=manifest,
-            worktree_path=worktree_path,
-            process=process,
-            backed_up_plans=backed_up_plans,
-        )
-        if effective_mode == "local":
-            self._local_active.append(worker)
-        else:
-            self._cloud_active.append(worker)
-
     def _start_ticket(self, ticket_id: str, linear_id: str) -> None:
-        """Dispatch a ticket: run all guards, then spawn the worker."""
+        """Load + enrich the manifest, then delegate to dispatch.start_ticket.
+
+        WOR-431: All dispatch logic (prereq checks, epic-branch gate, manifest
+        quality gates, stale-epic refusal, pool/vLLM readiness, worker spawn)
+        lives in dispatch.start_ticket. This wrapper handles the watcher-side
+        manifest loading + retry-context enrichment that dispatch can't do.
+        """
         manifest = self._load_manifest(ticket_id)
         manifest = self._enrich_with_retry_context(manifest)
-
-        if self._has_open_blockers(ticket_id, linear_id, manifest):
-            return
-        if self._epic_branch_in_use(ticket_id, linear_id, manifest):
-            return
-        if self._has_path_overlap(ticket_id, manifest):
-            return
-
-        effective_mode = resolve_effective_mode(
-            self._mode, manifest.implementation_mode
+        dispatch.start_ticket(
+            manifest=manifest,
+            linear=self._linear,
+            services=self._services,
+            worker_verbose=self._worker_verbose,
+            _local_active=self._local_active,
+            _cloud_active=self._cloud_active,
+            max_cloud_workers=self._max_cloud_workers,
+            _repo_root=self._repo_root,
+            _processed_tickets=self._processed_tickets,  # type: ignore[arg-type]
+            linear_id=linear_id,
+            ticket_id=ticket_id,
+            _escalation_policy=self._escalation_policy,
+            _dedup_state=self._last_deferral_state,
         )
-        if self._pool_full_for_mode(ticket_id, effective_mode):
-            return
-        if effective_mode == "local" and self._vllm_not_ready(ticket_id):
-            return
-
-        self._spawn_worker(ticket_id, linear_id, manifest, effective_mode)
 
     # ------------------------------------------------------------------
     # Worker lifecycle

--- a/tests/test_vllm_metrics_capture.py
+++ b/tests/test_vllm_metrics_capture.py
@@ -189,6 +189,8 @@ def test_dispatch_captures_vllm_snapshot_when_solo(tmp_path: Path) -> None:
         base_branch="main",
     )
     linear = MagicMock()
+
+    linear.get_open_blockers.return_value = []
     services = _services()
     local_active: list = []
     cloud_active: list = []
@@ -242,8 +244,12 @@ def test_dispatch_invalidates_solo_peer_when_second_worker_launches(
     from app.core.watcher.watcher_types import ActiveWorker
     from tests.conftest import make_manifest
 
-    # Pre-existing solo worker in the pool
-    solo_manifest = make_manifest(ticket_id="WOR-1")
+    # Pre-existing solo worker in the pool. WOR-431: dispatch.start_ticket now
+    # does path-overlap checking; use distinct allowed_paths so the second
+    # dispatch doesn't defer on overlap before reaching solo-peer invalidation.
+    solo_manifest = make_manifest(
+        ticket_id="WOR-1", allowed_paths=["app/core/solo_file.py"]
+    )
     solo_worker = ActiveWorker(
         ticket_id="WOR-1",
         linear_id="linear-1",
@@ -257,9 +263,14 @@ def test_dispatch_invalidates_solo_peer_when_second_worker_launches(
     cloud_active: list = []
 
     new_manifest = make_manifest(
-        ticket_id="WOR-2", base_branch="main", worker_branch="wor-2"
+        ticket_id="WOR-2",
+        base_branch="main",
+        worker_branch="wor-2",
+        allowed_paths=["app/core/peer_file.py"],
     )
     linear = MagicMock()
+
+    linear.get_open_blockers.return_value = []
     services = _services()
 
     with (
@@ -313,6 +324,8 @@ def test_dispatch_skips_snapshot_when_metrics_endpoint_unreachable(
 
     manifest = make_manifest(implementation_mode="local", base_branch="main")
     linear = MagicMock()
+
+    linear.get_open_blockers.return_value = []
     services = _services()
     local_active: list = []
     cloud_active: list = []

--- a/tests/test_watcher_dispatch.py
+++ b/tests/test_watcher_dispatch.py
@@ -46,6 +46,8 @@ def test_start_ticket_local_happy_path_appends_to_local_active(tmp_path: Path) -
     """Local-mode dispatch: worktree created, worker launched, appended to local."""
     manifest = make_manifest(implementation_mode="local")
     linear = MagicMock()
+
+    linear.get_open_blockers.return_value = []
     services = _services()
     local_active: list = []
     cloud_active: list = []
@@ -87,6 +89,8 @@ def test_start_ticket_cloud_happy_path_appends_to_cloud_active(tmp_path: Path) -
     """Cloud-mode dispatch: launches without vLLM probe, appends to cloud_active."""
     manifest = make_manifest(implementation_mode="cloud")
     linear = MagicMock()
+
+    linear.get_open_blockers.return_value = []
     services = _services()
     local_active: list = []
     cloud_active: list = []
@@ -130,6 +134,8 @@ def test_start_ticket_defers_when_vllm_not_ready(
     """Local dispatch with vLLM unhealthy → defers, logs warning, no worktree."""
     manifest = make_manifest(implementation_mode="local")
     linear = MagicMock()
+
+    linear.get_open_blockers.return_value = []
     services = _services(vllm_healthy=False)
     local_active: list = []
     cloud_active: list = []
@@ -165,6 +171,8 @@ def test_start_ticket_defers_when_cloud_pool_full(
     """Cloud-mode dispatch with cloud_active at capacity → defers without launching."""
     manifest = make_manifest(implementation_mode="cloud")
     linear = MagicMock()
+
+    linear.get_open_blockers.return_value = []
     services = _services()
     # Cloud pool already at max
     cloud_active: list = [MagicMock(), MagicMock(), MagicMock()]
@@ -206,6 +214,8 @@ def test_start_ticket_refuses_local_manifest_with_empty_allowed_paths(
     """Local-mode manifest with allowed_paths=[] is refused, ticket sent to Backlog."""
     manifest = make_manifest(implementation_mode="local", allowed_paths=[])
     linear = MagicMock()
+
+    linear.get_open_blockers.return_value = []
     services = _services()
     local_active: list = []
     cloud_active: list = []
@@ -249,6 +259,8 @@ def test_start_ticket_refuses_manifest_with_empty_required_checks(
     """Manifest with required_checks=[] is refused regardless of mode."""
     manifest = make_manifest(implementation_mode="cloud", required_checks=[])
     linear = MagicMock()
+
+    linear.get_open_blockers.return_value = []
     services = _services()
     local_active: list = []
     cloud_active: list = []
@@ -300,6 +312,8 @@ def test_start_ticket_refuses_when_epic_too_far_behind_main(
         base_branch="epic/wor-100-stale",
     )
     linear = MagicMock()
+
+    linear.get_open_blockers.return_value = []
     services = _services()
     local_active: list = []
     cloud_active: list = []
@@ -351,6 +365,8 @@ def test_start_ticket_proceeds_when_epic_within_threshold(
         base_branch="epic/wor-100-fresh",
     )
     linear = MagicMock()
+
+    linear.get_open_blockers.return_value = []
     services = _services()
     local_active: list = []
     cloud_active: list = []
@@ -403,6 +419,8 @@ def test_start_ticket_does_not_refuse_main_target(
         base_branch="main",
     )
     linear = MagicMock()
+
+    linear.get_open_blockers.return_value = []
     services = _services()
     local_active: list = []
     cloud_active: list = []
@@ -456,6 +474,8 @@ def test_start_ticket_vllm_not_ready_dedup_logs_warning_once(
     """Two consecutive vLLM-not-ready deferrals log the warning only once."""
     manifest = make_manifest(implementation_mode="local")
     linear = MagicMock()
+
+    linear.get_open_blockers.return_value = []
     services = _services(vllm_healthy=False)
     local_active: list = []
     cloud_active: list = []
@@ -530,6 +550,8 @@ def test_start_ticket_defers_when_another_epic_branch_already_in_flight(
         )
     ]
     linear = MagicMock()
+
+    linear.get_open_blockers.return_value = []
     services = _services()
     cloud_active: list = []
 
@@ -568,15 +590,20 @@ def test_start_ticket_proceeds_for_same_epic_branch(
     tmp_path: Path,
 ) -> None:
     """Dispatch within the SAME epic branch is unaffected — normal dispatch path."""
+    # WOR-431: dispatch.start_ticket now does path-overlap checking. Use
+    # distinct allowed_paths so the existing-worker fixture doesn't cause
+    # an unrelated overlap deferral.
     epic_manifest = make_manifest(
         implementation_mode="local",
         base_branch="epic/wor-335-active",
+        allowed_paths=["app/core/new_file.py"],
     )
     from app.core.watcher.watcher_types import ActiveWorker
 
     existing_worker_manifest = make_manifest(
         implementation_mode="local",
         base_branch="epic/wor-335-active",
+        allowed_paths=["app/core/other_file.py"],
     )
     local_active: list[ActiveWorker] = [
         ActiveWorker(
@@ -588,6 +615,8 @@ def test_start_ticket_proceeds_for_same_epic_branch(
         )
     ]
     linear = MagicMock()
+
+    linear.get_open_blockers.return_value = []
     services = _services()
     cloud_active: list = []
 
@@ -633,6 +662,8 @@ def test_start_ticket_unaffected_when_no_epic_workers_active(
     local_active: list = []  # no active workers at all
     cloud_active: list = []
     linear = MagicMock()
+
+    linear.get_open_blockers.return_value = []
     services = _services()
 
     with (

--- a/tests/test_watcher_dispatch_loop.py
+++ b/tests/test_watcher_dispatch_loop.py
@@ -193,13 +193,13 @@ def test_cloud_pool_full_does_not_block_local_dispatch(tmp_path: Path) -> None:
 
     with (
         patch.object(watcher, "_load_manifest", return_value=local_manifest),
-        patch("app.core.watcher.watcher.create_worktree", return_value=tmp_path),
-        patch("app.core.watcher.watcher.copy_manifest_to_worktree"),
-        patch("app.core.watcher.watcher.write_worker_pytest_config"),
+        patch("app.core.watcher.dispatch.create_worktree", return_value=tmp_path),
+        patch("app.core.watcher.dispatch.copy_manifest_to_worktree"),
+        patch("app.core.watcher.dispatch.write_worker_pytest_config"),
         patch.object(watcher._services, "ensure_vllm_anthropic_mode"),
         patch.object(watcher._services, "probe_vllm_health"),
         patch(
-            "app.core.watcher.watcher.launch_worker",
+            "app.core.watcher.dispatch.launch_worker",
             return_value=fake_local_process,
         ),
     ):
@@ -322,13 +322,13 @@ def test_dispatch_deferred_when_vllm_not_ready(tmp_path: Path) -> None:
 
     with (
         patch.object(w, "_load_manifest", return_value=manifest),
-        patch("app.core.watcher.watcher.create_worktree") as mock_create,
-        patch("app.core.watcher.watcher.copy_manifest_to_worktree"),
-        patch("app.core.watcher.watcher.write_worker_pytest_config"),
-        patch("app.core.watcher.watcher.safe_set_state") as mock_set_state,
-        patch("app.core.watcher.watcher.backup_plan_files", return_value=[]),
+        patch("app.core.watcher.dispatch.create_worktree") as mock_create,
+        patch("app.core.watcher.dispatch.copy_manifest_to_worktree"),
+        patch("app.core.watcher.dispatch.write_worker_pytest_config"),
+        patch("app.core.watcher.dispatch.safe_set_state") as mock_set_state,
+        patch("app.core.watcher.dispatch.backup_plan_files", return_value=[]),
         patch(
-            "app.core.watcher.watcher.launch_worker",
+            "app.core.watcher.dispatch.launch_worker",
             return_value=fake_process,
         ),
         patch.object(w._services, "probe_vllm_health", return_value=False),
@@ -366,14 +366,14 @@ def test_dispatch_proceeds_when_vllm_ready(tmp_path: Path) -> None:
     with (
         patch.object(w, "_load_manifest", return_value=manifest),
         patch(
-            "app.core.watcher.watcher.create_worktree", return_value=tmp_path
+            "app.core.watcher.dispatch.create_worktree", return_value=tmp_path
         ) as mock_create,
-        patch("app.core.watcher.watcher.copy_manifest_to_worktree"),
-        patch("app.core.watcher.watcher.write_worker_pytest_config"),
-        patch("app.core.watcher.watcher.safe_set_state"),
-        patch("app.core.watcher.watcher.backup_plan_files", return_value=[]),
+        patch("app.core.watcher.dispatch.copy_manifest_to_worktree"),
+        patch("app.core.watcher.dispatch.write_worker_pytest_config"),
+        patch("app.core.watcher.dispatch.safe_set_state"),
+        patch("app.core.watcher.dispatch.backup_plan_files", return_value=[]),
         patch(
-            "app.core.watcher.watcher.launch_worker",
+            "app.core.watcher.dispatch.launch_worker",
             return_value=fake_process,
         ),
         patch.object(w._services, "probe_vllm_health", return_value=True),
@@ -488,13 +488,13 @@ def test_dispatch_proceeds_when_manifest_blocked_by_tickets_is_empty(
 
     with (
         patch.object(w, "_load_manifest", return_value=manifest),
-        patch("app.core.watcher.watcher.create_worktree", return_value=tmp_path),
-        patch("app.core.watcher.watcher.copy_manifest_to_worktree"),
-        patch("app.core.watcher.watcher.write_worker_pytest_config"),
-        patch("app.core.watcher.watcher.safe_set_state"),
-        patch("app.core.watcher.watcher.backup_plan_files", return_value=[]),
+        patch("app.core.watcher.dispatch.create_worktree", return_value=tmp_path),
+        patch("app.core.watcher.dispatch.copy_manifest_to_worktree"),
+        patch("app.core.watcher.dispatch.write_worker_pytest_config"),
+        patch("app.core.watcher.dispatch.safe_set_state"),
+        patch("app.core.watcher.dispatch.backup_plan_files", return_value=[]),
         patch(
-            "app.core.watcher.watcher.launch_worker",
+            "app.core.watcher.dispatch.launch_worker",
             return_value=fake_process,
         ),
         patch.object(w._services, "ensure_vllm_anthropic_mode"),
@@ -527,13 +527,13 @@ def test_dispatch_proceeds_when_all_manifest_blockers_are_merged(
 
     with (
         patch.object(w, "_load_manifest", return_value=manifest),
-        patch("app.core.watcher.watcher.create_worktree", return_value=tmp_path),
-        patch("app.core.watcher.watcher.copy_manifest_to_worktree"),
-        patch("app.core.watcher.watcher.write_worker_pytest_config"),
-        patch("app.core.watcher.watcher.safe_set_state"),
-        patch("app.core.watcher.watcher.backup_plan_files", return_value=[]),
+        patch("app.core.watcher.dispatch.create_worktree", return_value=tmp_path),
+        patch("app.core.watcher.dispatch.copy_manifest_to_worktree"),
+        patch("app.core.watcher.dispatch.write_worker_pytest_config"),
+        patch("app.core.watcher.dispatch.safe_set_state"),
+        patch("app.core.watcher.dispatch.backup_plan_files", return_value=[]),
         patch(
-            "app.core.watcher.watcher.launch_worker",
+            "app.core.watcher.dispatch.launch_worker",
             return_value=fake_process,
         ),
         patch.object(w._services, "ensure_vllm_anthropic_mode"),
@@ -562,11 +562,11 @@ def test_start_ticket_set_state_failure_worker_still_starts(tmp_path: Path) -> N
 
     with (
         patch.object(w, "_load_manifest", return_value=manifest),
-        patch("app.core.watcher.watcher.create_worktree", return_value=tmp_path),
-        patch("app.core.watcher.watcher.create_worktree"),
-        patch("app.core.watcher.watcher.copy_manifest_to_worktree"),
+        patch("app.core.watcher.dispatch.create_worktree", return_value=tmp_path),
+        patch("app.core.watcher.dispatch.create_worktree"),
+        patch("app.core.watcher.dispatch.copy_manifest_to_worktree"),
         patch(
-            "app.core.watcher.watcher.launch_worker",
+            "app.core.watcher.dispatch.launch_worker",
             return_value=fake_process,
         ),
         patch.object(w._services, "ensure_vllm_anthropic_mode"),
@@ -903,7 +903,7 @@ def test_start_ticket_blocks_when_another_epic_branch_in_flight(
 
     with (
         patch.object(w, "_load_manifest", return_value=new_epic_manifest),
-        patch("app.core.watcher.watcher.create_worktree"),
+        patch("app.core.watcher.dispatch.create_worktree"),
         caplog.at_level(logging.WARNING, logger="app.core.watcher"),
     ):
         w._start_ticket("WOR-419", "fake-419")
@@ -952,13 +952,13 @@ def test_start_ticket_proceeds_for_same_epic_branch(
 
     with (
         patch.object(w, "_load_manifest", return_value=same_epic_manifest),
-        patch("app.core.watcher.watcher.create_worktree", return_value=tmp_path),
-        patch("app.core.watcher.watcher.copy_manifest_to_worktree"),
-        patch("app.core.watcher.watcher.write_worker_pytest_config"),
-        patch("app.core.watcher.watcher.safe_set_state"),
-        patch("app.core.watcher.watcher.backup_plan_files", return_value=[]),
+        patch("app.core.watcher.dispatch.create_worktree", return_value=tmp_path),
+        patch("app.core.watcher.dispatch.copy_manifest_to_worktree"),
+        patch("app.core.watcher.dispatch.write_worker_pytest_config"),
+        patch("app.core.watcher.dispatch.safe_set_state"),
+        patch("app.core.watcher.dispatch.backup_plan_files", return_value=[]),
         patch(
-            "app.core.watcher.watcher.launch_worker",
+            "app.core.watcher.dispatch.launch_worker",
             return_value=MagicMock(spec=subprocess.Popen),
         ),
         patch.object(w._services, "ensure_vllm_anthropic_mode"),
@@ -990,13 +990,13 @@ def test_start_ticket_unaffected_when_no_epic_workers(
 
     with (
         patch.object(w, "_load_manifest", return_value=main_manifest),
-        patch("app.core.watcher.watcher.create_worktree", return_value=tmp_path),
-        patch("app.core.watcher.watcher.copy_manifest_to_worktree"),
-        patch("app.core.watcher.watcher.write_worker_pytest_config"),
-        patch("app.core.watcher.watcher.safe_set_state"),
-        patch("app.core.watcher.watcher.backup_plan_files", return_value=[]),
+        patch("app.core.watcher.dispatch.create_worktree", return_value=tmp_path),
+        patch("app.core.watcher.dispatch.copy_manifest_to_worktree"),
+        patch("app.core.watcher.dispatch.write_worker_pytest_config"),
+        patch("app.core.watcher.dispatch.safe_set_state"),
+        patch("app.core.watcher.dispatch.backup_plan_files", return_value=[]),
         patch(
-            "app.core.watcher.watcher.launch_worker",
+            "app.core.watcher.dispatch.launch_worker",
             return_value=MagicMock(spec=subprocess.Popen),
         ),
         patch.object(w._services, "ensure_vllm_anthropic_mode"),

--- a/tests/test_watcher_multidispatch.py
+++ b/tests/test_watcher_multidispatch.py
@@ -111,13 +111,13 @@ class TestMultiDispatchPerCycle:
 
         with (
             patch.object(w, "_load_manifest", side_effect=capture_load),
-            patch("app.core.watcher.watcher.create_worktree", return_value=tmp_path),
-            patch("app.core.watcher.watcher.copy_manifest_to_worktree"),
-            patch("app.core.watcher.watcher.write_worker_pytest_config"),
-            patch("app.core.watcher.watcher.safe_set_state"),
-            patch("app.core.watcher.watcher.backup_plan_files", return_value=[]),
+            patch("app.core.watcher.dispatch.create_worktree", return_value=tmp_path),
+            patch("app.core.watcher.dispatch.copy_manifest_to_worktree"),
+            patch("app.core.watcher.dispatch.write_worker_pytest_config"),
+            patch("app.core.watcher.dispatch.safe_set_state"),
+            patch("app.core.watcher.dispatch.backup_plan_files", return_value=[]),
             patch(
-                "app.core.watcher.watcher.launch_worker",
+                "app.core.watcher.dispatch.launch_worker",
                 return_value=fake_process,
             ),
             patch.object(w._services, "ensure_vllm_anthropic_mode"),
@@ -172,13 +172,13 @@ class TestMultiDispatchPerCycle:
 
         with (
             patch.object(w, "_load_manifest", side_effect=load_for),
-            patch("app.core.watcher.watcher.create_worktree", return_value=tmp_path),
-            patch("app.core.watcher.watcher.copy_manifest_to_worktree"),
-            patch("app.core.watcher.watcher.write_worker_pytest_config"),
-            patch("app.core.watcher.watcher.safe_set_state"),
-            patch("app.core.watcher.watcher.backup_plan_files", return_value=[]),
+            patch("app.core.watcher.dispatch.create_worktree", return_value=tmp_path),
+            patch("app.core.watcher.dispatch.copy_manifest_to_worktree"),
+            patch("app.core.watcher.dispatch.write_worker_pytest_config"),
+            patch("app.core.watcher.dispatch.safe_set_state"),
+            patch("app.core.watcher.dispatch.backup_plan_files", return_value=[]),
             patch(
-                "app.core.watcher.watcher.launch_worker",
+                "app.core.watcher.dispatch.launch_worker",
                 return_value=fake_process,
             ),
             patch.object(w._services, "ensure_vllm_anthropic_mode"),
@@ -240,13 +240,13 @@ class TestMultiDispatchPerCycle:
 
         with (
             patch.object(w, "_load_manifest", side_effect=capture_load),
-            patch("app.core.watcher.watcher.create_worktree", return_value=tmp_path),
-            patch("app.core.watcher.watcher.copy_manifest_to_worktree"),
-            patch("app.core.watcher.watcher.write_worker_pytest_config"),
-            patch("app.core.watcher.watcher.safe_set_state"),
-            patch("app.core.watcher.watcher.backup_plan_files", return_value=[]),
+            patch("app.core.watcher.dispatch.create_worktree", return_value=tmp_path),
+            patch("app.core.watcher.dispatch.copy_manifest_to_worktree"),
+            patch("app.core.watcher.dispatch.write_worker_pytest_config"),
+            patch("app.core.watcher.dispatch.safe_set_state"),
+            patch("app.core.watcher.dispatch.backup_plan_files", return_value=[]),
             patch(
-                "app.core.watcher.watcher.launch_worker",
+                "app.core.watcher.dispatch.launch_worker",
                 return_value=fake_process,
             ),
             patch.object(w._services, "ensure_vllm_anthropic_mode"),
@@ -322,13 +322,13 @@ class TestInterDispatchDelay:
 
         with (
             patch.object(w, "_load_manifest", side_effect=capture_load),
-            patch("app.core.watcher.watcher.create_worktree", return_value=tmp_path),
-            patch("app.core.watcher.watcher.copy_manifest_to_worktree"),
-            patch("app.core.watcher.watcher.write_worker_pytest_config"),
-            patch("app.core.watcher.watcher.safe_set_state"),
-            patch("app.core.watcher.watcher.backup_plan_files", return_value=[]),
+            patch("app.core.watcher.dispatch.create_worktree", return_value=tmp_path),
+            patch("app.core.watcher.dispatch.copy_manifest_to_worktree"),
+            patch("app.core.watcher.dispatch.write_worker_pytest_config"),
+            patch("app.core.watcher.dispatch.safe_set_state"),
+            patch("app.core.watcher.dispatch.backup_plan_files", return_value=[]),
             patch(
-                "app.core.watcher.watcher.launch_worker",
+                "app.core.watcher.dispatch.launch_worker",
                 return_value=fake_process,
             ),
             patch.object(w._services, "ensure_vllm_anthropic_mode"),
@@ -378,14 +378,14 @@ class TestFailureDoesNotConsumeLimit:
 
         with (
             patch.object(w, "_load_manifest") as mock_load,
-            patch("app.core.watcher.watcher.create_worktree"),
+            patch("app.core.watcher.dispatch.create_worktree"),
         ):
             mock_load.side_effect = [
                 RuntimeError("boom"),  # First ticket fails
                 manifests[1],  # Second ticket succeeds
             ]
             # Patch safe_set_state to avoid actual Linear call
-            with patch("app.core.watcher.watcher.safe_set_state"):
+            with patch("app.core.watcher.dispatch.safe_set_state"):
                 w._dispatch_next_ticket()
 
         # Second ticket should have been loaded despite first failure


### PR DESCRIPTION
## Summary

Closes WOR-431. Eliminates the **duplicate ticket-dispatch implementation** in the watcher subpackage.

Before this PR there were two parallel paths:

| Path | Used by | Features |
|---|---|---|
| `Watcher._start_ticket` | Production | Open-blockers, path-overlap, epic-branch gate, pool capacity, vLLM probe, worker spawn |
| `dispatch.start_ticket` | Tests only | Epic-branch gate, manifest quality gates (WOR-378), stale-epic refusal (WOR-373), pool capacity, vLLM probe, dispatch_concurrency capture (WOR-363), vLLM solo-attribution (WOR-370) |

The two diverged — `dispatch.start_ticket` had WOR-373/378/363/370 features the class method didn't, and `Watcher._start_ticket` had the open-blockers and path-overlap prereqs the module function didn't. Tests exercised one path; production took the other. Bugs in either side stayed isolated.

## What changed

1. **`dispatch.start_ticket` becomes fully self-contained**:
   - Adds open-blockers + manifest-blocker checks at the top
   - Adds path-overlap check between the stale-epic refusal and effective-mode resolution (preserves the original ordering)

2. **`Watcher._start_ticket` reduces from ~150 LOC + 6 helpers to a 3-line wrapper**:
   ```python
   def _start_ticket(self, ticket_id, linear_id):
       manifest = self._load_manifest(ticket_id)
       manifest = self._enrich_with_retry_context(manifest)
       dispatch.start_ticket(...)  # delegates everything
   ```

3. **6 helpers from PR #886 deleted**: `_has_open_blockers`, `_epic_branch_in_use`, `_has_path_overlap`, `_pool_full_for_mode`, `_vllm_not_ready`, `_spawn_worker`. Their logic is now in `dispatch.start_ticket`.

4. **`Watcher.__init__` sets `self._services._mode = worker_mode`** so `dispatch.start_ticket`'s `effective_mode = resolve_effective_mode(services._mode, ...)` sees the correct watcher mode. Previously this attribute didn't exist and dispatch.start_ticket fell back to `"local"` — caught by tests once the production path went through it.

## Test changes

- **13 patch paths updated** from `app.core.watcher.watcher.X` to `app.core.watcher.dispatch.X` for helpers that moved (`create_worktree`, `launch_worker`, `copy_manifest_to_worktree`, `safe_set_state`, etc.)
- **16 tests** had `linear_mock.get_open_blockers.return_value = []` added so the new prereq check doesn't fire on a truthy MagicMock default.
- **Two tests** (`test_start_ticket_proceeds_for_same_epic_branch`, `test_dispatch_invalidates_solo_peer_when_second_worker_launches`) updated to use distinct `allowed_paths` — they accidentally overlapped on `conftest`'s default, which triggers a real path-overlap deferral now that `dispatch.start_ticket` has that check.

## File-size impact

| File | Before | After | Delta |
|---|---|---|---|
| `app/core/watcher/watcher.py` | 834 LOC | 684 LOC | **-150** |
| `app/core/watcher/dispatch.py` | 234 LOC | 264 LOC | +30 (the prereqs moved in) |

Combined with PR #886, `watcher.py` drops from **981 → 684 LOC (~30% reduction)** while gaining consistency between production and test paths.

## Test plan

- [x] Full pytest: **1578 passed, 0 failed**
- [x] mypy on `app/`: clean (37 files)
- [x] `lint-imports`: **6 contracts kept, 0 broken**
- [x] All pre-commit hooks pass

Closes WOR-431
