### PR TITLE
WOR-444 + WOR-445 PR creation safety: hook + watcher rebase

### DIFF
--- a/.claude/commands/implement-ticket.md
+++ b/.claude/commands/implement-ticket.md
@@ -383,3 +383,5 @@ Exit cleanly after writing the result artifact. The watcher will:
 4. Advance the Linear ticket state to `in_review`, then `merged_to_epic` once CI passes
 
 **Do NOT run `/finalize-ticket`** — calling it from a watcher-spawned session creates a duplicate PR and bypasses the correct state machine.
+
+**Do NOT call `gh pr create`, `gh pr edit`, `gh pr merge`, or `git push origin`** — the PreToolUse hook `check_no_worker_pr.py` (WOR-444) will block these in worker sessions. The watcher rebases the worker branch onto the latest base and opens the PR itself at finalize time (WOR-445). The WOR-67 incident on 2026-05-11 — where a worker opened its own PR and the watcher's later `attempt_pr` returned "already exists", marking the ticket Blocked despite an open PR — is the exact failure this hook prevents.

--- a/.claude/hooks/check_no_worker_pr.py
+++ b/.claude/hooks/check_no_worker_pr.py
@@ -1,0 +1,90 @@
+"""PreToolUse hook — block worker-side PR/push operations (WOR-444).
+
+Workers must not open PRs or push to origin themselves: those are the
+watcher's job, and a worker-side `gh pr create` collides with the
+watcher's later `attempt_pr` step, marking the ticket Blocked even
+though the PR is open and ready (the WOR-67 incident on 2026-05-11).
+
+This hook blocks the following commands when invoked from a watcher-
+spawned worker session (detected via `WATCHER_WORKER=1`):
+
+  - `gh pr create` (any variant)
+  - `gh pr edit` (any variant — prevent worker from touching PR metadata)
+  - `gh pr merge` (any variant — only the watcher's auto-merge should merge)
+  - `git push` to origin (worker should commit locally; watcher pushes)
+
+Operator-invoked sessions (no `WATCHER_WORKER` env var) bypass this hook,
+so `/finalize-ticket` works manually.
+
+Fails open on any JSON/IO error — never want this hook to surprise-break
+a session.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+
+# `gh pr <action>` patterns to block. Match the start of the command after
+# lstrip so chained/wrapped invocations are also caught.
+_GH_PR_BLOCKED = re.compile(r"^gh\s+pr\s+(create|edit|merge)\b")
+
+# `git push` to the origin remote. Matches `git push`, `git push origin`,
+# `git push -u origin <ref>`, etc. Does NOT match local-only operations
+# like `git push gh-pages-mirror` (different remote) or `git fetch origin`.
+# A bare `git push` resolves to the configured upstream (origin/<branch>)
+# in the watcher's worktree setup, so block bare pushes too.
+_GIT_PUSH_ORIGIN = re.compile(r"^git\s+push\b(?:\s+-[^\s]+)*(?:\s+origin\b|\s*$)")
+
+
+def _block(reason: str) -> int:
+    """Emit a structured block decision in the format Claude Code understands."""
+    print(json.dumps({"decision": "block", "reason": reason}))
+    return 0
+
+
+def main() -> int:
+    if os.environ.get("WATCHER_WORKER") != "1":
+        return 0  # operator session — let everything through
+
+    try:
+        payload = json.load(sys.stdin)
+    except json.JSONDecodeError:
+        return 0  # fail open
+
+    if payload.get("tool_name") != "Bash":
+        return 0
+
+    cmd = payload.get("tool_input", {}).get("command", "")
+    if not isinstance(cmd, str):
+        return 0
+    stripped = cmd.lstrip()
+
+    if _GH_PR_BLOCKED.match(stripped):
+        return _block(
+            "Hook-trust violation (WOR-444): `gh pr create/edit/merge` is "
+            "blocked in worker sessions. The watcher opens, edits, and "
+            "merges PRs at finalize time — calling it from inside the "
+            "worker creates a duplicate PR or races the state machine "
+            "(see WOR-67 incident 2026-05-11). Just commit your work and "
+            "exit; the watcher handles the rest. See "
+            ".claude/commands/implement-ticket.md step 6."
+        )
+
+    if _GIT_PUSH_ORIGIN.match(stripped):
+        return _block(
+            "Hook-trust violation (WOR-444): `git push` to origin is "
+            "blocked in worker sessions. The watcher pushes the worker "
+            "branch at finalize time (after rebasing onto the latest "
+            "base). Pushing from the worker bypasses that rebase and "
+            "can cause merge conflicts on the watcher's later PR step. "
+            "Just commit locally; the watcher will push for you."
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -54,6 +54,15 @@
             "command": "python .claude/hooks/check_quality_check_budget.py"
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python .claude/hooks/check_no_worker_pr.py"
+          }
+        ]
       }
     ],
     "PostToolUse": [

--- a/app/core/watcher/watcher_subprocess.py
+++ b/app/core/watcher/watcher_subprocess.py
@@ -237,14 +237,134 @@ def run_checks(
     return (len(failed_checks) == 0, failed_checks)
 
 
+def _rebase_onto_base(manifest: ExecutionManifest, worktree_path: Path) -> None:
+    """Fetch origin/<base_branch> and rebase the worker branch onto it (WOR-445).
+
+    On clean rebase: returns silently.
+    On conflict or fetch failure: aborts any in-progress rebase, then raises
+    CalledProcessError with a descriptive stderr — finalize_worker catches
+    it and marks the ticket Blocked with the reason.
+    """
+    base = manifest.base_branch
+    try:
+        subprocess.run(  # nosec B603 B607
+            ["git", "fetch", "origin", base],
+            cwd=str(worktree_path),
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        subprocess.run(  # nosec B603 B607
+            ["git", "rebase", f"origin/{base}"],
+            cwd=str(worktree_path),
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        # Best-effort cleanup so the worktree isn't left mid-rebase.
+        subprocess.run(  # nosec B603 B607
+            ["git", "rebase", "--abort"],
+            cwd=str(worktree_path),
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        stderr = (exc.stderr or exc.stdout or "").strip()
+        raise subprocess.CalledProcessError(
+            exc.returncode,
+            exc.cmd,
+            output=exc.output,
+            stderr=(
+                f"Rebase of {manifest.worker_branch} onto origin/{base} "
+                f"failed (WOR-445): {stderr}. Resolve manually: "
+                f"`cd <worktree>; git rebase origin/{base}` and push."
+            ),
+        ) from exc
+
+
+def _find_existing_pr_url(
+    exc: subprocess.CalledProcessError,
+    manifest: ExecutionManifest,
+    worktree_path: Path,
+) -> str | None:
+    """Recover from 'PR already exists' (WOR-444).
+
+    Returns the existing PR's URL if the failure was a duplicate-PR error
+    and we successfully looked up the existing PR. Returns None otherwise
+    (caller should re-raise).
+    """
+    stderr = (exc.stderr or "").lower()
+    if "already exists" not in stderr:
+        return None
+    try:
+        listing = subprocess.run(  # nosec B603 B607
+            [
+                "gh",
+                "pr",
+                "list",
+                "--head",
+                manifest.worker_branch,
+                "--state",
+                "open",
+                "--json",
+                "url",
+                "--jq",
+                ".[0].url",
+            ],
+            cwd=str(worktree_path),
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except subprocess.CalledProcessError:
+        return None
+    url = listing.stdout.strip()
+    if not url:
+        return None
+    logger.info(
+        "PR already exists for %s — using existing %s (WOR-444 recovery)",
+        manifest.worker_branch,
+        url,
+    )
+    return url
+
+
 def create_pr(manifest: ExecutionManifest, worktree_path: Path) -> str:
     """Push the worker branch and open a GitHub PR.
