### PR TITLE
WOR-441 retry_count column not incremented on in-dispatch retry (re-dispatch)

### DIFF
--- a/app/core/watcher/watcher_finalize.py
+++ b/app/core/watcher/watcher_finalize.py
@@ -250,6 +250,7 @@ def _run_retry_loop(
                 project_id=project_id,
             )
         )
+        worker.attempt_count += 1
         if not failed_checks:
             return (
                 outcome,
@@ -480,7 +481,7 @@ def finalize_worker(
             output_tokens_per_wall_second=cost["output_tokens_per_wall_second"],
             escalated_to_cloud=escalated,
             outcome=outcome,
-            retry_count=worker.attempt_count,
+            retry_count=worker.attempt_count - 1,
             context_compactions=context_compactions,
             check_failures=check_failures,
             lines_changed=lines_changed,

--- a/app/core/watcher/watcher_finalize_helpers.py
+++ b/app/core/watcher/watcher_finalize_helpers.py
@@ -168,8 +168,6 @@ def _execute_finalization(
         ticket_id=ticket_id,
         project_id=project_id,
     )
-    if not checks_ok:
-        worker.attempt_count += 1
     if not checks_ok and manifest.failure_policy.on_check_failure == "abort":
         escalated = _record_failure_state(
             worker,

--- a/tests/test_watcher_finalize.py
+++ b/tests/test_watcher_finalize.py
@@ -850,7 +850,7 @@ def test_finalize_worker_no_retry_when_max_retries_zero(
     ):
         _call_finalize(worker)
 
-    # No retry happened — attempt_count reflects the check failure
+    # No retry happened — attempt_count is 1 from the first loop iteration
     assert worker.attempt_count == 1
     # Verify launch_worker was NOT called (no retry happened)
     mock_launch.assert_not_called()
@@ -898,15 +898,16 @@ def test_finalize_worker_single_retry_then_success(
     ):
         _call_finalize(worker)
 
-    # After 2 calls (1 failure + 1 success), attempt_count=1.
-    # The break check sees 1 >= 1 = True, but success breaks first.
-    assert worker.attempt_count == 1
+    # After 2 calls (1 failure + 1 success), attempt_count=2 (one per loop iteration).
+    # The break check 2 > 1 = True, but success breaks first.
+    assert worker.attempt_count == 2
 
 
 def test_finalize_worker_hardcap_enforces_max_one_retry(
     tmp_path: Path,
 ) -> None:
-    """max_retries=5 but hardcapped at 1 — only one retry despite 5 budget."""
+    """max_retries=5 but hardcapped at 1 — only one retry despite 5 budget.
+    attempt_count increments at every loop iteration, so 2 iterations = 2."""
     manifest = make_manifest(
         ticket_id="WOR-10",
         worker_branch="wor-10-test",
@@ -920,7 +921,7 @@ def test_finalize_worker_hardcap_enforces_max_one_retry(
         process=MagicMock(spec=subprocess.Popen),
     )
 
-    # 2 failures: first call fails, retry succeeds on second call.
+    # 2 iterations: first fails, second succeeds.
     # With max_retries=5 and hardcap=1, max actual retries = min(5,1) = 1.
     check_results = [
         (False, [{"check": "ruff check .", "exit_code": 1}]),
@@ -944,7 +945,7 @@ def test_finalize_worker_hardcap_enforces_max_one_retry(
     ):
         _call_finalize(worker)
 
-    assert worker.attempt_count == 1
+    assert worker.attempt_count == 2
 
 
 def test_finalize_worker_retry_injects_extra_constraint(
@@ -1076,4 +1077,4 @@ def test_finalize_worker_no_retry_when_check_passes(
     ):
         _call_finalize(worker)
 
-    assert worker.attempt_count == 0
+    assert worker.attempt_count == 1


### PR DESCRIPTION
Closes WOR-441

wip commit acd36c4 verified correct, .quality_check_count file dropped from final commit, full unscoped pytest passes, all 4 required_checks pass. result.json lists exact required_checks names. No files outside allowed_paths in the final commit.