### PR TITLE
WOR-432: cli/ Phase 3 coverage fill (76% → 92%)

### DIFF
--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -1,0 +1,138 @@
+"""Tests for app.cli.config — config get/set/delete subcommand handlers.
+
+WOR-432: coverage fill for the cli/ Phase 3 work. Covers the previously-untested
+_config_set and _config_delete code paths (lines 27-45, 68-83 in config.py).
+"""
+
+from __future__ import annotations
+
+import argparse
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pytest
+from keyring.errors import KeyringError, NoKeyringError
+
+from app.cli.config import _config_delete, _config_set, _run_config
+
+if TYPE_CHECKING:
+    from _pytest.capture import CaptureFixture as CapSys
+else:
+    CapSys = pytest.CaptureFixture  # type: ignore[misc,assignment]
+
+
+# ── _config_set: github-token paths ────────────────────────────────────────────
+
+
+def test_config_set_github_token_via_value(capsys: CapSys) -> None:
+    """When --value is supplied, save_token receives it without prompting."""
+    args = argparse.Namespace(key="github-token", value="raw-token-abc")
+    with patch("app.cli.config.save_token") as mock_save:
+        rc = _config_set(args)
+    assert rc == 0
+    mock_save.assert_called_once_with("raw-token-abc")
+    assert "Done." in capsys.readouterr().err
+
+
+def test_config_set_github_token_via_stdin_prompt(capsys: CapSys) -> None:
+    """When --value omitted, getpass prompts and the result is saved."""
+    args = argparse.Namespace(key="github-token", value=None)
+    with (
+        patch("app.cli.config.getpass.getpass", return_value="prompted-token"),
+        patch("app.cli.config.save_token") as mock_save,
+    ):
+        rc = _config_set(args)
+    assert rc == 0
+    mock_save.assert_called_once_with("prompted-token")
+    assert "Done." in capsys.readouterr().err
+
+
+def test_config_set_github_token_empty_after_prompt(capsys: CapSys) -> None:
+    """Empty token (user hit Enter) returns 1 with an error message."""
+    args = argparse.Namespace(key="github-token", value=None)
+    with (
+        patch("app.cli.config.getpass.getpass", return_value=""),
+        patch("app.cli.config.save_token") as mock_save,
+    ):
+        rc = _config_set(args)
+    assert rc == 1
+    mock_save.assert_not_called()
+    assert "empty token" in capsys.readouterr().err
+
+
+def test_config_set_github_token_keyring_error(capsys: CapSys) -> None:
+    """KeyringError from save_token returns 1 with a clear stderr message."""
+    args = argparse.Namespace(key="github-token", value="token-x")
+    with patch("app.cli.config.save_token", side_effect=KeyringError("boom")):
+        rc = _config_set(args)
+    assert rc == 1
+    assert "KeyringError" in capsys.readouterr().err
+
+
+def test_config_set_github_token_no_keyring(capsys: CapSys) -> None:
+    """NoKeyringError (no backend installed) also returns 1."""
+    args = argparse.Namespace(key="github-token", value="token-y")
+    with patch("app.cli.config.save_token", side_effect=NoKeyringError("no backend")):
+        rc = _config_set(args)
+    assert rc == 1
+    assert "NoKeyringError" in capsys.readouterr().err
+
+
+# ── _config_set: regular preference paths ─────────────────────────────────────
+
+
+def test_config_set_regular_pref_saves_to_prefs_store(
+    capsys: CapSys,
+    tmp_path,
+) -> None:
+    """Setting author-name updates PrefsStore."""
+    from app.core.user_prefs import UserPreferences
+
+    existing = UserPreferences(author_name="Old")
+    args = argparse.Namespace(key="author-name", value="New Name")
+    with (
+        patch("app.cli.config.PrefsStore.load", return_value=existing),
+        patch("app.cli.config.PrefsStore.save") as mock_save,
+    ):
+        rc = _config_set(args)
+    assert rc == 0
+    mock_save.assert_called_once()
+    saved = mock_save.call_args[0][0]
+    assert saved.author_name == "New Name"
+    assert "✓ author-name = New Name" in capsys.readouterr().out
+
+
+# Note: unknown-key validation lives at the argparse level (choices=) — the
+# `key` argument is restricted to a known set, so _config_set never sees one
+# it can't look up. No test needed here for that path.
+
+
+# ── _config_delete paths ───────────────────────────────────────────────────────
+
+
+def test_config_delete_github_token_calls_cli_delete(capsys: CapSys) -> None:
+    """delete github-token routes to cli_delete_token (which manages keyring + msg)."""
+    args = argparse.Namespace(key="github-token")
+    with patch("app.cli.config.cli_delete_token", return_value=0) as mock_del:
+        rc = _config_delete(args)
+    assert rc == 0
+    mock_del.assert_called_once()
+
+
+def test_config_delete_unknown_key_returns_error(capsys: CapSys) -> None:
+    """delete on an unknown credential prints error + returns 1."""
+    args = argparse.Namespace(key="not-a-credential")
+    rc = _config_delete(args)
+    assert rc == 1
+    assert "unknown credential" in capsys.readouterr().err
+
+
+# ── _run_config dispatcher fallthrough ────────────────────────────────────────
+
+
+def test_run_config_no_subcommand_prints_usage(capsys: CapSys) -> None:
+    """When config_cmd is None/unknown, dispatcher prints usage and returns 1."""
+    args = argparse.Namespace(config_cmd=None)
+    rc = _run_config(args)
+    assert rc == 1
+    assert "Usage" in capsys.readouterr().err