+
+    Two safety steps run before `gh pr create`:
+
+    - **WOR-445 — rebase off origin/<base_branch>.** Catches main-side changes
+      that landed during the worker session so the PR opens against an
+      up-to-date base. Avoids merge conflicts at PR-merge time (which
+      otherwise force manual resolution per the WOR-132 incident).
+      Rebase conflicts raise CalledProcessError → finalize_worker marks
+      the ticket Blocked with a descriptive reason.
+
+    - **WOR-444 — PR-already-exists recovery.** If `gh pr create` fails with
+      "a pull request for branch ... already exists", re-fetch the
+      existing PR's URL via `gh pr list --head` and treat it as success.
+      The duplicate-PR error is downgraded from finalize failure (Blocked
+      in Linear) to an INFO log. Defense in depth alongside the worker
+      hook that blocks worker-side `gh pr create` in the first place.
 
     Auto-merge is enabled only when targeting an epic branch. PRs targeting
     main are left open for human review — auto-merging to main is forbidden.
     """
+    _rebase_onto_base(manifest, worktree_path)
+    # Force-with-lease handles the post-rebase case where the worker may
+    # have already pushed an earlier head (pre-WOR-444 behaviour). Safe on
+    # first push too: missing remote ref is a no-op for the lease check.
     subprocess.run(  # nosec B603 B607
-        ["git", "push", "-u", "origin", manifest.worker_branch],
+        [
+            "git",
+            "push",
+            "-u",
+            "--force-with-lease",
+            "origin",
+            manifest.worker_branch,
+        ],
         cwd=str(worktree_path),
         check=True,
         capture_output=True,
@@ -271,26 +391,35 @@ def create_pr(manifest: ExecutionManifest, worktree_path: Path) -> str:
                 f"{manifest.base_branch} — worker did not commit any changes"
             ),
         )
-    result = subprocess.run(  # nosec B603 B607
-        [
-            "gh",
-            "pr",
-            "create",
-            "--base",
-            manifest.base_branch,
-            "--head",
-            manifest.worker_branch,
-            "--title",
-            f"{manifest.ticket_id} {manifest.title}",
-            "--body",
-            f"Closes {manifest.ticket_id}\n\n{manifest.done_definition}",
-        ],
-        cwd=str(worktree_path),
-        capture_output=True,
-        text=True,
-        check=True,
-    )
-    pr_url = result.stdout.strip()
+    try:
+        result = subprocess.run(  # nosec B603 B607
+            [
+                "gh",
+                "pr",
+                "create",
+                "--base",
+                manifest.base_branch,
+                "--head",
+                manifest.worker_branch,
+                "--title",
+                f"{manifest.ticket_id} {manifest.title}",
+                "--body",
+                f"Closes {manifest.ticket_id}\n\n{manifest.done_definition}",
+            ],
+            cwd=str(worktree_path),
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        pr_url = result.stdout.strip()
+    except subprocess.CalledProcessError as exc:
+        # WOR-444 recovery: worker (or earlier finalize attempt) already
+        # opened a PR for this branch — re-fetch and proceed as if we
+        # created it ourselves.
+        existing = _find_existing_pr_url(exc, manifest, worktree_path)
+        if existing is None:
+            raise
+        pr_url = existing
 
     if manifest.base_branch == "main":
         logger.info(

--- a/tests/test_hooks_no_worker_pr.py
+++ b/tests/test_hooks_no_worker_pr.py
@@ -1,0 +1,162 @@
+"""Tests for the WOR-444 PreToolUse hook — block worker-side PR/push ops."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess  # nosec B404
+import sys
+from pathlib import Path
+
+_HOOK = (
+    Path(__file__).resolve().parent.parent
+    / ".claude"
+    / "hooks"
+    / "check_no_worker_pr.py"
+)
+
+
+def _run(
+    payload: dict[str, object],
+    *,
+    cwd: Path,
+    watcher_worker: str | None = "1",
+) -> tuple[int, str]:
+    env = os.environ.copy()
+    if watcher_worker is None:
+        env.pop("WATCHER_WORKER", None)
+    else:
+        env["WATCHER_WORKER"] = watcher_worker
+    proc = subprocess.run(  # nosec B603
+        [sys.executable, str(_HOOK)],
+        input=json.dumps(payload),
+        text=True,
+        cwd=cwd,
+        env=env,
+        capture_output=True,
+        timeout=10,
+    )
+    return proc.returncode, proc.stdout
+
+
+def _bash(command: str) -> dict[str, object]:
+    return {"tool_name": "Bash", "tool_input": {"command": command}}
+
+
+# ── No-fire paths (must allow) ──────────────────────────────────────────────
+
+
+def test_operator_session_unblocked(tmp_path: Path) -> None:
+    """WATCHER_WORKER unset → operator session → never block."""
+    for cmd in ("gh pr create", "gh pr merge --auto", "git push -u origin foo"):
+        rc, out = _run(_bash(cmd), cwd=tmp_path, watcher_worker=None)
+        assert rc == 0
+        assert out.strip() == ""
+
+
+def test_non_bash_tool_ignored(tmp_path: Path) -> None:
+    """Non-Bash tool calls are ignored regardless of payload."""
+    payload = {"tool_name": "Edit", "tool_input": {"command": "gh pr create"}}
+    rc, out = _run(payload, cwd=tmp_path)
+    assert rc == 0
+    assert out.strip() == ""
+
+
+def test_invalid_json_fails_open(tmp_path: Path) -> None:
+    proc = subprocess.run(  # nosec B603
+        [sys.executable, str(_HOOK)],
+        input="not valid json",
+        text=True,
+        cwd=tmp_path,
+        env={**os.environ, "WATCHER_WORKER": "1"},
+        capture_output=True,
+        timeout=10,
+    )
+    assert proc.returncode == 0
+    assert proc.stdout.strip() == ""
+
+
+# ── Allowed git/gh commands ─────────────────────────────────────────────────
+
+
+def test_allowed_git_commands_pass(tmp_path: Path) -> None:
+    """Local-only git commands (commit, status, etc.) must always pass."""
+    for cmd in (
+        "git commit -m 'work'",
+        "git status",
+        "git diff",
+        "git log --oneline",
+        "git add foo.py",
+        "git fetch origin",  # fetch is fine — only push is blocked
+        "git checkout -b feature",
+    ):
+        rc, out = _run(_bash(cmd), cwd=tmp_path)
+        assert rc == 0, f"unexpected block on: {cmd}"
+        assert out.strip() == "", f"unexpected output on: {cmd}"
+
+
+def test_allowed_gh_commands_pass(tmp_path: Path) -> None:
+    """Read-only gh queries pass (only create/edit/merge are blocked)."""
+    for cmd in (
+        "gh pr list --head foo",
+        "gh pr view 123",
+        "gh pr status",
+        "gh issue list",
+    ):
+        rc, out = _run(_bash(cmd), cwd=tmp_path)
+        assert rc == 0, f"unexpected block on: {cmd}"
+        assert out.strip() == "", f"unexpected output on: {cmd}"
+
+
+# ── Blocked paths ───────────────────────────────────────────────────────────
+
+
+def test_gh_pr_create_blocked(tmp_path: Path) -> None:
+    rc, out = _run(_bash("gh pr create --base main"), cwd=tmp_path)
+    assert rc == 0
+    decision = json.loads(out)
+    assert decision["decision"] == "block"
+    assert "WOR-444" in decision["reason"]
+    assert "gh pr create" in decision["reason"]
+
+
+def test_gh_pr_edit_blocked(tmp_path: Path) -> None:
+    rc, out = _run(_bash("gh pr edit 123 --add-label foo"), cwd=tmp_path)
+    assert rc == 0
+    decision = json.loads(out)
+    assert decision["decision"] == "block"
+
+
+def test_gh_pr_merge_blocked(tmp_path: Path) -> None:
+    rc, out = _run(_bash("gh pr merge --auto --squash"), cwd=tmp_path)
+    assert rc == 0
+    decision = json.loads(out)
+    assert decision["decision"] == "block"
+
+
+def test_git_push_origin_blocked(tmp_path: Path) -> None:
+    for cmd in (
+        "git push -u origin wor-1-branch",
+        "git push origin main",
+        "git push",  # bare push to upstream (origin in worktree setup)
+        "git push --force origin",
+    ):
+        rc, out = _run(_bash(cmd), cwd=tmp_path)
+        assert rc == 0
+        decision = json.loads(out)
+        assert decision["decision"] == "block", f"expected block on: {cmd}"
+        assert "WOR-444" in decision["reason"]
+
+
+def test_git_push_to_other_remote_unblocked(tmp_path: Path) -> None:
+    """Pushing to a non-origin remote is unusual but not blocked."""
+    rc, out = _run(_bash("git push my-fork branch"), cwd=tmp_path)
+    assert rc == 0
+    assert out.strip() == ""
+
+
+def test_leading_whitespace_still_blocked(tmp_path: Path) -> None:
+    rc, out = _run(_bash("   gh pr create"), cwd=tmp_path)
+    assert rc == 0
+    decision = json.loads(out)
+    assert decision["decision"] == "block"

