### PR TITLE
Clear 4 Sonar warnings in test files — S1244 + S3699

### DIFF
--- a/tests/test_cli_operator.py
+++ b/tests/test_cli_operator.py
@@ -201,8 +201,9 @@ def test_watch_loop_exits_on_terminal_state(capsys: CapSys) -> None:
     """If status is already in a terminal state, loop exits immediately (no poll)."""
     status = _make_status(state="Done")
     client = MagicMock()
-    rc = _run_ticket_status_watch_loop(client, "WOR-10", status)
-    assert rc is None
+    # _run_ticket_status_watch_loop returns None; assert on side effects
+    # rather than the return value (Sonar S3699 — don't capture a None return).
+    _run_ticket_status_watch_loop(client, "WOR-10", status)
     assert "terminal state: Done" in capsys.readouterr().out
     client.assert_not_called()
 
@@ -219,17 +220,16 @@ def test_watch_loop_polls_then_exits_on_state_change(capsys: CapSys) -> None:
             side_effect=[next_status],
         ),
     ):
-        rc = _run_ticket_status_watch_loop(client, "WOR-10", initial)
-    assert rc is None
+        _run_ticket_status_watch_loop(client, "WOR-10", initial)
     out = capsys.readouterr().out
     assert "polled" in out
     assert "terminal state: MergedToEpic" in out
 
 
-def test_watch_loop_keyboard_interrupt_returns_zero(capsys: CapSys) -> None:
-    """KeyboardInterrupt during sleep cleanly returns 0."""
+def test_watch_loop_keyboard_interrupt_returns_zero() -> None:
+    """KeyboardInterrupt during sleep cleanly returns from the loop."""
     status = _make_status(state="InProgressLocal")
     client = MagicMock()
     with patch("app.cli.operator.time.sleep", side_effect=KeyboardInterrupt):
-        rc = _run_ticket_status_watch_loop(client, "WOR-10", status)
-    assert rc is None
+        # No return value to inspect — assert the call completes cleanly.
+        _run_ticket_status_watch_loop(client, "WOR-10", status)

--- a/tests/test_watcher_class_methods.py
+++ b/tests/test_watcher_class_methods.py
@@ -134,14 +134,17 @@ def test_check_softstop_sentinel_noop_when_already_draining(tmp_path: Path) -> N
     """Already draining → return immediately, _draining_since unchanged."""
     w = _make_watcher(tmp_path)
     w._draining = True
-    w._draining_since = 1234.0  # sentinel value
+    original_since = 1234.0  # sentinel value
+    w._draining_since = original_since
 
     sentinel = softstop_sentinel_path(tmp_path)
     sentinel.parent.mkdir(parents=True, exist_ok=True)
     sentinel.touch()
 
     w._check_softstop_sentinel()
-    assert w._draining_since == 1234.0
+    # Identity comparison — the method must not have written a new value
+    # (avoids the floating-point-equality smell, S1244).
+    assert w._draining_since is original_since
 
 
 def test_check_softstop_sentinel_no_file_no_change(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Clears 4 Sonar warnings flagged by the IDE on the test files:

### S1244 — Floating-point equality

`tests/test_watcher_class_methods.py:144` compared `_draining_since` back to a literal `1234.0` we set ourselves. The check is technically safe but Sonar can't reason about that. Use `is` identity comparison against a stored reference instead — same intent (prove the value didn't change), no float-equality.

### S3699 — Captured-then-asserted void return

`tests/test_cli_operator.py` (3 occurrences at lines 204, 222, 234) captured the None return of `_run_ticket_status_watch_loop` into `rc` and asserted `rc is None`. The function's return type IS None — capturing it is pointless. Drop the capture; assert on side effects (stdout content, mock not called) which is what each test actually validates anyway.

## Verification

- `pytest tests/test_watcher_class_methods.py tests/test_cli_operator.py`: 39 passed
- `ruff check`: clean
- Test-only change — no production code touched

## Test plan
- [x] Local pytest pass
- [ ] CI green
- [ ] SonarCloud rescan: expect S1244 + 3× S3699 cleared