--- a/tests/test_cli_operator.py
+++ b/tests/test_cli_operator.py
@@ -1,0 +1,235 @@
+"""Tests for app.cli.operator — watcher-softstop, waste-score, ticket-status helpers.
+
+WOR-432: coverage fill for cli/ Phase 3 work. Covers the previously-untested
+paths in operator.py (lines 50-83 softstop, 111-134 waste-score, 155-213 the
+ticket-status full-output + watch-loop helpers).
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.cli.operator import (
+    _emit_ticket_status_full,
+    _run_ticket_status_watch_loop,
+    _run_waste_score,
+    _run_watcher_softstop,
+)
+from app.core.watcher.ticket_status import (
+    ArtifactInfo,
+    LogInfo,
+    TicketStatus,
+    ToolCallInfo,
+)
+
+if TYPE_CHECKING:
+    from _pytest.capture import CaptureFixture as CapSys
+else:
+    CapSys = pytest.CaptureFixture  # type: ignore[misc,assignment]
+
+
+# ── _run_watcher_softstop ──────────────────────────────────────────────────────
+
+
+def test_softstop_no_daemon_returns_error(tmp_path: Path, capsys: CapSys) -> None:
+    """When no .claude/watcher.pid exists, softstop is a no-op + returns 1."""
+    with patch("app.cli.operator.Path.cwd", return_value=tmp_path):
+        rc = _run_watcher_softstop(argparse.Namespace())
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "no .claude/watcher.pid" in err
+
+
+def test_softstop_writes_sentinel(tmp_path: Path, capsys: CapSys) -> None:
+    """When daemon is running (pid file exists), softstop writes the sentinel."""
+    claude_dir = tmp_path / ".claude"
+    claude_dir.mkdir()
+    pid_file = claude_dir / "watcher.pid"
+    pid_file.write_text("12345", encoding="utf-8")
+    with patch("app.cli.operator.Path.cwd", return_value=tmp_path):
+        rc = _run_watcher_softstop(argparse.Namespace())
+    assert rc == 0
+    sentinel = claude_dir / "watcher.softstop"
+    assert sentinel.exists()
+    assert "PID 12345" in capsys.readouterr().err
+
+
+def test_softstop_pid_file_unreadable_shows_unknown(
+    tmp_path: Path, capsys: CapSys
+) -> None:
+    """Unreadable pid file shows 'unknown' PID but still writes sentinel."""
+    claude_dir = tmp_path / ".claude"
+    claude_dir.mkdir()
+    pid_file = claude_dir / "watcher.pid"
+    pid_file.write_text("99999", encoding="utf-8")
+    with (
+        patch("app.cli.operator.Path.cwd", return_value=tmp_path),
+        patch.object(Path, "read_text", side_effect=OSError("denied")),
+    ):
+        rc = _run_watcher_softstop(argparse.Namespace())
+    assert rc == 0
+    assert "PID unknown" in capsys.readouterr().err
+
+
+# ── _run_waste_score ──────────────────────────────────────────────────────────
+
+
+def test_waste_score_missing_log_returns_error(
+    tmp_path: Path, capsys: CapSys, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When .claude/worker_<id>.log doesn't exist, return 1 with a clear error."""
+    monkeypatch.chdir(tmp_path)
+    args = argparse.Namespace(ticket_id="WOR-999")
+    rc = _run_waste_score(args)
+    assert rc == 1
+    assert "worker log not found" in capsys.readouterr().err
+
+
+def test_waste_score_reads_log_and_prints_report(
+    tmp_path: Path, capsys: CapSys, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When log exists, _run_waste_score calls compute_waste_score and prints report."""
+    monkeypatch.chdir(tmp_path)
+    claude = tmp_path / ".claude"
+    claude.mkdir()
+    log = claude / "worker_wor-10.log"
+    log.write_text('{"type":"assistant"}\n', encoding="utf-8")
+
+    fake_report = MagicMock(score=42, breakdown={"redundant_reads": 10, "tool_gap": 5})
+    with patch(
+        "app.core.watcher.worker_waste.compute_waste_score",
+        return_value=fake_report,
+    ):
+        rc = _run_waste_score(argparse.Namespace(ticket_id="WOR-10"))
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "WOR-10" in out
+    assert "42/100" in out
+    assert "redundant_reads: 10" in out
+
+
+# ── _emit_ticket_status_full ──────────────────────────────────────────────────
+
+
+def _make_status(**overrides) -> TicketStatus:
+    """Minimal TicketStatus for tests; overrides fill specific fields."""
+    base = {
+        "ticket_id": "WOR-10",
+        "title": "Test",
+        "state": "InProgressLocal",
+        "state_age_seconds": 60,
+        "worker_log": None,
+        "artifacts": None,
+        "worktree_exists": None,
+        "worktree_path": None,
+        "health_flags": {},
+    }
+    base.update(overrides)
+    return TicketStatus(**base)  # type: ignore[arg-type]
+
+
+def test_emit_full_minimal_status(capsys: CapSys) -> None:
+    """A status with all-None optional fields still prints sensibly."""
+    _emit_ticket_status_full(_make_status())
+    out = capsys.readouterr().out
+    assert "Ticket: WOR-10" in out
+    assert "no log file found" in out
+    assert "Artifacts: none" in out
+
+
+def test_emit_full_with_worker_log(capsys: CapSys) -> None:
+    """Worker log info is rendered when present, including recent actions."""
+    log = LogInfo(
+        size_bytes=1024,
+        last_activity_ago_seconds=30,
+        last_tool_calls=[ToolCallInfo(name="Edit", display="foo.py")],
+    )
+    _emit_ticket_status_full(_make_status(worker_log=log))
+    out = capsys.readouterr().out
+    assert "Worker process:" in out
+    assert "Edit foo.py" in out
+
+
+def test_emit_full_with_artifacts(capsys: CapSys, tmp_path: Path) -> None:
+    """Artifacts entries are listed line-by-line."""
+    art = ArtifactInfo(
+        path=str(tmp_path / ".claude/artifacts/wor_10"),
+        entries={"manifest.json": 1200},
+    )
+    _emit_ticket_status_full(_make_status(artifacts=art))
+    out = capsys.readouterr().out
+    assert "Artifacts" in out
+    assert "manifest.json" in out
+
+
+def test_emit_full_with_worktree_exists(capsys: CapSys, tmp_path: Path) -> None:
+    """worktree_exists=True renders the worktree path."""
+    _emit_ticket_status_full(
+        _make_status(worktree_exists=True, worktree_path=tmp_path / "wt")
+    )
+    out = capsys.readouterr().out
+    assert "Worktree" in out
+    assert "exists" in out
+
+
+def test_emit_full_with_worktree_missing(capsys: CapSys) -> None:
+    """worktree_exists=False renders 'none'."""
+    _emit_ticket_status_full(_make_status(worktree_exists=False))
+    assert "Worktree: none" in capsys.readouterr().out
+
+
+def test_emit_full_with_health_flags(capsys: CapSys) -> None:
+    """Health flag entries render as a single line."""
+    flags = {"api_retries": 3, "subagent_spawns": 2, "no_result_artifact": True}
+    _emit_ticket_status_full(_make_status(health_flags=flags))
+    out = capsys.readouterr().out
+    assert "Health flags" in out
+    assert "3 api_retry events" in out
+    assert "2 subagent spawns" in out
+    assert "no result artifact yet" in out
+
+
+# ── _run_ticket_status_watch_loop ─────────────────────────────────────────────
+
+
+def test_watch_loop_exits_on_terminal_state(capsys: CapSys) -> None:
+    """If status is already in a terminal state, loop exits immediately (no poll)."""
+    status = _make_status(state="Done")
+    client = MagicMock()
+    rc = _run_ticket_status_watch_loop(client, "WOR-10", status)
+    assert rc == 0
+    assert "terminal state: Done" in capsys.readouterr().out
+    client.assert_not_called()
+
+
+def test_watch_loop_polls_then_exits_on_state_change(capsys: CapSys) -> None:
+    """Non-terminal initial state polls once, transitions to terminal, exits."""
+    initial = _make_status(state="InProgressLocal")
+    next_status = _make_status(state="MergedToEpic")
+    client = MagicMock()
+    with (
+        patch("app.cli.operator.time.sleep"),
+        patch(
+            "app.cli.operator.fetch_ticket_status",
+            side_effect=[next_status],
+        ),
+    ):
+        rc = _run_ticket_status_watch_loop(client, "WOR-10", initial)
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "polled" in out
+    assert "terminal state: MergedToEpic" in out
+
+
+def test_watch_loop_keyboard_interrupt_returns_zero(capsys: CapSys) -> None:
+    """KeyboardInterrupt during sleep cleanly returns 0."""
+    status = _make_status(state="InProgressLocal")
+    client = MagicMock()
+    with patch("app.cli.operator.time.sleep", side_effect=KeyboardInterrupt):
+        rc = _run_ticket_status_watch_loop(client, "WOR-10", status)
+    assert rc == 0


### PR DESCRIPTION
## Summary

Closes WOR-432. Phase 3 of the cli.py architectural overhaul: coverage fill on the new `app/cli/` subpackage.

Coverage went from **76% → 92%** (+16 points), well past the ≥85% target.

## Coverage per module

| Module | Before | After |
|---|---|---|
| `__init__.py` | 100% | 100% |
| `__main__.py` | 0% | 0% (entry-point wrapper; not unit-testable in a meaningful way) |
| `config.py` | 68% | **98%** |
| `generate.py` | 85% | 85% |
| `main.py` | 86% | 86% |
| `operator.py` | **57%** | **97%** |
| `parser.py` | 100% | 100% |

Two modules jumped significantly: `config.py` (+30 pts) and `operator.py` (+40 pts) — exactly the gaps WOR-432 targeted.

## What's tested

**`tests/test_cli_config.py` (9 tests)** — `_config_set`, `_config_delete`, `_run_config`:
- github-token via `--value` arg vs. via interactive getpass prompt
- Empty token (user hit Enter) returns 1
- `KeyringError` and `NoKeyringError` both return 1
- Regular pref (author-name) saves through PrefsStore
- `_config_delete` routes github-token to `cli_delete_token`
- Unknown credential returns 1
- `_run_config` no-subcommand prints usage

**`tests/test_cli_operator.py` (14 tests)** — `_run_watcher_softstop`, `_run_waste_score`, `_emit_ticket_status_full`, `_run_ticket_status_watch_loop`:
- Softstop: no-daemon error, writes sentinel, unreadable pid file falls back to "unknown"
- Waste-score: missing log error, prints full report when log exists
- Full status output: minimal (all None), with worker log, with artifacts, with worktree exists/missing, with health flags
- Watch loop: terminal state immediate exit, polls once + transitions, KeyboardInterrupt clean exit

## Test plan

- [x] Full pytest: **1601 passed** (up from 1578; +23 new tests)
- [x] mypy on `app/`: clean (43 source files)
- [x] `lint-imports`: 7 contracts kept, 0 broken
- [x] All pre-commit hooks pass

## Sequence in the cli.py overhaul

This closes the 3-phase plan that started with PR #889:

1. **Phase 1** (PR #889) — split `cli.py` → `cli/` subpackage, no behavior change
2. **Phase 2** (PR #889) — reduce cognitive complexity in `operator.py` (CC 85 → <15) and `generate.py` (CC 29 → <15)
3. **Phase 3** (this PR) — coverage fill

After all three: the cli/ area has no Sonar S3776 findings, no over-RECOMMEND-LOC files, an `.importlinter` contract enforcing the layered structure (PR #889 part 3), and 92% test coverage.

Closes WOR-432
