### PR TITLE
WOR-435 Programmatic watcher launch: --detach + .env autoload

### DIFF
--- a/app/cli/operator.py
+++ b/app/cli/operator.py
@@ -17,9 +17,39 @@ from app.core.watcher.ticket_status import (
     _format_size,
     fetch_ticket_status,
 )
+from app.core.watcher.watcher_daemon import (
+    launch_detached,
+    launch_in_new_terminal,
+    load_env_file,
+)
 
 
 def _run_watcher(args: argparse.Namespace) -> int:
+    # WOR-435: auto-load .env so agent-spawned / remote shells inherit
+    # LINEAR_API_KEY without manual export. No-op if .env is absent.
+    load_env_file()
+
+    # WOR-435: --visible opens a new terminal window with the watcher
+    # attached and exits. --detach spawns a fully background daemon and
+    # exits. Both flags are mutually exclusive with each other and with
+    # the normal foreground path.
+    if args.detach and args.visible:
+        print(
+            "Error: --detach and --visible are mutually exclusive.",
+            file=sys.stderr,
+        )
+        return 2
+    if args.visible:
+        return launch_in_new_terminal()
+    if args.detach:
+        pid = launch_detached()
+        log_path = Path.cwd() / ".claude" / "watcher.log"
+        print(
+            f"Watcher daemon started (PID {pid}). Logs: {log_path}",
+            file=sys.stderr,
+        )
+        return 0
+
     import logging
 
     from app.core.watcher import Watcher

--- a/app/cli/parser.py
+++ b/app/cli/parser.py
@@ -228,6 +228,28 @@ def _build_parser() -> argparse.ArgumentParser:
             "Falls back to line-based logging when stderr is piped."
         ),
     )
