### PR TITLE
WOR-455 Enforce allowed_paths post-write + gitignore .claude/.quality_check_count

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,9 @@ litellm-local.yaml
 # Claude Code hook state (per-session, machine-generated)
 .claude/.read_counts.json
 
+# Claude Code quality-check budget counter (per-session, machine-generated)
+.claude/.quality_check_count
+
 # Forensic log dumps under retros/ (raw worker logs + manifests captured during
 # post-mortem analysis). The retro markdown itself is committed; raw evidence
 # lives in private gists or Linear attachments instead.

--- a/app/core/watcher/watcher_finalize.py
+++ b/app/core/watcher/watcher_finalize.py
@@ -27,7 +27,9 @@ from .watcher_finalize_helpers import (
     ATTEMPT_HARDCAP,
     _execute_finalization,
     _read_result_status,
+    _record_failure_state,
     _try_post_comment,
+    _validate_allowed_paths,
     _write_wip_sha_to_last_failure,
     _write_wip_state_to_last_failure,
     safe_set_state,
@@ -403,6 +405,30 @@ def finalize_worker(
     tracked_prs: list[TrackedPR] | None = None,
 ) -> Outcome:
     eff = resolve_effective_mode(mode, worker.manifest.implementation_mode)
+
+    # Validate that the worker only touched allowed_paths / did not touch
+    # forbidden_paths.  Run BEFORE the retry loop — violations are a scope
+    # failure, not a transient check failure, so retries won't help.
+    violations = _validate_allowed_paths(
+        worker.manifest,
+        worker.worktree_path,
+    )
+    if violations:
+        comment = (
+            f"Allowed-paths enforcement failed for `{worker.ticket_id}`. "
+            f"The worker diff touched files outside the declared scope:\n\n"
+            f"```\n" + "\n".join(violations) + "\n```\n\n"
+            f"Manifest allowed: `{worker.manifest.allowed_paths}`. "
+            f"Forbidden: `{worker.manifest.forbidden_paths}`. "
+            f"PR creation aborted."
+        )
+        _record_failure_state(
+            worker,
+            linear,
+            f"allowed_paths violation — {len(violations)} file(s) outside scope",
+        )
+        _try_post_comment(linear, worker.linear_id, worker.ticket_id, comment)
+        return "failure"
 
     # WOR-312: in-dispatch retry loop. Helper avoids the slower Linear
     # Blocked -> ReadyForLocal redispatch when checks transiently fail.

--- a/app/core/watcher/watcher_finalize_helpers.py
+++ b/app/core/watcher/watcher_finalize_helpers.py
@@ -7,8 +7,10 @@ them through the re-exports in watcher_finalize.py.
 
 from __future__ import annotations
 
+import fnmatch
 import json
 import logging
+import subprocess  # nosec B404
 import time
 from pathlib import Path
 from typing import Callable
@@ -47,6 +49,62 @@ logger = logging.getLogger(__name__)
 # failure_policy.max_retries. A value of 1 means: initial attempt + 1 retry.
 # Higher values from manifest are silently capped.
 ATTEMPT_HARDCAP = 1
+
+
+def _validate_allowed_paths(
+    manifest: ExecutionManifest,
+    worktree_path: Path,
+) -> list[str]:
+    """Validate the worker diff against allowed_paths and forbidden_paths.
+
+    Runs ``git diff --name-only <base_branch>...HEAD`` inside the worktree,
+    then matches each changed file against the manifest's ``allowed_paths``
+    and ``forbidden_paths`` globs using ``fnmatch``.
+
+    Returns a list of violation strings.  Empty list means the diff is clean
+    and the PR path is safe to continue.  Each violation is tagged with
+    ``ALLOWED`` or ``FORBIDDEN`` for easy display in a Linear comment.
+    """
+    violations: list[str] = []
+
+    # Get the list of changed files since the merge-base.
+    try:
+        diff_proc = subprocess.run(  # nosec B603 B607
+            [
+                "git",
+                "-C",
+                str(worktree_path),
+                "diff",
+                "--name-only",
+                f"{manifest.base_branch}...HEAD",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        files = (diff_proc.stdout or "").strip().splitlines()
+    except (OSError, subprocess.TimeoutExpired):
+        # If we can't read the diff, allow it — a git error is not a scope
+        # violation. The finalize checks (ruff/mypy/pytest) will still catch
+        # most problems.
+        return []
+
+    # Check against forbidden_paths first (they override).
+    if manifest.forbidden_paths:
+        for fpath in files:
+            for pattern in manifest.forbidden_paths:
+                if fnmatch.fnmatch(fpath, pattern):
+                    violations.append(f"FORBIDDEN {fpath}")
+                    break  # one match per file is enough
+
+    # Check against allowed_paths.  Empty list = no restriction (anything goes).
+    if manifest.allowed_paths:
+        for fpath in files:
+            if any(fnmatch.fnmatch(fpath, pat) for pat in manifest.allowed_paths):
+                continue  # file matches an allowed pattern
+            violations.append(f"ALLOWED {fpath}")
+
+    return violations
 
 
 def safe_set_state(

--- a/tests/test_watcher_finalize.py
+++ b/tests/test_watcher_finalize.py
@@ -1330,3 +1330,118 @@ def test_finalize_worker_waste_score_zero_not_null(tmp_path: Path) -> None:
     assert m.waste_score == 0
     # When breakdown dict is empty, waste_breakdown_json should stay NULL.
     assert m.waste_breakdown_json is None
+
+
+# ---------------------------------------------------------------------------
+# WOR-455: allowed-paths enforcement
+# ---------------------------------------------------------------------------
+
+
+def test_finalize_worker_allowed_paths_clean_proceeds(
+    tmp_path: Path,
+) -> None:
+    """No diff files → no violations → PR proceeds normally."""
+    manifest = make_manifest(
+        ticket_id="WOR-455",
+        worker_branch="wor-455-test",
+        allowed_paths=["app/core/watcher/watcher_finalize.py"],
+        forbidden_paths=["app/ui/**"],
+    )
+    metrics_mock = MagicMock()
+    worker = ActiveWorker(
+        ticket_id="WOR-455",
+        linear_id="fake-linear-id",
+        manifest=manifest,
+        worktree_path=tmp_path,
+        process=MagicMock(spec=subprocess.Popen),
+    )
+
+    with (
+        patch(
+            "app.core.watcher.watcher_finalize._validate_allowed_paths",
+            return_value=[],
+        ),
+        patch(
+            "app.core.watcher.watcher_finalize_helpers.run_checks",
+            return_value=(True, []),
+        ),
+        patch(
+            "app.core.watcher.watcher_finalize.create_pr",
+            return_value="https://github.com/example/pr/1",
+        ),
+        patch("app.core.watcher.watcher_finalize.cleanup_worktree"),
+    ):
+        _call_finalize(worker, metrics=metrics_mock)
+
+    metrics_mock.record.assert_called_once()
+    m = metrics_mock.record.call_args[0][0]
+    assert m.outcome == "success"
+    assert m.escalated_to_cloud is False
+
+
+def test_finalize_worker_allowed_path_violation_marks_blocked(
+    tmp_path: Path,
+) -> None:
+    """Worker diff touches a file NOT in allowed_paths → Blocked + comment."""
+    manifest = make_manifest(
+        ticket_id="WOR-455",
+        worker_branch="wor-455-test",
+        allowed_paths=["app/core/watcher/watcher_finalize.py"],
+        forbidden_paths=["app/ui/**"],
+    )
+    linear_mock = MagicMock()
+    worker = ActiveWorker(
+        ticket_id="WOR-455",
+        linear_id="fake-linear-id",
+        manifest=manifest,
+        worktree_path=tmp_path,
+        process=MagicMock(spec=subprocess.Popen),
+    )
+
+    with (
+        patch(
+            "app.core.watcher.watcher_finalize._validate_allowed_paths",
+            return_value=["ALLOWED app/core/ui/widget.py"],
+        ),
+    ):
+        _call_finalize(worker, linear=linear_mock)
+
+    # PR should NOT be attempted — we never call create_pr
+    linear_mock.set_state.assert_called_with("fake-linear-id", "Blocked")
+    comment_body: str = linear_mock.post_comment.call_args[0][1]
+    assert "WOR-455" in comment_body
+    assert "ALLOWED app/core/ui/widget.py" in comment_body
+    assert "PR creation aborted" in comment_body
+
+
+def test_finalize_worker_forbidden_path_violation_marks_blocked(
+    tmp_path: Path,
+) -> None:
+    """Worker diff touches a forbidden path → Blocked + FORBIDDEN tag."""
+    manifest = make_manifest(
+        ticket_id="WOR-455",
+        worker_branch="wor-455-test",
+        allowed_paths=["app/core/watcher/watcher_finalize.py"],
+        forbidden_paths=["app/ui/**"],
+    )
+    linear_mock = MagicMock()
+    worker = ActiveWorker(
+        ticket_id="WOR-455",
+        linear_id="fake-linear-id",
+        manifest=manifest,
+        worktree_path=tmp_path,
+        process=MagicMock(spec=subprocess.Popen),
+    )
+
+    with (
+        patch(
+            "app.core.watcher.watcher_finalize._validate_allowed_paths",
+            return_value=["FORBIDDEN app/ui/widget.py"],
+        ),
+    ):
+        _call_finalize(worker, linear=linear_mock)
+
+    linear_mock.set_state.assert_called_with("fake-linear-id", "Blocked")
+    comment_body: str = linear_mock.post_comment.call_args[0][1]
+    assert "FORBIDDEN app/ui/widget.py" in comment_body
+    assert "PR creation aborted" in comment_body

--- a/tests/test_watcher_finalize_metrics.py
+++ b/tests/test_watcher_finalize_metrics.py
@@ -650,6 +650,8 @@ def _finalize_with_real_diff(repo: Path, ticket_id: str = "WOR-354") -> object:
         ticket_id=ticket_id,
         worker_branch="worker",
         base_branch="epic",
+        allowed_paths=[],
+        forbidden_paths=[],
     )
     metrics_mock = MagicMock()
     worker = ActiveWorker(


### PR DESCRIPTION
Closes WOR-455

_validate_allowed_paths exists and is called before attempt_pr. .gitignore covers .claude/.quality_check_count. Unit tests for clean / allowed-violation / forbidden-violation all pass. Full pytest passes. All 4 required_checks pass.