### PR TITLE
WOR-459 Delete pytest.ini — pyproject.toml is the pytest config source of truth

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,0 @@
-[pytest]
-addopts = --tb=short


### PR DESCRIPTION
## Summary

Delete the tracked `pytest.ini` at repo root. It silently overrode `[tool.pytest.ini_options]` in `pyproject.toml` and was the root cause of the WOR-66 + WOR-428 finalize failures during the WOR-446 bundle dispatch.

## What broke

`pytest.ini` (2 lines) shadows pyproject's pytest config completely:

```ini
[pytest]
addopts = --tb=short
```

Every pytest invocation in the repo was silently running with this minimal config — `--cov=app`, `--cov-fail-under=80`, and `testpaths = ["tests"]` from `pyproject.toml` were all dropped, with the only signal being a one-line warning `WARNING: ignoring pytest config in pyproject.toml!` in pytest's header.

## Verification

After deletion, `pytest --tb=short -q` reports:

```
1791 passed, 23 warnings in 126.38s
Required test coverage of 80% reached. Total coverage: 91.37%
```

Coverage gate is now active (was silently disabled) and passing. ruff + mypy + lint-imports all clean.

## Notes

- The `--tb=short` flag was cosmetic; can be passed per-invocation where needed.
- Three tests that flaked in the WOR-446 epic close (`tests/test_watcher_gestures.py::test_forcestop_when_daemon_not_running` etc.) now pass — they were failing only because the live watcher daemon was leaking real PID-file state into the test environment, not because of pytest.ini. With the daemon stopped, they're green.
- WOR-453 (pytest --cov audit) gets resolved as a side-effect; the audit's question of "is --cov silently enabled everywhere?" turns out to be the opposite — `--cov` was silently *disabled* everywhere by pytest.ini's override.

## Test plan

- [x] `pytest --tb=short -q` — 1791 passed, 91.37% coverage (>= 80% gate)
- [x] `ruff check .` — clean
- [x] `mypy app/` — clean
- [x] `lint-imports` — 8/8 contracts kept
- [x] No `pyproject.toml` warning in pytest header

Closes WOR-459
Closes WOR-453
