### PR TITLE
Sonar wave: S3776 cognitive complexity reductions across 10 files

### DIFF
--- a/app/core/linear_client.py
+++ b/app/core/linear_client.py
@@ -29,6 +29,19 @@ class LinearError(Exception):
     pass
 
 
+def _classify_transient_or_raise(exc: Exception) -> Exception:
+    """Return *exc* if it's a retryable transport error; raise LinearError if not.
+
+    Non-retryable HTTPError codes (anything outside _RETRYABLE_HTTP_CODES) are
+    promoted to LinearError. URLError and RemoteDisconnected are always
+    retryable.
+    """
+    if isinstance(exc, urllib.error.HTTPError):
+        if exc.code not in _RETRYABLE_HTTP_CODES:
+            raise LinearError(f"Linear API HTTP {exc.code}: {exc.reason}") from exc
+    return exc
+
+
 class LinearClient:
     """Minimal Linear GraphQL client for watcher use."""
 
@@ -234,39 +247,18 @@ class LinearClient:
     def _query(
         self, query: str, variables: dict[str, Any] | None = None
     ) -> dict[str, Any]:
-        payload = json.dumps({"query": query, "variables": variables or {}}).encode()
-        req = urllib.request.Request(  # nosec B310
-            _LINEAR_API_URL,
-            data=payload,
-            headers={
-                "Content-Type": "application/json",
-                "Authorization": self._api_key,
-            },
-            method="POST",
-        )
+        req = self._build_request(query, variables)
         last_exc: Exception | None = None
         max_retries = len(_RETRY_DELAYS)
         for attempt in range(max_retries + 1):
             try:
-                with urllib.request.urlopen(req, timeout=30) as resp:  # nosec B310
-                    body: dict[str, Any] = json.loads(resp.read())
-                errors = body.get("errors")
-                if errors:
-                    raise LinearError(f"Linear API error: {errors}")
-                data = body.get("data")
-                if data is None:
-                    raise LinearError(f"Linear API returned no data: {body!r}")
-                return cast(dict[str, Any], data)
-            except LinearError:
-                raise
-            except urllib.error.HTTPError as exc:
-                if exc.code not in _RETRYABLE_HTTP_CODES:
-                    raise LinearError(
-                        f"Linear API HTTP {exc.code}: {exc.reason}"
-                    ) from exc
-                last_exc = exc
-            except (urllib.error.URLError, http.client.RemoteDisconnected) as exc:
-                last_exc = exc
+                return self._attempt_query(req)
+            except (
+                urllib.error.HTTPError,
+                urllib.error.URLError,
+                http.client.RemoteDisconnected,
+            ) as exc:
+                last_exc = _classify_transient_or_raise(exc)
             if attempt < max_retries:
                 delay = _RETRY_DELAYS[attempt]
                 logger.warning(
@@ -280,3 +272,34 @@ class LinearClient:
         raise LinearError(
             f"Linear API failed after {max_retries + 1} attempts: {last_exc}"
         ) from last_exc
+
+    def _build_request(
+        self, query: str, variables: dict[str, Any] | None
+    ) -> urllib.request.Request:
+        payload = json.dumps({"query": query, "variables": variables or {}}).encode()
+        return urllib.request.Request(  # nosec B310
+            _LINEAR_API_URL,
+            data=payload,
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": self._api_key,
+            },
+            method="POST",
+        )
+
+    def _attempt_query(self, req: urllib.request.Request) -> dict[str, Any]:
+        """Issue one request and parse the response.
+
+        Raises LinearError on a structural error (GraphQL errors or no data).
+        Raises HTTPError/URLError/RemoteDisconnected on transport failures
+        (the caller decides whether to retry).
+        """
+        with urllib.request.urlopen(req, timeout=30) as resp:  # nosec B310
+            body: dict[str, Any] = json.loads(resp.read())
+        errors = body.get("errors")
+        if errors:
+            raise LinearError(f"Linear API error: {errors}")
+        data = body.get("data")
+        if data is None:
+            raise LinearError(f"Linear API returned no data: {body!r}")
+        return cast(dict[str, Any], data)

--- a/app/core/metrics.py
+++ b/app/core/metrics.py
@@ -469,45 +469,142 @@ class MetricsStore:
     # WOR-Sonar: columns added by ALTER TABLE ADD COLUMN over time.
     # Data-driven migration; new columns just append to this list.
     _TICKET_METRICS_ADDED_COLUMNS: list[tuple[str, str]] = [
-        ("local_input_tokens", "INTEGER"),
-        ("local_output_tokens", "INTEGER"),
-        ("output_tokens_per_wall_second", "REAL"),
-        ("change_type", "TEXT"),
-        ("reasoning_demand", "INTEGER"),
-        ("scope_clarity", "INTEGER"),
-        ("constraint_density", "INTEGER"),
-        ("ac_specificity", "INTEGER"),
-        ("tech_stack", "TEXT"),
-        ("raw_extensions", "TEXT"),
-        ("waste_score", "INTEGER"),
-        ("waste_breakdown_json", "TEXT"),
-        ("tags", "TEXT"),
-        ("notes", "TEXT"),
-        ("effort", "TEXT"),
-        ("compact_duration_ms", "INTEGER"),
-        ("api_retry_count", "INTEGER"),
-        ("subagent_spawns", "INTEGER"),
-        ("hook_trust_violations", "INTEGER"),
-        ("dispatch_concurrency", "INTEGER"),
-        ("vllm_metrics_attributable", "INTEGER"),
-        ("vllm_prefix_cache_hits", "INTEGER"),
-        ("vllm_prefix_cache_queries", "INTEGER"),
-        ("vllm_prefix_cache_hit_ratio", "REAL"),
-        ("vllm_prompt_tokens", "INTEGER"),
-        ("vllm_generation_tokens", "INTEGER"),
-        ("vllm_ttft_seconds_sum", "REAL"),
-        ("vllm_ttft_count", "INTEGER"),
-        ("vllm_ttft_mean_seconds", "REAL"),
-        ("vllm_preemptions", "INTEGER"),
-        ("turn_count", "INTEGER"),
-        ("tool_calls_total", "INTEGER"),
-        ("tool_calls_breakdown", "TEXT"),
-        ("thinking_blocks", "INTEGER"),
-        ("thinking_chars_total", "INTEGER"),
-        ("input_tokens_max", "INTEGER"),
-        ("input_tokens_first", "INTEGER"),
-        ("input_tokens_last", "INTEGER"),
-        ("redundant_reads_count", "INTEGER"),
+        # (column_name, full_alter_sql) — literal SQL keeps semgrep's
+        # SQL-injection rules happy (the f-string version trips
+        # python.lang.security.audit.formatted-sql-query even though
+        # every value is a hardcoded class attribute).
+        (
+            "local_input_tokens",
+            "ALTER TABLE ticket_metrics ADD COLUMN local_input_tokens INTEGER",
+        ),
+        (
+            "local_output_tokens",
+            "ALTER TABLE ticket_metrics ADD COLUMN local_output_tokens INTEGER",
+        ),
+        (
+            "output_tokens_per_wall_second",
+            "ALTER TABLE ticket_metrics ADD COLUMN output_tokens_per_wall_second REAL",
+        ),
+        ("change_type", "ALTER TABLE ticket_metrics ADD COLUMN change_type TEXT"),
+        (
+            "reasoning_demand",
+            "ALTER TABLE ticket_metrics ADD COLUMN reasoning_demand INTEGER",
+        ),
+        (
+            "scope_clarity",
+            "ALTER TABLE ticket_metrics ADD COLUMN scope_clarity INTEGER",
+        ),
+        (
+            "constraint_density",
+            "ALTER TABLE ticket_metrics ADD COLUMN constraint_density INTEGER",
+        ),
+        (
+            "ac_specificity",
+            "ALTER TABLE ticket_metrics ADD COLUMN ac_specificity INTEGER",
+        ),
+        ("tech_stack", "ALTER TABLE ticket_metrics ADD COLUMN tech_stack TEXT"),
+        ("raw_extensions", "ALTER TABLE ticket_metrics ADD COLUMN raw_extensions TEXT"),
+        ("waste_score", "ALTER TABLE ticket_metrics ADD COLUMN waste_score INTEGER"),
+        (
+            "waste_breakdown_json",
+            "ALTER TABLE ticket_metrics ADD COLUMN waste_breakdown_json TEXT",
+        ),
+        ("tags", "ALTER TABLE ticket_metrics ADD COLUMN tags TEXT"),
+        ("notes", "ALTER TABLE ticket_metrics ADD COLUMN notes TEXT"),
+        ("effort", "ALTER TABLE ticket_metrics ADD COLUMN effort TEXT"),
+        (
+            "compact_duration_ms",
+            "ALTER TABLE ticket_metrics ADD COLUMN compact_duration_ms INTEGER",
+        ),
+        (
+            "api_retry_count",
+            "ALTER TABLE ticket_metrics ADD COLUMN api_retry_count INTEGER",
+        ),
+        (
+            "subagent_spawns",
+            "ALTER TABLE ticket_metrics ADD COLUMN subagent_spawns INTEGER",
+        ),
+        (
+            "hook_trust_violations",
+            "ALTER TABLE ticket_metrics ADD COLUMN hook_trust_violations INTEGER",
+        ),
+        (
+            "dispatch_concurrency",
+            "ALTER TABLE ticket_metrics ADD COLUMN dispatch_concurrency INTEGER",
+        ),
+        (
+            "vllm_metrics_attributable",
+            "ALTER TABLE ticket_metrics ADD COLUMN vllm_metrics_attributable INTEGER",
+        ),
+        (
+            "vllm_prefix_cache_hits",
+            "ALTER TABLE ticket_metrics ADD COLUMN vllm_prefix_cache_hits INTEGER",
+        ),
+        (
+            "vllm_prefix_cache_queries",
+            "ALTER TABLE ticket_metrics ADD COLUMN vllm_prefix_cache_queries INTEGER",
+        ),
+        (
+            "vllm_prefix_cache_hit_ratio",
+            "ALTER TABLE ticket_metrics ADD COLUMN vllm_prefix_cache_hit_ratio REAL",
+        ),
+        (
+            "vllm_prompt_tokens",
+            "ALTER TABLE ticket_metrics ADD COLUMN vllm_prompt_tokens INTEGER",
+        ),
+        (
+            "vllm_generation_tokens",
+            "ALTER TABLE ticket_metrics ADD COLUMN vllm_generation_tokens INTEGER",
+        ),
+        (
+            "vllm_ttft_seconds_sum",
+            "ALTER TABLE ticket_metrics ADD COLUMN vllm_ttft_seconds_sum REAL",
+        ),
+        (
+            "vllm_ttft_count",
+            "ALTER TABLE ticket_metrics ADD COLUMN vllm_ttft_count INTEGER",
+        ),
+        (
+            "vllm_ttft_mean_seconds",
+            "ALTER TABLE ticket_metrics ADD COLUMN vllm_ttft_mean_seconds REAL",
+        ),
+        (
+            "vllm_preemptions",
+            "ALTER TABLE ticket_metrics ADD COLUMN vllm_preemptions INTEGER",
+        ),
+        ("turn_count", "ALTER TABLE ticket_metrics ADD COLUMN turn_count INTEGER"),
+        (
+            "tool_calls_total",
+            "ALTER TABLE ticket_metrics ADD COLUMN tool_calls_total INTEGER",
+        ),
+        (
+            "tool_calls_breakdown",
+            "ALTER TABLE ticket_metrics ADD COLUMN tool_calls_breakdown TEXT",
+        ),
+        (
+            "thinking_blocks",
+            "ALTER TABLE ticket_metrics ADD COLUMN thinking_blocks INTEGER",
+        ),
+        (
+            "thinking_chars_total",
+            "ALTER TABLE ticket_metrics ADD COLUMN thinking_chars_total INTEGER",
+        ),
+        (
+            "input_tokens_max",
+            "ALTER TABLE ticket_metrics ADD COLUMN input_tokens_max INTEGER",
+        ),
+        (
+            "input_tokens_first",
+            "ALTER TABLE ticket_metrics ADD COLUMN input_tokens_first INTEGER",
+        ),
+        (
+            "input_tokens_last",
+            "ALTER TABLE ticket_metrics ADD COLUMN input_tokens_last INTEGER",
+        ),
+        (
+            "redundant_reads_count",
+            "ALTER TABLE ticket_metrics ADD COLUMN redundant_reads_count INTEGER",
+        ),
     ]
 
     def _migrate(self, conn: sqlite3.Connection) -> None:
@@ -531,11 +628,9 @@ class MetricsStore:
                 for row in conn.execute("PRAGMA table_info(ticket_metrics)").fetchall()
             }
 
-        for col, dtype in self._TICKET_METRICS_ADDED_COLUMNS:
+        for col, alter_sql in self._TICKET_METRICS_ADDED_COLUMNS:
             if col not in existing:
-                conn.execute(
-                    f"ALTER TABLE ticket_metrics ADD COLUMN {col} {dtype}"  # nosec B608
-                )
+                conn.execute(alter_sql)
 
     @contextmanager
     def _connect(self) -> Generator[sqlite3.Connection, None, None]:

--- a/app/core/metrics.py
+++ b/app/core/metrics.py
@@ -466,170 +466,76 @@ class MetricsStore:
             conn.execute(_CREATE_RUN_LOG)
             self._migrate(conn)
 
