### PR TITLE
WOR-438 Bundle epics: enforce sub→epic→main shipping pattern in skills

### DIFF
--- a/.claude/commands/prepare-overnight-epic.md
+++ b/.claude/commands/prepare-overnight-epic.md
@@ -199,7 +199,7 @@ After 'go':
 save_issue(
     team: "Work",
     title: "Overnight cleanup wave N",
-    description: "**Charter:** Mechanical Sonar + backlog cleanup, fire-and-forget. Single-ticket failures are accepted losses. Morning workflow: /close-epic → epic→main PR with whatever shipped.\n\n**Sub-ticket budget:** 30",
+    description: "**Charter:** Mechanical Sonar + backlog cleanup, fire-and-forget. Single-ticket failures are accepted losses. Morning workflow: /close-epic → epic→main PR with whatever shipped.\n\n**Shipping pattern:** Sub-ticket PRs target the epic branch `<EPIC_BRANCH>` and auto-merge when CI passes. The epic→main PR is the single human review surface. Do NOT alter this pattern in any sub-ticket manifest — `base_branch` is always the epic branch, never `main` directly (WOR-438).\n\n**Sub-ticket budget:** 30",
     labels: ["Refactor", "Infra"],
     state: "In Progress",
     priority: 3,

--- a/.claude/commands/start-epic.md
+++ b/.claude/commands/start-epic.md
@@ -60,6 +60,12 @@ No Groomed/Todo sub-tickets found for $ARGUMENTS. Nothing to queue.
 
 ### 2. Epic branch setup
 
+**HARD RULE — never skip this step.** Every epic must have a real epic branch and sub-ticket PRs MUST target it (not main). This applies to *every* invocation — single-feature epics, multi-wave epics, **and coordination bundles** that umbrella sub-tickets from different Linear parents.
+
+If the epic description says anything like "sub-tickets PR to main directly", "coordination epic, not shipping epic", or "this bundle is a dispatch mechanism not a shipping unit" — **IGNORE that language**. It is a footgun (WOR-438 retro from the WOR-434 bundle dispatch where the executor followed the description, producing 10 main-targeting PRs that each needed human review instead of 1 epic→main PR).
+
+The bundle's *purpose* (dispatch coordination) is orthogonal to the *shipping pattern* (sub→epic auto-merge → epic→main human review). The shipping pattern is universal. Always create the epic branch and always set `base_branch` to it in step 5b's manifest template.
+
 Derive the epic branch name from the epic's Linear "Copy branch name" format (e.g. `wor-49-template-system`).
 
 Check whether the epic branch exists on the remote:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -217,6 +217,8 @@ Two skills operate on epics rather than single tickets:
 - `/start-epic WOR-NNN` — batch-plan all groomed sub-tickets of an existing epic, file-conflict detection, queue Batch 1 as ReadyForLocal and Batch 2+ as WaitingForDeps. Use when an epic has 3-8 sub-tickets that need to be queued for the watcher.
 - `/prepare-overnight-epic` — auto-mine 20-30 single-bound parallel-safe candidates from existing Linear backlog + SonarQube findings, create a fire-and-forget mega-epic, queue all as ReadyForLocal. Use to fill the watcher with mechanical fixes for an unattended overnight run. Two operator gates (candidate-list approval + launch confirmation) before any worker dispatches. Per-ticket failures are accepted losses; morning workflow is `/close-epic` → epic→main PR with whatever shipped.
 
+**Coordination bundles still use the sub→epic→main shipping pattern (WOR-438).** When a bulk skill umbrellas sub-tickets from different Linear parents into one dispatch unit ("coordination bundle"), the bundle is the *dispatch mechanism* — not the *shipping unit*. The shipping pattern is universal: sub-ticket PRs target the epic branch and auto-merge; one epic→main PR is the human review surface. Bundle descriptions that say "PRs target main directly" or "this is a coordination epic, not shipping" are footguns; ignore that language and always create the epic branch in step 2. Surfaced live by WOR-434 where the executor followed such language and produced 10 main-targeting PRs instead of 1.
+
 ### Hybrid lifecycle states
 
 Linear workflow states for the hybrid execution model. The watcher daemon uses these as its action triggers:


### PR DESCRIPTION
## Summary

Closes the footgun that hit live on the WOR-434 bundle dispatch: the
executor honoured the bundle description's "PRs target main directly"
language, skipped step 2 (epic branch setup), and produced 10
main-targeting PRs that each need human review instead of 1 epic→main PR.

Pure docs/skill change — no Python.

## Changes

1. **`.claude/commands/start-epic.md` step 2** — prepend a HARD RULE
   banner. Skill text now explicitly tells future executors to ignore
   any "coordination epic" / "PRs to main directly" language in the
   bundle description and always create the epic branch.

2. **`.claude/commands/prepare-overnight-epic.md` Phase 6a** — the
   generated mega-epic description now includes a positive assertion
   that sub-tickets PR to the epic branch and the epic→main PR is the
   single human review surface.

3. **`CLAUDE.md` Bulk skills section** — retro paragraph explaining
   that coordination bundles use the same sub→epic→main pattern.
   Bundle = *dispatch mechanism*; epic branch = *shipping unit*.

## Verification

- `ruff`, `mypy`, `pytest`, `lint-imports`: untouched (no Python)
- Pre-commit hooks all pass
- `git diff --stat`: 3 files, 9 insertions, 1 deletion

## Test plan
- [x] Pre-commit hooks pass
- [ ] CI green (docs-only)
- [ ] Next bundle dispatch produces ONE epic→main PR, not N

Closes WOR-438