### PR TITLE
WOR-65 Wire wizard into CLI as generate --interactive

### DIFF
--- a/app/cli/generate.py
+++ b/app/cli/generate.py
@@ -346,6 +346,13 @@ def _execute_generation_pipeline(config: RepoConfig, args: argparse.Namespace) -
 
 def _run_generate(args: argparse.Namespace) -> int:
     """Top-level dispatcher for `generate` subcommand."""
+    if args.interactive and args.preset:
+        print(
+            "error: --interactive and --preset are mutually exclusive.",
+            file=sys.stderr,
+        )
+        return 1
+
     if args.interactive:
         return _run_interactive(args)
 

--- a/app/core/wizard.py
+++ b/app/core/wizard.py
@@ -96,7 +96,11 @@ def collect_wizard_input(
     and the user supplied no value (and no default is configured).
     """
     default_val = _resolve_default_value(step, prefs)
-    display = f" [{default_val}]" if default_val is not None else ""
+    display = ""
+    if step.choices:
+        display += f" ({', '.join(step.choices)})"
+    if default_val is not None:
+        display += f" [{default_val}]"
 
     while True:
         if inputs is not None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -896,3 +896,38 @@ class TestInteractiveWizard:
         # Import exists and callable
         assert callable(validate_repo_name)
         assert callable(collect_interactive_wizard)
+
+    def test_interactive_and_preset_are_mutually_exclusive(self, capsys):
+        """--interactive and --preset together must fail with clear error."""
+        rc = main(
+            [
+                "generate",
+                "--interactive",
+                "--preset",
+                "python_basic",
+                "--repo-name",
+                "myrepo",
+                "--output",
+                "/tmp/test",
+            ]
+        )
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "mutually exclusive" in err
+
+    def test_preset_choices_shown_in_wizard_prompt(self, output_dir, tmp_path):
+        """Preset choices appear in the wizard prompt string."""
+        prefs_path = tmp_path / "prefs.json"
+        with (
+            patch.object(PrefsStore, "get_path", return_value=prefs_path),
+            patch("app.cli.generate.generate") as mock_gen,
+            patch("app.core.wizard.input") as mock_input,
+        ):
+            mock_gen.return_value = [".gitignore"]
+            mock_input.side_effect = ["myrepo", "python_basic", str(output_dir)]
+            rc = main(["generate", "--interactive"])
+        assert rc == 0
+        # Second call is for preset prompt which shows choices
+        preset_call = mock_input.call_args_list[1][0][0]
+        assert "python_basic" in preset_call
+        assert "full_agentic" in preset_call


### PR DESCRIPTION
Closes WOR-65

All AC met; ruff/mypy/pytest/lint-imports clean; PR opened to main with auto-merge.