--- a/tests/test_watcher_subprocess.py
+++ b/tests/test_watcher_subprocess.py
@@ -956,3 +956,173 @@ def test_create_pr_warns_when_immediate_merge_also_fails(
 
     assert returned_url == pr_url
     assert any("gh pr merge --squash also failed" in msg for msg in caplog.messages)
+
+
+# ---------------------------------------------------------------------------
+# WOR-444 + WOR-445 — PR-already-exists recovery + rebase-before-PR
+# ---------------------------------------------------------------------------
+
+
+def test_create_pr_rebases_before_push(tmp_path: Path) -> None:
+    """WOR-445: fetch + rebase run before git push + gh pr create."""
+    manifest = _make_manifest()
+    call_order: list[str] = []
+
+    def fake_run(cmd: list[str], **_kwargs: object) -> MagicMock:
+        if cmd[:3] == ["git", "fetch", "origin"]:
+            call_order.append("fetch")
+        elif cmd[:2] == ["git", "rebase"]:
+            call_order.append("rebase")
+        elif cmd[:2] == ["git", "push"]:
+            call_order.append("push")
+        elif cmd[:3] == ["gh", "pr", "create"]:
+            call_order.append("gh_pr")
+        result = MagicMock()
+        result.stdout = "https://github.com/example/pr/2"
+        result.stderr = ""
+        result.returncode = 0
+        return result
+
+    with patch(
+        "app.core.watcher.watcher_subprocess.subprocess.run", side_effect=fake_run
+    ):
+        create_pr(manifest, tmp_path)
+
+    assert call_order[:4] == ["fetch", "rebase", "push", "gh_pr"]
+
+
+def test_create_pr_rebase_conflict_aborts_and_raises(tmp_path: Path) -> None:
+    """WOR-445: a rebase conflict triggers `git rebase --abort` and raises
+    with a descriptive stderr (finalize_worker catches it and marks Blocked)."""
+    import subprocess as sp
+
+    manifest = _make_manifest()
+    abort_called: list[bool] = []
+
+    def fake_run(cmd: list[str], **_kwargs: object) -> MagicMock:
+        if cmd[:3] == ["git", "fetch", "origin"]:
+            result = MagicMock(returncode=0, stdout="", stderr="")
+            return result
+        if cmd[:2] == ["git", "rebase"] and cmd[-1] != "--abort":
+            raise sp.CalledProcessError(1, cmd, output="", stderr="CONFLICT in foo.py")
+        if cmd[:3] == ["git", "rebase", "--abort"]:
+            abort_called.append(True)
+            return MagicMock(returncode=0, stdout="", stderr="")
+        # Should not reach here — rebase failure should short-circuit
+        raise AssertionError(f"unexpected call: {cmd}")
+
+    with (
+        patch(
+            "app.core.watcher.watcher_subprocess.subprocess.run", side_effect=fake_run
+        ),
+        pytest.raises(sp.CalledProcessError) as exc_info,
+    ):
+        create_pr(manifest, tmp_path)
+
+    assert abort_called == [True]
+    assert "Rebase" in (exc_info.value.stderr or "")
+    assert "WOR-445" in (exc_info.value.stderr or "")
+    assert "CONFLICT in foo.py" in (exc_info.value.stderr or "")
+
+
+def test_create_pr_recovers_from_pr_already_exists(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """WOR-444: when gh pr create says 'already exists', look up the existing
+    PR via gh pr list and return its URL."""
+    import subprocess as sp
+
+    manifest = _make_manifest()
+    existing_url = "https://github.com/example/pr/916"
+
+    def fake_run(cmd: list[str], **_kwargs: object) -> MagicMock:
+        if cmd[:3] == ["gh", "pr", "create"]:
+            raise sp.CalledProcessError(
+                1,
+                cmd,
+                output="",
+                stderr=(
+                    'a pull request for branch "wor-67-foo" into branch "main" '
+                    "already exists:"
+                ),
+            )
+        if cmd[:3] == ["gh", "pr", "list"]:
+            return MagicMock(returncode=0, stdout=existing_url + "\n", stderr="")
+        # default success for fetch/rebase/push/log/etc.
+        result = MagicMock()
+        result.returncode = 0
+        result.stdout = "abc1234 commit" if cmd[:2] == ["git", "log"] else ""
+        result.stderr = ""
+        return result
+
+    with (
+        patch(
+            "app.core.watcher.watcher_subprocess.subprocess.run", side_effect=fake_run
+        ),
+        caplog.at_level(logging.INFO, logger="app.core.watcher.watcher_subprocess"),
+    ):
+        url = create_pr(manifest, tmp_path)
+
+    assert url == existing_url
+    assert any(
+        "PR already exists" in msg and "WOR-444" in msg for msg in caplog.messages
+    )
+
+
+def test_create_pr_propagates_unrelated_gh_failure(tmp_path: Path) -> None:
+    """gh pr create failures that AREN'T 'already exists' still raise."""
+    import subprocess as sp
+
+    manifest = _make_manifest()
+
+    def fake_run(cmd: list[str], **_kwargs: object) -> MagicMock:
+        if cmd[:3] == ["gh", "pr", "create"]:
+            raise sp.CalledProcessError(
+                1, cmd, output="", stderr="HTTP 401: bad credentials"
+            )
+        result = MagicMock(returncode=0, stdout="", stderr="")
+        if cmd[:2] == ["git", "log"]:
+            result.stdout = "abc1234 commit"
+        return result
+
+    with (
+        patch(
+            "app.core.watcher.watcher_subprocess.subprocess.run", side_effect=fake_run
+        ),
+        pytest.raises(sp.CalledProcessError) as exc_info,
+    ):
+        create_pr(manifest, tmp_path)
+
+    assert "bad credentials" in (exc_info.value.stderr or "")
+
+
+def test_create_pr_gh_pr_list_lookup_failure_re_raises(tmp_path: Path) -> None:
+    """If `gh pr list` fails to find the existing PR, fall back to re-raising
+    the original 'already exists' CalledProcessError (don't silently lose
+    the signal)."""
+    import subprocess as sp
+
+    manifest = _make_manifest()
+
+    def fake_run(cmd: list[str], **_kwargs: object) -> MagicMock:
+        if cmd[:3] == ["gh", "pr", "create"]:
+            raise sp.CalledProcessError(
+                1, cmd, output="", stderr="a pull request ... already exists:"
+            )
+        if cmd[:3] == ["gh", "pr", "list"]:
+            raise sp.CalledProcessError(1, cmd, output="", stderr="gh CLI offline")
+        result = MagicMock(returncode=0, stdout="", stderr="")
+        if cmd[:2] == ["git", "log"]:
+            result.stdout = "abc1234 commit"
+        return result
+
+    with (
+        patch(
+            "app.core.watcher.watcher_subprocess.subprocess.run", side_effect=fake_run
+        ),
+        pytest.raises(sp.CalledProcessError) as exc_info,
+    ):
+        create_pr(manifest, tmp_path)
+
+    # The re-raised exception is the original "already exists" one.
+    assert "already exists" in (exc_info.value.stderr or "")


### PR DESCRIPTION
## Summary

Two coupled fixes for the WOR-67 failure mode (2026-05-11) where a worker opened its own PR and the watcher's later `attempt_pr` returned "already exists" — marking the ticket Blocked despite an open PR.

- **WOR-444** — PreToolUse hook `check_no_worker_pr.py` blocks worker-side `gh pr create/edit/merge` and `git push origin` (detected via `WATCHER_WORKER=1`). Operator sessions bypass. Watcher's `create_pr` also recovers gracefully if a worker somehow opens a PR anyway: `gh pr create`'s "already exists" error triggers a `gh pr list --head` lookup and returns the existing URL.
- **WOR-445** — `create_pr()` now rebases the worker branch onto `origin/<base>` before pushing and uses `git push --force-with-lease`. Rebase conflicts trigger `git rebase --abort` and raise a descriptive `CalledProcessError` (`Rebase ... failed (WOR-445): <stderr>. Resolve manually...`) so finalize_worker can mark the ticket Blocked with a clear comment. This eliminates the class of stale-base failures that previously needed a manual rebase before PR open.

`.claude/commands/implement-ticket.md` step 7 documents the worker-side ban.

## Test plan

- [x] `pytest` — 1760 tests pass (16 new: 11 hook + 5 rebase/PR-exists)
- [x] `mypy app/` — clean
- [x] `lint-imports` — 8/8 contracts kept
- [x] `ruff check .` — clean
- [ ] Watcher end-to-end on a sub-ticket against an updated base branch (next worker dispatch will exercise the rebase path)

Closes WOR-444
Closes WOR-445
