### PR TITLE
Clear 7 SonarCloud findings — constants + CC reductions

### DIFF
--- a/app/cli/operator.py
+++ b/app/cli/operator.py
@@ -23,6 +23,12 @@ from app.core.watcher.watcher_daemon import (
     load_env_file,
 )
 
+# Sonar S1192: shared constants for sentinel + pid file names to avoid the
+# repeated string literals these subcommand handlers used to spread across
+# the file.
+_CLAUDE_DIR_NAME = ".claude"
+_WATCHER_PID_FILE = "watcher.pid"
+
 
 def _run_watcher(args: argparse.Namespace) -> int:
     # WOR-435: auto-load .env so agent-spawned / remote shells inherit
@@ -43,7 +49,7 @@ def _run_watcher(args: argparse.Namespace) -> int:
         return launch_in_new_terminal()
     if args.detach:
         pid = launch_detached()
-        log_path = Path.cwd() / ".claude" / "watcher.log"
+        log_path = Path.cwd() / _CLAUDE_DIR_NAME / "watcher.log"
         print(
             f"Watcher daemon started (PID {pid}). Logs: {log_path}",
             file=sys.stderr,
@@ -91,8 +97,8 @@ def _run_watcher_softstop(_args: argparse.Namespace) -> int:
     Daemon polls .claude/watcher.softstop each cycle: if present, it stops
     accepting new dispatches, finishes in-flight workers, then exits cleanly.
     """
-    claude_dir = Path.cwd() / ".claude"
-    pid_file = claude_dir / "watcher.pid"
+    claude_dir = Path.cwd() / _CLAUDE_DIR_NAME
+    pid_file = claude_dir / _WATCHER_PID_FILE
     sentinel = claude_dir / "watcher.softstop"
     if not pid_file.exists():
         print(
@@ -122,8 +128,8 @@ def _run_watcher_forcestop(_args: argparse.Namespace) -> int:
     commits WIP for every active worker, terminates them, and pauses
     the dispatcher.
     """
-    claude_dir = Path.cwd() / ".claude"
-    pid_file = claude_dir / "watcher.pid"
+    claude_dir = Path.cwd() / _CLAUDE_DIR_NAME
+    pid_file = claude_dir / _WATCHER_PID_FILE
     sentinel = claude_dir / "watcher.forcestop"
     if not pid_file.exists():
         print(
@@ -153,8 +159,8 @@ def _run_watcher_pause(_args: argparse.Namespace) -> int:
     stops accepting new dispatches, promotions, and epic completions,
     but keeps reaping workers and health checks running.
     """
-    claude_dir = Path.cwd() / ".claude"
-    pid_file = claude_dir / "watcher.pid"
+    claude_dir = Path.cwd() / _CLAUDE_DIR_NAME
+    pid_file = claude_dir / _WATCHER_PID_FILE
     sentinel = claude_dir / "watcher.pause"
     if not pid_file.exists():
         print(
@@ -179,8 +185,8 @@ def _run_watcher_pause(_args: argparse.Namespace) -> int:
 
 def _run_watcher_resume(_args: argparse.Namespace) -> int:
     """Remove the pause sentinel to resume dispatch (WOR-352)."""
-    claude_dir = Path.cwd() / ".claude"
-    pid_file = claude_dir / "watcher.pid"
+    claude_dir = Path.cwd() / _CLAUDE_DIR_NAME
+    pid_file = claude_dir / _WATCHER_PID_FILE
     sentinel = claude_dir / "watcher.pause"
     if not pid_file.exists():
         print("Watcher is already running — pause is not active.", file=sys.stderr)
@@ -211,8 +217,8 @@ def _run_watcher_kill(args: argparse.Namespace) -> int:
     Each line in the sentinel file is a ticket ID (e.g. WOR-123).
     The daemon terminates matching workers after committing their WIP.
     """
-    claude_dir = Path.cwd() / ".claude"
-    pid_file = claude_dir / "watcher.pid"
+    claude_dir = Path.cwd() / _CLAUDE_DIR_NAME
+    pid_file = claude_dir / _WATCHER_PID_FILE
     sentinel = claude_dir / "watcher.kill"
     if not pid_file.exists():
         print(
@@ -277,7 +283,7 @@ def _run_waste_score(args: argparse.Namespace) -> int:
     # The worker log lives in .claude/ within the repo root.
     # We search for it relative to the current working directory.
     ticket_id = args.ticket_id.lower()
-    log_path = Path(".claude") / f"worker_{ticket_id}.log"
+    log_path = Path(_CLAUDE_DIR_NAME) / f"worker_{ticket_id}.log"
 
     if not log_path.exists():
         print(

--- a/app/core/watcher/watcher.py
+++ b/app/core/watcher/watcher.py
@@ -814,7 +814,7 @@ class Watcher:
             return
 
         completed: list[str] = []
-        for ticket_id, worker in list(self._pending_sonar_workers.items()):
+        for ticket_id, worker in self._pending_sonar_workers.items():
             if not worker.pending_sonar_fetch:
                 completed.append(ticket_id)
                 continue

--- a/app/core/watcher/watcher_heartbeat.py
+++ b/app/core/watcher/watcher_heartbeat.py
@@ -218,7 +218,7 @@ def build_tui_state(
     for w in local_active:
         elapsed = time.monotonic() - w.start_time
         log_path = _build_local_worker_log_path(w)
-        in_tok, out_tok, _, _ = _parse_worker_usage(log_path)
+        _, out_tok, _, _ = _parse_worker_usage(log_path)
         cost = _live_cost_estimate(out_tok)
         last_act = last_tool_call(log_path)
         workers.append(

--- a/app/core/watcher/watcher_log_parsing.py
+++ b/app/core/watcher/watcher_log_parsing.py
@@ -294,55 +294,68 @@ def format_elapsed(seconds: float) -> str:
 
 
 def last_tool_call(log_path: Path) -> str:
-    """Return the most recent tool call name from a stream-json log.
+    """Return the most recent tool call name (or thinking/text snippet) from
+    a stream-json log. Returns ``""`` if the log is missing/unparseable.
 
-    Walks the log in a single pass and returns the ``name`` of the last
-    ``type=tool_use`` content block (e.g. ``Read``, ``Bash``, ``Edit``).
-    Returns the most recent thinking/text summary when the last block was
-    a ``thinking`` or ``text`` type. Returns ``""`` when the log is missing,
-    unparseable, or has no assistant messages yet (running worker with no
-    assistant turns).
-
-    For in-progress workers this gives a live view of what the LLM is doing.
+    Walks the log in a single pass; the last-seen block wins (overwrites
+    earlier `result`). For in-progress workers this gives a live view of
+    what the LLM is doing.
     """
     try:
         with log_path.open(encoding="utf-8") as f:
             result = ""
             for raw in f:
-                line = raw.strip()
-                if not line:
-                    continue
-                try:
-                    obj = json.loads(line)
-                except json.JSONDecodeError:
-                    continue
-                if obj.get("type") != "assistant":
+                obj = _parse_assistant_event(raw)
+                if obj is None:
                     continue
                 msg = obj.get("message") or {}
                 for block in msg.get("content") or []:
                     if not isinstance(block, dict):
                         continue
-                    btype = block.get("type")
-                    if btype == "tool_use":
-                        name = block.get("name", "")
-                        if isinstance(name, str) and name:
-                            result = name
-                        else:
-                            result = ""
-                    elif btype in ("thinking", "text"):
-                        text = (
-                            block.get("thinking")
-                            or block.get("text")
-                            or block.get("text", "")
-                        )
-                        if isinstance(text, str) and text:
-                            # Truncate to ~40 chars to keep the TUI column usable
-                            result = (text[:37] + "...") if len(text) > 40 else text
-                        else:
-                            result = ""
+                    rendered = _render_content_block(block)
+                    if rendered is not None:
+                        result = rendered
             return result
     except Exception:
         return ""
+
+
+def _parse_assistant_event(raw_line: str) -> dict[str, Any] | None:
+    """Parse one JSONL line; return the dict only when it's an assistant event."""
+    stripped = raw_line.strip()
+    if not stripped:
+        return None
+    try:
+        obj = json.loads(stripped)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(obj, dict) or obj.get("type") != "assistant":
+        return None
+    return obj
+
+
+def _render_content_block(block: dict[str, Any]) -> str | None:
+    """Render one assistant content block as the last-action string.
+
+    Returns:
+        - tool name for ``tool_use`` blocks (empty string if no name)
+        - first ~37 chars of ``thinking``/``text`` for those block types
+        - None when the block type doesn't contribute to last-action display
+
+    (None vs empty-string matters: None means "skip", empty means
+    "explicitly clear the prior result".)
+    """
+    btype = block.get("type")
+    if btype == "tool_use":
+        name = block.get("name", "")
+        return name if isinstance(name, str) and name else ""
+    if btype in ("thinking", "text"):
+        text = block.get("thinking") or block.get("text") or ""
+        if not isinstance(text, str) or not text:
+            return ""
+        # Truncate to ~40 chars to keep the TUI column usable
+        return (text[:37] + "...") if len(text) > 40 else text
+    return None
 
 
 def format_worker_token_count(log_path: Path) -> str:

--- a/app/core/watcher/watcher_signals.py
+++ b/app/core/watcher/watcher_signals.py
@@ -29,6 +29,10 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# Sonar S1192: shared warning template — every stale-sentinel cleanup path
+# logs the same message when unlink fails, so consolidate the literal here.
+_STALE_SENTINEL_WARN_MSG = "Could not remove stale sentinel %s: %s"
+
 _SOFTSTOP_SENTINEL_NAME = "watcher.softstop"
 _SOFTSTOP_WARN_AFTER_MIN = 60
 
@@ -140,7 +144,7 @@ def remove_stale_softstop_sentinel(repo_root: Path) -> None:
             sentinel.unlink()
             logger.info("Removed stale soft-stop sentinel from prior run: %s", sentinel)
         except OSError as exc:
-            logger.warning("Could not remove stale sentinel %s: %s", sentinel, exc)
+            logger.warning(_STALE_SENTINEL_WARN_MSG, sentinel, exc)
 
 
 def remove_softstop_sentinel(repo_root: Path) -> None:
@@ -331,7 +335,7 @@ def remove_stale_forcestop_sentinel(repo_root: Path) -> None:
                 "Removed stale force-stop sentinel from prior run: %s", sentinel
             )
         except OSError as exc:
-            logger.warning("Could not remove stale sentinel %s: %s", sentinel, exc)
+            logger.warning(_STALE_SENTINEL_WARN_MSG, sentinel, exc)
 
 
 # ---------------------------------------------------------------------------
@@ -352,7 +356,7 @@ def remove_stale_pause_sentinel(repo_root: Path) -> None:
             sentinel.unlink()
             logger.info("Removed stale pause sentinel from prior run: %s", sentinel)
         except OSError as exc:
-            logger.warning("Could not remove stale sentinel %s: %s", sentinel, exc)
+            logger.warning(_STALE_SENTINEL_WARN_MSG, sentinel, exc)
 
 
 # ---------------------------------------------------------------------------
@@ -373,7 +377,7 @@ def remove_stale_kill_sentinel(repo_root: Path) -> None:
             sentinel.unlink()
             logger.info("Removed stale kill sentinel from prior run: %s", sentinel)
         except OSError as exc:
-            logger.warning("Could not remove stale sentinel %s: %s", sentinel, exc)
+            logger.warning(_STALE_SENTINEL_WARN_MSG, sentinel, exc)
 
 
 def read_kill_sentinel(repo_root: Path) -> list[str]:

--- a/app/core/watcher/watcher_tui.py
+++ b/app/core/watcher/watcher_tui.py
@@ -276,28 +276,8 @@ class WatcherDisplay:
         metrics = state.vllm_metrics
         if metrics is None:
             table.add_row("—", "No vLLM running")
-        else:
-            gen = metrics.get("vllm:generation_tokens_total") or 0
-            prompt = metrics.get("vllm:prompt_tokens_total") or 0
-            total_gen = gen + prompt
-            # Queue depth = num_preemptions (proxy for pending requests)
-            preempt = metrics.get("vllm:num_preemptions_total") or 0
-            hit_ratio = metrics.get("vllm:prefix_cache_hit_ratio")
-            # Show throughput if we have token data
-            if total_gen > 0:
-                table.add_row("Tokens", f"{total_gen:,.0f}")
-            else:
-                table.add_row("Tokens", "—")
-            table.add_row("Queue Depth", f"{int(preempt)}" if preempt else "—")
-            if hit_ratio is not None:
-                table.add_row("Cache Hit Ratio", f"{hit_ratio:.0%}")
-            else:
-                table.add_row("Cache Hit Ratio", "—")
-            ttft_mean = metrics.get("vllm:ttft_mean_seconds")
-            if ttft_mean is not None and ttft_mean > 0:
-                table.add_row("TTFT Mean", f"{ttft_mean:.3f}s")
-            else:
-                table.add_row("TTFT Mean", "—")
+            return table
+        _fill_vllm_rows(table, metrics)
         return table
 
     @staticmethod
@@ -440,3 +420,40 @@ class WatcherDisplay:
             return (state, merge_status)
         except Exception:
             return ("?", "?")
+
+
+# ---------------------------------------------------------------------------
+# Module-level vLLM-table helpers (extracted from _vllm_table for CC, S3776)
+# ---------------------------------------------------------------------------
+
+
+def _fill_vllm_rows(table: Table, metrics: dict[str, float]) -> None:
+    """Append the metric rows to the vLLM table.
+
+    Each helper formats one row; this keeps _vllm_table's branching cheap.
+    """
+    gen = metrics.get("vllm:generation_tokens_total") or 0
+    prompt = metrics.get("vllm:prompt_tokens_total") or 0
+    total_gen = gen + prompt
+    preempt = metrics.get("vllm:num_preemptions_total") or 0
+
+    table.add_row("Tokens", f"{total_gen:,.0f}" if total_gen > 0 else "—")
+    table.add_row("Queue Depth", f"{int(preempt)}" if preempt else "—")
+    table.add_row(
+        "Cache Hit Ratio",
+        _format_hit_ratio(metrics.get("vllm:prefix_cache_hit_ratio")),
+    )
+    table.add_row(
+        "TTFT Mean",
+        _format_ttft_mean(metrics.get("vllm:ttft_mean_seconds")),
+    )
+
+
+def _format_hit_ratio(value: float | None) -> str:
+    return f"{value:.0%}" if value is not None else "—"
+
+
+def _format_ttft_mean(value: float | None) -> str:
+    if value is None or value <= 0:
+        return "—"
+    return f"{value:.3f}s"


### PR DESCRIPTION
## Summary

Fixes the 7 open SonarCloud code-smell findings surfaced by today's
WOR-434 bundle dispatch + follow-up commits.

| File | Rule | Before | After |
|---|---|---|---|
| \`cli/operator.py\` | S1192 \".claude\" × 7 + \"watcher.pid\" × 5 | duplicated | \`_CLAUDE_DIR_NAME\` + \`_WATCHER_PID_FILE\` constants |
| \`watcher/watcher_signals.py\` | S1192 stale-sentinel warning × 4 | duplicated | \`_STALE_SENTINEL_WARN_MSG\` constant |
| \`watcher/watcher.py\` | S7504 unnecessary \`list()\` | wrapped | bare \`.items()\` (body doesn't mutate the dict) |
| \`watcher/watcher_heartbeat.py\` | S1481 unused \`in_tok\` | named binding | \`_\` |
| \`watcher/watcher_tui.py\` | S3776 \`_vllm_table\` CC 17 | inline branches | 3 module-level helpers (\`_fill_vllm_rows\`, \`_format_hit_ratio\`, \`_format_ttft_mean\`) |
| \`watcher/watcher_log_parsing.py\` | S3776 \`last_tool_call\` CC 37 | nested type-checks | 2 helpers (\`_parse_assistant_event\`, \`_render_content_block\`) |

## Verification

- \`pytest\`: 1691 passed
- \`mypy app/\`: clean (47 source files)
- \`ruff check\` + \`ruff format\`: clean
- \`lint-imports\`: 8 contracts kept, 0 broken

Behavior preserved across all changes — pure refactoring + literal extraction.

## Test plan
- [x] Full pytest
- [x] mypy / ruff / lint-imports
- [x] CI green
- [x] SonarCloud rescan: expect all 7 findings cleared