+    # WOR-435: programmatic launch flags.
+    watcher.add_argument(
+        "--detach",
+        action="store_true",
+        default=False,
+        help=(
+            "Run the watcher as a detached background daemon. Parent exits "
+            "immediately; child writes .claude/watcher.pid and streams logs "
+            "to .claude/watcher.log. Useful for agent-driven launches and "
+            "remote/mobile dispatch flows."
+        ),
+    )
+    watcher.add_argument(
+        "--visible",
+        action="store_true",
+        default=False,
+        help=(
+            "Windows only: open a new visible cmd.exe window with the "
+            "watcher running attached. .env is auto-loaded by the child. "
+            "Falls back with a clear error on non-Windows platforms."
+        ),
+    )
 
     # WOR-333: graceful drain/stop signal.
     sub.add_parser(

--- a/app/core/watcher/watcher_daemon.py
+++ b/app/core/watcher/watcher_daemon.py
@@ -1,0 +1,149 @@
+"""Cross-platform daemon launch + .env autoload helpers (WOR-435).
+
+Three pure functions used by `app.cli.operator._run_watcher`:
+
+- `load_env_file()` — read .env into os.environ before the watcher starts
+- `launch_detached()` — spawn the watcher as a background subprocess and
+  return its PID. Parent process exits; child continues independently.
+- `launch_in_new_terminal()` — Windows-only convenience: open a visible
+  cmd.exe window running the watcher attached, with env auto-loaded by
+  virtue of the child invocation also calling `load_env_file()`.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import subprocess  # nosec B404
+import sys
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Windows CreateProcess flags — defined here so we don't need win32 deps.
+_DETACHED_PROCESS = 0x00000008
+_CREATE_NEW_PROCESS_GROUP = 0x00000200
+_CREATE_NO_WINDOW = 0x08000000
+
+
+def load_env_file(repo_root: Path | None = None) -> int:
+    """Load .env from *repo_root* (default: cwd) into os.environ.
+
+    Existing env vars take precedence — the .env file is a fallback. Returns
+    the count of variables loaded (0 if no .env file exists, also 0 if all
+    keys were already set in the environment).
+
+    No-op on missing file; does not raise. Logs a debug line on success and
+    a warning if the file is present but unreadable.
+    """
+    root = repo_root or Path.cwd()
+    env_path = root / ".env"
+    if not env_path.exists():
+        return 0
+
+    try:
+        from dotenv import dotenv_values
+    except ImportError:
+        logger.warning(
+            "python-dotenv not installed; cannot auto-load %s. "
+            "Install with `pip install python-dotenv`.",
+            env_path,
+        )
+        return 0
+
+    try:
+        values = dotenv_values(env_path)
+    except OSError as exc:
+        logger.warning("Failed to read %s: %s", env_path, exc)
+        return 0
+
+    loaded = 0
+    for key, value in values.items():
+        if value is None or key in os.environ:
+            continue
+        os.environ[key] = value
+        loaded += 1
+    if loaded:
+        logger.debug("Loaded %d vars from %s", loaded, env_path)
+    return loaded
+
+
+def launch_detached(repo_root: Path | None = None) -> int:
+    """Spawn the watcher daemon as a fully detached subprocess.
+
+    The child inherits the parent's environment (which by the time this is
+    called includes any keys loaded from .env). stdout + stderr are
+    redirected to ``.claude/watcher.log`` (appended); stdin is /dev/null.
+
+    Returns the child PID. Parent should print + exit immediately; the
+    child writes its own ``.claude/watcher.pid`` on startup via the
+    existing watcher lifecycle.
+
+    The child invocation is `python -m app.cli watcher` without `--detach`,
+    so the child runs the foreground watcher path in its detached process.
+    """
+    root = repo_root or Path.cwd()
+    claude_dir = root / ".claude"
+    claude_dir.mkdir(exist_ok=True)
+    log_path = claude_dir / "watcher.log"
+
+    cmd = [sys.executable, "-m", "app.cli", "watcher"]
+
+    # Open the log file once; child inherits the fd. We close our handle
+    # after Popen returns — the child keeps its own copy alive.
+    log_file = log_path.open("ab")
+    try:
+        if sys.platform == "win32":
+            creationflags = (
+                _DETACHED_PROCESS | _CREATE_NEW_PROCESS_GROUP | _CREATE_NO_WINDOW
+            )
+            proc = subprocess.Popen(  # nosec B603
+                cmd,
+                cwd=str(root),
+                stdout=log_file,
+                stderr=subprocess.STDOUT,
+                stdin=subprocess.DEVNULL,
+                creationflags=creationflags,
+                close_fds=False,  # required when redirecting stdio on Windows
+            )
+        else:
+            proc = subprocess.Popen(  # nosec B603
+                cmd,
+                cwd=str(root),
+                stdout=log_file,
+                stderr=subprocess.STDOUT,
+                stdin=subprocess.DEVNULL,
+                start_new_session=True,
+                close_fds=True,
+            )
+    finally:
+        log_file.close()
+    return proc.pid
+
+
+def launch_in_new_terminal(repo_root: Path | None = None) -> int:
+    """Windows: open a new cmd.exe window with the watcher running attached.
+
+    The new window's title is "watcher"; the watcher runs in the foreground
+    inside it so the operator can see live logs. `.env` is auto-loaded by
+    the child's own `_run_watcher` call.
+
+    Returns 0 on success, 1 on non-Windows (with a clear stderr message).
+    Does not wait for the spawned window.
+    """
+    if sys.platform != "win32":
+        print(
+            "Error: --visible is only supported on Windows. "
+            "Use --detach for cross-platform background launch.",
+            file=sys.stderr,
+        )
+        return 1
+
+    root = repo_root or Path.cwd()
+    # `start "watcher" cmd /k "cd /d <root> && python -m app.cli watcher"`
+    inner = f'cd /d "{root}" && "{sys.executable}" -m app.cli watcher'
+    subprocess.run(  # nosec B603 B607
+        ["cmd.exe", "/c", "start", "watcher", "cmd", "/k", inner],
+        check=False,
+    )
+    return 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -326,6 +326,68 @@ def test_watcher_max_local_and_cloud_workers_forwarded():
     assert kwargs.get("max_cloud_workers") == 5
 
 
+# ── WOR-435: --detach / --visible / .env autoload ──────────────────────────
+
+
+def test_watcher_detach_spawns_subprocess_and_returns_zero(capsys):
+    """--detach calls launch_detached, prints the PID line, returns 0
+    without instantiating Watcher in this process."""
+    from unittest.mock import patch
+
+    with (
+        patch("app.cli.operator.launch_detached", return_value=12345) as mock_launch,
+        patch("app.core.watcher.Watcher") as MockWatcher,
+    ):
+        rc = main(["watcher", "--detach"])
+    assert rc == 0
+    mock_launch.assert_called_once()
+    MockWatcher.assert_not_called()
+    err = capsys.readouterr().err
+    assert "Watcher daemon started (PID 12345)" in err
+    assert "watcher.log" in err
+
+
+def test_watcher_visible_calls_helper_and_returns_zero():
+    """--visible calls launch_in_new_terminal; Watcher not invoked."""
+    from unittest.mock import patch
+
+    with (
+        patch("app.cli.operator.launch_in_new_terminal", return_value=0) as mock_helper,
+        patch("app.core.watcher.Watcher") as MockWatcher,
+    ):
+        rc = main(["watcher", "--visible"])
+    assert rc == 0
+    mock_helper.assert_called_once()
+    MockWatcher.assert_not_called()
+
+
+def test_watcher_detach_and_visible_are_mutually_exclusive(capsys):
+    """--detach + --visible together → rc=2, clear error, no spawn."""
+    from unittest.mock import patch
+
+    with (
+        patch("app.cli.operator.launch_detached") as mock_detach,
+        patch("app.cli.operator.launch_in_new_terminal") as mock_visible,
+    ):
+        rc = main(["watcher", "--detach", "--visible"])
+    assert rc == 2
+    mock_detach.assert_not_called()
+    mock_visible.assert_not_called()
+    assert "mutually exclusive" in capsys.readouterr().err
+
+
+def test_watcher_loads_env_file_before_dispatch():
+    """load_env_file is called before any other watcher logic, including detach."""
+    from unittest.mock import patch
+
+    with (
+        patch("app.cli.operator.load_env_file") as mock_load,
+        patch("app.cli.operator.launch_detached", return_value=1),
+    ):
+        main(["watcher", "--detach"])
+    mock_load.assert_called_once()
+
+
 def test_watcher_max_workers_alias_sets_both():
     from unittest.mock import MagicMock, patch
 

--- a/tests/test_watcher_daemon.py
+++ b/tests/test_watcher_daemon.py
@@ -1,0 +1,158 @@
+"""Tests for app.core.watcher.watcher_daemon (WOR-435)."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.core.watcher.watcher_daemon import (
+    launch_detached,
+    launch_in_new_terminal,
+    load_env_file,
+)
+
+# ── load_env_file ───────────────────────────────────────────────────────────
+
+
+def test_load_env_file_missing_returns_zero(tmp_path: Path) -> None:
+    """No .env file → returns 0, no env changes."""
+    before = dict(os.environ)
+    n = load_env_file(repo_root=tmp_path)
+    assert n == 0
+    assert dict(os.environ) == before
+
+
+def test_load_env_file_loads_keys(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A .env with two new keys → both loaded into os.environ."""
+    env_path = tmp_path / ".env"
+    env_path.write_text("WOR435_TEST_A=alpha\nWOR435_TEST_B=beta\n", encoding="utf-8")
+    monkeypatch.delenv("WOR435_TEST_A", raising=False)
+    monkeypatch.delenv("WOR435_TEST_B", raising=False)
+
+    n = load_env_file(repo_root=tmp_path)
+
+    assert n == 2
+    assert os.environ["WOR435_TEST_A"] == "alpha"
+    assert os.environ["WOR435_TEST_B"] == "beta"
+
+
+def test_load_env_file_existing_env_takes_precedence(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Keys already set in os.environ are NOT overwritten by .env."""
+    env_path = tmp_path / ".env"
+    env_path.write_text("WOR435_PRECEDENCE=fromfile\n", encoding="utf-8")
+    monkeypatch.setenv("WOR435_PRECEDENCE", "fromenv")
+
+    n = load_env_file(repo_root=tmp_path)
+
+    assert n == 0  # already set; not counted as loaded
+    assert os.environ["WOR435_PRECEDENCE"] == "fromenv"
+
+
+def test_load_env_file_unreadable_returns_zero_logs_warning(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """OSError reading .env → returns 0, warning logged, no env changes."""
+    env_path = tmp_path / ".env"
+    env_path.write_text("WOR435_X=1\n", encoding="utf-8")
+
+    # Shadow dotenv_values at its source module so the inline import picks
+    # up the patched function.
+    with patch("dotenv.dotenv_values", side_effect=OSError("denied")):
+        with caplog.at_level("WARNING"):
+            n = load_env_file(repo_root=tmp_path)
+
+    assert n == 0
+    assert any("Failed to read" in rec.message for rec in caplog.records)
+
+
+# ── launch_detached ─────────────────────────────────────────────────────────
+
+
+def test_launch_detached_returns_child_pid(tmp_path: Path) -> None:
+    """Popen is invoked with the watcher command; returns the child PID."""
+    fake_proc = MagicMock(pid=99999)
+    with patch(
+        "app.core.watcher.watcher_daemon.subprocess.Popen", return_value=fake_proc
+    ) as mock_popen:
+        pid = launch_detached(repo_root=tmp_path)
+
+    assert pid == 99999
+    call = mock_popen.call_args
+    cmd = call.args[0]
+    assert cmd[0] == sys.executable
+    assert cmd[1:] == ["-m", "app.cli", "watcher"]
+    assert call.kwargs["cwd"] == str(tmp_path)
+
+
+def test_launch_detached_creates_log_dir_and_file(tmp_path: Path) -> None:
+    """`.claude/watcher.log` is created before Popen so the child can inherit the fd."""
+    with patch("app.core.watcher.watcher_daemon.subprocess.Popen") as mock_popen:
+        mock_popen.return_value = MagicMock(pid=1)
+        launch_detached(repo_root=tmp_path)
+
+    assert (tmp_path / ".claude" / "watcher.log").exists()
+    assert (tmp_path / ".claude").is_dir()
+
+
+def test_launch_detached_platform_specific_flags(tmp_path: Path) -> None:
+    """Windows path passes creationflags; POSIX path passes start_new_session=True."""
+    with patch("app.core.watcher.watcher_daemon.subprocess.Popen") as mock_popen:
+        mock_popen.return_value = MagicMock(pid=1)
+        with patch("app.core.watcher.watcher_daemon.sys") as mock_sys:
+            mock_sys.platform = "win32"
+            mock_sys.executable = sys.executable
+            launch_detached(repo_root=tmp_path)
+        assert "creationflags" in mock_popen.call_args.kwargs
+
+    with patch("app.core.watcher.watcher_daemon.subprocess.Popen") as mock_popen:
+        mock_popen.return_value = MagicMock(pid=1)
+        with patch("app.core.watcher.watcher_daemon.sys") as mock_sys:
+            mock_sys.platform = "linux"
+            mock_sys.executable = sys.executable
+            launch_detached(repo_root=tmp_path)
+        assert mock_popen.call_args.kwargs.get("start_new_session") is True
+
+
+# ── launch_in_new_terminal ──────────────────────────────────────────────────
+
+
+def test_launch_in_new_terminal_non_windows_returns_one(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Non-Windows platform → returns 1 with a clear stderr message."""
+    monkeypatch.setattr(
+        "app.core.watcher.watcher_daemon.sys.platform", "linux", raising=False
+    )
+    rc = launch_in_new_terminal(repo_root=tmp_path)
+    assert rc == 1
+    assert "only supported on Windows" in capsys.readouterr().err
+
+
+def test_launch_in_new_terminal_windows_runs_cmd_start(tmp_path: Path) -> None:
+    """Windows path invokes `cmd.exe /c start watcher cmd /k <inner>`."""
+    with (
+        patch("app.core.watcher.watcher_daemon.sys") as mock_sys,
+        patch("app.core.watcher.watcher_daemon.subprocess.run") as mock_run,
+    ):
+        mock_sys.platform = "win32"
+        mock_sys.executable = sys.executable
+        rc = launch_in_new_terminal(repo_root=tmp_path)
+    assert rc == 0
+    args = mock_run.call_args.args[0]
+    assert args[0] == "cmd.exe"
+    assert "start" in args
+    assert "cmd" in args
+    # The inner command should include the tmp_path and the watcher invocation
+    inner = args[-1]
+    assert str(tmp_path) in inner
+    assert "app.cli watcher" in inner


### PR DESCRIPTION
## Summary

Adds three capabilities to the `watcher` subcommand so it can be launched
from agent shells and remote contexts where `LINEAR_API_KEY` isn't
pre-exported.

1. **Auto-load `.env`** — `python-dotenv` reads `.env` from cwd before any
   `LinearClient` instantiation. Existing env vars take precedence. Means
   `python -m app.cli watcher` works from any shell as long as `.env`
   exists in the repo root.

2. **`--detach`** — spawns the watcher as a fully detached background
   process. Parent exits in ~1s with `Watcher daemon started (PID N).
   Logs: .claude/watcher.log`. Cross-platform: Windows uses
   `DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP` creationflags; POSIX
   uses `start_new_session=True`. The child writes `.claude/watcher.pid`
   via its existing lifecycle, so `watcher-softstop` works unchanged
   against the detached daemon.

3. **`--visible`** — Windows-only: opens a new `cmd.exe` window with the
   watcher running attached. Replaces the hand-rolled
   `launch_watcher.bat` workaround. Clean `rc=1` + stderr message on
   non-Windows.

`--detach` and `--visible` are mutually exclusive (`rc=2`).

## Why

Anchored to today's WOR-434 bundle dispatch: I couldn't launch the
watcher from an agent shell because secrets aren't passed through to
sandboxed subprocesses, and the operator was afk on mobile. This PR
closes that gap.

## New module

`app/core/watcher/watcher_daemon.py` — three pure functions
(`load_env_file`, `launch_detached`, `launch_in_new_terminal`). L1 leaf
in the watcher-layers contract; imports only stdlib + dotenv. No new
.importlinter contracts needed.

## Verification

- `pytest`: 1614 passed (13 new — 9 watcher_daemon + 4 cli flags)
- `mypy app/`: clean (47 source files)
- `ruff check` + `ruff format`: clean
- `lint-imports`: 8 contracts kept, 0 broken
- `bandit`: clean (added `# nosec B603 B607` to the cmd.exe invocation)

## Test plan
- [x] Full pytest
- [x] mypy / ruff / lint-imports
- [ ] CI green
- [ ] Manual smoke: `python -m app.cli watcher --detach` writes pid file and exits quickly

Closes WOR-435