### PR TITLE
Sonar round-2 quick wins: BLOCKER + 3 logging + 2 CC

### DIFF
--- a/app/cli/generate.py
+++ b/app/cli/generate.py
@@ -285,20 +285,8 @@ def _run_github_phase(
     return 0, clone_url, repo_full_name
 
 
-def _run_generate(args: argparse.Namespace) -> int:
-    """Top-level dispatcher for `generate` subcommand."""
-    if args.interactive:
-        return _run_interactive(args)
-
-    if not _validate_generate_args(args):
-        return 1
-
-    try:
-        config = _build_config(args)
-    except ValidationError as exc:
-        print(f"Error: {exc}", file=sys.stderr)
-        return 1
-
+def _execute_generation_pipeline(config: RepoConfig, args: argparse.Namespace) -> int:
+    """Run render → fetch skills → post-setup → GitHub phase. Returns rc."""
     try:
         _render_and_report(config, args.output)
     except ValueError as exc:
@@ -319,3 +307,20 @@ def _run_generate(args: argparse.Namespace) -> int:
 
     exit_code, _clone_url, _repo_full_name = _run_github_phase(args, config)
     return exit_code
+
+
+def _run_generate(args: argparse.Namespace) -> int:
+    """Top-level dispatcher for `generate` subcommand."""
+    if args.interactive:
+        return _run_interactive(args)
+
+    if not _validate_generate_args(args):
+        return 1
+
+    try:
+        config = _build_config(args)
+    except ValidationError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    return _execute_generation_pipeline(config, args)

--- a/app/cli/operator.py
+++ b/app/cli/operator.py
@@ -10,6 +10,8 @@ from pathlib import Path
 from app.core.linear_client import LinearClient
 from app.core.metrics import MetricsStore
 from app.core.watcher.ticket_status import (
+    ArtifactInfo,
+    LogInfo,
     TicketStatus,
     _format_age,
     _format_size,
@@ -145,38 +147,33 @@ def _check_ticket_status_api_key() -> str | None:
     return api_key
 
 
-def _emit_ticket_status_full(status: TicketStatus) -> None:
-    """Print the default human-readable status block."""
-    print(f"Ticket: {status.ticket_id} — {status.title}")
-    age_str = _format_age(status.state_age_seconds) if status.state_age_seconds else "?"
-    print(f"State (Linear): {status.state} (age: {age_str})")
-
-    if status.worker_log is not None:
-        wl = status.worker_log
-        size_str = _format_size(wl.size_bytes)
-        last_ago = (
-            _format_age(wl.last_activity_ago_seconds)
-            if wl.last_activity_ago_seconds
-            else "?"
-        )
-        print("Worker process:")
-        print(f"  Log: {size_str}, last activity {last_ago}")
-        if wl.last_tool_calls:
-            print(f"  Recent actions (last {min(3, len(wl.last_tool_calls))}):")
-            for tc in wl.last_tool_calls[:3]:
-                print(f"    {tc.name} {tc.display}")
-        else:
-            print("  Recent actions: ?")
+def _emit_worker_log_block(wl: LogInfo) -> None:
+    """Print the worker-log section of the full status block."""
+    size_str = _format_size(wl.size_bytes)
+    last_ago = (
+        _format_age(wl.last_activity_ago_seconds)
+        if wl.last_activity_ago_seconds
+        else "?"
+    )
+    print("Worker process:")
+    print(f"  Log: {size_str}, last activity {last_ago}")
+    if wl.last_tool_calls:
+        print(f"  Recent actions (last {min(3, len(wl.last_tool_calls))}):")
+        for tc in wl.last_tool_calls[:3]:
+            print(f"    {tc.name} {tc.display}")
     else:
-        print("Worker process: no log file found")
+        print("  Recent actions: ?")
 
-    if status.artifacts is not None:
-        print(f"Artifacts ({status.artifacts.path}):")
-        for name, info in status.artifacts.entries.items():
-            print(f"  {name}    {info}")
-    else:
-        print("Artifacts: none")
 
+def _emit_artifacts_block(artifacts: ArtifactInfo) -> None:
+    """Print the artifacts section of the full status block."""
+    print(f"Artifacts ({artifacts.path}):")
+    for name, info in artifacts.entries.items():
+        print(f"  {name}    {info}")
+
+
+def _emit_worktree_block(status: TicketStatus) -> None:
+    """Print the worktree section of the full status block."""
     if status.worktree_exists is True:
         print(f"Worktree: {status.worktree_path}  exists")
     elif status.worktree_exists is False:
@@ -184,33 +181,60 @@ def _emit_ticket_status_full(status: TicketStatus) -> None:
     else:
         print("Worktree: ?")
 
+
+def _emit_health_flags_block(flags: dict[str, object]) -> None:
+    """Print the health-flags section (only when at least one flag is present)."""
+    parts = []
+    if "api_retries" in flags:
+        parts.append(f"{flags['api_retries']} api_retry events")
+    if "subagent_spawns" in flags:
+        parts.append(f"{flags['subagent_spawns']} subagent spawns")
+    if "no_result_artifact" in flags:
+        parts.append("no result artifact yet")
+    print(f"Health flags: {'; '.join(parts)}")
+
+
+def _emit_ticket_status_full(status: TicketStatus) -> None:
+    """Print the default human-readable status block."""
+    print(f"Ticket: {status.ticket_id} — {status.title}")
+    age_str = _format_age(status.state_age_seconds) if status.state_age_seconds else "?"
+    print(f"State (Linear): {status.state} (age: {age_str})")
+
+    if status.worker_log is not None:
+        _emit_worker_log_block(status.worker_log)
+    else:
+        print("Worker process: no log file found")
+
+    if status.artifacts is not None:
+        _emit_artifacts_block(status.artifacts)
+    else:
+        print("Artifacts: none")
+
+    _emit_worktree_block(status)
+
     if status.health_flags:
-        parts = []
-        if "api_retries" in status.health_flags:
-            parts.append(f"{status.health_flags['api_retries']} api_retry events")
-        if "subagent_spawns" in status.health_flags:
-            parts.append(f"{status.health_flags['subagent_spawns']} subagent spawns")
-        if "no_result_artifact" in status.health_flags:
-            parts.append("no result artifact yet")
-        print(f"Health flags: {'; '.join(parts)}")
+        _emit_health_flags_block(status.health_flags)
 
 
 def _run_ticket_status_watch_loop(
     client: LinearClient, ticket_id: str, status: TicketStatus
-) -> int:
-    """Poll the ticket every 30s until it reaches a terminal state."""
+) -> None:
+    """Poll the ticket every 30s until it reaches a terminal state.
+
+    Sonar S3516: the earlier int return had two identical `return 0`
+    paths; the caller now wraps this in `return 0` itself.
+    """
     terminal_states = {"Done", "MergedToEpic", "Cancelled", "Duplicate", "Blocked"}
     while status.state not in terminal_states:
         print(f"\n── polled {_format_age(status.state_age_seconds)} ──")
         try:
             time.sleep(30)
         except KeyboardInterrupt:
-            return 0
+            return
         status = fetch_ticket_status(client, ticket_id)
         print()
         _emit_ticket_status_full(status)
     print(f"\nTicket reached terminal state: {status.state}")
-    return 0
 
 
 def _run_ticket_status(args: argparse.Namespace) -> int:
@@ -240,6 +264,7 @@ def _run_ticket_status(args: argparse.Namespace) -> int:
     _emit_ticket_status_full(status)
 
     if args.watch:
-        return _run_ticket_status_watch_loop(client, ticket_id, status)
+        _run_ticket_status_watch_loop(client, ticket_id, status)
+        return 0
 
     return 0

--- a/app/core/watcher/watcher.py
+++ b/app/core/watcher/watcher.py
@@ -466,7 +466,7 @@ class Watcher:
                     break
                 time.sleep(DISPATCH_DELAY_SECONDS)
             except Exception as exc:
-                logger.error("Failed to start %s: %s", ticket_id, exc)
+                logger.exception("Failed to start %s: %s", ticket_id, exc)
 
     def _start_ticket(self, ticket_id: str, linear_id: str) -> None:
         """Load + enrich the manifest, then delegate to dispatch.start_ticket.
@@ -520,14 +520,13 @@ class Watcher:
             try:
                 outcome = self._finalize_one_worker(worker, rc)
             except Exception as exc:
-                logger.error(
+                logger.exception(
                     "finalize_worker raised for %s: %s. Worker slot freed; "
                     "result.json / last_failure.json may be incomplete and "
                     "Linear state may not have been advanced - investigate "
                     "manually.",
                     worker.ticket_id,
                     exc,
-                    exc_info=True,
                 )
                 outcome = "failure"
         # Remove in reverse so earlier indices stay valid.

--- a/app/core/watcher/watcher_worktrees.py
+++ b/app/core/watcher/watcher_worktrees.py
@@ -202,7 +202,7 @@ def _save_dirty_worktree_to_backup(
             ignore=shutil.ignore_patterns(".git", "__pycache__", "*.pyc"),
         )
     except OSError as exc:
-        logger.error(
+        logger.exception(
             "Failed to back up dirty worktree for %s to %s: %s",
             ticket_id,
             target,

--- a/tests/test_cli_operator.py
+++ b/tests/test_cli_operator.py
@@ -202,7 +202,7 @@ def test_watch_loop_exits_on_terminal_state(capsys: CapSys) -> None:
     status = _make_status(state="Done")
     client = MagicMock()
     rc = _run_ticket_status_watch_loop(client, "WOR-10", status)
-    assert rc == 0
+    assert rc is None
     assert "terminal state: Done" in capsys.readouterr().out
     client.assert_not_called()
 
@@ -220,7 +220,7 @@ def test_watch_loop_polls_then_exits_on_state_change(capsys: CapSys) -> None:
         ),
     ):
         rc = _run_ticket_status_watch_loop(client, "WOR-10", initial)
-    assert rc == 0
+    assert rc is None
     out = capsys.readouterr().out
     assert "polled" in out
     assert "terminal state: MergedToEpic" in out
@@ -232,4 +232,4 @@ def test_watch_loop_keyboard_interrupt_returns_zero(capsys: CapSys) -> None:
     client = MagicMock()
     with patch("app.cli.operator.time.sleep", side_effect=KeyboardInterrupt):
         rc = _run_ticket_status_watch_loop(client, "WOR-10", status)
-    assert rc == 0
+    assert rc is None


### PR DESCRIPTION
## Summary

Closes 6 SonarCloud findings in one focused PR — the quick wins surfaced after this session's bigger refactors.

| Rule | Severity | File:Line | Fix |
|---|---|---|---|
| S3516 | **BLOCKER** | `cli/operator.py:198` | `_run_ticket_status_watch_loop` both branches returned `0` — now returns `None`; caller wraps in `return 0` |
| S8572 | MAJOR | `watcher.py:469` | `logger.error` → `logger.exception` (dispatch loop) |
| S8572 | MAJOR | `watcher.py:523` | `logger.error` → `logger.exception` (finalize handler); also drops the redundant `exc_info=True` |
| S8572 | MAJOR | `watcher_worktrees.py:205` | `logger.error` → `logger.exception` (worktree backup) |
| S3776 | CRITICAL | `cli/operator.py:148` `_run_ticket_status` | CC 25 → <15: extracted 4 sub-emitters from `_emit_ticket_status_full` (worker_log, artifacts, worktree, health_flags) |
| S3776 | CRITICAL | `cli/generate.py:241` `_run_generate` | CC 22 → <15: extracted `_execute_generation_pipeline` holding the 3 try/except blocks for render / fetch-skills / post-setup + the GitHub phase |

## Why these became "quick wins"

The earlier Phase 2 refactor (PR #889) dropped these two CC findings substantially (CC 85→25 and CC 29→22) but didn't get under the 15 threshold. The follow-up extractions in this PR finish the job. The S3516 BLOCKER was introduced by my Phase 2 refactor (helper had identical return paths) — also closed here.

The 3 S8572 findings have been around since April/May; they're trivial swaps but were never bundled into a maintenance pass.

## Test plan

- [x] Full pytest: **1601 passed, 0 failed**
- [x] mypy on `app/`: clean (43 source files)
- [x] `lint-imports`: 7 contracts kept, 0 broken
- [x] Updated 3 watch-loop tests to assert `rc is None` (the new return type)

## Sonar projection

After merge, open findings drop from 21 → 15. Quality gate stays passing.
