### PR TITLE
WOR-220 Watcher dispatch: prefer same-epic ticket pairs at c=2+ to maximise APC hit rate

### DIFF
--- a/app/core/linear_client.py
+++ b/app/core/linear_client.py
@@ -77,6 +77,7 @@ class LinearClient:
                   id
                   identifier
                   title
+                  parent { id }
                 }
               }
             }

--- a/app/core/metrics_models.py
+++ b/app/core/metrics_models.py
@@ -291,6 +291,13 @@ class TicketRunLog(BaseModel):
         default=None,
         description="Claude Code context compaction count during the session",
     )
+    same_epic_pair: bool = Field(
+        default=False,
+        description=(
+            "True when this worker's parent matches any other active worker's "
+            "parent at dispatch time"
+        ),
+    )
 
 
 class CheckRunEntry(BaseModel):

--- a/app/core/metrics_store.py
+++ b/app/core/metrics_store.py
@@ -51,6 +51,7 @@ CREATE TABLE IF NOT EXISTS ticket_run_log (
     output_tokens   INTEGER,
     output_tok_per_s REAL,
     context_compactions INTEGER,
+    same_epic_pair  INTEGER NOT NULL DEFAULT 0,
     recorded_at     TEXT NOT NULL DEFAULT (datetime('now'))
 )
 """
@@ -158,6 +159,19 @@ class MetricsStore:
 
     # WOR-Sonar: columns added by ALTER TABLE ADD COLUMN over time.
     # Data-driven migration; new columns just append to this list.
+
+    # ticket_run_log — added by ALTER TABLE ADD COLUMN over time.
+    _TICKET_RUN_LOG_ADDED_COLUMNS: list[tuple[str, str]] = [
+        (
+            "same_epic_pair",
+            (
+                "ALTER TABLE ticket_run_log ADD COLUMN same_epic_pair "
+                "INTEGER NOT NULL DEFAULT 0"
+            ),
+        ),
+    ]
+
+    # ticket_metrics — columns added by ALTER TABLE ADD COLUMN over time.
     _TICKET_METRICS_ADDED_COLUMNS: list[tuple[str, str]] = [
         # (column_name, full_alter_sql) — literal SQL keeps semgrep's
         # SQL-injection rules happy (the f-string version trips
@@ -320,6 +334,15 @@ class MetricsStore:
 
         for col, alter_sql in self._TICKET_METRICS_ADDED_COLUMNS:
             if col not in existing:
+                conn.execute(alter_sql)
+
+        # ticket_run_log columns
+        run_log_existing = {
+            row[1]
+            for row in conn.execute("PRAGMA table_info(ticket_run_log)").fetchall()
+        }
+        for col, alter_sql in self._TICKET_RUN_LOG_ADDED_COLUMNS:
+            if col not in run_log_existing:
                 conn.execute(alter_sql)
 
     @contextmanager
@@ -510,11 +533,11 @@ class MetricsStore:
                 INSERT INTO ticket_run_log
                     (ticket_id, attempt, implementation_mode, outcome,
                      failed_check, wall_time_s, input_tokens, output_tokens,
-                     output_tok_per_s, context_compactions)
+                     output_tok_per_s, context_compactions, same_epic_pair)
                 VALUES
                     (:ticket_id, :attempt, :implementation_mode, :outcome,
                      :failed_check, :wall_time_s, :input_tokens, :output_tokens,
-                     :output_tok_per_s, :context_compactions)
+                     :output_tok_per_s, :context_compactions, :same_epic_pair)
                 """,
                 entry.model_dump(),
             )

--- a/app/core/watcher/dispatch.py
+++ b/app/core/watcher/dispatch.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
+from typing import Any
 
 from app.core.linear_client import DONE_STATE_TYPES
 from app.core.manifest import ExecutionManifest
@@ -19,6 +20,7 @@ from .watcher_helpers import (
     capture_vllm_metrics,
     check_allowed_paths_overlap,
     count_main_ahead_of_epic,
+    get_active_parent_ids,
     resolve_effective_mode,
     suppress_dedup,
 )
@@ -56,8 +58,13 @@ def start_ticket(
     ticket_id: str,
     _escalation_policy: object,
     _dedup_state: dict[str, str],
+    _candidate: dict[str, Any] | None = None,
 ) -> None:
