### PR TITLE
Exclude __main__.py from coverage — fixes SonarCloud Risk-chart 0% outlier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,3 +53,12 @@ DEP003 = ["yaml"]
 targets = ["app"]
 exclude_dirs = ["tests"]
 skips = []
+
+[tool.coverage.run]
+# __main__.py is pure entry-point shim ("sys.exit(main())") — only runs
+# under `python -m app.cli`, never during pytest. Including it skews the
+# SonarCloud Risk-view chart with a 0% datapoint that stretches the
+# Coverage y-axis (rest of the codebase is ~80% covered). Omit it.
+omit = [
+    "*/__main__.py",
+]

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,3 +4,7 @@ sonar.sources=app
 sonar.tests=tests
 sonar.python.coverage.reportPaths=coverage.xml
 sonar.python.version=3.12
+# Belt + suspenders for the pyproject omit: tell Sonar to exclude
+# __main__.py entry-point shims from coverage scoring so they don't
+# anchor the SonarCloud Risk-view Coverage axis at 0%.
+sonar.coverage.exclusions=**/__main__.py


### PR DESCRIPTION
## Summary

`app/cli/__main__.py` is a 4-line entry-point shim:

```python
import sys
from app.cli.main import main
if __name__ == "__main__":
    sys.exit(main())
```

It only runs under `python -m app.cli`, never during pytest. Including it in coverage data anchors the SonarCloud Risk-view Coverage axis at **0%** even though the rest of the codebase is **~91%** — all real datapoints get squeezed into the bottom band of the chart.

## Fix (two-pronged)

1. **`[tool.coverage.run]` in pyproject.toml** — `omit = ["*/__main__.py"]` keeps the file out of `coverage.xml` that CI produces and Sonar consumes. Verified locally: TOTAL line count drops 4706 → 4702.

2. **`sonar.coverage.exclusions=**/__main__.py` in sonar-project.properties** — belt-and-suspenders. If `__main__.py` ever leaks back into coverage.xml, Sonar still excludes it from the chart axis.

## Verification

- Local `pytest --cov=app` no longer reports `__main__.py`
- Pre-commit hooks pass
- Pure config change — no tests touched, no production code touched

## Test plan
- [x] Local coverage report excludes `__main__.py`
- [ ] CI green
- [ ] Next SonarCloud scan: Risk chart Coverage axis spans 70-95% (or whatever the actual range is) instead of 0-95%