### PR TITLE
WOR-463 PostToolUse hooks: ruff first, then mypy/bandit/lint-imports in parallel

### DIFF
--- a/.claude/hooks/posttooluse_parallel.py
+++ b/.claude/hooks/posttooluse_parallel.py
@@ -1,0 +1,125 @@
+"""PostToolUse: ruff first (mutates), then mypy/bandit/lint-imports in parallel.
+
+Replaces four sequential PostToolUse hooks in `.claude/settings.json` for
+`Edit|Write` of any `*.py` file. Cuts per-edit hook latency from ~3-5s to
+~slowest-single-tool wall (typically ~1-2s with cold mypy, ~500ms once
+WOR-452's dmypy lands).
+
+Phasing:
+  Phase 1 (sequential): ruff check --fix, ruff format — both mutate the
+                         file, so they must finish before readers run.
+  Phase 2 (parallel):    mypy, bandit, lint-imports — pure readers.
+
+Exit-code semantics (preserves the pre-WOR-463 per-hook behavior):
+  - ruff failure -> non-zero exit (matches the old `ruff check --fix &&
+    ruff format` chain).
+  - mypy/bandit/lint-imports failure -> short message printed, exit code
+    unaffected (matches the old `<tool> ... || echo "[tool] ..."` pattern
+    that always returned 0).
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess  # nosec B404
+import sys
+from concurrent.futures import Future, ThreadPoolExecutor
+from pathlib import Path
+from typing import Callable
+
+
+def _run(cmd: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(  # nosec B603
+        cmd,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _phase1_ruff(file_path: str) -> int:
+    """Run ruff check + format sequentially. Returns the worst exit code."""
+    if shutil.which("ruff") is None:
+        return 0
+    check = _run(["ruff", "check", "--fix", file_path])
+    fmt = _run(["ruff", "format", file_path])
+    if check.stdout:
+        sys.stdout.write(check.stdout)
+    if check.stderr:
+        sys.stderr.write(check.stderr)
+    if fmt.stdout:
+        sys.stdout.write(fmt.stdout)
+    if fmt.stderr:
+        sys.stderr.write(fmt.stderr)
+    return check.returncode or fmt.returncode
+
+
+def _phase2_mypy(file_path: str) -> str | None:
+    if shutil.which("mypy") is None:
+        return None
+    proc = _run(["mypy", file_path])
+    if proc.returncode != 0:
+        return f"[mypy] Type errors in {file_path}"
+    return None
+
+
+def _phase2_bandit(file_path: str) -> str | None:
+    if shutil.which("bandit") is None:
+        return None
+    proc = _run(["bandit", "-q", file_path])
+    if proc.returncode != 0:
+        return "[bandit] Issues found - run /security-check"
+    return None
+
+
+def _phase2_lint_imports(_file_path: str) -> str | None:
+    if shutil.which("lint-imports") is None:
+        return None
+    proc = _run(["lint-imports"])
+    if proc.returncode != 0:
+        return (
+            "[import-linter] Architecture contract violation - "
+            "run lint-imports for details"
+        )
+    return None
+
+
+# Stable output order for phase 2 results.
+_PHASE2: tuple[tuple[str, Callable[[str], str | None]], ...] = (
+    ("mypy", _phase2_mypy),
+    ("bandit", _phase2_bandit),
+    ("lint-imports", _phase2_lint_imports),
+)
+
+
+def run(file_path: str) -> int:
+    """Entry point. Returns ruff exit code; phase 2 failures only log."""
+    if not file_path.endswith(".py"):
+        return 0
+    if not Path(file_path).exists():
+        return 0
+
+    ruff_rc = _phase1_ruff(file_path)
+
+    with ThreadPoolExecutor(max_workers=len(_PHASE2)) as ex:
+        futures: dict[str, Future[str | None]] = {
+            name: ex.submit(fn, file_path) for name, fn in _PHASE2
+        }
+        # Drain in declaration order so output is stable, not interleaved.
+        for name, _ in _PHASE2:
+            msg = futures[name].result()
+            if msg:
+                print(msg)
+    return ruff_rc
+
+
+def main() -> int:
+    file_path = os.environ.get("CLAUDE_TOOL_INPUT_FILE_PATH", "")
+    if not file_path:
+        return 0
+    return run(file_path)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -71,34 +71,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "FILE=\"$CLAUDE_TOOL_INPUT_FILE_PATH\"; if [[ \"$FILE\" == *.py ]]; then ruff check --fix \"$FILE\" && ruff format \"$FILE\"; fi"
-          }
-        ]
-      },
-      {
-        "matcher": "Edit|Write",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "FILE=\"$CLAUDE_TOOL_INPUT_FILE_PATH\"; if [[ \"$FILE\" == *.py ]]; then mypy \"$FILE\" 2>/dev/null || echo \"[mypy] Type errors in $FILE\"; fi"
-          }
-        ]
-      },
-      {
-        "matcher": "Edit|Write",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "FILE=\"$CLAUDE_TOOL_INPUT_FILE_PATH\"; if [[ \"$FILE\" == *.py ]] && command -v bandit >/dev/null 2>&1; then bandit -q \"$FILE\" 2>/dev/null || echo \"[bandit] Issues found \u00e2\u20ac\u201d run /security-check\"; fi"
-          }
-        ]
-      },
-      {
-        "matcher": "Edit|Write",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "FILE=\"$CLAUDE_TOOL_INPUT_FILE_PATH\"; if [[ \"$FILE\" == *.py ]] && command -v lint-imports >/dev/null 2>&1; then lint-imports 2>/dev/null || echo \"[import-linter] Architecture contract violation \u00e2\u20ac\u201d run lint-imports for details\"; fi"
+            "command": "FILE=\"$CLAUDE_TOOL_INPUT_FILE_PATH\"; if [[ \"$FILE\" == *.py ]]; then python .claude/hooks/posttooluse_parallel.py; fi"
           }
         ]
       },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -281,11 +281,8 @@ The informational scan runs on `github.base_ref != 'main'`; the blocking scan ru
 
 `.claude/settings.json` ships with hooks that run automatically:
 
-- **PostToolUse** — ruff lint + format after any Python file edit
-- **PostToolUse** — mypy type-check on the edited file after any Python file edit
-- **PostToolUse** — bandit security scan after any Python file edit (if bandit is installed)
-- **PostToolUse** — `lint-imports` architecture contract check after any Python file edit
-- **PostToolUse** — pytest (no coverage) on the edited test file after changes to `tests/` files only
+- **PostToolUse** — `.claude/hooks/posttooluse_parallel.py` runs ruff lint+format first (sequential, mutator phase) then mypy + bandit + lint-imports concurrently (WOR-463). Cuts per-edit wall from ~0.6s warm / ~5.4s cold to ~0.3s warm / ~2.4s cold (2× speedup).
+- **PostToolUse** — pytest (no coverage, no xdist) on the edited test file after changes to `tests/` files only
 - **PreToolUse** — blocks destructive shell commands and writes to sensitive files (`.env`, `.mcp.json`, `.claude/settings*`)
 
 `.pre-commit-config.yaml` uses a **tiered split** — fast checks at `pre-commit`, slow checks at `pre-push` — to keep local commit latency under 3 seconds. The latency investigation (WOR-242) measured per-hook durations on a clean tree: semgrep 7.5s, mypy 1.35s, detect-secrets 1.12s, bandit 0.41s, the rest <0.5s. CI runs the full set plus pytest, deptry, and SonarCloud.
@@ -294,7 +291,7 @@ The informational scan runs on `github.base_ref != 'main'`; the blocking scan ru
 
 **Slow tier (pre-push):** mypy 1.35s, semgrep 7.5s.
 
-**PostToolUse hooks** (Claude Code only): ruff, mypy, bandit, lint-imports after any Python file edit; pytest on edited test files. These are separate from the pre-commit config — they run per-tool-use to give immediate feedback during implementation.
+**PostToolUse hooks** (Claude Code only): a single consolidated runner (`.claude/hooks/posttooluse_parallel.py`) executes ruff lint+format first (mutator phase, sequential) then mypy + bandit + lint-imports concurrently after any Python file edit; pytest on edited test files. These are separate from the pre-commit config — they run per-tool-use to give immediate feedback during implementation.
 
 ---
 

--- a/tests/test_hooks_posttooluse_parallel.py
+++ b/tests/test_hooks_posttooluse_parallel.py
@@ -1,0 +1,204 @@
+"""Tests for .claude/hooks/posttooluse_parallel.py (WOR-463).
+
+Asserts:
+  - All four tools (ruff check, ruff format, mypy, bandit, lint-imports)
+    are invoked for a .py file.
+  - Phase 2 (mypy/bandit/lint-imports) runs concurrently, not serially:
+    wall time is bounded by the slowest single tool, not the sum.
+  - Output order is stable (mypy, bandit, lint-imports), not interleaved.
+  - Exit code matches ruff's exit code (phase 1 mutator semantics preserved).
+  - Non-.py files are skipped silently with exit 0.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# Load the hook script as a module without registering it in tests/.
+_HOOK_PATH = (
+    Path(__file__).parent.parent / ".claude" / "hooks" / "posttooluse_parallel.py"
+)
+_spec = importlib.util.spec_from_file_location("posttooluse_parallel", _HOOK_PATH)
+assert _spec is not None and _spec.loader is not None
+posttooluse_parallel = importlib.util.module_from_spec(_spec)
+sys.modules["posttooluse_parallel"] = posttooluse_parallel
+_spec.loader.exec_module(posttooluse_parallel)
+
+
+def _make_proc(
+    returncode: int = 0, stdout: str = "", stderr: str = ""
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(
+        args=[], returncode=returncode, stdout=stdout, stderr=stderr
+    )
+
+
+def test_skips_non_python_files(tmp_path: Path) -> None:
+    f = tmp_path / "notes.md"
+    f.write_text("hello")
+    with patch.object(posttooluse_parallel, "_run") as mock_run:
+        rc = posttooluse_parallel.run(str(f))
+    assert rc == 0
+    mock_run.assert_not_called()
+
+
+def test_skips_missing_files(tmp_path: Path) -> None:
+    f = tmp_path / "missing.py"
+    # File does not exist on disk.
+    with patch.object(posttooluse_parallel, "_run") as mock_run:
+        rc = posttooluse_parallel.run(str(f))
+    assert rc == 0
+    mock_run.assert_not_called()
+
+
+def test_invokes_all_four_tools(tmp_path: Path) -> None:
+    f = tmp_path / "thing.py"
+    f.write_text("x = 1\n")
+    with patch.object(
+        posttooluse_parallel, "_run", return_value=_make_proc(0)
+    ) as mock_run:
+        with patch.object(
+            posttooluse_parallel.shutil, "which", return_value="/usr/bin/x"
+        ):
+            rc = posttooluse_parallel.run(str(f))
+    assert rc == 0
+    invoked_cmds = [call.args[0][0] for call in mock_run.call_args_list]
+    # ruff is called twice (check then format); the three readers each once.
+    assert invoked_cmds.count("ruff") == 2
+    assert "mypy" in invoked_cmds
+    assert "bandit" in invoked_cmds
+    assert "lint-imports" in invoked_cmds
+
+
+def test_phase2_runs_concurrently(tmp_path: Path) -> None:
+    """Phase 2 wall time should be ~slowest single tool, not the sum."""
+    f = tmp_path / "thing.py"
+    f.write_text("x = 1\n")
+
+    def slow_run(cmd: list[str]) -> subprocess.CompletedProcess[str]:
+        # Each phase-2 tool sleeps 200ms. Serial = 600ms; parallel ~200ms.
+        if cmd[0] in ("mypy", "bandit", "lint-imports"):
+            time.sleep(0.2)
+        return _make_proc(0)
+
+    with patch.object(posttooluse_parallel, "_run", side_effect=slow_run):
+        with patch.object(
+            posttooluse_parallel.shutil, "which", return_value="/usr/bin/x"
+        ):
+            t0 = time.perf_counter()
+            posttooluse_parallel.run(str(f))
+            elapsed = time.perf_counter() - t0
+
+    # Phase 1 (ruff x2) returns instantly under the mock; phase 2 should take
+    # ~200ms parallel + ThreadPoolExecutor overhead. Generous ceiling 500ms
+    # (well below the 600ms serial baseline).
+    assert elapsed < 0.5, f"Phase 2 not parallel: took {elapsed:.2f}s, expected < 0.5s"
+
+
+def test_stable_output_order(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    f = tmp_path / "thing.py"
+    f.write_text("x = 1\n")
+
+    def failing_run(cmd: list[str]) -> subprocess.CompletedProcess[str]:
+        if cmd[0] in ("mypy", "bandit", "lint-imports"):
+            return _make_proc(1)  # all three fail
+        return _make_proc(0)  # ruff succeeds
+
+    with patch.object(posttooluse_parallel, "_run", side_effect=failing_run):
+        with patch.object(
+            posttooluse_parallel.shutil, "which", return_value="/usr/bin/x"
+        ):
+            posttooluse_parallel.run(str(f))
+
+    captured = capsys.readouterr()
+    out = captured.out
+    mypy_idx = out.find("[mypy]")
+    bandit_idx = out.find("[bandit]")
+    lint_idx = out.find("[import-linter]")
+    assert mypy_idx >= 0 and bandit_idx >= 0 and lint_idx >= 0
+    # Stable order: mypy < bandit < lint-imports
+    assert mypy_idx < bandit_idx < lint_idx
+
+
+def test_ruff_failure_propagates_exit_code(tmp_path: Path) -> None:
+    f = tmp_path / "thing.py"
+    f.write_text("x = 1\n")
+
+    def ruff_fails(cmd: list[str]) -> subprocess.CompletedProcess[str]:
+        if cmd[0] == "ruff":
+            return _make_proc(1)
+        return _make_proc(0)
+
+    with patch.object(posttooluse_parallel, "_run", side_effect=ruff_fails):
+        with patch.object(
+            posttooluse_parallel.shutil, "which", return_value="/usr/bin/x"
+        ):
+            rc = posttooluse_parallel.run(str(f))
+    assert rc == 1
+
+
+def test_phase2_failure_does_not_change_exit(tmp_path: Path) -> None:
+    """mypy/bandit/lint-imports failures log a message but exit code stays 0."""
+    f = tmp_path / "thing.py"
+    f.write_text("x = 1\n")
+
+    def phase2_fails(cmd: list[str]) -> subprocess.CompletedProcess[str]:
+        if cmd[0] in ("mypy", "bandit", "lint-imports"):
+            return _make_proc(1)
+        return _make_proc(0)
+
+    with patch.object(posttooluse_parallel, "_run", side_effect=phase2_fails):
+        with patch.object(
+            posttooluse_parallel.shutil, "which", return_value="/usr/bin/x"
+        ):
+            rc = posttooluse_parallel.run(str(f))
+    assert rc == 0
+
+
+def test_missing_tool_is_skipped(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """When `which` returns None for bandit, it's skipped without error."""
+    f = tmp_path / "thing.py"
+    f.write_text("x = 1\n")
+
+    def which_skip_bandit(name: str) -> str | None:
+        if name == "bandit":
+            return None
+        return f"/usr/bin/{name}"
+
+    with patch.object(posttooluse_parallel, "_run", return_value=_make_proc(0)):
+        with patch.object(
+            posttooluse_parallel.shutil, "which", side_effect=which_skip_bandit
+        ):
+            rc = posttooluse_parallel.run(str(f))
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "[bandit]" not in out
+
+
+def test_main_reads_env_var(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    f = tmp_path / "thing.py"
+    f.write_text("x = 1\n")
+    monkeypatch.setenv("CLAUDE_TOOL_INPUT_FILE_PATH", str(f))
+    with patch.object(posttooluse_parallel, "run", return_value=0) as mock_run:
+        rc = posttooluse_parallel.main()
+    assert rc == 0
+    mock_run.assert_called_once_with(str(f))
+
+
+def test_main_no_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("CLAUDE_TOOL_INPUT_FILE_PATH", raising=False)
+    with patch.object(posttooluse_parallel, "run") as mock_run:
+        rc = posttooluse_parallel.main()
+    assert rc == 0
+    mock_run.assert_not_called()


### PR DESCRIPTION
## Summary
- Replace four sequential `.claude/settings.json` PostToolUse hooks (ruff check+format, mypy, bandit, lint-imports) for `*.py` edits with one consolidated runner: `.claude/hooks/posttooluse_parallel.py`.
- ruff runs first (sequential) because it mutates the file. mypy + bandit + lint-imports run concurrently in a `ThreadPoolExecutor` afterwards.
- Output is printed in stable order (mypy, bandit, lint-imports) even though executions complete asynchronously.
- 10 unit tests in `tests/test_hooks_posttooluse_parallel.py` cover phase-2 concurrency timing, stable output, exit-code semantics, missing-tool skip, env-var entrypoint.

## Real-world benchmark

Target: `app/core/watcher/watcher_finalize.py` (large production file), 9950X3D (16C/32T), 3 iterations after warm-up.

| Scenario                       | Sequential | Parallel | Saved  | Speedup |
|--------------------------------|-----------:|---------:|-------:|--------:|
| Warm cache (mypy hot)          |     0.56s  |   0.28s  | 0.28s  |  2.00x  |
| Cold cache (first of session)  |     5.37s  |   2.42s  | 2.96s  |  2.22x  |

Per-session estimate:
- 30 edits: 3s (cold first) + 29 × 0.28s ≈ **~11s saved**
- 80 edits: 3s (cold first) + 79 × 0.28s ≈ **~25s saved**

Smaller than the ticket's original "1–3 min/session" prediction because modern ruff/mypy on a warm cache are already fast. The 2× speedup is real and consistent — and it will compound once WOR-452 (dmypy daemon) lands and dropping mypy's per-call cost makes the parallelism win a larger fraction of total wall time.

## Exit-code semantics

Preserved exactly from the old per-hook chain:
- **ruff failure** → non-zero exit (matched old `ruff check --fix && ruff format`)
- **mypy / bandit / lint-imports failure** → short log line, exit 0 (matched old `<tool> ... || echo "[tool] ..."` pattern)

This keeps worker context noise unchanged. Failures still surface as warnings; they don't block edits.

## Test plan
- [x] `ruff check .` clean
- [x] `mypy app/ .claude/hooks/posttooluse_parallel.py` — no issues (49 source files)
- [x] `pytest --no-cov -q` — 1840 passed (1830 baseline + 10 new), 44s wall
- [x] `lint-imports` — 8 contracts kept, 0 broken
- [x] Smoke test: ran the new hook on itself; observed ruff fix-up + concurrent phase 2.

## Files
- `.claude/hooks/posttooluse_parallel.py` (new) — phase-1/phase-2 runner
- `.claude/settings.json` — 4 separate hooks consolidated to 1 invocation
- `tests/test_hooks_posttooluse_parallel.py` (new) — 10 unit tests
- `CLAUDE.md` — updated hooks list to describe new structure

Closes WOR-463

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>