+    # WOR-Sonar: columns added by ALTER TABLE ADD COLUMN over time.
+    # Data-driven migration; new columns just append to this list.
+    _TICKET_METRICS_ADDED_COLUMNS: list[tuple[str, str]] = [
+        ("local_input_tokens", "INTEGER"),
+        ("local_output_tokens", "INTEGER"),
+        ("output_tokens_per_wall_second", "REAL"),
+        ("change_type", "TEXT"),
+        ("reasoning_demand", "INTEGER"),
+        ("scope_clarity", "INTEGER"),
+        ("constraint_density", "INTEGER"),
+        ("ac_specificity", "INTEGER"),
+        ("tech_stack", "TEXT"),
+        ("raw_extensions", "TEXT"),
+        ("waste_score", "INTEGER"),
+        ("waste_breakdown_json", "TEXT"),
+        ("tags", "TEXT"),
+        ("notes", "TEXT"),
+        ("effort", "TEXT"),
+        ("compact_duration_ms", "INTEGER"),
+        ("api_retry_count", "INTEGER"),
+        ("subagent_spawns", "INTEGER"),
+        ("hook_trust_violations", "INTEGER"),
+        ("dispatch_concurrency", "INTEGER"),
+        ("vllm_metrics_attributable", "INTEGER"),
+        ("vllm_prefix_cache_hits", "INTEGER"),
+        ("vllm_prefix_cache_queries", "INTEGER"),
+        ("vllm_prefix_cache_hit_ratio", "REAL"),
+        ("vllm_prompt_tokens", "INTEGER"),
+        ("vllm_generation_tokens", "INTEGER"),
+        ("vllm_ttft_seconds_sum", "REAL"),
+        ("vllm_ttft_count", "INTEGER"),
+        ("vllm_ttft_mean_seconds", "REAL"),
+        ("vllm_preemptions", "INTEGER"),
+        ("turn_count", "INTEGER"),
+        ("tool_calls_total", "INTEGER"),
+        ("tool_calls_breakdown", "TEXT"),
+        ("thinking_blocks", "INTEGER"),
+        ("thinking_chars_total", "INTEGER"),
+        ("input_tokens_max", "INTEGER"),
+        ("input_tokens_first", "INTEGER"),
+        ("input_tokens_last", "INTEGER"),
+        ("redundant_reads_count", "INTEGER"),
+    ]
+
     def _migrate(self, conn: sqlite3.Connection) -> None:
-        """Add new columns to existing databases using PRAGMA table_info."""
+        """Add missing columns to ticket_metrics via PRAGMA table_info."""
         existing = {
             row[1]
             for row in conn.execute("PRAGMA table_info(ticket_metrics)").fetchall()
         }
-        if "local_input_tokens" not in existing:
+
+        # WOR-361: legacy → new name rename. Idempotent across DB ages.
+        if (
+            "output_tokens_per_wall_second" not in existing
+            and "local_output_tokens_per_second" in existing
+        ):
             conn.execute(
-                "ALTER TABLE ticket_metrics ADD COLUMN local_input_tokens INTEGER"
+                "ALTER TABLE ticket_metrics RENAME COLUMN "
+                "local_output_tokens_per_second TO output_tokens_per_wall_second"
             )
-        if "local_output_tokens" not in existing:
-            conn.execute(
-                "ALTER TABLE ticket_metrics ADD COLUMN local_output_tokens INTEGER"
-            )
-        # WOR-361: rename misleading column. Idempotent across states:
-        # - fresh DB: CREATE TABLE already used the new name
-        # - already-migrated: new name exists, skip
-        # - pre-rename DB: rename old → new
-        # - very old DB without either: ADD COLUMN with new name
-        if "output_tokens_per_wall_second" not in existing:
-            if "local_output_tokens_per_second" in existing:
+            existing = {
+                row[1]
+                for row in conn.execute("PRAGMA table_info(ticket_metrics)").fetchall()
+            }
+
+        for col, dtype in self._TICKET_METRICS_ADDED_COLUMNS:
+            if col not in existing:
                 conn.execute(
-                    "ALTER TABLE ticket_metrics RENAME COLUMN "
-                    "local_output_tokens_per_second TO output_tokens_per_wall_second"
+                    f"ALTER TABLE ticket_metrics ADD COLUMN {col} {dtype}"  # nosec B608
                 )
-            else:
-                conn.execute(
-                    "ALTER TABLE ticket_metrics "
-                    "ADD COLUMN output_tokens_per_wall_second REAL"
-                )
-        # WOR-262 taxonomy columns
-        if "change_type" not in existing:
-            conn.execute("ALTER TABLE ticket_metrics ADD COLUMN change_type TEXT")
-        if "reasoning_demand" not in existing:
-            conn.execute(
-                "ALTER TABLE ticket_metrics ADD COLUMN reasoning_demand INTEGER"
-            )
-        if "scope_clarity" not in existing:
-            conn.execute("ALTER TABLE ticket_metrics ADD COLUMN scope_clarity INTEGER")
-        if "constraint_density" not in existing:
-            conn.execute(
-                "ALTER TABLE ticket_metrics ADD COLUMN constraint_density INTEGER"
-            )
-        if "ac_specificity" not in existing:
-            conn.execute("ALTER TABLE ticket_metrics ADD COLUMN ac_specificity INTEGER")
-        if "tech_stack" not in existing:
-            conn.execute("ALTER TABLE ticket_metrics ADD COLUMN tech_stack TEXT")
-        if "raw_extensions" not in existing:
-            conn.execute("ALTER TABLE ticket_metrics ADD COLUMN raw_extensions TEXT")
-        if "waste_score" not in existing:
-            conn.execute("ALTER TABLE ticket_metrics ADD COLUMN waste_score INTEGER")
-        if "waste_breakdown_json" not in existing:
-            conn.execute(
-                "ALTER TABLE ticket_metrics ADD COLUMN waste_breakdown_json TEXT"
-            )
-        if "tags" not in existing:
-            conn.execute("ALTER TABLE ticket_metrics ADD COLUMN tags TEXT")
-        if "notes" not in existing:
-            conn.execute("ALTER TABLE ticket_metrics ADD COLUMN notes TEXT")
-        if "effort" not in existing:
-            conn.execute("ALTER TABLE ticket_metrics ADD COLUMN effort TEXT")
-        if "compact_duration_ms" not in existing:
-            conn.execute(
-                "ALTER TABLE ticket_metrics ADD COLUMN compact_duration_ms INTEGER"
-            )
-        if "api_retry_count" not in existing:
-            conn.execute(
-                "ALTER TABLE ticket_metrics ADD COLUMN api_retry_count INTEGER"
-            )
-        if "subagent_spawns" not in existing:
-            conn.execute(
-                "ALTER TABLE ticket_metrics ADD COLUMN subagent_spawns INTEGER"
-            )
-        if "hook_trust_violations" not in existing:
-            conn.execute(
-                "ALTER TABLE ticket_metrics ADD COLUMN hook_trust_violations INTEGER"
-            )
-        if "dispatch_concurrency" not in existing:
-            conn.execute(
-                "ALTER TABLE ticket_metrics ADD COLUMN dispatch_concurrency INTEGER"
-            )
-        # WOR-370: vLLM /metrics delta capture (only populated when
-        # dispatch_concurrency==0 at dispatch AND no peer was launched
-        # during the session — otherwise the server-wide counters mix
-        # multiple workers' traffic and per-ticket attribution breaks).
-        if "vllm_metrics_attributable" not in existing:
-            conn.execute(
-                "ALTER TABLE ticket_metrics "
-                "ADD COLUMN vllm_metrics_attributable INTEGER"
-            )
-        if "vllm_prefix_cache_hits" not in existing:
-            conn.execute(
-                "ALTER TABLE ticket_metrics ADD COLUMN vllm_prefix_cache_hits INTEGER"
-            )
-        if "vllm_prefix_cache_queries" not in existing:
-            conn.execute(
-                "ALTER TABLE ticket_metrics "
-                "ADD COLUMN vllm_prefix_cache_queries INTEGER"
-            )
-        if "vllm_prefix_cache_hit_ratio" not in existing:
-            conn.execute(
-                "ALTER TABLE ticket_metrics ADD COLUMN vllm_prefix_cache_hit_ratio REAL"
-            )
-        if "vllm_prompt_tokens" not in existing:
-            conn.execute(
-                "ALTER TABLE ticket_metrics ADD COLUMN vllm_prompt_tokens INTEGER"
-            )
-        if "vllm_generation_tokens" not in existing:
-            conn.execute(
-                "ALTER TABLE ticket_metrics ADD COLUMN vllm_generation_tokens INTEGER"
-            )
-        if "vllm_ttft_seconds_sum" not in existing:
-            conn.execute(
-                "ALTER TABLE ticket_metrics ADD COLUMN vllm_ttft_seconds_sum REAL"
-            )
-        if "vllm_ttft_count" not in existing:
-            conn.execute(
-                "ALTER TABLE ticket_metrics ADD COLUMN vllm_ttft_count INTEGER"
-            )
-        if "vllm_ttft_mean_seconds" not in existing:
-            conn.execute(
-                "ALTER TABLE ticket_metrics ADD COLUMN vllm_ttft_mean_seconds REAL"
-            )
-        if "vllm_preemptions" not in existing:
-            conn.execute(
-                "ALTER TABLE ticket_metrics ADD COLUMN vllm_preemptions INTEGER"
-            )
-        # WOR-380: per-worker behavior telemetry from stream-json log.
-        # Concurrency-safe sibling to WOR-370 — all derived from the
-        # worker's own log file.
-        if "turn_count" not in existing:
-            conn.execute("ALTER TABLE ticket_metrics ADD COLUMN turn_count INTEGER")
-        if "tool_calls_total" not in existing:
-            conn.execute(
-                "ALTER TABLE ticket_metrics ADD COLUMN tool_calls_total INTEGER"
-            )
-        if "tool_calls_breakdown" not in existing:
-            conn.execute(
-                "ALTER TABLE ticket_metrics ADD COLUMN tool_calls_breakdown TEXT"
-            )
-        if "thinking_blocks" not in existing:
-            conn.execute(
-                "ALTER TABLE ticket_metrics ADD COLUMN thinking_blocks INTEGER"
-            )
-        if "thinking_chars_total" not in existing:
-            conn.execute(
-                "ALTER TABLE ticket_metrics ADD COLUMN thinking_chars_total INTEGER"
-            )
-        if "input_tokens_max" not in existing:
-            conn.execute(
-                "ALTER TABLE ticket_metrics ADD COLUMN input_tokens_max INTEGER"
-            )
-        if "input_tokens_first" not in existing:
-            conn.execute(
-                "ALTER TABLE ticket_metrics ADD COLUMN input_tokens_first INTEGER"
-            )
-        if "input_tokens_last" not in existing:
-            conn.execute(
-                "ALTER TABLE ticket_metrics ADD COLUMN input_tokens_last INTEGER"
-            )
-        if "redundant_reads_count" not in existing:
-            conn.execute(
-                "ALTER TABLE ticket_metrics ADD COLUMN redundant_reads_count INTEGER"
-            )
 
     @contextmanager
     def _connect(self) -> Generator[sqlite3.Connection, None, None]:
