### PR TITLE
WOR-132 SonarCloud findings fetch: deferred-retry via poll loop

### DIFF
--- a/app/core/metrics_store.py
+++ b/app/core/metrics_store.py
@@ -412,6 +412,23 @@ class MetricsStore:
                 (tags_json, ticket_id, project_id),
             )
 
+    def update_sonar_count(
+        self, ticket_id: str, project_id: str, count: int | None
+    ) -> None:
+        """Update only the sonar_findings_count column for an existing row.
+
+        Uses UPDATE instead of INSERT OR REPLACE so it does not rewrite the
+        whole row — the initial record is still fresh, and this is a
+        targeted backfill.
+        """
+        with self._connect() as conn:
+            conn.execute(
+                "UPDATE ticket_metrics SET sonar_findings_count = ? "
+                "WHERE ticket_id = ? AND project_id = ? "
+                "AND sonar_findings_count IS NULL",
+                (count, ticket_id, project_id),
+            )
+
     def get_by_epic(self, epic_id: str, project_id: str) -> list[TicketMetrics]:
         """Return all ticket metrics for an epic."""
         with self._connect() as conn:

--- a/app/core/watcher/watcher.py
+++ b/app/core/watcher/watcher.py
@@ -47,6 +47,7 @@ from .watcher_signals import (
     wait_for_active_workers,
     write_pid_file,
 )
