### PR TITLE
Sonar residual: clear remaining 9 findings after PR #893

### DIFF
--- a/app/cli/generate.py
+++ b/app/cli/generate.py
@@ -245,44 +245,79 @@ def _run_github_phase(
 
     Returns (exit_code, clone_url, repo_full_name). exit_code is 0 on success.
     """
-    clone_url: str | None = None
-    repo_full_name: str | None = None
     rollback = not args.no_rollback_on_failure
 
-    if args.github_create:
-        try:
-            clone_url = _run_github_create(config, args)
-        except RuntimeError as exc:
-            print(f"Error: {exc}", file=sys.stderr)
-            return 1, None, None
+    clone_url, rc = _gh_create_step(args, config)
+    if rc != 0:
+        return rc, None, None
 
-    if clone_url is not None:
-        repo_full_name = _parse_repo_full_name(clone_url)
+    repo_full_name = _parse_repo_full_name(clone_url) if clone_url is not None else None
 
-    if repo_full_name is not None and clone_url is not None:
-        try:
-            configure_github_repo(repo_full_name, config.preset, config.include_ci)
-            print("✓ Configured GitHub repository settings")
-        except RuntimeError as exc:
-            if rollback:
-                delete_github_repo(repo_full_name)
-            print(f"Error: {exc}", file=sys.stderr)
-            return 1, None, None
+    rc = _gh_configure_step(repo_full_name, clone_url, config, rollback)
+    if rc != 0:
+        return rc, None, None
 
-    if args.git_push:
-        push_url: str | None = clone_url if clone_url is not None else args.remote_url
-        if push_url is None:
-            print("Error: no remote URL specified", file=sys.stderr)
-            return 1, None, None
-        try:
-            _run_initial_push(args.output, push_url)
-        except RuntimeError as exc:
-            if rollback and repo_full_name is not None:
-                delete_github_repo(repo_full_name)
-            print(f"Error: {exc}", file=sys.stderr)
-            return 1, None, None
+    rc = _gh_push_step(args, clone_url, repo_full_name, rollback)
+    if rc != 0:
+        return rc, None, None
 
     return 0, clone_url, repo_full_name
+
+
+def _gh_create_step(
+    args: argparse.Namespace, config: RepoConfig
+) -> tuple[str | None, int]:
+    """Optional GitHub repo create. Returns (clone_url, exit_code)."""
+    if not args.github_create:
+        return None, 0
+    try:
+        return _run_github_create(config, args), 0
+    except RuntimeError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return None, 1
+
+
+def _gh_configure_step(
+    repo_full_name: str | None,
+    clone_url: str | None,
+    config: RepoConfig,
+    rollback: bool,
+) -> int:
+    """Optional GitHub repo settings configure. Returns exit_code."""
+    if repo_full_name is None or clone_url is None:
+        return 0
+    try:
+        configure_github_repo(repo_full_name, config.preset, config.include_ci)
+        print("✓ Configured GitHub repository settings")
+        return 0
+    except RuntimeError as exc:
+        if rollback:
+            delete_github_repo(repo_full_name)
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+
+def _gh_push_step(
+    args: argparse.Namespace,
+    clone_url: str | None,
+    repo_full_name: str | None,
+    rollback: bool,
+) -> int:
+    """Optional initial git push. Returns exit_code."""
+    if not args.git_push:
+        return 0
+    push_url: str | None = clone_url if clone_url is not None else args.remote_url
+    if push_url is None:
+        print("Error: no remote URL specified", file=sys.stderr)
+        return 1
+    try:
+        _run_initial_push(args.output, push_url)
+        return 0
+    except RuntimeError as exc:
+        if rollback and repo_full_name is not None:
+            delete_github_repo(repo_full_name)
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
 
 
 def _execute_generation_pipeline(config: RepoConfig, args: argparse.Namespace) -> int:

--- a/app/core/linear_client.py
+++ b/app/core/linear_client.py
@@ -253,11 +253,7 @@ class LinearClient:
         for attempt in range(max_retries + 1):
             try:
                 return self._attempt_query(req)
-            except (
-                urllib.error.HTTPError,
-                urllib.error.URLError,
-                http.client.RemoteDisconnected,
-            ) as exc:
+            except (urllib.error.URLError, http.client.RemoteDisconnected) as exc:
                 last_exc = _classify_transient_or_raise(exc)
             if attempt < max_retries:
                 delay = _RETRY_DELAYS[attempt]

--- a/app/core/watcher/dispatch.py
+++ b/app/core/watcher/dispatch.py
@@ -77,23 +77,12 @@ def start_ticket(
         services._mode if hasattr(services, "_mode") else "local",
         manifest.implementation_mode,
     )
-
-    if effective_mode != "local" and len(_cloud_active) >= max_cloud_workers:
-        logger.info(
-            "Deferring %s — cloud pool full (%d/%d)",
-            ticket_id,
-            len(_cloud_active),
-            max_cloud_workers,
-        )
+    if not _check_pool_capacity(
+        effective_mode, _cloud_active, max_cloud_workers, ticket_id
+    ):
         return
-
-    if effective_mode == "local":
-        if not services.probe_vllm_health():
-            reason_msg = "Deferring %s — vLLM not ready yet" % (ticket_id,)
-            if suppress_dedup(ticket_id, "vllm_not_ready", reason_msg, _dedup_state):
-                logger.warning("%s", reason_msg)
-            return
-        services.ensure_vllm_anthropic_mode()
+    if not _check_vllm_health(effective_mode, services, ticket_id, _dedup_state):
+        return
 
     worktree_path = create_worktree(_repo_root, manifest)
     copy_manifest_to_worktree(_repo_root, manifest, worktree_path)
@@ -111,24 +100,9 @@ def start_ticket(
     # WOR-363: capture pool size BEFORE launching this worker. Counts OTHER
     # workers — does not include the one we're about to add.
     dispatch_concurrency = len(_local_active) + len(_cloud_active)
-
-    # WOR-370: vLLM /metrics attribution gate.
-    # 1. If we're solo (dispatch_concurrency==0) and the /metrics endpoint
-    #    responds, snapshot for later delta computation.
-    # 2. If we're NOT solo, any peer that previously had remained_solo=True
-    #    must lose that flag — they're no longer alone, so their session's
-    #    deltas would be polluted by this worker's traffic.
-    vllm_metrics_before: dict[str, float] | None = None
-    remained_solo = False
-    if dispatch_concurrency == 0:
-        snapshot = capture_vllm_metrics()
-        if snapshot is not None:
-            vllm_metrics_before = snapshot
-            remained_solo = True
-    else:
-        for peer in (*_local_active, *_cloud_active):
-            if peer.remained_solo:
-                peer.remained_solo = False
+    vllm_metrics_before, remained_solo = _snapshot_vllm_solo(
+        dispatch_concurrency, _local_active, _cloud_active
+    )
 
     process = launch_worker(
         _repo_root, manifest, worktree_path, effective_mode, worker_verbose
@@ -319,3 +293,63 @@ def _check_path_overlap(
     if suppress_dedup(ticket_id, reason, reason_msg, _dedup_state):
         logger.info(reason_msg)
     return False
+
+
+def _check_pool_capacity(
+    effective_mode: str,
+    _cloud_active: list[ActiveWorker],
+    max_cloud_workers: int,
+    ticket_id: str,
+) -> bool:
+    """Defer cloud dispatch when the cloud pool is at capacity."""
+    if effective_mode == "local" or len(_cloud_active) < max_cloud_workers:
+        return True
+    logger.info(
+        "Deferring %s — cloud pool full (%d/%d)",
+        ticket_id,
+        len(_cloud_active),
+        max_cloud_workers,
+    )
+    return False
+
+
+def _check_vllm_health(
+    effective_mode: str,
+    services: ServiceManager,
+    ticket_id: str,
+    _dedup_state: dict[str, str],
+) -> bool:
+    """For local mode: defer until vLLM probes healthy + Anthropic mode is set."""
+    if effective_mode != "local":
+        return True
+    if not services.probe_vllm_health():
+        reason_msg = "Deferring %s — vLLM not ready yet" % (ticket_id,)
+        if suppress_dedup(ticket_id, "vllm_not_ready", reason_msg, _dedup_state):
+            logger.warning("%s", reason_msg)
+        return False
+    services.ensure_vllm_anthropic_mode()
+    return True
+
+
+def _snapshot_vllm_solo(
+    dispatch_concurrency: int,
+    _local_active: list[ActiveWorker],
+    _cloud_active: list[ActiveWorker],
+) -> tuple[dict[str, float] | None, bool]:
+    """WOR-370: vLLM /metrics attribution gate.
+
+    1. Solo (dispatch_concurrency==0): snapshot /metrics for later delta;
+       returns (snapshot, True) on success or (None, False) if probe fails.
+    2. Not solo: clear remained_solo on any peer that previously had it set
+       — their deltas would now be polluted by this worker's traffic.
+       Returns (None, False).
+    """
+    if dispatch_concurrency == 0:
+        snapshot = capture_vllm_metrics()
+        if snapshot is not None:
+            return snapshot, True
+        return None, False
+    for peer in (*_local_active, *_cloud_active):
+        if peer.remained_solo:
+            peer.remained_solo = False
+    return None, False

--- a/app/core/watcher/watcher_finalize.py
+++ b/app/core/watcher/watcher_finalize.py
@@ -11,6 +11,7 @@ import logging
 import os
 import subprocess  # nosec B404
 from pathlib import Path
+from typing import Any
 
 from app.core.escalation_policy import EscalationPolicy, get_waste_warn_threshold
 from app.core.manifest import ExecutionManifest
@@ -425,16 +426,7 @@ def finalize_worker(
     api_retry_count = _parse_worker_api_retries(log_path)
     subagent_spawns = _parse_worker_subagent_spawns(log_path)
     hook_trust_violations = _parse_hook_trust_violations(log_path)
-    # WOR-274: warn when the worker manually re-ran quality checks outside
-    # the PostToolUse hook loop.  Threshold > 1 because a single accidental
-    # re-run may be harmless; repeated re-runs indicate systematic distrust
-    # of the hook infrastructure.
-    if hook_trust_violations is not None and hook_trust_violations > 1:
-        logger.warning(
-            "hook-trust violation: %s ran quality-check tools manually %d times",
-            worker.ticket_id,
-            hook_trust_violations,
-        )
+    _warn_hook_trust(worker.ticket_id, hook_trust_violations)
     # WOR-380: per-worker behavior telemetry. Concurrency-safe — extracted
     # from this worker's own log file.
     behavior = _parse_worker_behavior(log_path)
@@ -449,34 +441,7 @@ def finalize_worker(
         worker.worktree_path, worker.manifest.base_branch
     )
 
-    # Cloud metrics — populated only when eff == "cloud"
-    cloud_model: str | None = None
-    cloud_tokens: int | None = None
-    cloud_cost_estimate: float | None = None
-    if eff == "cloud" and input_tokens is not None and output_tokens is not None:
-        cloud_model = _resolve_cloud_model()
-        cloud_tokens = input_tokens + output_tokens
-        cloud_cost_estimate = _estimate_cloud_cost(
-            input_tokens, output_tokens, cloud_model
-        )
-
-    # Local metrics — populated only when eff == "local"
-    local_tokens: int | None = None
-    local_input_tokens: int | None = None
-    local_output_tokens: int | None = None
-    output_tokens_per_wall_second: float | None = None
-    local_model_str: str | None = None
-    if eff == "local":
-        local_tokens = (
-            (input_tokens or 0) + (output_tokens or 0)
-            if input_tokens is not None and output_tokens is not None
-            else None
-        )
-        local_input_tokens = input_tokens
-        local_output_tokens = output_tokens
-        local_model_str = _LOCAL_MODEL
-        if output_tokens is not None and wall_time and wall_time > 0:
-            output_tokens_per_wall_second = output_tokens / wall_time
+    cost = _build_cost_metrics(eff, input_tokens, output_tokens, wall_time)
 
     # Compute waste score from the worker log (WOR-277).
     waste_report = compute_waste_score(log_path)
@@ -484,20 +449,7 @@ def finalize_worker(
     waste_breakdown_json: str | None = (
         json.dumps(waste_report.breakdown) if waste_report.score > 0 else None
     )
-    if waste_score is not None and waste_score > get_waste_warn_threshold():
-        top_reasons = ", ".join(
-            f"{k}={v}"
-            for k, v in sorted(
-                waste_report.breakdown.items(), key=lambda x: x[1], reverse=True
-            )
-            if v > 0
-        )
-        logger.warning(
-            "High waste score for %s: %d/100 (%s)",
-            worker.ticket_id,
-            waste_score,
-            top_reasons,
-        )
+    _warn_high_waste(worker.ticket_id, waste_score, waste_report)
 
     # failed_check: store JSON array of all failed check names (WOR-312)
     failed_check_json: str | None = (
@@ -516,16 +468,16 @@ def finalize_worker(
             epic_id=worker.manifest.epic_id,
             implementation_mode=_to_metrics_mode(eff),
             local_used=(eff == "local"),
-            local_model=local_model_str,
+            local_model=cost["local_model"],
             cloud_used=(eff == "cloud"),
-            cloud_model=cloud_model,
-            cloud_tokens=cloud_tokens,
-            cloud_cost_estimate=cloud_cost_estimate,
-            local_input_tokens=local_input_tokens,
-            local_output_tokens=local_output_tokens,
-            local_tokens=local_tokens,
+            cloud_model=cost["cloud_model"],
+            cloud_tokens=cost["cloud_tokens"],
+            cloud_cost_estimate=cost["cloud_cost_estimate"],
+            local_input_tokens=cost["local_input_tokens"],
+            local_output_tokens=cost["local_output_tokens"],
+            local_tokens=cost["local_tokens"],
             local_wall_time=wall_time,
-            output_tokens_per_wall_second=output_tokens_per_wall_second,
+            output_tokens_per_wall_second=cost["output_tokens_per_wall_second"],
             escalated_to_cloud=escalated,
             outcome=outcome,
             retry_count=worker.attempt_count,
@@ -594,23 +546,12 @@ def finalize_worker(
             wall_time_s=wall_time,
             input_tokens=input_tokens,
             output_tokens=output_tokens,
-            output_tok_per_s=output_tokens_per_wall_second,
+            output_tok_per_s=cost["output_tokens_per_wall_second"],
             context_compactions=context_compactions,
         )
     )
 
-    # Auto-detect tags for morning retros (WOR-332).
-    _manifest = worker.manifest
-    _row = metrics.get_by_ticket(worker.ticket_id, project_id)
-    if _row is not None:
-        _tags = compute_tags(
-            _row,
-            _read_result_status(repo_root, _manifest) or "",
-            _read_result_flags(repo_root / _manifest.artifact_paths.result_json),
-            tracked_prs,
-        )
-        if _tags:
-            metrics.set_tags(worker.ticket_id, project_id, _tags)
+    _apply_auto_tags(metrics, worker, project_id, repo_root, tracked_prs)
 
     restore_plan_files(worker.backed_up_plans)
 
@@ -627,7 +568,94 @@ def finalize_worker(
         worker.manifest.worker_branch,
         backup_root=backup_root,
     )
-    # Surface silent commit_wip_state failures for operator visibility (WOR-309).
+    _handle_wip_result(wip_result, worker)
+
+    if not artifacts_preserved:
+        # Failure path: also preserve full worker artifacts (logs, last_failure,
+        # etc.) for forensic analysis. Success path doesn't need this — the PR
+        # itself is the artifact.
+        preserve_worker_artifacts(repo_root, worker)
+
+    if wip_result.status in ("clean", "pushed", "backup"):
+        cleanup_worktree(repo_root, worker.worktree_path)
+    # else: status == "failed" — WOR-288: WIP preservation failed (commit
+    # could neither push nor back up). Leaving the worktree in place for
+    # human salvage. The ERROR log at the call site above already surfaces
+    # the path and error for manual recovery.
+    return outcome
+
+
+def _warn_hook_trust(ticket_id: str, hook_trust_violations: int | None) -> None:
+    """WOR-274: warn when the worker manually re-ran quality checks outside hooks.
+
+    Threshold > 1 because a single accidental re-run may be harmless; repeated
+    re-runs indicate systematic distrust of the hook infrastructure.
+    """
+    if hook_trust_violations is None or hook_trust_violations <= 1:
+        return
+    logger.warning(
+        "hook-trust violation: %s ran quality-check tools manually %d times",
+        ticket_id,
+        hook_trust_violations,
+    )
+
+
+def _build_cost_metrics(
+    eff: str,
+    input_tokens: int | None,
+    output_tokens: int | None,
+    wall_time: float,
+) -> dict[str, Any]:
+    """Compute cloud + local cost/token fields based on effective mode."""
+    cost: dict[str, Any] = {
+        "cloud_model": None,
+        "cloud_tokens": None,
+        "cloud_cost_estimate": None,
+        "local_model": None,
+        "local_input_tokens": None,
+        "local_output_tokens": None,
+        "local_tokens": None,
+        "output_tokens_per_wall_second": None,
+    }
+    if eff == "cloud" and input_tokens is not None and output_tokens is not None:
+        cost["cloud_model"] = _resolve_cloud_model()
+        cost["cloud_tokens"] = input_tokens + output_tokens
+        cost["cloud_cost_estimate"] = _estimate_cloud_cost(
+            input_tokens, output_tokens, cost["cloud_model"]
+        )
+        return cost
+    if eff != "local":
+        return cost
+    cost["local_model"] = _LOCAL_MODEL
+    cost["local_input_tokens"] = input_tokens
+    cost["local_output_tokens"] = output_tokens
+    if input_tokens is not None and output_tokens is not None:
+        cost["local_tokens"] = input_tokens + output_tokens
+    if output_tokens is not None and wall_time and wall_time > 0:
+        cost["output_tokens_per_wall_second"] = output_tokens / wall_time
+    return cost
+
+
+def _warn_high_waste(
+    ticket_id: str, waste_score: int | None, waste_report: Any
+) -> None:
+    """WOR-277: surface a warning when the waste score exceeds the threshold."""
+    if waste_score is None or waste_score <= get_waste_warn_threshold():
+        return
+    top_reasons = ", ".join(
+        f"{k}={v}"
+        for k, v in sorted(
+            waste_report.breakdown.items(), key=lambda x: x[1], reverse=True
+        )
+        if v > 0
+    )
+    logger.warning(
+        "High waste score for %s: %d/100 (%s)", ticket_id, waste_score, top_reasons
+    )
+
+
+def _handle_wip_result(wip_result: Any, worker: ActiveWorker) -> None:
+    """Log + persist outcome of commit_wip_state per WIP status."""
     if wip_result.status == "backup":
         logger.warning(
             "WIP backup for %s — commit or push failed, dirty worktree saved to %s",
@@ -648,16 +676,24 @@ def finalize_worker(
         _write_wip_sha_to_last_failure(worker, wip_result.sha)
     _write_wip_state_to_last_failure(worker, wip_result.status, wip_result.backup_path)
 
-    if not artifacts_preserved:
-        # Failure path: also preserve full worker artifacts (logs, last_failure,
-        # etc.) for forensic analysis. Success path doesn't need this — the PR
-        # itself is the artifact.
-        preserve_worker_artifacts(repo_root, worker)
 
-    if wip_result.status in ("clean", "pushed", "backup"):
-        cleanup_worktree(repo_root, worker.worktree_path)
-    # else: status == "failed" — WOR-288: WIP preservation failed (commit
-    # could neither push nor back up). Leaving the worktree in place for
-    # human salvage. The ERROR log at the call site above already surfaces
-    # the path and error for manual recovery.
-    return outcome
+def _apply_auto_tags(
+    metrics: MetricsStore,
+    worker: ActiveWorker,
+    project_id: str,
+    repo_root: Path,
+    tracked_prs: list[TrackedPR] | None,
+) -> None:
+    """WOR-332: compute and persist auto-tags from the metrics row + result.json."""
+    manifest = worker.manifest
+    row = metrics.get_by_ticket(worker.ticket_id, project_id)
+    if row is None:
+        return
+    tags = compute_tags(
+        row,
+        _read_result_status(repo_root, manifest) or "",
+        _read_result_flags(repo_root / manifest.artifact_paths.result_json),
+        tracked_prs,
+    )
+    if tags:
+        metrics.set_tags(worker.ticket_id, project_id, tags)

--- a/app/core/watcher/watcher_helpers.py
+++ b/app/core/watcher/watcher_helpers.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import json
 import logging
 import subprocess  # nosec B404
+from collections.abc import Iterable
 from pathlib import Path
 from typing import IO, Any
 
@@ -621,57 +622,7 @@ def _parse_worker_behavior(log_path: Path) -> WorkerBehavior:
     """
     try:
         with log_path.open(encoding="utf-8") as f:
-            turn_count = 0
-            behavior_accum = {
-                "thinking_blocks": 0,
-                "thinking_chars": 0,
-                "tool_calls_total": 0,
-            }
-            tool_breakdown: dict[str, int] = {}
-            input_tokens_first: int | None = None
-            input_tokens_last: int | None = None
-            input_tokens_max: int | None = None
-            read_counts: dict[str, int] = {}
-            for raw in f:
-                line = raw.strip()
-                if not line:
-                    continue
-                try:
-                    obj = json.loads(line)
-                except json.JSONDecodeError:
-                    continue
-                if obj.get("type") != "assistant":
-                    continue
-                turn_count += 1
-                msg = obj.get("message") or {}
-                usage = msg.get("usage") or {}
-                input_tokens_first, input_tokens_last, input_tokens_max = (
-                    _update_input_tokens(
-                        usage.get("input_tokens"),
-                        input_tokens_first,
-                        input_tokens_last,
-                        input_tokens_max,
-                    )
-                )
-                for blk in msg.get("content") or []:
-                    if isinstance(blk, dict):
-                        _accumulate_content_block(
-                            blk, behavior_accum, tool_breakdown, read_counts
-                        )
-            if turn_count == 0:
-                return WorkerBehavior.empty_readable()
-            redundant = sum(1 for n in read_counts.values() if n > 2)
-            return WorkerBehavior(
-                turn_count=turn_count,
-                tool_calls_total=behavior_accum["tool_calls_total"],
-                tool_calls_breakdown=tool_breakdown,
-                thinking_blocks=behavior_accum["thinking_blocks"],
-                thinking_chars_total=behavior_accum["thinking_chars"],
-                input_tokens_max=input_tokens_max,
-                input_tokens_first=input_tokens_first,
-                input_tokens_last=input_tokens_last,
-                redundant_reads_count=redundant,
-            )
+            return _walk_behavior_log(f)
     except (OSError, ValueError) as exc:
         logger.warning(
             "Failed to read %s — behaviour telemetry columns will be NULL; %s",
@@ -680,3 +631,64 @@ def _parse_worker_behavior(log_path: Path) -> WorkerBehavior:
             exc_info=True,
         )
         return WorkerBehavior.empty_unparseable()
+
+
+def _load_assistant_event(line: str) -> dict[str, Any] | None:
+    """Parse one JSONL line; return dict only if it is an assistant event."""
+    stripped = line.strip()
+    if not stripped:
+        return None
+    try:
+        obj = json.loads(stripped)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(obj, dict) or obj.get("type") != "assistant":
+        return None
+    return obj
+
+
+def _walk_behavior_log(lines: Iterable[str]) -> WorkerBehavior:
+    """Aggregate per-session behavior signals from a stream of JSONL lines."""
+    turn_count = 0
+    behavior_accum = {
+        "thinking_blocks": 0,
+        "thinking_chars": 0,
+        "tool_calls_total": 0,
+    }
+    tool_breakdown: dict[str, int] = {}
+    input_tokens_first: int | None = None
+    input_tokens_last: int | None = None
+    input_tokens_max: int | None = None
+    read_counts: dict[str, int] = {}
+    for raw in lines:
+        obj = _load_assistant_event(raw)
+        if obj is None:
+            continue
+        turn_count += 1
+        msg = obj.get("message") or {}
+        usage = msg.get("usage") or {}
+        input_tokens_first, input_tokens_last, input_tokens_max = _update_input_tokens(
+            usage.get("input_tokens"),
+            input_tokens_first,
+            input_tokens_last,
+            input_tokens_max,
+        )
+        for blk in msg.get("content") or []:
+            if isinstance(blk, dict):
+                _accumulate_content_block(
+                    blk, behavior_accum, tool_breakdown, read_counts
+                )
+    if turn_count == 0:
+        return WorkerBehavior.empty_readable()
+    redundant = sum(1 for n in read_counts.values() if n > 2)
+    return WorkerBehavior(
+        turn_count=turn_count,
+        tool_calls_total=behavior_accum["tool_calls_total"],
+        tool_calls_breakdown=tool_breakdown,
+        thinking_blocks=behavior_accum["thinking_blocks"],
+        thinking_chars_total=behavior_accum["thinking_chars"],
+        input_tokens_max=input_tokens_max,
+        input_tokens_first=input_tokens_first,
+        input_tokens_last=input_tokens_last,
+        redundant_reads_count=redundant,
+    )

--- a/app/core/watcher/watcher_log_parsing.py
+++ b/app/core/watcher/watcher_log_parsing.py
@@ -26,28 +26,29 @@ logger = logging.getLogger(__name__)
 _CHARS_PER_TOKEN_ESTIMATE = 4
 
 
+def _block_text_chars(block: dict[str, Any]) -> int:
+    """Approximate character length of one content block (WOR-384 sentinel)."""
+    btype = block.get("type")
+    if btype in ("thinking", "text"):
+        key = "thinking" if btype == "thinking" else "text"
+        text = block.get(key) or block.get("text") or ""
+        return len(text) if isinstance(text, str) else 0
+    if btype != "tool_use":
+        return 0
+    inp_dict = block.get("input")
+    if inp_dict is None:
+        return 0
+    try:
+        return len(json.dumps(inp_dict))
+    except (TypeError, ValueError):
+        return 0
+
+
 def _accumulate_content_chars(content: Any) -> int:
-    """Sum approximate character lengths of content blocks for the WOR-384 sentinel."""
+    """Sum approximate character lengths across content blocks."""
     if not isinstance(content, list):
         return 0
-    total = 0
-    for blk in content:
-        if not isinstance(blk, dict):
-            continue
-        btype = blk.get("type")
-        if btype in ("thinking", "text"):
-            key = "thinking" if btype == "thinking" else "text"
-            text = blk.get(key) or blk.get("text") or ""
-            if isinstance(text, str):
-                total += len(text)
-        elif btype == "tool_use":
-            inp_dict = blk.get("input")
-            if inp_dict is not None:
-                try:
-                    total += len(json.dumps(inp_dict))
-                except (TypeError, ValueError):
-                    pass
-    return total
+    return sum(_block_text_chars(b) for b in content if isinstance(b, dict))
 
 
 def _process_assistant_event(obj: dict[str, Any]) -> tuple[int, int, bool, int]:

--- a/app/core/watcher/worker_waste.py
+++ b/app/core/watcher/worker_waste.py
@@ -70,13 +70,11 @@ def _read_log_lines(log_path: Path) -> list[str] | None:
         return None
 
 
-def _classify_bash(
-    command: str, manual_check_count: int, cd_count: int, bash_buffer: list[str]
-) -> tuple[int, int]:
-    """Update manual_check / cd / bash counters from a single Bash command.
+def _classify_bash(command: str, bash_buffer: list[str]) -> tuple[int, int]:
+    """Classify one Bash command into (manual_check_delta, cd_delta).
 
-    Returns (manual_check_delta, cd_delta). Mutates `bash_buffer` in place
-    when the command should count toward redundancy detection.
+    Mutates `bash_buffer` in place when the command counts toward redundancy
+    detection (i.e. is not a check tool, not a `cd`, and not empty).
     """
     is_cd = command.strip().startswith("cd ")
     cd_delta = 1 if is_cd else 0
@@ -169,9 +167,7 @@ def _extract_signals(
                     command = str(inp.get("command", ""))
                 elif isinstance(inp, str):
                     command = inp
-                check_delta, cd_delta = _classify_bash(
-                    command, manual_check_runs, cd_commands, bash_commands
-                )
+                check_delta, cd_delta = _classify_bash(command, bash_commands)
                 manual_check_runs += check_delta
                 cd_commands += cd_delta
 

--- a/app/core/watcher/worker_waste.py
+++ b/app/core/watcher/worker_waste.py
@@ -121,6 +121,47 @@ def _parse_tool_input(inp: Any) -> Any:
     return inp
 
 
+def _load_event_or_none(raw_line: str) -> dict[str, Any] | None:
+    """Parse one JSONL line into a dict, or return None on blank/invalid lines."""
+    line = raw_line.strip()
+    if not line:
+        return None
+    try:
+        loaded = json.loads(line)
+    except json.JSONDecodeError:
+        return None
+    return loaded if isinstance(loaded, dict) else None
+
+
+def _accumulate_tool_use(
+    tool_use: dict[str, Any],
+    read_counts: dict[str, int],
+    bash_commands: list[str],
+) -> tuple[int, int]:
+    """Update read_counts / bash_commands from one tool_use block.
+
+    Returns (manual_check_delta, cd_delta) so the caller can advance its
+    aggregate counters without exposing the parsing details.
+    """
+    name = tool_use.get("name", "")
+    inp = _parse_tool_input(tool_use.get("input", {}))
+    if name == "Read":
+        fp = ""
+        if isinstance(inp, dict):
+            fp = inp.get("file_path", "") or inp.get("path", "") or inp.get("file", "")
+        if fp:
+            read_counts[fp] = read_counts.get(fp, 0) + 1
+        return 0, 0
+    if name == "Bash":
+        command = ""
+        if isinstance(inp, dict):
+            command = str(inp.get("command", ""))
+        elif isinstance(inp, str):
+            command = inp
+        return _classify_bash(command, bash_commands)
+    return 0, 0
+
+
 def _extract_signals(
     lines: list[str],
 ) -> tuple[dict[str, int], int, list[str], int, int, int]:
@@ -139,38 +180,15 @@ def _extract_signals(
     total_output_tokens = 0
 
     for raw_line in lines:
-        line = raw_line.strip()
-        if not line:
+        obj = _load_event_or_none(raw_line)
+        if obj is None:
             continue
-        try:
-            obj = json.loads(line)
-        except json.JSONDecodeError:
-            continue
-
         for tool_use in _extract_tool_uses(obj):
-            name = tool_use.get("name", "")
-            inp = _parse_tool_input(tool_use.get("input", {}))
-
-            if name == "Read":
-                fp = ""
-                if isinstance(inp, dict):
-                    fp = (
-                        inp.get("file_path", "")
-                        or inp.get("path", "")
-                        or inp.get("file", "")
-                    )
-                if fp:
-                    read_counts[fp] = read_counts.get(fp, 0) + 1
-            elif name == "Bash":
-                command = ""
-                if isinstance(inp, dict):
-                    command = str(inp.get("command", ""))
-                elif isinstance(inp, str):
-                    command = inp
-                check_delta, cd_delta = _classify_bash(command, bash_commands)
-                manual_check_runs += check_delta
-                cd_commands += cd_delta
-
+            check_delta, cd_delta = _accumulate_tool_use(
+                tool_use, read_counts, bash_commands
+            )
+            manual_check_runs += check_delta
+            cd_commands += cd_delta
         chars, output = _accumulate_thinking_tokens(obj)
         total_thinking_chars += chars
         total_output_tokens += output


### PR DESCRIPTION
## Summary

Clears the 9 remaining SonarCloud findings after PR #893 closed the
highest-CC pile. One commit per file, in CC-descending order.

| File | Rule | Before | After |
|---|---|---|---|
| `linear_client.py:257` | S5713 redundant exception | — | drop `HTTPError` from except tuple (URLError catches it) |
| `worker_waste.py:74` | S1172 × 2 unused params | — | drop `manual_check_count`, `cd_count` (regression from PR #893's `_classify_bash` extraction) |
| `watcher_finalize.py:390` | S3776 CC | 31 | ~8 — 5 new helpers (warn_hook_trust, build_cost_metrics, warn_high_waste, handle_wip_result, apply_auto_tags) |
| `dispatch.py:45` | S3776 CC | 25 | ~7 — 3 more helpers on top of PR #893's split (check_pool_capacity, check_vllm_health, snapshot_vllm_solo) |
| `worker_waste.py:126` | S3776 CC | 25 | ~6 — load_event_or_none + accumulate_tool_use |
| `generate.py:241` | S3776 CC | 22 | ~6 — split into 3 GitHub-phase helpers (create/configure/push) |
| `watcher_log_parsing.py:29` | S3776 CC | 21 | ~3 — `_block_text_chars` per-block helper; outer becomes sum() |
| `watcher_helpers.py:614` | S3776 CC | 17 | ~3 — `_load_assistant_event` + `_walk_behavior_log` |

## Why some of these regressed from PR #893

Three of the CC findings sit on functions that PR #893 already touched:
`dispatch.start_ticket`, `worker_waste._extract_signals`,
`watcher_log_parsing._accumulate_content_chars`. The first pass extracted
*some* logic out but the parent function (or a new big helper) retained
too many branches. This PR finishes those extractions.

The 2 S1172 findings on `worker_waste._classify_bash` are a direct
regression from PR #893 — I introduced `manual_check_count` and
`cd_count` parameters that the helper never reads. Fixed by dropping them
from both the signature and the call site.

## Verification

- `pytest`: 1601 passed
- `mypy app/`: clean
- `ruff check` + `ruff format`: clean on every commit
- `lint-imports`: 8 contracts kept, 0 broken

## Test plan
- [x] Full pytest
- [x] mypy / ruff / lint-imports per commit
- [ ] CI green
- [ ] SonarCloud informational scan: expect all 9 findings cleared

🤖 Generated with [Claude Code](https://claude.com/claude-code)
