### PR TITLE
WOR-425 ticket-status CLI: rc=1 on missing API key / unknown ticket

### DIFF
--- a/app/cli/operator.py
+++ b/app/cli/operator.py
@@ -278,6 +278,19 @@ def _run_ticket_status(args: argparse.Namespace) -> int:
     client = LinearClient(api_key=api_key)
     status = fetch_ticket_status(client, ticket_id)
 
+    if status.state == "Unknown":
+        if "error fetching" in status.title:
+            print(
+                f"Error: {status.title}",
+                file=sys.stderr,
+            )
+        else:
+            print(
+                f"Error: {status.title} (fetching full status)",
+                file=sys.stderr,
+            )
+        return 1
+
     if args.json:
         import json as json_mod
 

--- a/app/core/watcher/ticket_status.py
+++ b/app/core/watcher/ticket_status.py
@@ -308,6 +308,17 @@ def _fetch_linear_state(
             worktree_exists=None,
             worktree_path=None,
         )
+    if issue is None:
+        return TicketStatus(
+            ticket_id=ticket_id,
+            title="ticket not found",
+            state="Unknown",
+            state_age_seconds=None,
+            worker_log=None,
+            artifacts=None,
+            worktree_exists=None,
+            worktree_path=None,
+        )
     title = issue.get("title", "")
     state_data = issue.get("state") or {}
     state = state_data.get("name", state_data.get("type", "Unknown"))

--- a/tests/test_cli_ticket_status.py
+++ b/tests/test_cli_ticket_status.py
@@ -68,9 +68,22 @@ class TestTicketStatusNotFound:
             patch("app.cli.operator.LinearClient", return_value=client),
         ):
             rc = main(["ticket-status", "WOR-999"])
-        assert rc == 0
-        out = capsys.readouterr().out
-        assert "issue not found" in out
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "error fetching" in err
+
+    def test_unknown_ticket_id_exits_with_error(self, capsys: CapSys) -> None:
+        """A valid LinearClient that returns None for an unknown ticket id."""
+        client = MagicMock()
+        client.get_issue.return_value = None
+        with (
+            patch.dict("os.environ", {"LINEAR_API_KEY": FAKE_API_KEY}, clear=True),
+            patch("app.cli.operator.LinearClient", return_value=client),
+        ):
+            rc = main(["ticket-status", "WOR-999"])
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "ticket not found" in err
 
 
 # ── --json flag tests ──────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes WOR-425

All AC met; ruff/mypy/pytest/lint-imports clean; PR opened to main with auto-merge.