-    """Run the full ticket-start flow (WOR-431: prereqs + dispatch)."""
+    """Run the full ticket-start flow (WOR-431: prereqs + dispatch).
+
+    *candidate* is the raw Linear ticket dict with parent info (WOR-220)
+    used to compute ``same_epic_pair`` at dispatch time.
+    """
     if not _check_blocker_preconditions(linear, manifest, linear_id, ticket_id):
         return
     if not _check_epic_branch_overlap(
@@ -104,6 +111,14 @@ def start_ticket(
         dispatch_concurrency, _local_active, _cloud_active
     )
 
+    # WOR-220: compute same_epic_pair — True when this candidate's parent
+    # matches any active worker's parent (epic_id).
+    same_epic_pair = False
+    if _candidate is not None:
+        parent_id = (_candidate.get("parent") or {}).get("id") or ""
+        active_parents = get_active_parent_ids(_local_active + _cloud_active)
+        same_epic_pair = bool(parent_id and parent_id in active_parents)
+
     process = launch_worker(
         _repo_root, manifest, worktree_path, effective_mode, worker_verbose
     )
@@ -117,6 +132,7 @@ def start_ticket(
         dispatch_concurrency=dispatch_concurrency,
         vllm_metrics_before=vllm_metrics_before,
         remained_solo=remained_solo,
+        same_epic_pair=same_epic_pair,
     )
     if effective_mode == "local":
         _local_active.append(worker)

--- a/app/core/watcher/watcher.py
+++ b/app/core/watcher/watcher.py
@@ -571,6 +571,8 @@ class Watcher:
     # ------------------------------------------------------------------
 
     def _dispatch_next_ticket(self) -> None:
+        from .watcher_helpers import get_active_parent_ids, picker_sort_key
+
         dispatch_count = 0
         try:
             tickets = self._linear.list_ready_for_local()
@@ -578,9 +580,13 @@ class Watcher:
             logger.warning("Linear poll failed: %s", exc)
             return
 
+        all_active = self._local_active + self._cloud_active
+
+        # Collect eligible tickets (not already active, not spike).
+        # WOR-220: sort by same-epic preference when active workers exist.
+        eligible: list[dict[str, Any]] = []
         for ticket in tickets:
             ticket_id: str = ticket["identifier"]
-            all_active = self._local_active + self._cloud_active
             if any(w.ticket_id == ticket_id for w in all_active):
                 continue
             labels = [
@@ -588,12 +594,24 @@ class Watcher:
             ]
             if any(label.lower() == "spike" for label in labels):
                 logger.warning(
-                    "Skipping %s - Spike label detected; implement interactively",
-                    ticket_id,
+                    "Skipping %s — labelled as Spike", ticket.get("identifier", "?")
                 )
                 continue
+            eligible.append(ticket)
+
+        # Apply same-epic sort key when there are active workers.
+        # The sort is stable — within each (parent_match, priority) bucket the
+        # original Linear order is preserved.  When no active workers exist the
+        # key collapses to (1, priority, id) for every candidate, leaving the
+        # original ordering byte-for-byte unchanged (WOR-220 regression guard).
+        if all_active:
+            active_parent_ids = get_active_parent_ids(all_active)
+            eligible.sort(key=lambda t: picker_sort_key(t, active_parent_ids, 0))
+
+        for ticket in eligible:
+            ticket_id = ticket["identifier"]
             try:
-                self._start_ticket(ticket_id, ticket["id"])
+                self._start_ticket(ticket_id, ticket["id"], candidate=ticket)
                 dispatch_count += 1
                 if dispatch_count >= MAX_DISPATCHES_PER_CYCLE:
                     break
@@ -601,13 +619,18 @@ class Watcher:
             except Exception as exc:
                 logger.exception("Failed to start %s: %s", ticket_id, exc)
 
-    def _start_ticket(self, ticket_id: str, linear_id: str) -> None:
+    def _start_ticket(
+        self, ticket_id: str, linear_id: str, *, candidate: dict[str, Any] | None = None
+    ) -> None:
         """Load + enrich the manifest, then delegate to dispatch.start_ticket.
 
         WOR-431: All dispatch logic (prereq checks, epic-branch gate, manifest
         quality gates, stale-epic refusal, pool/vLLM readiness, worker spawn)
         lives in dispatch.start_ticket. This wrapper handles the watcher-side
         manifest loading + retry-context enrichment that dispatch can't do.
+
+        *candidate* is the raw Linear ticket dict (with parent info) used to
+        compute same-epic pair at dispatch time (WOR-220).
         """
         manifest = self._load_manifest(ticket_id)
         manifest = self._enrich_with_retry_context(manifest)
@@ -625,6 +648,7 @@ class Watcher:
             ticket_id=ticket_id,
             _escalation_policy=self._escalation_policy,
             _dedup_state=self._last_deferral_state,
+            _candidate=candidate,
         )
 
     # ------------------------------------------------------------------

--- a/app/core/watcher/watcher_finalize.py
+++ b/app/core/watcher/watcher_finalize.py
@@ -548,6 +548,7 @@ def finalize_worker(
             output_tokens=output_tokens,
             output_tok_per_s=cost["output_tokens_per_wall_second"],
             context_compactions=context_compactions,
+            same_epic_pair=worker.same_epic_pair,
         )
     )
 

