### PR TITLE
Part of WOR-435: document --detach + --visible + .env autoload

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,9 @@ python -m app.cli watcher                        # respects each manifest's impl
 python -m app.cli watcher --worker-mode cloud    # force cloud (Anthropic API) for all tickets
 python -m app.cli watcher --worker-mode local    # force local (LiteLLM proxy + RTX 5090)
 # Also: WORKER_MODE=cloud python -m app.cli watcher
+# Auto-loads .env from cwd (WOR-435) — LINEAR_API_KEY etc. inherited automatically
+python -m app.cli watcher --detach               # spawn detached daemon; parent exits; logs → .claude/watcher.log
+python -m app.cli watcher --visible              # Windows only: open new cmd.exe window with watcher attached
 # Concurrency (pools are independent — local is never starved by cloud burst):
 python -m app.cli watcher --max-local-workers 8  # default 8; vLLM handles concurrency
 python -m app.cli watcher --max-cloud-workers 3  # default 3; parallelisable

--- a/README.md
+++ b/README.md
@@ -37,8 +37,11 @@ python -m app.cli config delete github-token
 
 # Watcher daemon (local worker orchestrator)
 python -m app.cli watcher                        # respects each manifest's implementation_mode
+                                                 # auto-loads .env from cwd (WOR-435)
 python -m app.cli watcher --worker-mode cloud    # force cloud (Anthropic API)
 python -m app.cli watcher --worker-mode local    # force local (vLLM-served Qwen)
+python -m app.cli watcher --detach               # spawn detached daemon; parent exits; logs → .claude/watcher.log
+python -m app.cli watcher --visible              # Windows only: open new cmd.exe window with watcher attached
 python -m app.cli watcher --max-local-workers 8  # default 8; vLLM handles concurrency
 python -m app.cli watcher --max-cloud-workers 3  # default 3
 python -m app.cli watcher --verbose              # DEBUG level on the watcher's own logger


### PR DESCRIPTION
Follow-up to PR #900 — adds the new watcher CLI flags to CLAUDE.md and README.md. Docs commit landed locally after the implementation PR merged, so opening as a small follow-up.