### PR TITLE
WOR-469 watcher: parallelize Linear set_state + post_comment in finalize

### DIFF
--- a/app/core/watcher/watcher_finalize.py
+++ b/app/core/watcher/watcher_finalize.py
@@ -34,6 +34,7 @@ from .watcher_finalize_helpers import (
     _write_wip_sha_to_last_failure,
     _write_wip_state_to_last_failure,
     safe_set_state,
+    safe_set_state_and_comment,
 )
 from .watcher_helpers import (
     _parse_worker_telemetry,
@@ -217,12 +218,11 @@ def attempt_pr(
                 ticket_id,
                 manifest.worker_branch,
             )
-            safe_set_state(
-                linear, linear_id, manifest.ticket_state_map.failed, ticket_id
-            )
-            _try_post_comment(
+            # WOR-469: parallelise the independent set_state + comment writes.
+            safe_set_state_and_comment(
                 linear,
                 linear_id,
+                manifest.ticket_state_map.failed,
                 ticket_id,
                 f"PR creation failed for `{ticket_id}`:\n```\n{err_detail}\n```",
             )

--- a/app/core/watcher/watcher_finalize_helpers.py
+++ b/app/core/watcher/watcher_finalize_helpers.py
@@ -138,6 +138,49 @@ def safe_set_state(
         logger.warning("set_state failed for %s (state=%s): %s", ticket_id, state, exc)
 
 
+# WOR-469: Module-level executor for parallelising independent Linear API
+# writes (set_state + post_comment on the same issue). Each call is a
+# blocking ~300-800ms HTTP roundtrip; firing them in parallel halves the
+# wait. Separate from the WOR-465 Sonar executor and the WOR-451 finalize
+# executor to keep failure domains isolated.
+_linear_executor: ThreadPoolExecutor | None = None
+
+
+def _get_linear_executor() -> ThreadPoolExecutor:
+    """Lazy-init the Linear-API executor on first use."""
+    global _linear_executor
+    if _linear_executor is None:
+        _linear_executor = ThreadPoolExecutor(
+            max_workers=8, thread_name_prefix="watcher-linear"
+        )
+    return _linear_executor
+
+
+def safe_set_state_and_comment(
+    linear: LinearClientProtocol,
+    linear_id: str,
+    state: str,
+    ticket_id: str,
+    body: str,
+) -> None:
+    """Fire safe_set_state and _try_post_comment concurrently (WOR-469).
+
+    Linear is consistent within an issue but doesn't require ordering
+    between a state transition and a comment post — both are independent
+    writes on the same issue. Running them in parallel halves the
+    blocking Linear API wait from ~600-1600ms to ~300-800ms per pair.
+
+    Errors in either call are swallowed by the wrapped helpers (their
+    existing semantics — neither raises). Both calls always complete
+    before this function returns.
+    """
+    ex = _get_linear_executor()
+    f1 = ex.submit(safe_set_state, linear, linear_id, state, ticket_id)
+    f2 = ex.submit(_try_post_comment, linear, linear_id, ticket_id, body)
+    f1.result()
+    f2.result()
+
+
 def _read_result_status(repo_root: Path, manifest: ExecutionManifest) -> str | None:
     """Return the worker's self-reported status from result.json, or None.
 
@@ -175,10 +218,12 @@ def _record_failure_state(
     escalated = bool(manifest.failure_policy.escalate_to_cloud)
     if escalated:
         logger.info("Escalating %s to cloud per failure policy", ticket_id)
-        safe_set_state(linear, linear_id, _IN_PROGRESS_STATE, ticket_id)
-        _try_post_comment(
+        # WOR-469: state + comment are independent on the same issue;
+        # run concurrently to halve the Linear API wait.
+        safe_set_state_and_comment(
             linear,
             linear_id,
+            _IN_PROGRESS_STATE,
             ticket_id,
             f"Local worker failed for `{ticket_id}` ({escalate_reason}). "
             f"Escalating to cloud per failure policy.",
@@ -304,10 +349,11 @@ def _handle_policy_outcome(
     if action == "escalate":
         triggering = next((f for f in _POLICY_FLAGS if flags.get(f)), "unknown")
         logger.info("Escalating %s to cloud (flag=%s)", ticket_id, triggering)
-        safe_set_state(linear, linear_id, _IN_PROGRESS_STATE, ticket_id)
-        _try_post_comment(
+        # WOR-469: parallelise the independent set_state + comment writes.
+        safe_set_state_and_comment(
             linear,
             linear_id,
+            _IN_PROGRESS_STATE,
             ticket_id,
             f"Local worker escalating `{ticket_id}` to cloud. "
             f"Triggering flag: `{triggering}`.",
@@ -343,10 +389,11 @@ def _handle_policy_outcome(
         worker.sonar_fetch_attempts = 1
         worker.sonar_first_attempted_at = time.monotonic()
     if _sonar_requires_escalation(sonar_findings, ticket_id, escalation_policy):
-        safe_set_state(linear, linear_id, _IN_PROGRESS_STATE, ticket_id)
-        _try_post_comment(
+        # WOR-469: parallelise the independent set_state + comment writes.
+        safe_set_state_and_comment(
             linear,
             linear_id,
+            _IN_PROGRESS_STATE,
             ticket_id,
             f"Local worker escalating `{ticket_id}` to cloud due "
             f"to Sonar finding requiring immediate action.",

--- a/tests/test_watcher_linear_parallel.py
+++ b/tests/test_watcher_linear_parallel.py
@@ -1,0 +1,91 @@
+"""Tests for WOR-469: parallel Linear API writes in finalize.
+
+Asserts that `safe_set_state_and_comment` fires the underlying
+`safe_set_state` and `_try_post_comment` calls concurrently in a
+ThreadPoolExecutor, halving the blocking Linear API wait per pair.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+from unittest.mock import MagicMock
+
+from app.core.watcher.watcher_finalize_helpers import (
+    _get_linear_executor,
+    safe_set_state_and_comment,
+)
+
+
+def test_safe_set_state_and_comment_runs_in_parallel() -> None:
+    """Both Linear writes must overlap; total wall ≈ max(both)."""
+    linear = MagicMock()
+    starts: list[float] = []
+    ends: list[float] = []
+
+    def slow_set_state(*_args: Any, **_kwargs: Any) -> None:
+        starts.append(time.perf_counter())
+        time.sleep(0.2)
+        ends.append(time.perf_counter())
+
+    def slow_post_comment(*_args: Any, **_kwargs: Any) -> None:
+        starts.append(time.perf_counter())
+        time.sleep(0.2)
+        ends.append(time.perf_counter())
+
+    linear.set_state.side_effect = slow_set_state
+    linear.post_comment.side_effect = slow_post_comment
+
+    t0 = time.perf_counter()
+    safe_set_state_and_comment(linear, "issue-id", "Blocked", "WOR-1", "some body")
+    elapsed = time.perf_counter() - t0
+
+    # Both methods called once each
+    linear.set_state.assert_called_once()
+    linear.post_comment.assert_called_once()
+
+    # Serial: 400ms; parallel: ~200ms + small overhead. Ceiling 350ms.
+    assert elapsed < 0.35, (
+        f"Linear writes did not run in parallel: total={elapsed:.2f}s, expected < 0.35s"
+    )
+
+    # Both started before either finished — overlap proof.
+    assert starts[0] < ends[0]
+    assert starts[1] < ends[1]
+    earlier_end = min(ends)
+    later_start = max(starts)
+    assert later_start < earlier_end, (
+        f"Calls did not overlap: starts={starts}, ends={ends}"
+    )
+
+
+def test_safe_set_state_and_comment_both_called_even_on_state_error() -> None:
+    """If set_state raises LinearError, post_comment still fires."""
+    from app.core.linear_client import LinearError
+
+    linear = MagicMock()
+    linear.set_state.side_effect = LinearError("boom")
+
+    safe_set_state_and_comment(linear, "issue-id", "Blocked", "WOR-1", "some body")
+
+    linear.set_state.assert_called_once()
+    linear.post_comment.assert_called_once()
+
+
+def test_safe_set_state_and_comment_both_called_even_on_comment_error() -> None:
+    """If post_comment raises, set_state still fires (and vice versa)."""
+    linear = MagicMock()
+    linear.post_comment.side_effect = RuntimeError("server down")
+
+    # Should not propagate (existing wrapper semantics)
+    safe_set_state_and_comment(linear, "issue-id", "Blocked", "WOR-1", "some body")
+
+    linear.set_state.assert_called_once()
+    linear.post_comment.assert_called_once()
+
+
+def test_get_linear_executor_is_singleton() -> None:
+    """Lazy-init returns the same instance across calls."""
+    ex1 = _get_linear_executor()
+    ex2 = _get_linear_executor()
+    assert ex1 is ex2


### PR DESCRIPTION
## Summary
- New `safe_set_state_and_comment(linear, linear_id, state, ticket_id, body)` helper in `watcher_finalize_helpers.py` fires `safe_set_state` and `_try_post_comment` concurrently in a module-level `_linear_executor` (8-worker ThreadPoolExecutor, lazy-init; same pattern as WOR-465's `_sonar_executor`).
- Replaced 4 sequential (set_state → post_comment) pairs in the finalize hot paths.
- Bundled fix from WOR-465's still-open PR: catch `sqlite3.OperationalError` in `MetricsStore._migrate` so the xdist-exposed concurrent migration race doesn't flake CI.

## Why this is safe
Linear is consistent within an issue but doesn't require ordering between two independent writes on the same issue. The audit found four places in the finalize pipeline where `set_state` was followed immediately by `post_comment` on the same `linear_id` — both runnable in parallel. No ordering-sensitive call sites were touched (e.g. `set_state` on a parent epic AFTER a sub-ticket transition stays serial).

## Savings per pair
Each Linear API call is ~300–800ms of blocking HTTP. A sequential pair: ~600–1600ms wait. Parallel: ~300–800ms (max of both). Saved per fired pair: **~300–800ms**.

The pairs fire on escalation / failure / Sonar-escalation / PR-creation-failure paths — not the common success path. Average savings across a wave depend on failure rate; typical bundle: 1–2 such fires.

## Call sites updated
| Site | Path | Previous |
|---|---|---|
| `_record_failure_state` escalation | failure → cloud | 2 sequential calls |
| `_handle_policy_outcome` action=escalate | flag-triggered escalation | 2 sequential calls |
| `_handle_policy_outcome` Sonar-finding escalation | sonar-driven escalation | 2 sequential calls |
| `attempt_pr` PR-creation-failure | gh pr create errored | 2 sequential calls |

## MetricsStore race fix (bundled)
Same fix as in WOR-465 #971 (still OPEN). CI on Linux exposed a race in `_migrate` where `pytest-xdist -n 8` workers concurrently `ALTER TABLE ADD COLUMN` against the shared default DB. The `if col not in existing` check was non-atomic. Adding `try/except sqlite3.OperationalError` makes the migration idempotent under concurrency. Self-contained so this PR doesn't depend on WOR-465 merging first.

## Test plan
- [x] `ruff check .` clean
- [x] `mypy app/` clean (48 source files)
- [x] `pytest --no-cov -q` — 1861 passed in 45s
- [x] `lint-imports` — 8 contracts kept, 0 broken
- [x] 4 new tests in `tests/test_watcher_linear_parallel.py`:
  - **runs_in_parallel**: 2 × 200ms mocked Linear writes complete in <350ms (parallel) not 400ms+ (serial); overlap proven via start/end timestamps
  - **both_called_even_on_state_error**: LinearError on set_state → post_comment still fires
  - **both_called_even_on_comment_error**: raising post_comment → set_state still fires
  - **executor_is_singleton**: lazy-init returns same instance

## Files
- `app/core/watcher/watcher_finalize_helpers.py` — `_linear_executor` + `safe_set_state_and_comment`; 3 call sites updated
- `app/core/watcher/watcher_finalize.py` — 1 call site updated + import
- `app/core/metrics_store.py` — `try/except sqlite3.OperationalError` in `_migrate` (xdist race fix)
- `tests/test_watcher_linear_parallel.py` (new) — 4 unit tests

Closes WOR-469

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>