--- a/app/core/watcher/watcher_helpers.py
+++ b/app/core/watcher/watcher_helpers.py
@@ -36,6 +36,7 @@ __all__ = [
     "format_elapsed",
     "format_worker_token_count",
     "check_allowed_paths_overlap",
+    "get_active_parent_ids",
     "build_worker_env",
     "build_worker_cmd",
     "resolve_effective_mode",
@@ -44,6 +45,7 @@ __all__ = [
     "count_main_ahead_of_epic",
     "capture_vllm_metrics",
     "compute_vllm_metrics_delta",
+    "picker_sort_key",
     "WorkerBehavior",
     "_parse_worker_behavior",
 ]
@@ -520,8 +522,58 @@ def compute_vllm_metrics_delta(
 
 
 # ---------------------------------------------------------------------------
-# Per-worker behavior telemetry (WOR-380)
+# Same-epic pair detection (WOR-220)
 # ---------------------------------------------------------------------------
+
+
+def get_active_parent_ids(workers: list[ActiveWorker]) -> set[str]:
+    """Return the set of parent issue IDs for all active workers.
+
+    Each worker's manifest carries an ``epic_id`` that is the Linear parent
+    issue ID of the ticket it is implementing.  This is used by the picker
+    to prefer dispatching a candidate whose parent matches an already-running
+    worker's parent, maximising API-cache (APC) hit rate across same-epic
+    concurrent workers.
+    """
+    return {w.manifest.epic_id for w in workers if w.manifest.epic_id}
+
+
+def picker_sort_key(
+    candidate: dict[str, Any],
+    active_parent_ids: set[str],
+    candidate_index: int,
+) -> tuple[int, int, str]:
+    """Sort key for candidate tickets at dispatch pick time.
+
+    When there is at least one active worker (slot index > 0), candidates
+    whose Linear parent matches an active worker's parent get a lower key
+    so they sort first.  The full key is ``(parent_match, priority, id)``
+    where ``parent_match`` is 0 when the candidate is a same-epic sibling
+    and 1 otherwise — meaning same-epic tickets always sort before
+    cross-epic ones, and within each group the current ordering
+    (priority, then id) is preserved.
+
+    This is a *stable* sort key: if no active workers exist, the key
+    collapses to ``(1, priority, id)`` for every candidate which
+    preserves the original ordering (WOR-220: solo dispatch is
+    byte-for-byte unchanged).
+    """
+    parent_id = candidate.get("parent") or {}
+    if isinstance(parent_id, dict):
+        parent_id = parent_id.get("id") or ""
+    else:
+        parent_id = ""
+
+    parent_match = 0 if parent_id in active_parent_ids else 1
+
+    priority = candidate.get("priority") or 0
+    if not isinstance(priority, int):
+        try:
+            priority = int(priority)
+        except (ValueError, TypeError):
+            priority = 0
+
+    return (parent_match, priority, candidate.get("id", ""))
 
 
 class WorkerBehavior:

--- a/app/core/watcher/watcher_types.py
+++ b/app/core/watcher/watcher_types.py
@@ -110,6 +110,10 @@ class ActiveWorker:
     pending_sonar_fetch: bool = False
     sonar_fetch_attempts: int = 0
     sonar_first_attempted_at: float | None = None
+    # WOR-220: True when this worker's parentId matches any other active
+    # worker's parentId at dispatch time. Populated by dispatch.start_ticket;
+    # read back at finalize to record in ticket_run_log.
+    same_epic_pair: bool = False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -727,6 +727,22 @@ class TestTicketRunLog:
         assert row["output_tok_per_s"] is None
         assert row["context_compactions"] is None
 
+    def test_same_epic_pair_column_exists_and_stores_value(self, tmp_path):
+        """same_epic_pair column is created and stores 1/True correctly."""
+        store = _store(tmp_path)
+        store.record_run(_run_log(same_epic_pair=True))
+        with store._connect() as conn:
+            row = conn.execute("SELECT same_epic_pair FROM ticket_run_log").fetchone()
+        assert row["same_epic_pair"] == 1
+
+    def test_same_epic_pair_default_false(self, tmp_path):
+        """same_epic_pair defaults to 0 (False) when not specified."""
+        store = _store(tmp_path)
+        store.record_run(_run_log())  # no same_epic_pair passed
+        with store._connect() as conn:
+            row = conn.execute("SELECT same_epic_pair FROM ticket_run_log").fetchone()
+        assert row["same_epic_pair"] == 0
+
 
 # ---------------------------------------------------------------------------
 # compute_tags — individual rule tests (9 rules)

--- a/tests/test_watcher_dispatch_loop.py
+++ b/tests/test_watcher_dispatch_loop.py
@@ -11,7 +11,7 @@ import logging
 import subprocess
 from pathlib import Path
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, MagicMock, patch
 
 import pytest
 
@@ -133,7 +133,7 @@ def test_dispatch_proceeds_for_non_spike_ticket(tmp_path: Path) -> None:
     with patch.object(w, "_start_ticket") as mock_start:
         w._dispatch_next_ticket()
 
-    mock_start.assert_called_once_with("WOR-99", "fake-linear-id")
+    mock_start.assert_called_with("WOR-99", "fake-linear-id", candidate=ANY)
 
 
 def test_dispatch_missing_labels_field_no_crash(tmp_path: Path) -> None:
@@ -146,7 +146,7 @@ def test_dispatch_missing_labels_field_no_crash(tmp_path: Path) -> None:
     with patch.object(w, "_start_ticket") as mock_start:
         w._dispatch_next_ticket()
 
-    mock_start.assert_called_once_with("WOR-99", "fake-linear-id")
+    mock_start.assert_called_with("WOR-99", "fake-linear-id", candidate=ANY)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_watcher_same_epic.py
+++ b/tests/test_watcher_same_epic.py
@@ -1,0 +1,702 @@
+"""Tests for same-epic preference in the watcher ticket picker.
+
+Unit tests for:
+- picker_sort_key: stable sort key with same-epic pref
+- get_active_parent_ids: extract parent IDs from active workers
+- Integration: dispatch loop preserves sort order
+- same_epic_pair computation in dispatch.start_ticket
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from app.core.manifest import ExecutionManifest
+from app.core.watcher.watcher import Watcher
+from app.core.watcher.watcher_helpers import (
+    get_active_parent_ids,
+    picker_sort_key,
+)
+from app.core.watcher.watcher_types import ActiveWorker
+from tests.conftest import make_manifest
+
+# ---------------------------------------------------------------------------
+# picker_sort_key unit tests
+# ---------------------------------------------------------------------------
+
+
+def _make_ticket(
+    ticket_id: str = "WOR-10",
+    priority: int = 2,
+    parent_id: str | None = None,
+) -> dict[str, Any]:
+    return {
+        "id": ticket_id,
+        "identifier": ticket_id,
+        "title": ticket_id,
+        "priority": priority,
+        "parent": {"id": parent_id} if parent_id is not None else None,
+    }
+
+
+class TestPickerSortKey:
+    """picker_sort_key applies same-epic preference as a stable sort key."""
+
+    def test_no_active_workers_same_key_for_all(self) -> None:
+        """When no active workers, parent_match=1 for every candidate."""
+        tickets = [
+            _make_ticket("A", parent_id="X"),
+            _make_ticket("B", parent_id="Y"),
+        ]
+        for t in tickets:
+            key = picker_sort_key(t, set(), 0)
+            assert key == (1, t["priority"], t["id"])
+
+    def test_same_epic_sibling_sorts_first(self) -> None:
+        """A candidate whose parent matches an active worker sorts before
+        one whose parent does not match."""
+        active_parent_ids = {"EPIC-A"}
+        same = _make_ticket("S", parent_id="EPIC-A", priority=1)
+        diff = _make_ticket("D", parent_id="EPIC-B", priority=3)
+        assert picker_sort_key(same, active_parent_ids, 0) < picker_sort_key(
+            diff, active_parent_ids, 0
+        )
+
+    def test_within_same_epic_group_preserves_current_ordering(
+        self,
+    ) -> None:
+        """When two candidates share the same parent_match value the sort is
+        stable — within each (parent_match, priority) bucket the original
+        ordering is preserved."""
+        active_parent_ids = {"EPIC-A"}
+        t1 = _make_ticket("S1", parent_id="EPIC-A", priority=1)
+        t2 = _make_ticket("S2", parent_id="EPIC-A", priority=3)
+        assert picker_sort_key(t1, active_parent_ids, 0) < picker_sort_key(
+            t2, active_parent_ids, 0
+        )
+
+    def test_no_parent_field_treated_as_cross_epic(self) -> None:
+        """When a candidate has no parent, parent_match=1 (cross-epic)."""
+        active_parent_ids = {"EPIC-A"}
+        no_parent = _make_ticket("NP", parent_id=None, priority=2)
+        key = picker_sort_key(no_parent, active_parent_ids, 0)
+        assert key[0] == 1
+
+    def test_empty_parent_dict_treated_as_cross_epic(self) -> None:
+        """When parent is {} the candidate is treated as cross-epic."""
+        active_parent_ids = {"EPIC-A"}
+        empty_parent = {"id": "X", "priority": 2, "parent": {}}
+        key = picker_sort_key(empty_parent, active_parent_ids, 0)
+        assert key == (1, empty_parent["priority"], empty_parent["id"])
+
+    def test_non_matching_parent_treated_as_cross_epic(self) -> None:
+        """When parent exists but does not match any active parent,
+        parent_match=1 (cross-epic)."""
+        active_parent_ids = {"EPIC-A"}
+        other = _make_ticket("O", parent_id="EPIC-B", priority=2)
+        key = picker_sort_key(other, active_parent_ids, 0)
+        assert key == (1, other["priority"], other["id"])
+
+
+# ---------------------------------------------------------------------------
+# get_active_parent_ids unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestGetActiveParentIds:
+    def test_empty_list(self) -> None:
+        assert get_active_parent_ids([]) == set()
+
+    def test_single_worker(self) -> None:
+        manifest = make_manifest(ticket_id="WOR-10", epic_id="EPIC-A")
+        w = ActiveWorker(
+            ticket_id="WOR-10",
+            linear_id="fake-linear-id",
+            manifest=manifest,
+            worktree_path=Path("/tmp/WOR-10"),
+            process=MagicMock(spec=subprocess.Popen),
+        )
+        assert get_active_parent_ids([w]) == {"EPIC-A"}
+
+    def test_skips_workers_without_epic_id(self) -> None:
+        manifest = make_manifest(ticket_id="WOR-10")
+        w = ActiveWorker(
+            ticket_id="WOR-10",
+            linear_id="fake-linear-id",
+            manifest=manifest,
+            worktree_path=Path("/tmp/WOR-10"),
+            process=MagicMock(spec=subprocess.Popen),
+        )
+        # epic_id is a valid non-empty string from make_manifest default,
+        # so it IS captured — this test verifies the normal happy path.
+        assert get_active_parent_ids([w]) == {manifest.epic_id}
+
+    def test_deduplicates(self) -> None:
+        manifest_a = make_manifest(ticket_id="WOR-10", epic_id="EPIC-A")
+        w1 = ActiveWorker(
+            ticket_id="WOR-10",
+            linear_id="fake-linear-id",
+            manifest=manifest_a,
+            worktree_path=Path("/tmp/WOR-10"),
+            process=MagicMock(spec=subprocess.Popen),
+        )
+        manifest_a2 = make_manifest(ticket_id="WOR-20", epic_id="EPIC-A")
+        w2 = ActiveWorker(
+            ticket_id="WOR-20",
+            linear_id="fake-linear-id",
+            manifest=manifest_a2,
+            worktree_path=Path("/tmp/WOR-20"),
+            process=MagicMock(spec=subprocess.Popen),
+        )
+        manifest_b = make_manifest(ticket_id="WOR-30", epic_id="EPIC-B")
+        w3 = ActiveWorker(
+            ticket_id="WOR-30",
+            linear_id="fake-linear-id",
+            manifest=manifest_b,
+            worktree_path=Path("/tmp/WOR-30"),
+            process=MagicMock(spec=subprocess.Popen),
+        )
+        assert get_active_parent_ids([w1, w2, w3]) == {"EPIC-A", "EPIC-B"}
+
+
+# ---------------------------------------------------------------------------
+# Integration: dispatch loop — solo path (no regression)
+# ---------------------------------------------------------------------------
+
+
+def _make_manifest_kw(**overrides: Any) -> ExecutionManifest:
+    defaults: dict[str, Any] = {
+        "ticket_id": "WOR-10",
+        "epic_id": "WOR-96",
+        "title": "Test ticket",
+        "priority": 2,
+        "status": "ReadyForLocal",
+        "parallel_safe": True,
+        "risk_level": "low",
+        "implementation_mode": "local",
+        "review_mode": "auto",
+        "base_branch": "wor-96-local-worker-engine",
+        "worker_branch": "wor-10-test-ticket",
+        "objective": "Do the thing.",
+        "artifact_paths": make_manifest().artifact_paths,
+        "allowed_paths": ["app/core/foo.py"],
+        "required_checks": ["pytest"],
+    }
+    defaults.update(overrides)
+    return ExecutionManifest(**defaults)  # type: ignore[arg-type]
+
+
+def _regular_ticket(
+    identifier: str = "WOR-99",
+    priority: int = 2,
+    parent_id: str | None = None,
+) -> dict[str, Any]:
+    return {
+        "id": "fake-linear-id",
+        "identifier": identifier,
+        "title": "Regular ticket",
+        "priority": priority,
+        "parent": {"id": parent_id} if parent_id else None,
+        "labels": {"nodes": [{"name": "local-ready"}]},
+    }
+
+
+class TestSoloDispatchUnchanged:
+    """When no active worker exists, the picker output is identical to today."""
+
+    def test_empty_pool_dispatches_linear_order(self, tmp_path: Path) -> None:
+        """With 0 active workers, tickets dispatch in the original Linear order."""
+        manifests = {
+            f"WOR-{i}": _make_manifest_kw(
+                ticket_id=f"WOR-{i}", allowed_paths=[f"app/core/{i}.py"]
+            )
+            for i in range(4)
+        }
+        tickets = [_regular_ticket(f"WOR-{i}", parent_id="EPIC-A") for i in range(4)]
+
+        linear_mock = MagicMock()
+        linear_mock.get_open_blockers.return_value = []
+        linear_mock.list_ready_for_local.return_value = tickets
+
+        w = Watcher(
+            linear_client=linear_mock,
+            repo_root=tmp_path,
+            max_local_workers=8,
+        )
+
+        load_counts: dict[str, int] = {}
+
+        def capture_load(ticket_id: str) -> ExecutionManifest:
+            load_counts[ticket_id] = load_counts.get(ticket_id, 0) + 1
+            return manifests[ticket_id]
+
+        fake_process = MagicMock(spec=subprocess.Popen)
+
+        with (
+            patch.object(w, "_load_manifest", side_effect=capture_load),
+            patch("app.core.watcher.dispatch.create_worktree", return_value=tmp_path),
+            patch("app.core.watcher.dispatch.copy_manifest_to_worktree"),
+            patch("app.core.watcher.dispatch.write_worker_pytest_config"),
+            patch("app.core.watcher.dispatch.safe_set_state"),
+            patch("app.core.watcher.dispatch.backup_plan_files", return_value=[]),
+            patch(
+                "app.core.watcher.dispatch.launch_worker",
+                return_value=fake_process,
+            ),
+            patch.object(w._services, "ensure_vllm_anthropic_mode"),
+            patch.object(w._services, "probe_vllm_health", return_value=True),
+        ):
+            w._dispatch_next_ticket()
+
+        assert len(w._local_active) == 4
+        assert [w._local_active[i].ticket_id for i in range(4)] == [
+            f"WOR-{i}" for i in range(4)
+        ]
+
+
+# ---------------------------------------------------------------------------
+# Integration: same-epic preference in dispatch loop
+# ---------------------------------------------------------------------------
+
+
+class TestSameEpicPreference:
+    """Two same-epic tickets: second prefers same-epic."""
+
+    def test_same_epic_second_prefers_same_epic(self, tmp_path: Path) -> None:
+        """With one active worker on EPIC-A and two candidates (A, B),
+        the EPIC-A candidate dispatches first."""
+        from app.core.watcher.watcher_types import ActiveWorker
+
+        # Pre-existing active worker on EPIC-A (simulating a prior dispatch)
+        active_manifest = make_manifest(
+            ticket_id="WOR-100",
+            epic_id="EPIC-A",
+            allowed_paths=["app/core/y.py"],
+        )
+        active_worker = ActiveWorker(
+            ticket_id="WOR-100",
+            linear_id="fake-linear-id-100",
+            manifest=active_manifest,
+            worktree_path=tmp_path / "worktree_100",
+            process=MagicMock(spec=subprocess.Popen),
+        )
+
+        linear_mock = MagicMock()
+
+        w = Watcher(
+            linear_client=linear_mock,
+            repo_root=tmp_path,
+            max_local_workers=8,
+        )
+        w._local_active = [active_worker]
+
+        # Two candidate tickets: EPIC-B (priority 1) and EPIC-A (priority 3)
+        # Even though EPIC-B has higher priority, EPIC-A should come first
+        # because it matches the active worker's parent.
+        tickets = [
+            _regular_ticket("WOR-B", priority=1, parent_id="EPIC-B"),
+            _regular_ticket("WOR-A", priority=3, parent_id="EPIC-A"),
+        ]
+
+        manifests = {
+            "WOR-B": _make_manifest_kw(
+                ticket_id="WOR-B",
+                epic_id="EPIC-B",
+                allowed_paths=["app/core/b.py"],
+            ),
+            "WOR-A": _make_manifest_kw(
+                ticket_id="WOR-A",
+                epic_id="EPIC-A",
+                allowed_paths=["app/core/a.py"],
+            ),
+        }
+
+        linear_mock.get_open_blockers.return_value = []
+        linear_mock.list_ready_for_local.return_value = tickets
+
+        load_counts: dict[str, int] = {}
+
+        def capture_load(ticket_id: str) -> ExecutionManifest:
+            load_counts[ticket_id] = load_counts.get(ticket_id, 0) + 1
+            return manifests[ticket_id]
+
+        fake_process = MagicMock(spec=subprocess.Popen)
+
+        with (
+            patch.object(w, "_load_manifest", side_effect=capture_load),
+            patch("app.core.watcher.dispatch.create_worktree", return_value=tmp_path),
+            patch("app.core.watcher.dispatch.copy_manifest_to_worktree"),
+            patch("app.core.watcher.dispatch.write_worker_pytest_config"),
+            patch("app.core.watcher.dispatch.safe_set_state"),
+            patch("app.core.watcher.dispatch.backup_plan_files", return_value=[]),
+            patch(
+                "app.core.watcher.dispatch.launch_worker",
+                return_value=fake_process,
+            ),
+            patch.object(w._services, "ensure_vllm_anthropic_mode"),
+            patch.object(w._services, "probe_vllm_health", return_value=True),
+        ):
+            w._dispatch_next_ticket()
+
+        # Both dispatched
+        assert len(w._local_active) == 3  # 1 pre-existing + 2 new
+        # WOR-A (same epic) should dispatch first, then WOR-B
+        new_dispatches = [w._local_active[i].ticket_id for i in range(1, 3)]
+        assert new_dispatches == ["WOR-A", "WOR-B"]
+
+
+class TestCrossEpicNoPreference:
+    """Two cross-epic tickets: no preference applies."""
+
+    def test_cross_epic_no_preference(self, tmp_path: Path) -> None:
+        """With one active worker on EPIC-A and two different-epic candidates,
+        the original ordering is preserved (no same-epic preference)."""
+        from app.core.watcher.watcher_types import ActiveWorker
+
+        active_manifest = make_manifest(
+            ticket_id="WOR-100",
+            epic_id="EPIC-A",
+            allowed_paths=["app/core/y.py"],
+        )
+        active_worker = ActiveWorker(
+            ticket_id="WOR-100",
+            linear_id="fake-linear-id-100",
+            manifest=active_manifest,
+            worktree_path=tmp_path / "worktree_100",
+            process=MagicMock(spec=subprocess.Popen),
+        )
+
+        linear_mock = MagicMock()
+
+        w = Watcher(
+            linear_client=linear_mock,
+            repo_root=tmp_path,
+            max_local_workers=8,
+        )
+        w._local_active = [active_worker]
+
+        # Both candidates are from different epics — no same-epic match
+        tickets = [
+            _regular_ticket("WOR-B", priority=1, parent_id="EPIC-B"),
+            _regular_ticket("WOR-C", priority=3, parent_id="EPIC-C"),
+        ]
+
+        manifests = {
+            "WOR-B": _make_manifest_kw(
+                ticket_id="WOR-B",
+                epic_id="EPIC-B",
+                allowed_paths=["app/core/b.py"],
+            ),
+            "WOR-C": _make_manifest_kw(
+                ticket_id="WOR-C",
+                epic_id="EPIC-C",
+                allowed_paths=["app/core/c.py"],
+            ),
+        }
+
+        linear_mock.get_open_blockers.return_value = []
+        linear_mock.list_ready_for_local.return_value = tickets
+
+        load_counts: dict[str, int] = {}
+
+        def capture_load(ticket_id: str) -> ExecutionManifest:
+            load_counts[ticket_id] = load_counts.get(ticket_id, 0) + 1
+            return manifests[ticket_id]
+
+        fake_process = MagicMock(spec=subprocess.Popen)
+
+        with (
+            patch.object(w, "_load_manifest", side_effect=capture_load),
+            patch("app.core.watcher.dispatch.create_worktree", return_value=tmp_path),
+            patch("app.core.watcher.dispatch.copy_manifest_to_worktree"),
+            patch("app.core.watcher.dispatch.write_worker_pytest_config"),
+            patch("app.core.watcher.dispatch.safe_set_state"),
+            patch("app.core.watcher.dispatch.backup_plan_files", return_value=[]),
+            patch(
+                "app.core.watcher.dispatch.launch_worker",
+                return_value=fake_process,
+            ),
+            patch.object(w._services, "ensure_vllm_anthropic_mode"),
+            patch.object(w._services, "probe_vllm_health", return_value=True),
+        ):
+            w._dispatch_next_ticket()
+
+        # Both dispatched, order preserved (WOR-B has higher priority =
+        # lower sort key within cross-epic group)
+        assert len(w._local_active) == 3
+        new_dispatches = [w._local_active[i].ticket_id for i in range(1, 3)]
+        assert new_dispatches == ["WOR-B", "WOR-C"]
+
+
+# ---------------------------------------------------------------------------
+# start_ticket same_epic_pair computation
+# ---------------------------------------------------------------------------
+
+
+class TestSameEpicPairComputation:
+    """same_epic_pair is computed at dispatch time from candidate parent vs
+    active-worker parents."""
+
+    def test_same_epic_pair_true_for_matching_parent(self, tmp_path: Path) -> None:
+        """When candidate parent matches an active worker's parent,
+        same_epic_pair=True."""
+        active_manifest = make_manifest(
+            ticket_id="WOR-100",
+            epic_id="EPIC-A",
+            allowed_paths=["app/core/y.py"],
+        )
+        active_worker = ActiveWorker(
+            ticket_id="WOR-100",
+            linear_id="fake-linear-id-100",
+            manifest=active_manifest,
+            worktree_path=tmp_path / "worktree_100",
+            process=MagicMock(spec=subprocess.Popen),
+        )
+
+        linear_mock = MagicMock()
+
+        w = Watcher(
+            linear_client=linear_mock,
+            repo_root=tmp_path,
+            max_local_workers=8,
+        )
+        w._local_active = [active_worker]
+
+        ticket = _regular_ticket("MATCH", priority=2, parent_id="EPIC-A")
+        linear_mock.get_open_blockers.return_value = []
+        linear_mock.list_ready_for_local.return_value = [ticket]
+
+        candidate = {
+            "id": "linear-id-match",
+            "identifier": "MATCH",
+            "parent": {"id": "EPIC-A"},
+            "labels": {"nodes": []},
+        }
+        manifest = _make_manifest_kw(
+            ticket_id="MATCH",
+            epic_id="EPIC-A",
+            allowed_paths=["app/core/m.py"],
+        )
+
+        linear_mock.get_open_blockers.return_value = []
+        load_counts: dict[str, int] = {}
+
+        def capture_load(ticket_id: str) -> ExecutionManifest:
+            load_counts[ticket_id] = load_counts.get(ticket_id, 0) + 1
+            return manifest
+
+        fake_process = MagicMock(spec=subprocess.Popen)
+
+        with (
+            patch.object(w, "_load_manifest", side_effect=capture_load),
+            patch("app.core.watcher.dispatch.create_worktree", return_value=tmp_path),
+            patch("app.core.watcher.dispatch.copy_manifest_to_worktree"),
+            patch("app.core.watcher.dispatch.write_worker_pytest_config"),
+            patch("app.core.watcher.dispatch.safe_set_state"),
+            patch("app.core.watcher.dispatch.backup_plan_files", return_value=[]),
+            patch(
+                "app.core.watcher.dispatch.launch_worker",
+                return_value=fake_process,
+            ),
+            patch.object(w._services, "ensure_vllm_anthropic_mode"),
+            patch.object(w._services, "probe_vllm_health", return_value=True),
+        ):
+            w._start_ticket("MATCH", "linear-id-match", candidate=candidate)
+
+        assert len(w._local_active) == 2
+        same_epic = w._local_active[1].same_epic_pair
+        assert same_epic is True
+
+    def test_same_epic_pair_false_for_different_parent(self, tmp_path: Path) -> None:
+        """When candidate parent does not match any active worker's parent,
+        same_epic_pair=False."""
+        active_manifest = make_manifest(
+            ticket_id="WOR-100",
+            epic_id="EPIC-A",
+            allowed_paths=["app/core/y.py"],
+        )
+        active_worker = ActiveWorker(
+            ticket_id="WOR-100",
+            linear_id="fake-linear-id-100",
+            manifest=active_manifest,
+            worktree_path=tmp_path / "worktree_100",
+            process=MagicMock(spec=subprocess.Popen),
+        )
+
+        linear_mock = MagicMock()
+
+        w = Watcher(
+            linear_client=linear_mock,
+            repo_root=tmp_path,
+            max_local_workers=8,
+        )
+        w._local_active = [active_worker]
+
+        ticket = _regular_ticket("DIFF", priority=2, parent_id="EPIC-B")
+        linear_mock.get_open_blockers.return_value = []
+        linear_mock.list_ready_for_local.return_value = [ticket]
+
+        candidate = {
+            "id": "linear-id-diff",
+            "identifier": "DIFF",
+            "parent": {"id": "EPIC-B"},
+            "labels": {"nodes": []},
+        }
+        manifest = _make_manifest_kw(
+            ticket_id="DIFF",
+            epic_id="EPIC-B",
+            allowed_paths=["app/core/d.py"],
+        )
+
+        linear_mock.get_open_blockers.return_value = []
+        load_counts: dict[str, int] = {}
+
+        def capture_load(ticket_id: str) -> ExecutionManifest:
+            load_counts[ticket_id] = load_counts.get(ticket_id, 0) + 1
+            return manifest
+
+        fake_process = MagicMock(spec=subprocess.Popen)
+
+        with (
+            patch.object(w, "_load_manifest", side_effect=capture_load),
+            patch("app.core.watcher.dispatch.create_worktree", return_value=tmp_path),
+            patch("app.core.watcher.dispatch.copy_manifest_to_worktree"),
+            patch("app.core.watcher.dispatch.write_worker_pytest_config"),
+            patch("app.core.watcher.dispatch.safe_set_state"),
+            patch("app.core.watcher.dispatch.backup_plan_files", return_value=[]),
+            patch(
+                "app.core.watcher.dispatch.launch_worker",
+                return_value=fake_process,
+            ),
+            patch.object(w._services, "ensure_vllm_anthropic_mode"),
+            patch.object(w._services, "probe_vllm_health", return_value=True),
+        ):
+            w._start_ticket("DIFF", "linear-id-diff", candidate=candidate)
+
+        assert len(w._local_active) == 2
+        same_epic = w._local_active[1].same_epic_pair
+        assert same_epic is False
+
+    def test_same_epic_pair_false_when_no_active_workers(self, tmp_path: Path) -> None:
+        """When no active workers exist, same_epic_pair=False even if the
+        candidate has a parent."""
+        linear_mock = MagicMock()
+
+        w = Watcher(
+            linear_client=linear_mock,
+            repo_root=tmp_path,
+            max_local_workers=8,
+        )
+        w._local_active = []  # empty pool
+
+        ticket = _regular_ticket("NOPE", priority=2, parent_id="EPIC-A")
+        linear_mock.get_open_blockers.return_value = []
+        linear_mock.list_ready_for_local.return_value = [ticket]
+
+        candidate = {
+            "id": "linear-id-nope",
+            "identifier": "NOPE",
+            "parent": {"id": "EPIC-A"},
+            "labels": {"nodes": []},
+        }
+        manifest = _make_manifest_kw(
+            ticket_id="NOPE",
+            epic_id="EPIC-A",
+            allowed_paths=["app/core/n.py"],
+        )
+
+        linear_mock.get_open_blockers.return_value = []
+        load_counts: dict[str, int] = {}
+
+        def capture_load(ticket_id: str) -> ExecutionManifest:
+            load_counts[ticket_id] = load_counts.get(ticket_id, 0) + 1
+            return manifest
+
+        fake_process = MagicMock(spec=subprocess.Popen)
+
+        with (
+            patch.object(w, "_load_manifest", side_effect=capture_load),
+            patch("app.core.watcher.dispatch.create_worktree", return_value=tmp_path),
+            patch("app.core.watcher.dispatch.copy_manifest_to_worktree"),
+            patch("app.core.watcher.dispatch.write_worker_pytest_config"),
+            patch("app.core.watcher.dispatch.safe_set_state"),
+            patch("app.core.watcher.dispatch.backup_plan_files", return_value=[]),
+            patch(
+                "app.core.watcher.dispatch.launch_worker",
+                return_value=fake_process,
+            ),
+            patch.object(w._services, "ensure_vllm_anthropic_mode"),
+            patch.object(w._services, "probe_vllm_health", return_value=True),
+        ):
+            w._start_ticket("NOPE", "linear-id-nope", candidate=candidate)
+
+        assert len(w._local_active) == 1
+        same_epic = w._local_active[0].same_epic_pair
+        assert same_epic is False
+
+    def test_same_epic_pair_false_when_no_candidate(self, tmp_path: Path) -> None:
+        """When candidate is None, same_epic_pair=False."""
+        active_manifest = make_manifest(
+            ticket_id="WOR-100",
+            epic_id="EPIC-A",
+            allowed_paths=["app/core/y.py"],
+        )
+        active_worker = ActiveWorker(
+            ticket_id="WOR-100",
+            linear_id="fake-linear-id-100",
+            manifest=active_manifest,
+            worktree_path=tmp_path / "worktree_100",
+            process=MagicMock(spec=subprocess.Popen),
+        )
+
+        linear_mock = MagicMock()
+
+        w = Watcher(
+            linear_client=linear_mock,
+            repo_root=tmp_path,
+            max_local_workers=8,
+        )
+        w._local_active = [active_worker]
+
+        ticket = _regular_ticket("NOCAND", priority=2, parent_id="EPIC-A")
+        linear_mock.get_open_blockers.return_value = []
+        linear_mock.list_ready_for_local.return_value = [ticket]
+
+        manifest = _make_manifest_kw(
+            ticket_id="NOCAND",
+            epic_id="EPIC-A",
+            allowed_paths=["app/core/c.py"],
+        )
+
+        linear_mock.get_open_blockers.return_value = []
+        load_counts: dict[str, int] = {}
+
+        def capture_load(ticket_id: str) -> ExecutionManifest:
+            load_counts[ticket_id] = load_counts.get(ticket_id, 0) + 1
+            return manifest
+
+        fake_process = MagicMock(spec=subprocess.Popen)
+
+        with (
+            patch.object(w, "_load_manifest", side_effect=capture_load),
+            patch("app.core.watcher.dispatch.create_worktree", return_value=tmp_path),
+            patch("app.core.watcher.dispatch.copy_manifest_to_worktree"),
+            patch("app.core.watcher.dispatch.write_worker_pytest_config"),
+            patch("app.core.watcher.dispatch.safe_set_state"),
+            patch("app.core.watcher.dispatch.backup_plan_files", return_value=[]),
+            patch(
+                "app.core.watcher.dispatch.launch_worker",
+                return_value=fake_process,
+            ),
+            patch.object(w._services, "ensure_vllm_anthropic_mode"),
+            patch.object(w._services, "probe_vllm_health", return_value=True),
+        ):
+            # Pass candidate=None — same_epic_pair must be False
+            w._start_ticket("NOCAND", "linear-id-nocand", candidate=None)
+
+        assert len(w._local_active) == 2
+        same_epic = w._local_active[1].same_epic_pair
+        assert same_epic is False


### PR DESCRIPTION
Closes WOR-220

Picker sort key implemented with concurrency=1 invariant guard. same_epic_pair column added via _migrate. dispatch.start_ticket populates it. Unit tests cover all three scenarios. All checks pass.