### PR TITLE
WOR-351 Watcher: finalize_worker:252 nulls valid waste_score=0

### DIFF
--- a/app/core/post_setup.py
+++ b/app/core/post_setup.py
@@ -291,7 +291,7 @@ def create_github_repo(
 
     Args:
         repo_name: Desired repository name (must be unique for the authenticated user).
-        prefs: User preferences (currently unused; retained for API compatibility).
+
         private: Whether the repository should be private. Defaults to ``True``.
         description: Optional repository description.
 
@@ -299,7 +299,7 @@ def create_github_repo(
         The HTML clone URL (e.g. ``https://github.com/owner/repo``).
 
     Example:
-        >>> create_github_repo("my-repo", prefs)  # doctest: +SKIP
+        >>> create_github_repo("my-repo")  # doctest: +SKIP
     """
     token = get_token()
     if token is None:

--- a/app/core/watcher/watcher_finalize.py
+++ b/app/core/watcher/watcher_finalize.py
@@ -445,10 +445,12 @@ def finalize_worker(
     cost = _build_cost_metrics(eff, input_tokens, output_tokens, wall_time)
 
     # Compute waste score from the worker log (WOR-277).
+    # WOR-351: always record waste_score (0 = clean run, not NULL).
+    #           only null breakdown_json when the dict is empty.
     waste_report = compute_waste_score(log_path)
-    waste_score: int | None = waste_report.score if waste_report.score > 0 else None
+    waste_score: int | None = waste_report.score
     waste_breakdown_json: str | None = (
-        json.dumps(waste_report.breakdown) if waste_report.score > 0 else None
+        json.dumps(waste_report.breakdown) if waste_report.breakdown else None
     )
     _warn_high_waste(worker.ticket_id, waste_score, waste_report)
 

--- a/tests/test_watcher_finalize.py
+++ b/tests/test_watcher_finalize.py
@@ -1276,3 +1276,57 @@ def test_finalize_worker_e2e_behavior_from_worker_log(tmp_path: Path) -> None:
     assert m.turn_count is not None
     assert m.tool_calls_total is not None
     assert m.thinking_blocks is not None
+
+
+# ---------------------------------------------------------------------------
+# WOR-351: waste_score=0 recorded (not NULL), breakdown_json NULL when empty
+# ---------------------------------------------------------------------------
+
+
+def test_finalize_worker_waste_score_zero_not_null(tmp_path: Path) -> None:
+    """waste_score column receives the actual score even when 0.
+
+    A clean run (no waste signals) produces score=0; the metrics row must
+    store 0, not NULL, so dashboards can distinguish "measured 0 = clean"
+    from "not measured = NULL".
+    """
+    manifest = make_manifest(ticket_id="WOR-351", worker_branch="wor-351-test")
+    metrics_mock = MagicMock()
+
+    # Minimal log with zero waste signals -> compute_waste_score returns 0.
+    log_dir = tmp_path / ".claude"
+    log_dir.mkdir(parents=True)
+    log_file = log_dir / "worker_wor-351.log"
+    log_file.write_text(
+        json.dumps(
+            {"type": "result", "usage": {"input_tokens": 100, "output_tokens": 50}}
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    worker = ActiveWorker(
+        ticket_id="WOR-351",
+        linear_id="fake-linear-id",
+        manifest=manifest,
+        worktree_path=tmp_path,
+        process=MagicMock(spec=subprocess.Popen),
+    )
+
+    with (
+        patch(
+            "app.core.watcher.watcher_finalize_helpers.run_checks",
+            return_value=(True, []),
+        ),
+        patch(
+            "app.core.watcher.watcher_finalize.create_pr",
+            return_value="https://gh/pr/1",
+        ),
+        patch("app.core.watcher.watcher_finalize.cleanup_worktree"),
+    ):
+        _call_finalize(worker, metrics=metrics_mock)
+
+    m = metrics_mock.record.call_args[0][0]
+    assert m.waste_score == 0
+    # When breakdown dict is empty, waste_breakdown_json should stay NULL.
+    assert m.waste_breakdown_json is None


### PR DESCRIPTION
Closes WOR-351

watcher_finalize.py records waste_score=0 (not NULL) when measured-as-zero; only nulls breakdown when empty. Unit test covers the 0 path. All checks pass.