### PR TITLE
WOR-437 watcher --detach / --visible: forward extra CLI args to the spawned child

### DIFF
--- a/app/cli/operator.py
+++ b/app/cli/operator.py
@@ -18,6 +18,7 @@ from app.core.watcher.ticket_status import (
     fetch_ticket_status,
 )
 from app.core.watcher.watcher_daemon import (
+    _build_child_argv,
     launch_detached,
     launch_in_new_terminal,
     load_env_file,
@@ -45,10 +46,14 @@ def _run_watcher(args: argparse.Namespace) -> int:
             file=sys.stderr,
         )
         return 2
+    # Capture extra CLI flags (everything after the subcommand) and forward
+    # them to the spawned child, stripping --detach/--visible first.
+    extra = _build_child_argv(sys.argv[3:]) if len(sys.argv) > 3 else None
+
     if args.visible:
-        return launch_in_new_terminal()
+        return launch_in_new_terminal(extra_args=extra)
     if args.detach:
-        pid = launch_detached()
+        pid = launch_detached(extra_args=extra)
         log_path = Path.cwd() / _CLAUDE_DIR_NAME / "watcher.log"
         print(
             f"Watcher daemon started (PID {pid}). Logs: {log_path}",

--- a/app/core/watcher/watcher_daemon.py
+++ b/app/core/watcher/watcher_daemon.py
@@ -20,6 +20,21 @@ from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
+# Flags consumed by the parent process that must NOT be forwarded to the
+# child watcher process.
+_CHILD_ARGV_STRIP_SET = frozenset({"--detach", "--visible"})
+
+
+def _build_child_argv(argv: list[str]) -> list[str]:
+    """Strip *--detach* and *--visible* from *argv*, return the remainder.
+
+    Used so the operator can forward every CLI flag the user passed alongside
+    ``--detach`` / ``--visible`` to the spawned child watcher process, except
+    for the two flags that only make sense on the parent side.
+    """
+    return [arg for arg in argv if arg not in _CHILD_ARGV_STRIP_SET]
+
+
 # Windows CreateProcess flags — defined here so we don't need win32 deps.
 _DETACHED_PROCESS = 0x00000008
 _CREATE_NEW_PROCESS_GROUP = 0x00000200
@@ -68,12 +83,18 @@ def load_env_file(repo_root: Path | None = None) -> int:
     return loaded
 
 
-def launch_detached(repo_root: Path | None = None) -> int:
+def launch_detached(
+    repo_root: Path | None = None, extra_args: list[str] | None = None
+) -> int:
     """Spawn the watcher daemon as a fully detached subprocess.
 
     The child inherits the parent's environment (which by the time this is
     called includes any keys loaded from .env). stdout + stderr are
     redirected to ``.claude/watcher.log`` (appended); stdin is /dev/null.
+
+    *extra_args* — additional CLI flags to forward to the child watcher
+    process.  ``--detach`` and ``--visible`` are stripped so they are not
+    forwarded.
 
     Returns the child PID. Parent should print + exit immediately; the
     child writes its own ``.claude/watcher.pid`` on startup via the
@@ -87,7 +108,8 @@ def launch_detached(repo_root: Path | None = None) -> int:
     claude_dir.mkdir(exist_ok=True)
     log_path = claude_dir / "watcher.log"
 
-    cmd = [sys.executable, "-m", "app.cli", "watcher"]
+    base_cmd = [sys.executable, "-m", "app.cli", "watcher"]
+    cmd = base_cmd + (_build_child_argv(extra_args or []) if extra_args else [])
 
     # Open the log file once; child inherits the fd. We close our handle
     # after Popen returns — the child keeps its own copy alive.
@@ -121,12 +143,18 @@ def launch_detached(repo_root: Path | None = None) -> int:
     return proc.pid
 
 
-def launch_in_new_terminal(repo_root: Path | None = None) -> int:
+def launch_in_new_terminal(
+    repo_root: Path | None = None, extra_args: list[str] | None = None
+) -> int:
     """Windows: open a new cmd.exe window with the watcher running attached.
 
     The new window's title is "watcher"; the watcher runs in the foreground
     inside it so the operator can see live logs. `.env` is auto-loaded by
     the child's own `_run_watcher` call.
+
+    *extra_args* — additional CLI flags to forward to the child watcher
+    process.  ``--detach`` and ``--visible`` are stripped so they are not
+    forwarded.
 
     Returns 0 on success, 1 on non-Windows (with a clear stderr message).
     Does not wait for the spawned window.
@@ -140,8 +168,10 @@ def launch_in_new_terminal(repo_root: Path | None = None) -> int:
         return 1
 
     root = repo_root or Path.cwd()
+    forwarded = _build_child_argv(extra_args) if extra_args else []
+    extra = " " + " ".join(f'"{a}"' for a in forwarded) if forwarded else ""
     # `start "watcher" cmd /k "cd /d <root> && python -m app.cli watcher"`
-    inner = f'cd /d "{root}" && "{sys.executable}" -m app.cli watcher'
+    inner = f'cd /d "{root}" && "{sys.executable}" -m app.cli watcher{extra}'
     subprocess.run(  # nosec B603 B607
         ["cmd.exe", "/c", "start", "watcher", "cmd", "/k", inner],
         check=False,

--- a/tests/test_watcher_daemon.py
+++ b/tests/test_watcher_daemon.py
@@ -10,10 +10,44 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from app.core.watcher.watcher_daemon import (
+    _build_child_argv,
     launch_detached,
     launch_in_new_terminal,
     load_env_file,
 )
+
+# ── _build_child_argv ───────────────────────────────────────────────────────
+
+
+def test_build_child_argv_strips_detach_visible() -> None:
+    """--detach and --visible are removed; all other args preserved in order."""
+    result = _build_child_argv(
+        ["--detach", "--worker-mode", "local", "--visible", "--verbose"]
+    )
+    assert result == ["--worker-mode", "local", "--verbose"]
+
+
+def test_build_child_argv_no_match_returns_unchanged() -> None:
+    """No --detach/--visible → full list returned as-is."""
+    args = ["--worker-mode", "local", "--max-workers", "8"]
+    assert _build_child_argv(args) == args
+
+
+def test_build_child_argv_empty_list() -> None:
+    """Empty input → empty output."""
+    assert _build_child_argv([]) == []
+
+
+def test_build_child_argv_only_strip_flags() -> None:
+    """Only --detach and --visible → empty list."""
+    assert _build_child_argv(["--detach", "--visible"]) == []
+
+
+def test_build_child_argv_duplicate_removal() -> None:
+    """Duplicate --detach entries are all stripped."""
+    result = _build_child_argv(["--detach", "--detach", "--verbose"])
+    assert result == ["--verbose"]
+
 
 # ── load_env_file ───────────────────────────────────────────────────────────
 
@@ -155,4 +189,76 @@ def test_launch_in_new_terminal_windows_runs_cmd_start(tmp_path: Path) -> None:
     # The inner command should include the tmp_path and the watcher invocation
     inner = args[-1]
     assert str(tmp_path) in inner
+    assert "app.cli watcher" in inner
+
+
+def test_launch_detached_forwards_extra_args(tmp_path: Path) -> None:
+    """extra_args are appended to the child command after 'watcher'."""
+    fake_proc = MagicMock(pid=1)
+    with patch(
+        "app.core.watcher.watcher_daemon.subprocess.Popen", return_value=fake_proc
+    ) as mock_popen:
+        launch_detached(
+            repo_root=tmp_path,
+            extra_args=["--worker-mode", "local", "--verbose"],
+        )
+
+    cmd = mock_popen.call_args.args[0]
+    assert cmd == [
+        sys.executable,
+        "-m",
+        "app.cli",
+        "watcher",
+        "--worker-mode",
+        "local",
+        "--verbose",
+    ]
+
+
+def test_launch_detached_extra_args_strips_detach_visible(tmp_path: Path) -> None:
+    """--detach/--visible in extra_args are stripped before forwarding."""
+    fake_proc = MagicMock(pid=1)
+    with patch(
+        "app.core.watcher.watcher_daemon.subprocess.Popen", return_value=fake_proc
+    ) as mock_popen:
+        launch_detached(
+            repo_root=tmp_path,
+            extra_args=["--detach", "--worker-mode", "local", "--visible"],
+        )
+
+    cmd = mock_popen.call_args.args[0]
+    assert "--detach" not in cmd
+    assert "--visible" not in cmd
+    assert "--worker-mode" in cmd
+    assert cmd.index("--worker-mode") == cmd.index("local") - 1
+
+
+def test_launch_detached_no_extra_args_unchanged(tmp_path: Path) -> None:
+    """Default call (no extra_args) still produces the base command."""
+    fake_proc = MagicMock(pid=1)
+    with patch(
+        "app.core.watcher.watcher_daemon.subprocess.Popen", return_value=fake_proc
+    ) as mock_popen:
+        launch_detached(repo_root=tmp_path)
+
+    cmd = mock_popen.call_args.args[0]
+    assert cmd == [sys.executable, "-m", "app.cli", "watcher"]
+
+
+def test_launch_in_new_terminal_forwards_extra_args(tmp_path: Path) -> None:
+    """extra_args are appended to the inner command string."""
+    with (
+        patch("app.core.watcher.watcher_daemon.sys") as mock_sys,
+        patch("app.core.watcher.watcher_daemon.subprocess.run") as mock_run,
+    ):
+        mock_sys.platform = "win32"
+        mock_sys.executable = sys.executable
+        rc = launch_in_new_terminal(
+            repo_root=tmp_path,
+            extra_args=["--worker-mode", "local", "--verbose"],
+        )
+    assert rc == 0
+    inner = mock_run.call_args.args[0][-1]
+    assert "--worker-mode" in inner
+    assert "--verbose" in inner
     assert "app.cli watcher" in inner


### PR DESCRIPTION
Closes WOR-437

Operator running `python -m app.cli watcher --worker-mode local --detach` spawns a child that runs in forced-local mode (not default auto mode). Unit test covers _build_child_argv. All checks pass.