@@ -885,75 +791,65 @@ def compute_tags(
     Returns:
         A list of tag name strings.  May be empty.
     """
+    return [
+        *_anomaly_tags(ticket_metrics_row, result_json_status, tracked_prs),
+        *_category_tags(ticket_metrics_row, result_json_flags),
+    ]
+
+
+def _anomaly_tags(
+    m: TicketMetrics,
+    result_json_status: str,
+    tracked_prs: list[Any] | None,
+) -> list[str]:
+    """Anomaly-detection tags (2026-05-03 retro).
+
+    Type-strict isinstance guards keep the function robust to non-numeric inputs
+    leaking from MagicMocks in tests that mock metrics.get_by_ticket.
+    """
     tags: list[str] = []
-    outcome = ticket_metrics_row.outcome
-    lines_changed = ticket_metrics_row.lines_changed
-    waste_score = ticket_metrics_row.waste_score
-    retry_count = ticket_metrics_row.retry_count
-    local_tokens = ticket_metrics_row.local_tokens
-    local_wall_time = ticket_metrics_row.local_wall_time
-    api_retry_count = ticket_metrics_row.api_retry_count
-    context_compactions = ticket_metrics_row.context_compactions
-
-    # --- Anomaly detection rules (4) ---
-    # Type-strict guards (isinstance vs `is not None`) so the function is
-    # robust to non-numeric inputs (e.g. MagicMock leaking through tests that
-    # mock `metrics.get_by_ticket`). Without this guard, comparisons against
-    # non-numeric values raise TypeError and break unrelated tests.
-
-    # zero_tokens_high_wall_time: local worker burned wall time with almost no
-    # tokens — likely a failed run that still consumed time (2026-05-03 retro).
-    if isinstance(local_tokens, (int, float)) and isinstance(
-        local_wall_time, (int, float)
+    if (
+        isinstance(m.local_tokens, (int, float))
+        and isinstance(m.local_wall_time, (int, float))
+        and m.local_tokens < 100_000
+        and m.local_wall_time > 1_800
     ):
-        if local_tokens < 100_000 and local_wall_time > 1_800:
-            tags.append("zero_tokens_high_wall_time")
-
-    # no_diff_against_base: the worker reported failure but produced no diff —
-    # it never got far enough to write code (2026-05-03 retro).
-    if outcome == "failure" and isinstance(lines_changed, int) and lines_changed == 0:
+        tags.append("zero_tokens_high_wall_time")
+    if (
+        m.outcome == "failure"
+        and isinstance(m.lines_changed, int)
+        and m.lines_changed == 0
+    ):
         tags.append("no_diff_against_base")
-
-    # success_outcome_state_mismatch: result.json says success but metrics
-    # record captured failure — state machine inconsistency (2026-05-03 retro).
-    if result_json_status == "success" and outcome == "failure":
+    if result_json_status == "success" and m.outcome == "failure":
         tags.append("success_outcome_state_mismatch")
-
-    # success_pr_create_failed: the worker succeeded but the PR push failed —
-    # the PR is not visible in the repo (2026-05-03 retro).
-    if outcome == "success" and tracked_prs is not None and len(tracked_prs) == 0:
+    if m.outcome == "success" and tracked_prs is not None and len(tracked_prs) == 0:
         tags.append("success_pr_create_failed")
+    return tags
 
-    # --- Categorization rules (4) ---
 
-    # scope_drift: the worker itself flagged that it went beyond scope.
+def _category_tags(
+    m: TicketMetrics,
+    result_json_flags: dict[str, bool] | None,
+) -> list[str]:
+    """Categorization tags from result.json signals and metric thresholds.
+
+    backend_unstable threshold (6) calibrated 2026-05-04: Pearson r=0.665 vs
+    wall_time, 6+ bucket runs 4x slower than no-retry baseline (WOR-366).
+    """
+    tags: list[str] = []
     if result_json_flags and result_json_flags.get("scope_drift"):
         tags.append("scope_drift")
-
-    # escalated: the final outcome was an escalation to cloud.
-    if outcome == "escalated":
+    if m.outcome == "escalated":
         tags.append("escalated")
-
-    # high_waste: the waste score exceeds the 80 threshold.
-    if isinstance(waste_score, (int, float)) and waste_score > 80:
+    if isinstance(m.waste_score, (int, float)) and m.waste_score > 80:
         tags.append("high_waste")
-
-    # rework: the ticket required at least one retry.
-    if isinstance(retry_count, int) and retry_count > 0:
+    if isinstance(m.retry_count, int) and m.retry_count > 0:
         tags.append("rework")
-
-    # mid_session_compaction: the session performed at least one context
-    # compaction — the LLM context was truncated during the run.
-    if isinstance(context_compactions, int) and context_compactions > 0:
+    if isinstance(m.context_compactions, int) and m.context_compactions > 0:
         tags.append("mid_session_compaction")
-
-    # backend_unstable: high count of Claude Code internal api_retry events.
-    # Threshold 6 calibrated on 2026-05-04 backfill — Pearson r=0.665 vs
-    # wall_time, with the 6+ bucket running 4× slower than the no-retry
-    # baseline (28 min vs 121 min mean). WOR-366.
-    if isinstance(api_retry_count, int) and api_retry_count >= 6:
+    if isinstance(m.api_retry_count, int) and m.api_retry_count >= 6:
         tags.append("backend_unstable")
-
     return tags
 
 

--- a/app/core/watcher/dispatch.py
+++ b/app/core/watcher/dispatch.py
@@ -58,134 +58,19 @@ def start_ticket(
     _dedup_state: dict[str, str],
 ) -> None:
     """Run the full ticket-start flow (WOR-431: prereqs + dispatch)."""
-    # Prerequisite checks (WOR-431: moved here from Watcher._start_ticket
-    # so dispatch.start_ticket is fully self-contained).
-    open_blockers = linear.get_open_blockers(linear_id)
-    if open_blockers:
-        logger.info("Skipping %s - open blockers: %s", ticket_id, open_blockers)
+    if not _check_blocker_preconditions(linear, manifest, linear_id, ticket_id):
         return
-    for blocker_id in manifest.blocked_by_tickets:
-        state_type = linear.get_issue_state_type(blocker_id)
-        if state_type not in DONE_STATE_TYPES:
-            logger.info(
-                "Skipping %s - manifest declares unmerged blocker %s (state=%s)",
-                ticket_id,
-                blocker_id,
-                state_type,
-            )
-            return
-
-    # WOR-419: defense-in-depth — refuse to spawn a worker on a new epic/*
-    # branch when another epic/* branch is already in flight. This prevents
-    # overlapping epic work from competing for the same shared files
-    # (CLAUDE.md, templates/, etc.) and keeps the epic branch topology clean.
-    # Gate fires ONLY when this ticket's base_branch is epic/* AND another
-    # active worker is already on a different epic/* branch. Sub-ticket
-    # branches under the same epic are unaffected — those are the normal
-    # dispatch path and handled by the overlap check above.
-    if manifest.base_branch.startswith("epic/"):
-        for worker in _local_active:
-            if (
-                hasattr(worker, "manifest")
-                and worker.manifest.base_branch.startswith("epic/")
-                and worker.manifest.base_branch != manifest.base_branch
-            ):
-                logger.warning(
-                    "Deferring %s — epic branch %s already in-flight (worker on %s)",
-                    ticket_id,
-                    manifest.base_branch,
-                    worker.manifest.base_branch,
-                )
-                linear.post_comment(
-                    linear_id,
-                    (
-                        f"Dispatch deferred: another worker is already "
-                        f"in-flight on epic branch "
-                        f"`{worker.manifest.base_branch}`. "
-                        f"Cannot dispatch to a new epic branch "
-                        f"`{manifest.base_branch}` until the in-flight "
-                        f"worker completes (one-active-epic-branch "
-                        f"principle, WOR-419)."
-                    ),
-                )
-                return
-
-    # Manifest quality gates (WOR-378) — Pydantic validation accepts these as
-    # legal but they are almost certainly authoring mistakes. Refuse early
-    # with a clear Linear comment so the operator knows to re-author.
-    if manifest.implementation_mode == "local" and not manifest.allowed_paths:
-        logger.warning(
-            "Refusing %s — local manifest has empty allowed_paths", ticket_id
-        )
-        safe_set_state(linear, linear_id, "Backlog", ticket_id)
-        linear.post_comment(
-            linear_id,
-            (
-                "Manifest refused: `allowed_paths` is empty. Local worker "
-                "dispatch requires explicit path scoping so the watcher can "
-                "guarantee path-overlap parallelism. Re-run `/start-ticket` "
-                "to populate the field."
-            ),
-        )
+    if not _check_epic_branch_overlap(
+        linear, manifest, _local_active, linear_id, ticket_id
+    ):
         return
-    if not manifest.required_checks:
-        logger.warning("Refusing %s — manifest has empty required_checks", ticket_id)
-        safe_set_state(linear, linear_id, "Backlog", ticket_id)
-        linear.post_comment(
-            linear_id,
-            (
-                "Manifest refused: `required_checks` is empty. Worker must "
-                "have at least one check (typically: `ruff check .`, "
-                "`mypy app/`, `pytest`) before declaring success. Re-run "
-                "`/start-ticket`."
-            ),
-        )
+    if not _check_manifest_quality(linear, manifest, linear_id, ticket_id):
         return
-
-    # WOR-373: stale-epic refusal. If the sub-ticket's base_branch is an
-    # epic that has fallen too far behind main, block dispatch. Stale epics
-    # silently drop main-side work during the next merge conflict resolution
-    # (see WOR-282 forensic — 13 tests lost on a 107-commit-behind epic).
-    drift = count_main_ahead_of_epic(manifest.base_branch, _repo_root)
-    if drift > _EPIC_DRIFT_THRESHOLD:
-        logger.warning(
-            "Refusing %s — epic %s is %d commits behind origin/main (threshold %d)",
-            ticket_id,
-            manifest.base_branch,
-            drift,
-            _EPIC_DRIFT_THRESHOLD,
-        )
-        safe_set_state(linear, linear_id, "Backlog", ticket_id)
-        linear.post_comment(
-            linear_id,
-            (
-                f"Manifest refused: epic branch `{manifest.base_branch}` is "
-                f"{drift} commits behind `origin/main` (threshold: "
-                f"{_EPIC_DRIFT_THRESHOLD}). Stale epics silently drop tests "
-                f"during merge conflict resolution — see WOR-282 forensic. "
-                f"Merge main into the epic first, then re-dispatch:\n\n"
-                f"  git fetch origin\n"
-                f"  git checkout {manifest.base_branch}\n"
-                f"  git merge origin/main\n"
-                f"  # resolve conflicts...\n"
-                f"  git push"
-            ),
-        )
+    if not _check_epic_drift(linear, manifest, _repo_root, linear_id, ticket_id):
         return
-
-    # WOR-431: path-overlap check (was in Watcher._start_ticket pre-#886).
-    # Runs AFTER the WOR-419 epic-branch gate, WOR-378 manifest gates,
-    # and WOR-373 stale-epic check to preserve original ordering.
-    all_active = _local_active + _cloud_active
-    conflicts = check_allowed_paths_overlap(all_active, manifest)
-    if conflicts:
-        reason = f"overlap:{','.join(conflicts)}"
-        reason_msg = "Deferring %s - allowed_paths overlap with active workers: %s" % (
-            ticket_id,
-            conflicts,
-        )
-        if suppress_dedup(ticket_id, reason, reason_msg, _dedup_state):
-            logger.info(reason_msg)
+    if not _check_path_overlap(
+        manifest, _local_active, _cloud_active, ticket_id, _dedup_state
+    ):
         return
 
     effective_mode = resolve_effective_mode(
@@ -263,3 +148,174 @@ def start_ticket(
         _local_active.append(worker)
     else:
         _cloud_active.append(worker)
+
+
+def _check_blocker_preconditions(
+    linear: LinearClientProtocol,
+    manifest: ExecutionManifest,
+    linear_id: str,
+    ticket_id: str,
+) -> bool:
+    """Return True to proceed; False to defer silently.
+
+    Skips dispatch when Linear lists open blockers OR when
+    manifest.blocked_by_tickets declares dependencies that have not reached a
+    Done-equivalent state yet.
+    """
+    open_blockers = linear.get_open_blockers(linear_id)
+    if open_blockers:
+        logger.info("Skipping %s - open blockers: %s", ticket_id, open_blockers)
+        return False
+    for blocker_id in manifest.blocked_by_tickets:
+        state_type = linear.get_issue_state_type(blocker_id)
+        if state_type not in DONE_STATE_TYPES:
+            logger.info(
+                "Skipping %s - manifest declares unmerged blocker %s (state=%s)",
+                ticket_id,
+                blocker_id,
+                state_type,
+            )
+            return False
+    return True
+
+
+def _check_epic_branch_overlap(
+    linear: LinearClientProtocol,
+    manifest: ExecutionManifest,
+    _local_active: list[ActiveWorker],
+    linear_id: str,
+    ticket_id: str,
+) -> bool:
+    """WOR-419: defense-in-depth.
+
+    Refuse to spawn a worker on a new epic/* branch when another epic/*
+    branch is already in flight. Sub-ticket branches under the same epic
+    are unaffected.
+    """
+    if not manifest.base_branch.startswith("epic/"):
+        return True
+    for worker in _local_active:
+        if not hasattr(worker, "manifest"):
+            continue
+        peer_base = worker.manifest.base_branch
+        if not peer_base.startswith("epic/") or peer_base == manifest.base_branch:
+            continue
+        logger.warning(
+            "Deferring %s — epic branch %s already in-flight (worker on %s)",
+            ticket_id,
+            manifest.base_branch,
+            peer_base,
+        )
+        linear.post_comment(
+            linear_id,
+            (
+                f"Dispatch deferred: another worker is already "
+                f"in-flight on epic branch `{peer_base}`. "
+                f"Cannot dispatch to a new epic branch "
+                f"`{manifest.base_branch}` until the in-flight "
+                f"worker completes (one-active-epic-branch "
+                f"principle, WOR-419)."
+            ),
+        )
+        return False
+    return True
+
+
+def _check_manifest_quality(
+    linear: LinearClientProtocol,
+    manifest: ExecutionManifest,
+    linear_id: str,
+    ticket_id: str,
+) -> bool:
+    """WOR-378 quality gates: empty allowed_paths or required_checks -> reject."""
+    if manifest.implementation_mode == "local" and not manifest.allowed_paths:
+        logger.warning(
+            "Refusing %s — local manifest has empty allowed_paths", ticket_id
+        )
+        safe_set_state(linear, linear_id, "Backlog", ticket_id)
+        linear.post_comment(
+            linear_id,
+            (
+                "Manifest refused: `allowed_paths` is empty. Local worker "
+                "dispatch requires explicit path scoping so the watcher can "
+                "guarantee path-overlap parallelism. Re-run `/start-ticket` "
+                "to populate the field."
+            ),
+        )
+        return False
+    if not manifest.required_checks:
+        logger.warning("Refusing %s — manifest has empty required_checks", ticket_id)
+        safe_set_state(linear, linear_id, "Backlog", ticket_id)
+        linear.post_comment(
+            linear_id,
+            (
+                "Manifest refused: `required_checks` is empty. Worker must "
+                "have at least one check (typically: `ruff check .`, "
+                "`mypy app/`, `pytest`) before declaring success. Re-run "
+                "`/start-ticket`."
+            ),
+        )
+        return False
+    return True
+
+
+def _check_epic_drift(
+    linear: LinearClientProtocol,
+    manifest: ExecutionManifest,
+    _repo_root: Path,
+    linear_id: str,
+    ticket_id: str,
+) -> bool:
+    """WOR-373: refuse stale epics.
+
+    Stale epics silently drop main-side work during merge conflict
+    resolution (WOR-282 forensic: 13 tests lost on a 107-commit-behind epic).
+    """
+    drift = count_main_ahead_of_epic(manifest.base_branch, _repo_root)
+    if drift <= _EPIC_DRIFT_THRESHOLD:
+        return True
+    logger.warning(
+        "Refusing %s — epic %s is %d commits behind origin/main (threshold %d)",
+        ticket_id,
+        manifest.base_branch,
+        drift,
+        _EPIC_DRIFT_THRESHOLD,
+    )
+    safe_set_state(linear, linear_id, "Backlog", ticket_id)
+    linear.post_comment(
+        linear_id,
+        (
+            f"Manifest refused: epic branch `{manifest.base_branch}` is "
+            f"{drift} commits behind `origin/main` (threshold: "
+            f"{_EPIC_DRIFT_THRESHOLD}). Stale epics silently drop tests "
+            f"during merge conflict resolution — see WOR-282 forensic. "
+            f"Merge main into the epic first, then re-dispatch:\n\n"
+            f"  git fetch origin\n"
+            f"  git checkout {manifest.base_branch}\n"
+            f"  git merge origin/main\n"
+            f"  # resolve conflicts...\n"
+            f"  git push"
+        ),
+    )
+    return False
+
+
+def _check_path_overlap(
+    manifest: ExecutionManifest,
+    _local_active: list[ActiveWorker],
+    _cloud_active: list[ActiveWorker],
+    ticket_id: str,
+    _dedup_state: dict[str, str],
+) -> bool:
+    """WOR-431: defer when allowed_paths overlap with any active worker."""
+    conflicts = check_allowed_paths_overlap(_local_active + _cloud_active, manifest)
+    if not conflicts:
+        return True
+    reason = f"overlap:{','.join(conflicts)}"
+    reason_msg = "Deferring %s - allowed_paths overlap with active workers: %s" % (
+        ticket_id,
+        conflicts,
+    )
+    if suppress_dedup(ticket_id, reason, reason_msg, _dedup_state):
+        logger.info(reason_msg)
+    return False

--- a/app/core/watcher/ticket_status.py
+++ b/app/core/watcher/ticket_status.py
@@ -160,12 +160,32 @@ def _truncate(s: str, max_len: int = 40) -> str:
     return s[: max_len - 3] + "..."
 
 
-def _parse_last_tool_calls(log_path: Path) -> list[ToolCallInfo]:
-    """Tail the last ~10 lines of the log and extract tool_use events.
+def _parse_assistant_line(line: str) -> list[dict[str, Any]]:
+    """Return tool_use blocks from a single JSONL assistant event.
 
-    Returns up to 3 most recent tool calls as ToolCallInfo objects.
-    Returns [] when the log is empty or has no tool_use events.
+    Returns [] for any line that isn't a parseable assistant event with
+    a content array.
     """
+    line = line.strip()
+    if not line:
+        return []
+    try:
+        obj = json.loads(line)
+    except json.JSONDecodeError:
+        return []
+    if obj.get("type") != "assistant":
+        return []
+    msg = obj.get("message", {}) or {}
+    content = msg.get("content") or []
+    return [
+        b
+        for b in content
+        if isinstance(b, dict) and b.get("type") == "tool_use" and b.get("name")
+    ]
+
+
+def _parse_last_tool_calls(log_path: Path) -> list[ToolCallInfo]:
+    """Tail the last ~30 lines of the log and extract the 3 most recent tool calls."""
     try:
         lines = log_path.read_text(encoding="utf-8").splitlines()
         tail = lines[-30:] if len(lines) > 30 else lines
@@ -174,27 +194,9 @@ def _parse_last_tool_calls(log_path: Path) -> list[ToolCallInfo]:
 
     calls: list[ToolCallInfo] = []
     for line in tail:
-        line = line.strip()
-        if not line:
-            continue
-        try:
-            obj = json.loads(line)
-        except json.JSONDecodeError:
-            continue
-        if obj.get("type") != "assistant":
-            continue
-        msg = obj.get("message", {}) or {}
-        for block in msg.get("content") or []:
-            if not isinstance(block, dict):
-                continue
-            if block.get("type") != "tool_use":
-                continue
-            name = block.get("name", "")
-            if not name:
-                continue
-            input_data = block.get("input") or {}
-            display = _build_display(name, input_data)
-            calls.append(ToolCallInfo(name=name, display=_truncate(display)))
+        for block in _parse_assistant_line(line):
+            display = _build_display(block["name"], block.get("input") or {})
+            calls.append(ToolCallInfo(name=block["name"], display=_truncate(display)))
             if len(calls) >= 3:
                 return list(reversed(calls))
     return list(reversed(calls))
@@ -257,113 +259,21 @@ def fetch_ticket_status(
     """
     ticket_id_lower = ticket_id.lower()
 
-    # ---- Linear data ----
-    try:
-        issue = linear_client.get_issue(ticket_id)
-    except Exception as exc:
-        # Fallback: return minimal info when Linear is unreachable.
-        return TicketStatus(
-            ticket_id=ticket_id,
-            title=f"(error fetching: {exc})",
-            state="Unknown",
-            state_age_seconds=None,
-            worker_log=None,
-            artifacts=None,
-            worktree_exists=None,
-            worktree_path=None,
-        )
+    linear_data = _fetch_linear_state(linear_client, ticket_id)
+    if isinstance(linear_data, TicketStatus):
+        return linear_data
+    title, state, state_age_seconds = linear_data
 
-    title = issue.get("title", "")
-    state_data = issue.get("state") or {}
-    state = state_data.get("name", state_data.get("type", "Unknown"))
-    state_created = state_data.get("createdAt") or state_data.get("created_at")
-
-    state_age_seconds: int | None = None
-    if state_created:
-        try:
-            # Linear returns ISO-8601 strings like "2026-05-10T06:19:32.000Z"
-            created_dt = time.mktime(
-                time.strptime(state_created[:19], "%Y-%m-%dT%H:%M:%S")
-            )
-            state_age_seconds = max(0, int(time.time() - created_dt))
-        except (ValueError, TypeError):
-            state_age_seconds = None
-
-    # ---- Log file ----
     log_path = _parse_log_path(ticket_id_lower)
-    log_info: LogInfo | None = None
-    if log_path.exists():
-        stat = log_path.stat()
-        size_bytes = stat.st_size
-        mtime = stat.st_mtime
-        last_activity = max(0, int(time.time() - mtime))
+    log_info = _load_log_info(log_path) if log_path.exists() else None
 
-        # Last 3 tool calls
-        last_tool_calls = _parse_last_tool_calls(log_path)
-
-        # API retries and subagent spawns from existing helpers
-        from app.core.watcher.watcher_log_parsing import (
-            _parse_worker_api_retries,
-            _parse_worker_subagent_spawns,
-        )
-
-        api_retries = _parse_worker_api_retries(log_path)
-        subagent_spawns = _parse_worker_subagent_spawns(log_path)
-
-        log_info = LogInfo(
-            size_bytes=size_bytes,
-            last_activity_ago_seconds=last_activity,
-            last_tool_calls=last_tool_calls,
-            api_retries=api_retries,
-            subagent_spawns=subagent_spawns,
-        )
-
-    # ---- Artifacts ----
     if artifact_dir is None:
         artifact_paths = ArtifactPaths.from_ticket_id(ticket_id)
         artifact_dir = Path(artifact_paths.result_json).parent
+    artifacts = _load_artifacts(artifact_dir)
 
-    entries: dict[str, int] = {}
-    if artifact_dir.exists():
-        for child in sorted(artifact_dir.iterdir()):
-            if child.is_file():
-                entries[child.name] = child.stat().st_size
-
-    if entries:
-        artifacts = ArtifactInfo(path=str(artifact_dir), entries=entries)
-    else:
-        artifacts = None
-
-    # ---- Worktree ----
-    worktree_path = None
-    if worktree_dir is None:
-        slug = ticket_id_lower.replace("-", "_")
-        worktree_dir = Path(".claude") / "worktrees" / slug
-    else:
-        worktree_path = str(worktree_dir)
-
-    worktree_exists = worktree_dir.exists() if worktree_dir else None
-    if worktree_path is None and worktree_dir is not None:
-        worktree_path = str(worktree_dir)
-
-    # ---- Health flags ----
-    health_flags: dict[str, Any] = {}
-    if log_info is not None:
-        if log_info.api_retries is not None:
-            health_flags["api_retries"] = log_info.api_retries
-        if log_info.subagent_spawns is not None:
-            health_flags["subagent_spawns"] = log_info.subagent_spawns
-
-    # If there are no artifacts beyond what's expected, flag it
-    result_json_path = artifact_dir / "result.json"
-    if not result_json_path.exists() and state not in (
-        "Done",
-        "MergedToEpic",
-        "Cancelled",
-        "Duplicate",
-        "Blocked",
-    ):
-        health_flags["no_result_artifact"] = True
+    worktree_exists, worktree_path = _resolve_worktree(worktree_dir, ticket_id_lower)
+    health_flags = _compute_health_flags(log_info, artifact_dir, state)
 
     return TicketStatus(
         ticket_id=ticket_id,
@@ -376,3 +286,101 @@ def fetch_ticket_status(
         worktree_path=worktree_path,
         health_flags=health_flags,
     )
+
+
+def _fetch_linear_state(
+    linear_client: Any, ticket_id: str
+) -> tuple[str, str, int | None] | TicketStatus:
+    """Fetch issue from Linear and extract (title, state, state_age_seconds).
+
+    Returns a fallback TicketStatus directly when Linear is unreachable.
+    """
+    try:
+        issue = linear_client.get_issue(ticket_id)
+    except Exception as exc:
+        return TicketStatus(
+            ticket_id=ticket_id,
+            title=f"(error fetching: {exc})",
+            state="Unknown",
+            state_age_seconds=None,
+            worker_log=None,
+            artifacts=None,
+            worktree_exists=None,
+            worktree_path=None,
+        )
+    title = issue.get("title", "")
+    state_data = issue.get("state") or {}
+    state = state_data.get("name", state_data.get("type", "Unknown"))
+    state_created = state_data.get("createdAt") or state_data.get("created_at")
+    state_age_seconds: int | None = None
+    if state_created:
+        try:
+            created_dt = time.mktime(
+                time.strptime(state_created[:19], "%Y-%m-%dT%H:%M:%S")
+            )
+            state_age_seconds = max(0, int(time.time() - created_dt))
+        except (ValueError, TypeError):
+            state_age_seconds = None
+    return title, state, state_age_seconds
+
+
+def _load_log_info(log_path: Path) -> LogInfo:
+    """Build LogInfo from an existing worker log file."""
+    from app.core.watcher.watcher_log_parsing import (
+        _parse_worker_api_retries,
+        _parse_worker_subagent_spawns,
+    )
+
+    stat = log_path.stat()
+    return LogInfo(
+        size_bytes=stat.st_size,
+        last_activity_ago_seconds=max(0, int(time.time() - stat.st_mtime)),
+        last_tool_calls=_parse_last_tool_calls(log_path),
+        api_retries=_parse_worker_api_retries(log_path),
+        subagent_spawns=_parse_worker_subagent_spawns(log_path),
+    )
+
+
+def _load_artifacts(artifact_dir: Path) -> ArtifactInfo | None:
+    """Enumerate files in artifact_dir; None if empty or missing."""
+    if not artifact_dir.exists():
+        return None
+    entries: dict[str, int] = {
+        child.name: child.stat().st_size
+        for child in sorted(artifact_dir.iterdir())
+        if child.is_file()
+    }
+    if not entries:
+        return None
+    return ArtifactInfo(path=str(artifact_dir), entries=entries)
+
+
+def _resolve_worktree(
+    worktree_dir: Path | None, ticket_id_lower: str
+) -> tuple[bool | None, str | None]:
+    """Resolve worktree existence + display path."""
+    if worktree_dir is None:
+        slug = ticket_id_lower.replace("-", "_")
+        worktree_dir = Path(".claude") / "worktrees" / slug
+    return worktree_dir.exists(), str(worktree_dir)
+
+
+def _compute_health_flags(
+    log_info: LogInfo | None, artifact_dir: Path, state: str
+) -> dict[str, Any]:
+    """Aggregate health-flag dict for the snapshot."""
+    health_flags: dict[str, Any] = {}
+    if log_info is not None:
+        if log_info.api_retries is not None:
+            health_flags["api_retries"] = log_info.api_retries
+        if log_info.subagent_spawns is not None:
+            health_flags["subagent_spawns"] = log_info.subagent_spawns
+    if not (artifact_dir / "result.json").exists() and state not in (
+        "Done",
+        "MergedToEpic",
+        "Cancelled",
+        "Duplicate",
+        "Blocked",
+    ):
+        health_flags["no_result_artifact"] = True
+    return health_flags

--- a/app/core/watcher/watcher_finalize.py
+++ b/app/core/watcher/watcher_finalize.py
@@ -220,24 +220,19 @@ def attempt_pr(
     return "success", pr_url
 
 
-def finalize_worker(
+def _run_retry_loop(
     worker: ActiveWorker,
-    *,
     returncode: int,
-    wall_time: float,
     linear: LinearClientProtocol,
-    metrics: MetricsStore,
     escalation_policy: EscalationPolicy,
     repo_root: Path,
-    mode: str,
+    eff: str,
+    tracked_prs: list[TrackedPR] | None,
+    metrics: MetricsStore,
     project_id: str,
-    tracked_prs: list[TrackedPR] | None = None,
-) -> Outcome:
-    eff = resolve_effective_mode(mode, worker.manifest.implementation_mode)
-
-    # WOR-312: in-dispatch retry loop. On check failure, re-launch the worker
-    # with a RETRY hint and loop back to re-run checks — avoiding the slower
-    # Linear Blocked → ReadyForLocal redispatch path.
+) -> tuple[Outcome, bool, bool, list[str] | None, list[dict[str, int | str]]]:
+    """Execute the in-dispatch retry loop (WOR-312). Returns the final
+    finalization tuple after the last attempt."""
     first_finalization = True
     max_retries = min(ATTEMPT_HARDCAP, worker.manifest.failure_policy.max_retries)
     while True:
@@ -255,32 +250,34 @@ def finalize_worker(
             )
         )
         if not failed_checks:
-            break
-        # WOR-312: attempt_count is the number of _execute_finalization calls
-        # so far. Use > (not >=) so that max_retries=1 means: 1 initial attempt
-        # + 1 retry before breaking.  max_retries=0 breaks immediately.
-        if worker.attempt_count > max_retries:
-            break
-        if first_finalization:
-            first_finalization = False
-            failed_checks_json = json.dumps([str(f["check"]) for f in failed_checks])
-            extra = (
-                f"Worker failed checks: {failed_checks_json}. "
-                f"Re-launching with RETRY hint."
+            return (
+                outcome,
+                escalated,
+                artifacts_preserved,
+                sonar_findings,
+                failed_checks,
             )
-            logger.info("%s — %s", worker.ticket_id, extra)
-        else:
-            logger.warning(
-                "%s check retry %d/%d — %s",
-                worker.ticket_id,
-                worker.attempt_count,
-                max_retries,
-                "checks failed",
+        if worker.attempt_count > max_retries:
+            return (
+                outcome,
+                escalated,
+                artifacts_preserved,
+                sonar_findings,
+                failed_checks,
             )
         failed_checks_json = json.dumps([str(f["check"]) for f in failed_checks])
         extra_constraint = (
             f"Worker failed checks: {failed_checks_json}. Re-launching with RETRY hint."
         )
+        if first_finalization:
+            logger.info("%s — %s", worker.ticket_id, extra_constraint)
+        else:
+            logger.warning(
+                "%s check retry %d/%d — checks failed",
+                worker.ticket_id,
+                worker.attempt_count,
+                max_retries,
+            )
         launch_worker(
             repo_root,
             worker.manifest,
@@ -289,6 +286,137 @@ def finalize_worker(
             extra_constraint=extra_constraint,
         )
         first_finalization = False
+
+
+def _compute_diff_stats(worktree_path: Path, base_branch: str) -> tuple[int, int]:
+    """Run `git diff --shortstat` against the merge-base; return (lines, files)."""
+    try:
+        diff_output = subprocess.run(  # nosec B603 B607
+            [
+                "git",
+                "-C",
+                str(worktree_path),
+                "diff",
+                "--shortstat",
+                f"{base_branch}...HEAD",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        raw = (diff_output.stdout or "") + (diff_output.stderr or "")
+        return parse_git_shortstat(raw)
+    except (OSError, subprocess.TimeoutExpired):
+        return 0, 0
+
+
+def _capture_vllm_post(
+    worker: ActiveWorker, repo_root: Path
+) -> tuple[bool | None, dict[str, float | int | None]]:
+    """WOR-370: capture the post-session vLLM /metrics snapshot.
+
+    Returns (attributable, deltas). Three states:
+      - (True, deltas) — worker remained solo, after-snapshot succeeded
+      - (False, {})   — concurrent during session, OR after-snapshot failed
+      - (None, {})    — no pre-snapshot was taken
+    """
+    if worker.vllm_metrics_before is None:
+        return None, {}
+    if not worker.remained_solo:
+        _write_vllm_metrics_artifact(
+            repo_root,
+            worker.ticket_id,
+            attributable=False,
+            before=worker.vllm_metrics_before,
+            after=None,
+            deltas={},
+            reason="concurrent worker dispatched during session",
+        )
+        return False, {}
+    after = capture_vllm_metrics()
+    if after is None:
+        _write_vllm_metrics_artifact(
+            repo_root,
+            worker.ticket_id,
+            attributable=False,
+            before=worker.vllm_metrics_before,
+            after=None,
+            deltas={},
+            reason="after-snapshot failed (vLLM /metrics unreachable)",
+        )
+        return False, {}
+    deltas = compute_vllm_metrics_delta(worker.vllm_metrics_before, after)
+    _write_vllm_metrics_artifact(
+        repo_root,
+        worker.ticket_id,
+        attributable=True,
+        before=worker.vllm_metrics_before,
+        after=after,
+        deltas=deltas,
+    )
+    return True, deltas
+
+
+def _post_improvement_log(linear: LinearClientProtocol, worker: ActiveWorker) -> None:
+    """WOR-303: harvest result.json notes and post to WOR-254."""
+    result_path = worker.worktree_path / worker.manifest.artifact_paths.result_json
+    try:
+        if not result_path.exists():
+            return
+        result_data = json.loads(result_path.read_text(encoding="utf-8"))
+        notes = (result_data.get("notes") or "").strip()
+        if len(notes) <= NOTES_MIN_CHARS:
+            return
+        try:
+            linear.post_comment(
+                "WOR-254",
+                f"## Side-discovery from {worker.ticket_id}\n\n"
+                f"From the {worker.ticket_id} worker session "
+                f"({worker.manifest.title}):\n\n"
+                f"{notes}\n\n"
+                f"Ref: {worker.ticket_id}, branch "
+                f"`{worker.manifest.worker_branch}`.",
+            )
+        except Exception:
+            logger.warning(
+                "Could not post improvement-log comment for %s", worker.ticket_id
+            )
+    except (OSError, ValueError) as exc:
+        logger.warning(
+            "Could not read result.json for improvement-log harvest: %s", exc
+        )
+
+
+def finalize_worker(
+    worker: ActiveWorker,
+    *,
+    returncode: int,
+    wall_time: float,
+    linear: LinearClientProtocol,
+    metrics: MetricsStore,
+    escalation_policy: EscalationPolicy,
+    repo_root: Path,
+    mode: str,
+    project_id: str,
+    tracked_prs: list[TrackedPR] | None = None,
+) -> Outcome:
+    eff = resolve_effective_mode(mode, worker.manifest.implementation_mode)
+
+    # WOR-312: in-dispatch retry loop. Helper avoids the slower Linear
+    # Blocked -> ReadyForLocal redispatch when checks transiently fail.
+    outcome, escalated, artifacts_preserved, sonar_findings, failed_checks = (
+        _run_retry_loop(
+            worker,
+            returncode,
+            linear,
+            escalation_policy,
+            repo_root,
+            eff,
+            tracked_prs,
+            metrics,
+            project_id,
+        )
+    )
 
     log_path = worker.worktree_path / f".claude/worker_{worker.ticket_id.lower()}.log"
     input_tokens, output_tokens, context_compactions, compact_duration_ms = (
@@ -316,29 +444,10 @@ def finalize_worker(
         else None
     )
 
-    # Parse git diff --shortstat to populate lines_changed / files_changed.
-    # Three-dot diff against the merge-base — invariant under base_branch
-    # advancing during the worker's lifetime (WOR-354). Two-dot would attribute
-    # sibling-merge upstream commits to this worker.
-    # Must run before preserve_worker_artifacts tears down the worktree.
-    try:
-        diff_output = subprocess.run(  # nosec B603 B607
-            [
-                "git",
-                "-C",
-                str(worker.worktree_path),
-                "diff",
-                "--shortstat",
-                f"{worker.manifest.base_branch}...HEAD",
-            ],
-            capture_output=True,
-            text=True,
-            timeout=30,
-        )
-        raw_shortstat = (diff_output.stdout or "") + (diff_output.stderr or "")
-        lines_changed, files_changed = parse_git_shortstat(raw_shortstat)
-    except (OSError, subprocess.TimeoutExpired):
-        lines_changed, files_changed = 0, 0
+    # WOR-354: 3-dot diff against merge-base. Helper to keep finalize_worker tight.
+    lines_changed, files_changed = _compute_diff_stats(
+        worker.worktree_path, worker.manifest.base_branch
+    )
 
     # Cloud metrics — populated only when eff == "cloud"
     cloud_model: str | None = None
@@ -397,53 +506,8 @@ def finalize_worker(
     # check_failures: store the list when non-empty, else None
     check_failures = failed_checks if failed_checks else None
 
-    # WOR-370: vLLM /metrics delta capture. Three states:
-    #   1. Attributable — worker was solo throughout. Take after-snapshot,
-    #      compute deltas, write artifact + populate TicketMetrics columns.
-    #   2. Concurrent during session — sentinel artifact, columns stay None,
-    #      attributable=False on the row.
-    #   3. Never captured — no artifact, columns stay None, attributable=None.
-    vllm_attributable: bool | None = None
-    vllm_deltas: dict[str, float | int | None] = {}
-    if worker.vllm_metrics_before is not None:
-        if worker.remained_solo:
-            after = capture_vllm_metrics()
-            if after is not None:
-                vllm_attributable = True
-                vllm_deltas = compute_vllm_metrics_delta(
-                    worker.vllm_metrics_before, after
-                )
-                _write_vllm_metrics_artifact(
-                    repo_root,
-                    worker.ticket_id,
-                    attributable=True,
-                    before=worker.vllm_metrics_before,
-                    after=after,
-                    deltas=vllm_deltas,
-                )
-            else:
-                # before captured, after failed — un-attributable, but the
-                # before is still useful for audit. Write sentinel.
-                _write_vllm_metrics_artifact(
-                    repo_root,
-                    worker.ticket_id,
-                    attributable=False,
-                    before=worker.vllm_metrics_before,
-                    after=None,
-                    deltas={},
-                    reason="after-snapshot failed (vLLM /metrics unreachable)",
-                )
-        else:
-            vllm_attributable = False
-            _write_vllm_metrics_artifact(
-                repo_root,
-                worker.ticket_id,
-                attributable=False,
-                before=worker.vllm_metrics_before,
-                after=None,
-                deltas={},
-                reason="concurrent worker dispatched during session",
-            )
+    # WOR-370: vLLM /metrics delta capture (3-state helper).
+    vllm_attributable, vllm_deltas = _capture_vllm_post(worker, repo_root)
 
     metrics.record(
         TicketMetrics(
@@ -518,35 +582,7 @@ def finalize_worker(
         )
     )
 
-    # -----------------------------------------------------------------------
-    # WOR-303 — improvement-log: auto-post worker side-discoveries to WOR-254
-    # -----------------------------------------------------------------------
-    result_path = worker.worktree_path / worker.manifest.artifact_paths.result_json
-    try:
-        if result_path.exists():
-            result_data = json.loads(result_path.read_text(encoding="utf-8"))
-            notes = (result_data.get("notes") or "").strip()
-            if len(notes) > NOTES_MIN_CHARS:
-                try:
-                    linear.post_comment(
-                        "WOR-254",
-                        f"## Side-discovery from {worker.ticket_id}\n\n"
-                        f"From the {worker.ticket_id} worker session "
-                        f"({worker.manifest.title}):\n\n"
-                        f"{notes}\n\n"
-                        f"Ref: {worker.ticket_id}, branch "
-                        f"`{worker.manifest.worker_branch}`.",
-                    )
-                except Exception as exc:
-                    logger.warning(
-                        "Could not post improvement-log comment for %s: %s",
-                        worker.ticket_id,
-                        exc,
-                    )
-    except (OSError, ValueError) as exc:
-        logger.warning(
-            "Could not read result.json for improvement-log harvest: %s", exc
-        )
+    _post_improvement_log(linear, worker)
 
     metrics.record_run(
         TicketRunLog(

--- a/app/core/watcher/watcher_finalize_helpers.py
+++ b/app/core/watcher/watcher_finalize_helpers.py
@@ -85,6 +85,31 @@ def _read_result_status(repo_root: Path, manifest: ExecutionManifest) -> str | N
     return status if isinstance(status, str) else None
 
 
+def _record_failure_state(
+    worker: ActiveWorker,
+    linear: LinearClientProtocol,
+    escalate_reason: str,
+) -> bool:
+    """Set Linear state for a failed worker; return whether we escalated."""
+    manifest = worker.manifest
+    ticket_id = worker.ticket_id
+    linear_id = worker.linear_id
+    escalated = bool(manifest.failure_policy.escalate_to_cloud)
+    if escalated:
+        logger.info("Escalating %s to cloud per failure policy", ticket_id)
+        safe_set_state(linear, linear_id, _IN_PROGRESS_STATE, ticket_id)
+        _try_post_comment(
+            linear,
+            linear_id,
+            ticket_id,
+            f"Local worker failed for `{ticket_id}` ({escalate_reason}). "
+            f"Escalating to cloud per failure policy.",
+        )
+    else:
+        safe_set_state(linear, linear_id, manifest.ticket_state_map.failed, ticket_id)
+    return escalated
+
+
 def _execute_finalization(
     worker: ActiveWorker,
     returncode: int,
@@ -106,7 +131,6 @@ def _execute_finalization(
     """
     manifest = worker.manifest
     ticket_id = worker.ticket_id
-    linear_id = worker.linear_id
 
     # WOR-286: Trust the worker's in-band success signal (result.json) over
     # the subprocess exit code. Claude Code CLI sometimes exits non-zero
@@ -114,40 +138,27 @@ def _execute_finalization(
     # the work. Only treat non-zero exit as failure when result.json is
     # missing or also reports failure.
     result_status = _read_result_status(repo_root, manifest)
+    if returncode != 0 and result_status != "success":
+        logger.error(
+            "Worker %s exited non-zero (%d); result.json status=%s — "
+            "routing to failure path",
+            ticket_id,
+            returncode,
+            result_status if result_status is not None else "missing",
+        )
+        escalated = _record_failure_state(
+            worker,
+            linear,
+            escalate_reason="non-zero exit",
+        )
+        return "failure", escalated, False, None, [], None
     if returncode != 0:
-        if result_status == "success":
-            logger.warning(
-                "Worker %s exited non-zero (%d) but result.json reports "
-                "status=success — trusting in-band signal and proceeding "
-                "with checks.",
-                ticket_id,
-                returncode,
-            )
-            # Fall through to run_checks; treat as if returncode == 0.
-        else:
-            logger.error(
-                "Worker %s exited non-zero (%d); result.json status=%s — "
-                "routing to failure path",
-                ticket_id,
-                returncode,
-                result_status if result_status is not None else "missing",
-            )
-            escalated = bool(manifest.failure_policy.escalate_to_cloud)
-            if escalated:
-                logger.info("Escalating %s to cloud per failure policy", ticket_id)
-                safe_set_state(linear, linear_id, _IN_PROGRESS_STATE, ticket_id)
-                _try_post_comment(
-                    linear,
-                    linear_id,
-                    ticket_id,
-                    f"Local worker failed for `{ticket_id}` (non-zero exit). "
-                    f"Escalating to cloud per failure policy.",
-                )
-            else:
-                safe_set_state(
-                    linear, linear_id, manifest.ticket_state_map.failed, ticket_id
-                )
-            return "failure", escalated, False, None, [], None
+        logger.warning(
+            "Worker %s exited non-zero (%d) but result.json reports "
+            "status=success — trusting in-band signal and proceeding with checks.",
+            ticket_id,
+            returncode,
+        )
 
     checks_ok, failed_checks = run_checks(
         manifest,
@@ -159,21 +170,11 @@ def _execute_finalization(
     if not checks_ok:
         worker.attempt_count += 1
     if not checks_ok and manifest.failure_policy.on_check_failure == "abort":
-        escalated = bool(manifest.failure_policy.escalate_to_cloud)
-        if escalated:
-            logger.info("Escalating %s to cloud after check failure", ticket_id)
-            safe_set_state(linear, linear_id, _IN_PROGRESS_STATE, ticket_id)
-            _try_post_comment(
-                linear,
-                linear_id,
-                ticket_id,
-                f"Local worker failed checks for `{ticket_id}`. "
-                f"Escalating to cloud per failure policy.",
-            )
-        else:
-            safe_set_state(
-                linear, linear_id, manifest.ticket_state_map.failed, ticket_id
-            )
+        escalated = _record_failure_state(
+            worker,
+            linear,
+            escalate_reason="failed checks",
+        )
         return "failure", escalated, False, None, failed_checks, None
 
     preserve_worker_artifacts(repo_root, worker)

--- a/app/core/watcher/watcher_helpers.py
+++ b/app/core/watcher/watcher_helpers.py
@@ -10,7 +10,7 @@ import json
 import logging
 import subprocess  # nosec B404
 from pathlib import Path
-from typing import IO
+from typing import IO, Any
 
 from app.core.manifest import ExecutionManifest
 
@@ -372,34 +372,13 @@ _VLLM_COUNTERS = (
 )
 
 
-def capture_vllm_metrics(timeout: float = 5.0) -> dict[str, float] | None:
-    """Snapshot the small subset of vLLM Prometheus metrics needed for
-    per-ticket attribution.
-
-    Returns a dict keyed by metric name (without label suffixes) mapping to
-    the most recent value, or ``None`` if the endpoint is unreachable or
-    returns malformed text. Failure is non-fatal — callers treat ``None``
-    as "no snapshot, skip attribution."
-
-    Prometheus text format lines look like:
-        vllm:prefix_cache_hits_total{model="qwen3-coder",engine="0"} 12345.0
-
-    We strip everything after the metric name, sum across labels (there's
-    typically just one model/engine combo, but be safe), and emit a flat dict.
-
-    Uses ``http.client`` (matching ``watcher_services.probe_vllm_health``)
-    rather than ``urllib.request`` — the latter accepts ``file://`` URLs
-    so semgrep flags any urlopen call. This API only speaks HTTP to a
-    fixed localhost host:port pair so there is no SSRF surface.
-    """
+def _fetch_vllm_metrics_body(timeout: float) -> str | None:
+    """Fetch raw vLLM /metrics body via http.client; returns None on failure."""
     import http.client
 
-    # _VLLM_BASE_URL has the form "http://localhost:8000"; strip the scheme
-    # and split host:port for http.client.HTTPConnection.
     netloc = _VLLM_BASE_URL.split("://", 1)[1]
     host, _, port_str = netloc.partition(":")
     port = int(port_str) if port_str else 80
-
     try:
         conn = http.client.HTTPConnection(host, port, timeout=timeout)
         try:
@@ -407,10 +386,40 @@ def capture_vllm_metrics(timeout: float = 5.0) -> dict[str, float] | None:
             resp = conn.getresponse()
             if resp.status != 200:
                 return None
-            body = resp.read().decode("utf-8", errors="replace")
+            return resp.read().decode("utf-8", errors="replace")
         finally:
             conn.close()
     except (OSError, http.client.HTTPException):
+        return None
+
+
+def _parse_metric_line(line: str, targets: set[str]) -> tuple[str | None, float | None]:
+    """Parse one Prometheus text line; return (name, value) or (None, None)."""
+    for ch_idx, ch in enumerate(line):
+        if ch == "{" or ch.isspace():
+            metric_name = line[:ch_idx]
+            rest = line[ch_idx:]
+            break
+    else:
+        return None, None
+    if metric_name not in targets:
+        return None, None
+    try:
+        value = float(rest.rsplit(maxsplit=1)[-1])
+    except (ValueError, IndexError):
+        return None, None
+    return metric_name, value
+
+
+def capture_vllm_metrics(timeout: float = 5.0) -> dict[str, float] | None:
+    """Snapshot vLLM Prometheus metrics for per-ticket attribution.
+
+    Returns a dict {metric_name: aggregated_value} or None if the endpoint
+    is unreachable / malformed / not a vLLM /metrics surface. Aggregates
+    values across label combinations (typically one model/engine combo).
+    """
+    body = _fetch_vllm_metrics_body(timeout)
+    if body is None:
         return None
 
     targets = set(_VLLM_COUNTERS)
@@ -421,26 +430,12 @@ def capture_vllm_metrics(timeout: float = 5.0) -> dict[str, float] | None:
         line = raw.strip()
         if not line or line.startswith("#"):
             continue
-        # Metric name extends from start to first '{' or whitespace
-        for ch_idx, ch in enumerate(line):
-            if ch == "{" or ch.isspace():
-                metric_name = line[:ch_idx]
-                rest = line[ch_idx:]
-                break
-        else:
+        name, value = _parse_metric_line(line, targets)
+        if name is None or value is None:
             continue
-        if metric_name not in targets:
-            continue
-        # Value is the LAST whitespace-separated token
-        try:
-            value = float(rest.rsplit(maxsplit=1)[-1])
-        except (ValueError, IndexError):
-            continue
-        aggregated[metric_name] += value
-        seen[metric_name] = True
+        aggregated[name] += value
+        seen[name] = True
 
-    # If we saw none of the target metrics, treat as failure — endpoint
-    # responded but probably isn't a vLLM /metrics endpoint.
     if not any(seen.values()):
         return None
     return aggregated
@@ -577,25 +572,62 @@ class WorkerBehavior:
         return cls(0, 0, {}, 0, 0, None, None, None, 0)
 
 
+def _update_input_tokens(
+    inp: object,
+    first: int | None,
+    last: int | None,
+    cur_max: int | None,
+) -> tuple[int | None, int | None, int | None]:
+    """Fold a single usage.input_tokens value into the running (first, last, max)."""
+    if not isinstance(inp, int):
+        return first, last, cur_max
+    new_first = inp if first is None else first
+    new_last = inp
+    new_max = inp if cur_max is None else max(cur_max, inp)
+    return new_first, new_last, new_max
+
+
+def _accumulate_content_block(
+    block: dict[str, Any],
+    behavior_accum: dict[str, int],
+    tool_breakdown: dict[str, int],
+    read_counts: dict[str, int],
+) -> None:
+    """Update accumulators for one content block (thinking or tool_use)."""
+    btype = block.get("type")
+    if btype == "thinking":
+        behavior_accum["thinking_blocks"] += 1
+        text = block.get("thinking") or block.get("text") or ""
+        if isinstance(text, str):
+            behavior_accum["thinking_chars"] += len(text)
+    elif btype == "tool_use":
+        behavior_accum["tool_calls_total"] += 1
+        name = block.get("name") or "?"
+        tool_breakdown[name] = tool_breakdown.get(name, 0) + 1
+        if name == "Read":
+            fp = (block.get("input") or {}).get("file_path")
+            if isinstance(fp, str) and fp:
+                key = fp.replace("\\", "/")
+                read_counts[key] = read_counts.get(key, 0) + 1
+
+
 def _parse_worker_behavior(log_path: Path) -> WorkerBehavior:
     """Extract per-session behavior signals from the stream-json worker log.
 
-    Counts assistant turns, tool-call totals + breakdown by name, thinking
-    blocks + their text length, and per-file Read counts to derive a
-    redundant-reads count. Also captures the input_tokens trajectory
-    (first / last / max) which is a proxy for context-window pressure.
-
-    Returns a WorkerBehavior with None fields if the log is missing or
-    cannot be opened. Returns zero-valued fields if the log is parseable
-    but has no assistant turns.
+    Counts turns, tool calls + breakdown, thinking blocks + chars, and the
+    input_tokens trajectory (first/last/max). Derives redundant_reads_count
+    from per-file Read counts. Returns ``empty_unparseable()`` on read/parse
+    failure; ``empty_readable()`` if parsed but no assistant turns.
     """
     try:
         with log_path.open(encoding="utf-8") as f:
             turn_count = 0
-            tool_calls_total = 0
+            behavior_accum = {
+                "thinking_blocks": 0,
+                "thinking_chars": 0,
+                "tool_calls_total": 0,
+            }
             tool_breakdown: dict[str, int] = {}
-            thinking_blocks = 0
-            thinking_chars = 0
             input_tokens_first: int | None = None
             input_tokens_last: int | None = None
             input_tokens_max: int | None = None
@@ -613,42 +645,28 @@ def _parse_worker_behavior(log_path: Path) -> WorkerBehavior:
                 turn_count += 1
                 msg = obj.get("message") or {}
                 usage = msg.get("usage") or {}
-                inp = usage.get("input_tokens")
-                if isinstance(inp, int):
-                    if input_tokens_first is None:
-                        input_tokens_first = inp
-                    input_tokens_last = inp
-                    input_tokens_max = (
-                        inp if input_tokens_max is None else max(input_tokens_max, inp)
+                input_tokens_first, input_tokens_last, input_tokens_max = (
+                    _update_input_tokens(
+                        usage.get("input_tokens"),
+                        input_tokens_first,
+                        input_tokens_last,
+                        input_tokens_max,
                     )
+                )
                 for blk in msg.get("content") or []:
-                    if not isinstance(blk, dict):
-                        continue
-                    btype = blk.get("type")
-                    if btype == "thinking":
-                        thinking_blocks += 1
-                        text = blk.get("thinking") or blk.get("text") or ""
-                        if isinstance(text, str):
-                            thinking_chars += len(text)
-                    elif btype == "tool_use":
-                        tool_calls_total += 1
-                        name = blk.get("name") or "?"
-                        tool_breakdown[name] = tool_breakdown.get(name, 0) + 1
-                        if name == "Read":
-                            fp = (blk.get("input") or {}).get("file_path")
-                            if isinstance(fp, str) and fp:
-                                # Normalize Windows back-slashes for grouping
-                                key = fp.replace("\\", "/")
-                                read_counts[key] = read_counts.get(key, 0) + 1
+                    if isinstance(blk, dict):
+                        _accumulate_content_block(
+                            blk, behavior_accum, tool_breakdown, read_counts
+                        )
             if turn_count == 0:
                 return WorkerBehavior.empty_readable()
             redundant = sum(1 for n in read_counts.values() if n > 2)
             return WorkerBehavior(
                 turn_count=turn_count,
-                tool_calls_total=tool_calls_total,
+                tool_calls_total=behavior_accum["tool_calls_total"],
                 tool_calls_breakdown=tool_breakdown,
-                thinking_blocks=thinking_blocks,
-                thinking_chars_total=thinking_chars,
+                thinking_blocks=behavior_accum["thinking_blocks"],
+                thinking_chars_total=behavior_accum["thinking_chars"],
                 input_tokens_max=input_tokens_max,
                 input_tokens_first=input_tokens_first,
                 input_tokens_last=input_tokens_last,

--- a/app/core/watcher/watcher_log_parsing.py
+++ b/app/core/watcher/watcher_log_parsing.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import json
 import logging
 from pathlib import Path
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -25,51 +26,92 @@ logger = logging.getLogger(__name__)
 _CHARS_PER_TOKEN_ESTIMATE = 4
 
 
+def _accumulate_content_chars(content: Any) -> int:
+    """Sum approximate character lengths of content blocks for the WOR-384 sentinel."""
+    if not isinstance(content, list):
+        return 0
+    total = 0
+    for blk in content:
+        if not isinstance(blk, dict):
+            continue
+        btype = blk.get("type")
+        if btype in ("thinking", "text"):
+            key = "thinking" if btype == "thinking" else "text"
+            text = blk.get(key) or blk.get("text") or ""
+            if isinstance(text, str):
+                total += len(text)
+        elif btype == "tool_use":
+            inp_dict = blk.get("input")
+            if inp_dict is not None:
+                try:
+                    total += len(json.dumps(inp_dict))
+                except (TypeError, ValueError):
+                    pass
+    return total
+
+
+def _process_assistant_event(obj: dict[str, Any]) -> tuple[int, int, bool, int]:
+    """Extract (input_delta, output_delta, has_usage, content_chars) from one event."""
+    msg = obj.get("message") or {}
+    usage = msg.get("usage") or {}
+    inp = usage.get("input_tokens")
+    out = usage.get("output_tokens")
+    if inp is not None and out is not None:
+        input_delta = int(inp)
+        output_delta = int(out)
+        has_usage = True
+    else:
+        input_delta = output_delta = 0
+        has_usage = False
+    content_chars = _accumulate_content_chars(msg.get("content"))
+    return input_delta, output_delta, has_usage, content_chars
+
+
+def _process_compact_boundary(obj: dict[str, Any]) -> tuple[int, int]:
+    """Extract (count_delta=1, duration_delta) from a compact_boundary event."""
+    meta = obj.get("compact_metadata") or {}
+    dur = meta.get("duration_ms")
+    return 1, int(dur) if isinstance(dur, (int, float)) else 0
+
+
+def _resolve_usage_totals(
+    total_input: int,
+    total_output: int,
+    has_assistant_usage: bool,
+    compact_count: int,
+    compact_duration_ms: int,
+    last_input: int | None,
+    last_output: int | None,
+    content_chars: int,
+) -> tuple[int | None, int | None, int | None, int | None]:
+    """Apply WOR-384 sentinel + result-fallback rules to produce the final tuple."""
+    if has_assistant_usage:
+        if total_output == 0 and total_input > 0 and content_chars > 0:
+            estimated = content_chars // _CHARS_PER_TOKEN_ESTIMATE
+            return total_input, estimated, compact_count, compact_duration_ms
+        return total_input, total_output, compact_count, compact_duration_ms
+    if last_input is not None and last_output is not None:
+        return int(last_input), int(last_output), compact_count, compact_duration_ms
+    return None, None, compact_count, compact_duration_ms
+
+
 def _parse_worker_usage(
     log_path: Path,
 ) -> tuple[int | None, int | None, int | None, int | None]:
-    """Return 4-tuple from the stream-json worker log:
-    ``(input_tokens, output_tokens, context_compactions, compact_duration_ms)``.
+    """Return (input_tokens, output_tokens, context_compactions, compact_duration_ms).
 
-    Assistant-turn deltas are summed so that downstream metrics
-    (``local_output_tokens``, ``output_tokens_per_wall_second``) reflect the
-    true token volume of a session.
-
-    *context_compactions* is the count of ``compact_boundary`` system events
-    (WOR-357). *compact_duration_ms* (WOR-358) is the sum of
-    ``compact_metadata.duration_ms`` across those events — total wall time
-    spent on compaction during the session.
-
-    The actual compaction signal lives in events of the form::
-
-        {"type":"system","subtype":"compact_boundary",
-         "compact_metadata":{"trigger":"auto","pre_tokens":...,"post_tokens":...,
-                             "duration_ms":...}}
-
-    When assistant events carry usage data, their cumulative sum is returned.
-    When no assistant events have usage, the last ``type=result`` event's
-    usage snapshot is used as a fallback for tokens. Returns
-    ``(None, None, None, None)`` when the log itself cannot be opened or
-    parsed at all; returns ``(in, out, 0, 0)`` for parseable logs containing
-    zero compact_boundary events.
-
-    *vLLM-direct sentinel (WOR-384):* when assistant events report
-    ``output_tokens: 0`` for every turn but ``input_tokens > 0`` (the
-    post-WOR-368 vLLM-direct path emits that pattern because vLLM doesn't
-    fill per-message output token counts), we fall back to estimating output
-    from the assistant content blocks' character lengths divided by
-    ``_CHARS_PER_TOKEN_ESTIMATE``. The estimate is rough (±20% typical) but
-    drastically better than the alternative of recording 0. Forward-
-    compatible: when vLLM starts populating real output_tokens, the sentinel
-    won't trigger.
+    Sums assistant-turn deltas. Counts compact_boundary system events
+    (WOR-357) and their durations (WOR-358). WOR-384 sentinel: when
+    output_tokens is 0 across all assistant events but input_tokens > 0,
+    estimates output from content character length / _CHARS_PER_TOKEN_ESTIMATE.
+    Falls back to the last result event's usage snapshot if no assistant
+    events carry usage. Returns (None, None, None, None) on read/parse failure.
     """
     try:
         with log_path.open(encoding="utf-8") as f:
-            total_input = 0
-            total_output = 0
+            total_input = total_output = 0
             has_assistant_usage = False
-            compact_count = 0
-            compact_duration_ms = 0
+            compact_count = compact_duration_ms = 0
             last_input: int | None = None
             last_output: int | None = None
             content_chars = 0
@@ -83,68 +125,31 @@ def _parse_worker_usage(
                     continue
                 obj_type = obj.get("type")
                 if obj_type == "assistant":
-                    msg = obj.get("message") or {}
-                    usage = msg.get("usage") or {}
-                    inp = usage.get("input_tokens")
-                    out = usage.get("output_tokens")
-                    if inp is not None and out is not None:
-                        total_input += int(inp)
-                        total_output += int(out)
-                        has_assistant_usage = True
-                    # Always accumulate content chars for the WOR-384 sentinel
-                    # fallback. Cheap to compute; only used when the primary
-                    # output_tokens signal is unreliable.
-                    for blk in msg.get("content") or []:
-                        if not isinstance(blk, dict):
-                            continue
-                        btype = blk.get("type")
-                        if btype == "thinking":
-                            text = blk.get("thinking") or blk.get("text") or ""
-                            if isinstance(text, str):
-                                content_chars += len(text)
-                        elif btype == "text":
-                            text = blk.get("text") or ""
-                            if isinstance(text, str):
-                                content_chars += len(text)
-                        elif btype == "tool_use":
-                            inp_dict = blk.get("input")
-                            if inp_dict is not None:
-                                try:
-                                    content_chars += len(json.dumps(inp_dict))
-                                except (TypeError, ValueError):
-                                    pass
+                    i_d, o_d, has_u, cc = _process_assistant_event(obj)
+                    total_input += i_d
+                    total_output += o_d
+                    has_assistant_usage = has_assistant_usage or has_u
+                    content_chars += cc
                 elif obj_type == "system" and obj.get("subtype") == "compact_boundary":
-                    compact_count += 1
-                    meta = obj.get("compact_metadata") or {}
-                    dur = meta.get("duration_ms")
-                    if isinstance(dur, (int, float)):
-                        compact_duration_ms += int(dur)
+                    c_d, d_d = _process_compact_boundary(obj)
+                    compact_count += c_d
+                    compact_duration_ms += d_d
                 elif obj_type == "result":
                     usage = obj.get("usage") or {}
                     last_input = usage.get("input_tokens")
                     last_output = usage.get("output_tokens")
-            if has_assistant_usage:
-                # WOR-384 sentinel: vLLM-direct emits output_tokens=0 in every
-                # assistant.message.usage. Detect via "input>0 but output is
-                # exactly 0 across all events" and fall back to a content-
-                # length estimate. Anthropic API and any future vLLM that
-                # fills output_tokens correctly will skip this branch.
-                if total_output == 0 and total_input > 0 and content_chars > 0:
-                    estimated = content_chars // _CHARS_PER_TOKEN_ESTIMATE
-                    return total_input, estimated, compact_count, compact_duration_ms
-                return total_input, total_output, compact_count, compact_duration_ms
-            # Fallback to result snapshot when no assistant events carry usage.
-            if last_input is not None and last_output is not None:
-                return (
-                    int(last_input),
-                    int(last_output),
-                    compact_count,
-                    compact_duration_ms,
-                )
-            return None, None, compact_count, compact_duration_ms
+            return _resolve_usage_totals(
+                total_input,
+                total_output,
+                has_assistant_usage,
+                compact_count,
+                compact_duration_ms,
+                last_input,
+                last_output,
+                content_chars,
+            )
     except Exception:
         return None, None, None, None
-    return None, None, None, None
 
 
 def _parse_worker_subagent_spawns(log_path: Path) -> int | None:
@@ -218,21 +223,40 @@ _HOOK_VIOLATION_TOKENS = frozenset(
 )
 
 
+def _is_violation_bash_command(block: Any) -> str | None:
+    """Return the first token of a Bash command in a tool_use block, else None."""
+    if (
+        not isinstance(block, dict)
+        or block.get("type") != "tool_use"
+        or block.get("name") != "Bash"
+    ):
+        return None
+    command = (block.get("input") or {}).get("command", "")
+    if not isinstance(command, str):
+        return None
+    return command.lstrip().split()[0] if command.lstrip() else None
+
+
+def _count_violations_in_event(obj: dict[str, Any]) -> int:
+    """Count violation tokens in a single assistant event's tool_use blocks."""
+    if obj.get("type") != "assistant":
+        return 0
+    msg = obj.get("message", {}) or {}
+    count = 0
+    for block in msg.get("content", []):
+        token = _is_violation_bash_command(block)
+        if token and token in _HOOK_VIOLATION_TOKENS:
+            count += 1
+    return count
+
+
 def _parse_hook_trust_violations(log_path: Path) -> int | None:
-    """Count manual invocations of quality-check tools as Bash tool_use events.
+    """Count manual quality-check tool invocations in Bash tool_use events.
 
-    Scans the worker stream-json log for ``type=assistant`` events whose
-    ``content`` includes a ``Bash`` tool_use block.  The first whitespace-
-    delimited token of the command (after stripping leading whitespace) is
-    compared against ``{"ruff", "mypy", "pytest", "bandit", "lint-imports"}``
-    (case-sensitive).  Each match increments the count.
+    Targets ruff/mypy/pytest/bandit/lint-imports. Count > 1 = hook-trust
+    violation per CLAUDE.md / WOR-274.
 
-    This detects when a worker manually re-runs checks that should only be
-    triggered by PostToolUse hooks (step 3 of /implement-ticket).  A count
-    greater than 1 is considered a hook-trust violation.
-
-    Returns ``None`` if the log cannot be opened/parsed; ``0`` for
-    parseable logs with no matching Bash tool_use events.
+    Returns None on read/parse failure; 0 for parseable logs with no matches.
     """
     try:
         with log_path.open(encoding="utf-8") as f:
@@ -245,24 +269,7 @@ def _parse_hook_trust_violations(log_path: Path) -> int | None:
                     obj = json.loads(line)
                 except json.JSONDecodeError:
                     continue
-                if obj.get("type") != "assistant":
-                    continue
-                msg = obj.get("message", {}) or {}
-                for block in msg.get("content", []):
-                    if (
-                        not isinstance(block, dict)
-                        or block.get("type") != "tool_use"
-                        or block.get("name") != "Bash"
-                    ):
-                        continue
-                    command = (block.get("input") or {}).get("command", "")
-                    if not isinstance(command, str):
-                        continue
-                    first_token = (
-                        command.lstrip().split()[0] if command.lstrip() else ""
-                    )
-                    if first_token in _HOOK_VIOLATION_TOKENS:
-                        count += 1
+                count += _count_violations_in_event(obj)
             return count
     except Exception:
         return None

--- a/app/core/watcher/worker_waste.py
+++ b/app/core/watcher/worker_waste.py
@@ -31,62 +31,114 @@ class WasteReport:
     thinking_to_text_ratio: float
 
 
-def compute_waste_score(log_path: Path) -> WasteReport:
-    """Compute a 0-100 waste score from a worker session log.
+_CHECK_COMMANDS = (
+    "ruff",
+    "mypy",
+    "pytest",
+    "pre-commit",
+    "bandit",
+    "semgrep",
+    "flake8",
+    "black",
+    "isort",
+    "pylint",
+)
 
-    Parses the stream-json log for tool_use entries and counts waste signals:
-    redundant_reads, manual_check_runs, redundant_bash, cd_commands, and
-    thinking_to_text_ratio.
 
-    Returns a WasteReport with the composite score and per-signal breakdown.
-    Returns a zero-score report when the log is missing or unreadable.
-    """
+def _empty_report() -> "WasteReport":
+    """Zero-score sentinel returned when the log is missing/unreadable."""
+    return WasteReport(
+        score=0,
+        breakdown={},
+        redundant_reads=0,
+        manual_check_runs=0,
+        redundant_bash=0,
+        cd_commands=0,
+        thinking_to_text_ratio=0.0,
+    )
+
+
+def _read_log_lines(log_path: Path) -> list[str] | None:
+    """Return log lines or None if the file is missing/unreadable."""
     if not log_path.exists():
         logger.debug("Waste score: log not found at %s", log_path)
-        return WasteReport(
-            score=0,
-            breakdown={},
-            redundant_reads=0,
-            manual_check_runs=0,
-            redundant_bash=0,
-            cd_commands=0,
-            thinking_to_text_ratio=0.0,
-        )
-
+        return None
     try:
-        lines = log_path.read_text(encoding="utf-8").splitlines()
+        return log_path.read_text(encoding="utf-8").splitlines()
     except OSError:
         logger.warning("Waste score: could not read %s", log_path)
-        return WasteReport(
-            score=0,
-            breakdown={},
-            redundant_reads=0,
-            manual_check_runs=0,
-            redundant_bash=0,
-            cd_commands=0,
-            thinking_to_text_ratio=0.0,
-        )
+        return None
 
-    # --- Collect raw signals ---
-    read_counts: dict[str, int] = {}  # file path -> count
+
+def _classify_bash(
+    command: str, manual_check_count: int, cd_count: int, bash_buffer: list[str]
+) -> tuple[int, int]:
+    """Update manual_check / cd / bash counters from a single Bash command.
+
+    Returns (manual_check_delta, cd_delta). Mutates `bash_buffer` in place
+    when the command should count toward redundancy detection.
+    """
+    is_cd = command.strip().startswith("cd ")
+    cd_delta = 1 if is_cd else 0
+
+    check_delta = 0
+    is_check_tool = False
+    for check_cmd in _CHECK_COMMANDS:
+        if check_cmd in command:
+            check_delta = 1
+            is_check_tool = True
+            break
+
+    if command and not is_check_tool and not is_cd:
+        bash_buffer.append(command)
+    return check_delta, cd_delta
+
+
+def _accumulate_thinking_tokens(obj: dict[str, Any]) -> tuple[int, int]:
+    """Return (thinking_chars, output_tokens) contributed by an assistant event."""
+    if obj.get("type") != "assistant":
+        return 0, 0
+    msg = obj.get("message") or {}
+    usage = msg.get("usage") or {}
+    output = int(usage.get("output_tokens") or 0)
+
+    thinking_chars = 0
+    content = msg.get("content", [])
+    if isinstance(content, list):
+        for block in content:
+            if isinstance(block, dict) and block.get("type") == "thinking":
+                text = block.get("thinking", "")
+                if isinstance(text, str):
+                    thinking_chars += len(text)
+    return thinking_chars, output
+
+
+def _parse_tool_input(inp: Any) -> Any:
+    """Normalise the `input` field of a tool_use — may arrive as str or dict."""
+    if isinstance(inp, str):
+        try:
+            return json.loads(inp)
+        except (json.JSONDecodeError, TypeError):
+            return inp
+    return inp
+
+
+def _extract_signals(
+    lines: list[str],
+) -> tuple[dict[str, int], int, list[str], int, int, int]:
+    """Walk log lines and aggregate the raw waste signals.
+
+    Returns
+    -------
+    (read_counts, manual_check_runs, bash_commands, cd_commands,
+     total_thinking_chars, total_output_tokens)
+    """
+    read_counts: dict[str, int] = {}
     manual_check_runs = 0
-    bash_commands: list[str] = []  # for redundancy detection
+    bash_commands: list[str] = []
     cd_commands = 0
-    total_thinking_tokens = 0
+    total_thinking_chars = 0
     total_output_tokens = 0
-
-    _CHECK_COMMANDS = (
-        "ruff",
-        "mypy",
-        "pytest",
-        "pre-commit",
-        "bandit",
-        "semgrep",
-        "flake8",
-        "black",
-        "isort",
-        "pylint",
-    )
 
     for raw_line in lines:
         line = raw_line.strip()
@@ -99,99 +151,71 @@ def compute_waste_score(log_path: Path) -> WasteReport:
 
         for tool_use in _extract_tool_uses(obj):
             name = tool_use.get("name", "")
-            inp = tool_use.get("input", {})
-            if isinstance(inp, str):
-                try:
-                    inp = json.loads(inp)
-                except (json.JSONDecodeError, TypeError):
-                    pass
+            inp = _parse_tool_input(tool_use.get("input", {}))
 
             if name == "Read":
-                # Count reads per file path to detect redundant reads.
-                # Claude Code's Read tool uses `file_path` as the parameter
-                # name (WOR-349); legacy fallbacks kept defensively in case
-                # synthetic logs use other keys.
-                file_path = (
-                    inp.get("file_path", "")
-                    or inp.get("path", "")
-                    or inp.get("file", "")
-                )
-                if file_path:
-                    read_counts[file_path] = read_counts.get(file_path, 0) + 1
-
+                fp = ""
+                if isinstance(inp, dict):
+                    fp = (
+                        inp.get("file_path", "")
+                        or inp.get("path", "")
+                        or inp.get("file", "")
+                    )
+                if fp:
+                    read_counts[fp] = read_counts.get(fp, 0) + 1
             elif name == "Bash":
                 command = ""
                 if isinstance(inp, dict):
                     command = str(inp.get("command", ""))
                 elif isinstance(inp, str):
                     command = inp
+                check_delta, cd_delta = _classify_bash(
+                    command, manual_check_runs, cd_commands, bash_commands
+                )
+                manual_check_runs += check_delta
+                cd_commands += cd_delta
 
-                # Count cd commands.
-                if command.strip().startswith("cd "):
-                    cd_commands += 1
+        chars, output = _accumulate_thinking_tokens(obj)
+        total_thinking_chars += chars
+        total_output_tokens += output
 
-                # Count manual check runs — only for check tool commands,
-                # not for plain cd / ls / etc.
-                is_check_tool = False
-                for check_cmd in _CHECK_COMMANDS:
-                    if check_cmd in command:
-                        manual_check_runs += 1
-                        is_check_tool = True
-                        break
+    return (
+        read_counts,
+        manual_check_runs,
+        bash_commands,
+        cd_commands,
+        total_thinking_chars,
+        total_output_tokens,
+    )
 
-                # Collect bash commands for redundancy detection.
-                # Exclude check-tool commands (already counted as
-                # manual_check_runs) and cd commands (already counted as
-                # cd_commands) to avoid double-counting.
-                is_cd = command.strip().startswith("cd ")
-                if command and not is_check_tool and not is_cd:
-                    bash_commands.append(command)
 
-        # Collect token counts for thinking ratio.
-        if obj.get("type") == "assistant":
-            msg = obj.get("message") or {}
-            usage = msg.get("usage") or {}
-            out_tok = usage.get("output_tokens")
-            if out_tok is not None:
-                total_output_tokens += int(out_tok)
-
-            # Thinking tokens come from content blocks of type "thinking" on
-            # assistant messages (WOR-349). The previous code looked for a
-            # top-level `message.reasoning` field that does not exist in
-            # Claude Code's stream-json format, so total_thinking_tokens was
-            # always 0 for real logs.
-            content = msg.get("content", [])
-            if isinstance(content, list):
-                for block in content:
-                    if isinstance(block, dict) and block.get("type") == "thinking":
-                        text = block.get("thinking", "")
-                        if isinstance(text, str):
-                            total_thinking_tokens += len(text)
-
-    # --- Compute signals ---
+def _compute_redundancies(
+    read_counts: dict[str, int], bash_commands: list[str]
+) -> tuple[int, int]:
+    """Return (redundant_reads, redundant_bash) — counts of excess repeats."""
     redundant_reads = sum(max(0, c - 1) for c in read_counts.values() if c > 1)
-
-    # Redundant bash: commands that appear more than once (exact match).
     cmd_freq: dict[str, int] = {}
     for cmd in bash_commands:
         cmd_freq[cmd] = cmd_freq.get(cmd, 0) + 1
     redundant_bash = sum(max(0, c - 1) for c in cmd_freq.values() if c > 1)
+    return redundant_reads, redundant_bash
 
-    # Thinking-to-text ratio: ratio of thinking tokens to output tokens.
-    # When output_tokens is 0 or None, ratio is 0.
-    if total_output_tokens > 0:
-        # Normalize thinking token count (char count) to an approximate token
-        # count (roughly 4 chars per token for English text).
-        thinking_tokens_approx = total_thinking_tokens / 4.0
-        thinking_to_text_ratio = (
-            thinking_tokens_approx / total_output_tokens
-            if total_output_tokens > 0
-            else 0.0
-        )
-    else:
-        thinking_to_text_ratio = 0.0
 
-    # --- Compute composite score ---
+def _compute_thinking_ratio(thinking_chars: int, output_tokens: int) -> float:
+    """Normalise thinking chars to approximate tokens and divide by output."""
+    if output_tokens <= 0:
+        return 0.0
+    return (thinking_chars / 4.0) / output_tokens
+
+
+def _compute_composite_score(
+    redundant_reads: int,
+    manual_check_runs: int,
+    redundant_bash: int,
+    cd_commands: int,
+    thinking_to_text_ratio: float,
+) -> int:
+    """Combine the per-signal counts into a 0-100 waste score."""
     score = 0
     score += min(redundant_reads * 2, 30)
     score += min(manual_check_runs * 3, 25)
@@ -199,10 +223,41 @@ def compute_waste_score(log_path: Path) -> WasteReport:
     score += min(cd_commands, 15)
     if thinking_to_text_ratio > 5:
         score += min(int(thinking_to_text_ratio), 10)
+    return min(score, 100)
 
-    score = min(score, 100)
 
-    # Only include signals that actually contribute (value > 0).
+def compute_waste_score(log_path: Path) -> WasteReport:
+    """Compute a 0-100 waste score from a worker session log.
+
+    Parses the stream-json log for tool_use entries and counts waste signals:
+    redundant_reads, manual_check_runs, redundant_bash, cd_commands, and
+    thinking_to_text_ratio.
+    """
+    lines = _read_log_lines(log_path)
+    if lines is None:
+        return _empty_report()
+
+    (
+        read_counts,
+        manual_check_runs,
+        bash_commands,
+        cd_commands,
+        total_thinking_chars,
+        total_output_tokens,
+    ) = _extract_signals(lines)
+
+    redundant_reads, redundant_bash = _compute_redundancies(read_counts, bash_commands)
+    thinking_to_text_ratio = _compute_thinking_ratio(
+        total_thinking_chars, total_output_tokens
+    )
+    score = _compute_composite_score(
+        redundant_reads,
+        manual_check_runs,
+        redundant_bash,
+        cd_commands,
+        thinking_to_text_ratio,
+    )
+
     breakdown: dict[str, int] = {
         k: int(v)
         for k, v in {
@@ -226,38 +281,32 @@ def compute_waste_score(log_path: Path) -> WasteReport:
     )
 
 
+def _tool_uses_from_blocks(blocks: list[Any]) -> list[dict[str, Any]]:
+    """Filter a content/tool_calls list down to tool_use dict entries."""
+    out: list[dict[str, Any]] = []
+    for block in blocks:
+        if isinstance(block, dict) and block.get("type") == "tool_use":
+            out.append(block)
+    return out
+
+
 def _extract_tool_uses(obj: dict[str, Any]) -> list[dict[str, Any]]:
     """Extract all tool_use blocks from a stream-json event.
 
     Claude Code's stream-json format puts tool_use blocks in
-    ``message.content[]`` with ``type == "tool_use"``. A single assistant
-    turn can emit multiple tool_use blocks. Returns all of them in order
-    (empty list if none).
-
-    Also handles legacy/synthetic forms:
-    - direct ``{type: "tool_use", ...}`` event
-    - ``{type: "assistant", message: {tool_calls: [{...}]}}`` (legacy field)
+    ``message.content[]`` with ``type == "tool_use"``. Also handles legacy
+    forms (direct tool_use event, or assistant.tool_calls list).
     """
     if obj.get("type") == "tool_use":
         return [obj]
     if obj.get("type") != "assistant":
         return []
-
     msg = obj.get("message") or {}
+    content = msg.get("content", []) or []
+    tool_calls = msg.get("tool_calls", []) or []
     found: list[dict[str, Any]] = []
-
-    # Primary path: content blocks (Claude Code stream-json format).
-    content = msg.get("content", [])
     if isinstance(content, list):
-        for block in content:
-            if isinstance(block, dict) and block.get("type") == "tool_use":
-                found.append(block)
-
-    # Legacy fallback: tool_calls list (kept for any synthetic logs).
-    tool_calls = msg.get("tool_calls", [])
+        found.extend(_tool_uses_from_blocks(content))
     if isinstance(tool_calls, list):
-        for tc in tool_calls:
-            if isinstance(tc, dict) and tc.get("type") == "tool_use":
-                found.append(tc)
-
+        found.extend(_tool_uses_from_blocks(tool_calls))
     return found

--- a/app/core/wizard.py
+++ b/app/core/wizard.py
@@ -63,64 +63,56 @@ def validate_bool(value: str) -> str:
     return value.strip().lower()
 
 
+def _resolve_default_value(
+    step: WizardStep, prefs: UserPreferences | None
+) -> str | None:
+    """Extract the pre-fill string default from prefs for *step*, if any."""
+    if prefs is None or step.default is None:
+        return None
+    field = step.default
+    if not isinstance(field, str) or not hasattr(prefs, field):
+        return None
+    val = getattr(prefs, field, "")
+    return str(val) if val else None
+
+
+def _handle_empty_input(step: WizardStep, default_val: str | None) -> str:
+    """Resolve the empty-input branch: default → skip-signal → raise."""
+    if default_val is not None:
+        return default_val
+    if step.skip_on_default:
+        return step.key  # signal skip
+    raise ValueError(f"{step.prompt} cannot be empty")
+
+
 def collect_wizard_input(
     step: WizardStep,
     inputs: Iterator[str] | None = None,
     prefs: UserPreferences | None = None,
 ) -> str:
-    """Collect one piece of input from the user with validation.
+    """Collect one piece of input with validation and pre-fill.
 
-    Args:
-        step: The wizard step describing the prompt/validation/defaults.
-        inputs: Iterator of canned answers (used in tests).
-        prefs: User preferences for pre-fill.
-
-    Returns:
-        The validated input string.
-
-    Raises:
-        ValueError: If validation fails after all retries exhausted.
+    Returns the validated input. Raises ValueError if the field is required
+    and the user supplied no value (and no default is configured).
     """
-    prompt = step.prompt
-    default_val = None
-    if prefs is not None and step.default is not None:
-        field = step.default
-        if isinstance(field, str) and hasattr(prefs, field):
-            val = getattr(prefs, field, "")
-            if val:
-                default_val = str(val)
-
-    display = ""
-    if default_val is not None:
-        display = f" [{default_val}]"
+    default_val = _resolve_default_value(step, prefs)
+    display = f" [{default_val}]" if default_val is not None else ""
 
     while True:
         if inputs is not None:
             raw = next(inputs)
         else:
-            raw = input(prompt + display + ": ")  # noqa: T201
+            raw = input(step.prompt + display + ": ")  # noqa: T201
 
-        # Handle empty input
         if raw.strip() == "":
-            if default_val is not None:
-                value = default_val
-            elif step.skip_on_default:
-                value = step.key  # return key to signal skip
-            else:
-                raise ValueError(f"{step.prompt} cannot be empty")
-            break
+            return _handle_empty_input(step, default_val)
 
-        # Validate
-        if step.validator is not None:
-            try:
-                value = step.validator(raw)
-            except ValueError:
-                continue
-        else:
-            value = raw.strip()
-        break
-
-    return value
+        if step.validator is None:
+            return raw.strip()
+        try:
+            return step.validator(raw)
+        except ValueError:
+            continue
 
 
 def _collect_bool_input(


### PR DESCRIPTION
## Summary

Wave of S3776 Cognitive Complexity reductions across all flagged files.
One commit per file, starting from the highest CC. Behaviour is preserved
in every commit — refactoring only, no functional changes.

| File | Function | CC before | Approach |
|---|---|---|---|
| `worker_waste.py` | `compute_waste_score` + `_extract_tool_uses` | 80, 17 | 9 helpers (classify_bash, parse, signals, redundancies, ratio, composite) |
| `watcher_log_parsing.py` | `_parse_worker_usage` + `_parse_hook_trust_violations` | 65, 25 | per-event helpers (assistant event, compact boundary, sentinel resolve, violation count) |
| `watcher_finalize.py` | `finalize_worker` | 58 | 4 helpers (retry loop, diff stats, vLLM delta capture, improvement log post) |
| `watcher_helpers.py` | `_parse_worker_behavior` + `capture_vllm_metrics` | 46, 19 | per-block / per-metric helpers |
| `metrics.py` | `_migrate` + `compute_tags` | 42, 22 | data-driven `_TICKET_METRICS_ADDED_COLUMNS` table + `_anomaly_tags` / `_category_tags` split |
| `dispatch.py` | `start_ticket` | 31 | 5 precondition helpers (blockers, epic-overlap, manifest-quality, epic-drift, path-overlap) |
| `ticket_status.py` | `fetch_ticket_status` + `_parse_last_tool_calls` | 28, 26 | phase split + `_parse_assistant_line` extraction |
| `wizard.py` | `collect_wizard_input` | 26 | `_resolve_default_value` + `_handle_empty_input` |
| `watcher_finalize_helpers.py` | `_execute_finalization` | 17 | `_record_failure_state` deduplicates two escalate-or-fail branches |
| `linear_client.py` | `_query` | 17 | split into `_build_request` + `_attempt_query` + module-level `_classify_transient_or_raise` |

## Verification

- `pytest`: 1601 passed
- `ruff check`, `ruff format`, `mypy app/`: clean on every commit
- `lint-imports`: 7 contracts kept, 0 broken on every commit

## Analysis — further splits and new import contracts

**Splits worth doing in a follow-up (no action in this PR):**

| File | LOC | Threshold | Recommendation |
|---|---|---|---|
| `app/core/metrics.py` | 864 | RECOMMEND (≥700) | Split into `metrics_models.py` (Pydantic row models), `metrics_store.py` (MetricsStore class + migrations), `metrics_tags.py` (`compute_tags` + anomaly/category helpers). Add an import-linter contract that `metrics_models` cannot import `metrics_store` (data classes must stay independent of their store). |
| `app/core/watcher/watcher_helpers.py` | 682 | ADVISORY (≥500) | Approaching RECOMMEND; consider extracting the worker-output parsing block into a sibling module. |
| `app/core/watcher/watcher.py` | 676 | ADVISORY | Already heavily split (WOR-401, WOR-403, WOR-404); the remaining body is the orchestration loop. Hold the line. |
| `app/core/watcher/watcher_finalize.py` | 663 | ADVISORY | Refactored this PR (extracted 4 helpers); CC reduced but LOC parked here intentionally to avoid further file fragmentation. |
| `app/core/watcher/watcher_worktrees.py` | 630 | ADVISORY | Cohesive (git-worktree lifecycle). No split needed. |

**Import-linter contracts:**

Reviewed the seven existing contracts in `.importlinter` against the diff. **No new contracts are required for this PR** — every helper was extracted within its own file; no new modules were created, so no new boundaries to police.

If the `metrics.py` split above is done in a follow-up, the new contract to add would be:

```ini
[importlinter:contract:metrics-models-no-store]
name = metrics_models must not import metrics_store
type = forbidden
source_modules = app.core.metrics_models
forbidden_modules = app.core.metrics_store
```

## Test plan

- [x] `pytest` (1601 tests)
- [x] `mypy app/`
- [x] `ruff check .` + `ruff format .`
- [x] `lint-imports` (7 contracts)
- [ ] SonarCloud informational scan on the sub→epic PR — expect 14 S3776 findings removed, no new ones

🤖 Generated with [Claude Code](https://claude.com/claude-code)