+from .watcher_subprocess import fetch_sonar_findings
 from .watcher_tui import TrackedPR, WatcherDisplay
 from .watcher_types import (
     _ARTIFACTS_DIR,
@@ -141,6 +142,11 @@ class Watcher:
         self._draining: bool = False
         self._draining_since: float | None = None
         self._softstop_warned_stuck: bool = False
+        # WOR-132: workers that finished with pending_sonar_fetch=True, keyed
+        # by ticket_id. Used by _retry_pending_sonar to retry sonar findings
+        # asynchronously on the poll loop after the worker has been removed
+        # from the active pools.
+        self._pending_sonar_workers: dict[str, ActiveWorker] = {}
 
     # ------------------------------------------------------------------
     # Public entry point
@@ -193,6 +199,8 @@ class Watcher:
         terminate_overrun_workers(self._local_active, self._cloud_active, self._linear)
         self._reap_pool(self._local_active)
         self._reap_pool(self._cloud_active)
+        # WOR-132: retry deferred SonarCloud findings fetches
+        self._retry_pending_sonar()
         if self._display is not None:
             self._display.update_state(
                 build_tui_state(
@@ -578,6 +586,11 @@ class Watcher:
             project_id=self._project_id,
             tracked_prs=self._tracked_prs,
         )
+        # Register workers that need async sonar retries (WOR-132).
+        # Must happen here — before _reap_pool removes the worker from the
+        # active pool, because the poll loop retry needs access to it.
+        if worker.pending_sonar_fetch:
+            self._pending_sonar_workers[worker.ticket_id] = worker
         self._processed_tickets.append(
             _ProcessedTicket(
                 ticket_id=worker.ticket_id,
@@ -663,6 +676,58 @@ class Watcher:
                 ]
             }
         )
+
+    def _retry_pending_sonar(self) -> None:
+        """Retry deferred SonarCloud findings fetches (WOR-132).
+
+        Iterates over ``_pending_sonar_workers``, fetches findings for each
+        worker's branch, and backfills ``sonar_findings_count`` in the
+        metrics store. Workers that exhaust 3 attempts are logged and
+        removed from the pending set without updating metrics.
+        """
+        if not self._pending_sonar_workers:
+            return
+
+        completed: list[str] = []
+        for ticket_id, worker in list(self._pending_sonar_workers.items()):
+            if not worker.pending_sonar_fetch:
+                completed.append(ticket_id)
+                continue
+
+            # Retry budget: 3 attempts total (1 initial + 2 poll-loop retries)
+            if worker.sonar_fetch_attempts >= 3:
+                logger.warning(
+                    "Sonar fetch retry budget exhausted for %s "
+                    "(%d attempts) — sonar_findings_count remains NULL",
+                    ticket_id,
+                    worker.sonar_fetch_attempts,
+                )
+                completed.append(ticket_id)
+                continue
+
+            findings = fetch_sonar_findings(worker.manifest.worker_branch)
+            if findings is not None:
+                self._metrics.update_sonar_count(
+                    ticket_id, self._project_id, len(findings)
+                )
+                logger.info(
+                    "Sonar findings backfilled for %s: %d findings (attempt %d)",
+                    ticket_id,
+                    len(findings),
+                    worker.sonar_fetch_attempts + 1,
+                )
+                worker.pending_sonar_fetch = False
+                completed.append(ticket_id)
+            else:
+                worker.sonar_fetch_attempts += 1
+                logger.debug(
+                    "Sonar fetch still unavailable for %s — retry attempt %d/3",
+                    ticket_id,
+                    worker.sonar_fetch_attempts,
+                )
+
+        for ticket_id in completed:
+            self._pending_sonar_workers.pop(ticket_id, None)
 
     def _load_manifest(self, ticket_id: str) -> ExecutionManifest:
         from app.core.manifest import ArtifactPaths

--- a/app/core/watcher/watcher_finalize_helpers.py
+++ b/app/core/watcher/watcher_finalize_helpers.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import logging
+import time
 from pathlib import Path
 from typing import Callable
 
@@ -240,6 +241,11 @@ def _handle_policy_outcome(
 
     # fix_locally — check Sonar findings before creating PR
     sonar_findings = fetch_sonar_findings(manifest.worker_branch)
+    if sonar_findings is None:
+        # Immediate fetch failed — mark for async retry in the poll loop
+        worker.pending_sonar_fetch = True
+        worker.sonar_fetch_attempts = 1
+        worker.sonar_first_attempted_at = time.monotonic()
     if _sonar_requires_escalation(sonar_findings, ticket_id, escalation_policy):
         safe_set_state(linear, linear_id, _IN_PROGRESS_STATE, ticket_id)
         _try_post_comment(

--- a/app/core/watcher/watcher_types.py
+++ b/app/core/watcher/watcher_types.py
@@ -99,6 +99,12 @@ class ActiveWorker:
     # is dispatched. At reap, only workers with remained_solo=True get
     # attributable vLLM /metrics deltas; the rest get a sentinel artifact.
     remained_solo: bool = False
+    # WOR-132: deferred SonarCloud findings fetch state. When the immediate
+    # fetch at finalize time returns None, this flag is set so the watcher
+    # poll loop can retry asynchronously.
+    pending_sonar_fetch: bool = False
+    sonar_fetch_attempts: int = 0
+    sonar_first_attempted_at: float | None = None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1051,3 +1051,44 @@ class TestComputeTags:
         assert result is not None
         assert result.tags is None
         assert result.notes is None
+
+
+# ---------------------------------------------------------------------------
+# WOR-132: update_sonar_count — targeted backfill
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateSonarCount:
+    def test_backfills_null_count(self, tmp_path):
+        """update_sonar_count writes when the row's count is NULL."""
+        store = _store(tmp_path)
+        store.record(_ticket())
+        store.update_sonar_count("WOR-1", "proj-a", 42)
+        result = store.get_by_ticket("WOR-1", "proj-a")
+        assert result is not None
+        assert result.sonar_findings_count == 42
+
+    def test_noop_when_count_already_set(self, tmp_path):
+        """Does not overwrite a non-NULL sonar_findings_count."""
+        store = _store(tmp_path)
+        store.record(_ticket(sonar_findings_count=7))
+        store.update_sonar_count("WOR-1", "proj-a", 42)
+        result = store.get_by_ticket("WOR-1", "proj-a")
+        assert result is not None
+        assert result.sonar_findings_count == 7
+
+    def test_backfill_zero_distinct_from_none(self, tmp_path):
+        """Zero findings is a valid value that should be stored."""
+        store = _store(tmp_path)
+        store.record(_ticket())
+        store.update_sonar_count("WOR-1", "proj-a", 0)
+        result = store.get_by_ticket("WOR-1", "proj-a")
+        assert result is not None
+        assert result.sonar_findings_count == 0
+
+    def test_no_row_idempotent_noop(self, tmp_path):
+        """Calling on a missing ticket does not raise."""
+        store = _store(tmp_path)
+        store.update_sonar_count("WOR-99", "proj-a", 5)
+        # Should complete without error
+        store.get_by_ticket("WOR-99", "proj-a") is None

--- a/tests/test_watcher_finalize_helpers.py
+++ b/tests/test_watcher_finalize_helpers.py
@@ -348,3 +348,60 @@ def test_try_post_comment_swallows_exception(
         _try_post_comment(linear_mock, "lin-id", "WOR-10", "some comment body")
 
     assert any("Could not post comment" in msg for msg in caplog.messages)
+
+
+# ---------------------------------------------------------------------------
+# WOR-132: deferred SonarCloud fetch sets pending_sonar_fetch flag
+# ---------------------------------------------------------------------------
+
+
+def test_execute_finalization_sonar_none_sets_pending_flag(
+    tmp_path: Path,
+) -> None:
+    """When fetch_sonar_findings returns None in the fix_locally path,
+    the worker gets pending_sonar_fetch=True so the poll loop can retry."""
+    manifest = make_manifest(ticket_id="WOR-10", worker_branch="wor-10-test-ticket")
+    linear_mock = MagicMock()
+    worker = ActiveWorker(
+        ticket_id="WOR-10",
+        linear_id="fake-linear-id",
+        manifest=manifest,
+        worktree_path=tmp_path,
+        process=MagicMock(spec=__import__("subprocess").Popen),
+    )
+    # result.json reports success so we enter the fix_locally path
+    result_path = tmp_path / ".claude" / "artifacts" / "wor_10" / "result.json"
+    result_path.parent.mkdir(parents=True, exist_ok=True)
+    result_path.write_text('{"status": "success"}', encoding="utf-8")
+
+    with patch(
+        "app.core.watcher.watcher_finalize_helpers.run_checks",
+        return_value=(True, []),
+    ):
+        with patch(
+            "app.core.watcher.watcher_finalize_helpers.fetch_sonar_findings",
+            return_value=None,
+        ):
+            with patch(
+                "app.core.watcher.watcher_finalize_helpers.preserve_worker_artifacts",
+            ):
+                with patch(
+                    "app.core.watcher.watcher_finalize_helpers.squash_wip_commits",
+                ):
+                    attempt_fn = MagicMock(return_value=("success", "https://pr.url"))
+                    outcome, escalated, preserved, findings, _, _ = (
+                        _execute_finalization(
+                            worker,
+                            0,
+                            linear_mock,
+                            EscalationPolicy.from_toml(),
+                            tmp_path,
+                            attempt_fn,
+                        )
+                    )
+
+    assert outcome == "success"
+    assert findings is None
+    assert worker.pending_sonar_fetch is True
+    assert worker.sonar_fetch_attempts == 1
+    assert worker.sonar_first_attempted_at is not None

--- a/tests/test_watcher_worker_lifecycle.py
+++ b/tests/test_watcher_worker_lifecycle.py
@@ -524,7 +524,9 @@ def test_emit_heartbeat_tick_boundary_no_duplicate() -> None:
 def test_retry_pending_sonar_success_on_first_poll(tmp_path: Path) -> None:
     """When the pending worker is found, findings are fetched and metrics
     are backfilled, then the worker is removed from the pending set."""
-    w = Watcher(repo_root=tmp_path, metrics_store=MagicMock())
+    w = Watcher(
+        repo_root=tmp_path, metrics_store=MagicMock(), linear_client=MagicMock()
+    )
     w._project_id = "test-proj"
     manifest = _make_manifest(ticket_id="WOR-10", worker_branch="wor-10-branch")
     worker = ActiveWorker(
@@ -552,7 +554,9 @@ def test_retry_pending_sonar_success_on_first_poll(tmp_path: Path) -> None:
 def test_retry_pending_sonar_exhausts_budget(tmp_path: Path) -> None:
     """After 3 attempts the worker is removed from the pending set without
     updating metrics."""
-    w = Watcher(repo_root=tmp_path, metrics_store=MagicMock())
+    w = Watcher(
+        repo_root=tmp_path, metrics_store=MagicMock(), linear_client=MagicMock()
+    )
     w._project_id = "test-proj"
     manifest = _make_manifest(ticket_id="WOR-10", worker_branch="wor-10-branch")
     worker = ActiveWorker(
@@ -579,7 +583,9 @@ def test_retry_pending_sonar_exhausts_budget(tmp_path: Path) -> None:
 
 def test_retry_pending_sonar_empty_set_noop(tmp_path: Path) -> None:
     """When there are no pending workers, the method returns without error."""
-    w = Watcher(repo_root=tmp_path, metrics_store=MagicMock())
+    w = Watcher(
+        repo_root=tmp_path, metrics_store=MagicMock(), linear_client=MagicMock()
+    )
     w._project_id = "test-proj"
     assert w._pending_sonar_workers == {}
     w._retry_pending_sonar()  # Should not raise

--- a/tests/test_watcher_worker_lifecycle.py
+++ b/tests/test_watcher_worker_lifecycle.py
@@ -514,3 +514,73 @@ def test_emit_heartbeat_tick_boundary_no_duplicate() -> None:
 
     # Heartbeat should still be at tick 2 (no crossing to 3 at 70s)
     assert w._heartbeat["WOR-BND"][1] == 2
+
+
+# ---------------------------------------------------------------------------
+# WOR-132: _retry_pending_sonar — deferred SonarCloud fetch retry
+# ---------------------------------------------------------------------------
+
+
+def test_retry_pending_sonar_success_on_first_poll(tmp_path: Path) -> None:
+    """When the pending worker is found, findings are fetched and metrics
+    are backfilled, then the worker is removed from the pending set."""
+    w = Watcher(repo_root=tmp_path, metrics_store=MagicMock())
+    w._project_id = "test-proj"
+    manifest = _make_manifest(ticket_id="WOR-10", worker_branch="wor-10-branch")
+    worker = ActiveWorker(
+        ticket_id="WOR-10",
+        linear_id="fake-linear-id",
+        manifest=manifest,
+        worktree_path=tmp_path,
+        process=MagicMock(spec=subprocess.Popen),
+    )
+    worker.pending_sonar_fetch = True
+    worker.sonar_fetch_attempts = 1
+    w._pending_sonar_workers["WOR-10"] = worker
+    w._metrics.get_by_ticket = MagicMock(return_value=None)
+
+    with patch(
+        "app.core.watcher.watcher.fetch_sonar_findings",
+        return_value=["BLOCKER", "CRITICAL"],
+    ):
+        w._retry_pending_sonar()
+
+    w._metrics.update_sonar_count.assert_called_once_with("WOR-10", "test-proj", 2)
+    assert "WOR-10" not in w._pending_sonar_workers
+
+
+def test_retry_pending_sonar_exhausts_budget(tmp_path: Path) -> None:
+    """After 3 attempts the worker is removed from the pending set without
+    updating metrics."""
+    w = Watcher(repo_root=tmp_path, metrics_store=MagicMock())
+    w._project_id = "test-proj"
+    manifest = _make_manifest(ticket_id="WOR-10", worker_branch="wor-10-branch")
+    worker = ActiveWorker(
+        ticket_id="WOR-10",
+        linear_id="fake-linear-id",
+        manifest=manifest,
+        worktree_path=tmp_path,
+        process=MagicMock(spec=subprocess.Popen),
+    )
+    worker.pending_sonar_fetch = True
+    worker.sonar_fetch_attempts = 3  # already at budget
+    w._pending_sonar_workers["WOR-10"] = worker
+    w._metrics.get_by_ticket = MagicMock(return_value=None)
+
+    with patch(
+        "app.core.watcher.watcher.fetch_sonar_findings",
+        return_value=None,
+    ):
+        w._retry_pending_sonar()
+
+    w._metrics.update_sonar_count.assert_not_called()
+    assert "WOR-10" not in w._pending_sonar_workers
+
+
+def test_retry_pending_sonar_empty_set_noop(tmp_path: Path) -> None:
+    """When there are no pending workers, the method returns without error."""
+    w = Watcher(repo_root=tmp_path, metrics_store=MagicMock())
+    w._project_id = "test-proj"
+    assert w._pending_sonar_workers == {}
+    w._retry_pending_sonar()  # Should not raise
+    w._metrics.update_sonar_count.assert_not_called()


### PR DESCRIPTION
Closes WOR-132

All AC met; ruff/mypy/pytest/lint-imports clean; PR opened to main with auto-merge.