### PR TITLE
WOR-443 Split-on-multi-feature heuristic in /start-ticket and /start-epic

### DIFF
--- a/.claude/commands/start-epic.md
+++ b/.claude/commands/start-epic.md
@@ -112,8 +112,17 @@ For each eligible ticket (process them all before writing any manifests):
   - `tech_stack` — comma-separated tags of the technologies involved, e.g. `python,sqlite,pydantic` or `markdown,yaml`
   - `raw_extensions` — JSON array string of file extensions touched, e.g. `[".py",".md"]`
 
+**3b.5. Split-on-multi-feature check (WOR-443)**
+Apply the same criteria as `/start-ticket` step 2. All three must hold to flag:
+
+1. The ticket's AC enumerates **3 or more** bullets that each describe a *separately-scoped feature* (not 3+ bullets describing edge cases of one feature)
+2. The features touch **distinct files or surfaces** (not just different methods of the same class)
+3. Each feature could be **independently tested and shipped**
+
+If all three hold, record `split_candidate: true` for this ticket along with the separable feature list (`split_features: [<X>, <Y>, <Z>]`). **Do not split automatically** — surface it in step 4's batching plan. If any criterion fails, set `split_candidate: false` and continue.
+
 **3c. Record inferred file set**
-Store `{ ticket_id, branch_name, files: [...] }` for conflict detection in step 4.
+Store `{ ticket_id, branch_name, files: [...], split_candidate, split_features }` for conflict detection and the step 4 plan.
 
 ---
 
@@ -165,6 +174,15 @@ Batch 2 — blocked until batch 1 merges (file conflicts):
 Skipped (already past Groomed):
   WOR-47  InProgressLocal
 ```
+
+If any ticket was marked `split_candidate: true` in step 3b.5, append a section to the plan after "Skipped":
+
+```
+Split candidates (multi-feature — consider re-filing before queuing):
+  WOR-NNN  <N> separable improvements (<X>, <Y>, <Z>) — each independently testable, distinct files
+```
+
+Default recommendation: **re-file**. A multi-feature ticket inside a bundle bogs down the whole batch — it runs disproportionately long, risks mid-session compaction, and can lock a shared file gating its batch peers (WOR-306 retro: 77 min wall, compaction, `watcher.py` locked ~60 min). The operator can either approve the bundle as-is or close-and-re-file the flagged ticket as `<N>` sub-tickets and re-run `/start-epic`. The decision is the operator's; the recommendation must be surfaced.
 
 **STOP HERE. Do not write any manifests or create branches until the human approves this batching plan.**
 

--- a/.claude/commands/start-ticket.md
+++ b/.claude/commands/start-ticket.md
@@ -216,6 +216,37 @@ If no siblings are In Progress, skip this block silently.
 - Note the milestone this ticket belongs to and how it fits the current milestone's goal
 - Flag any active blockers from Linear — if this ticket is blocked by an open issue, warn before proceeding
 
+### 2. Split-on-multi-feature check (WOR-443)
+
+Before the architect plans the implementation, inspect the acceptance criteria from step 1.
+
+**Split criteria — all three must hold to recommend a split:**
+
+1. The AC enumerates **3 or more** bullets that each describe a *separately-scoped feature* (not 3+ bullets that together describe edge cases of one feature)
+2. The features touch **distinct files or surfaces** (not just different methods of the same class)
+3. Each feature could be **independently tested and shipped**
+
+If all three hold, print this and wait for the operator's answer before continuing to step 2.5:
+
+```
+Heads-up: this ticket enumerates <N> separable improvements (<X>, <Y>, <Z>, ...).
+Consider splitting before /start-ticket — each could be its own ticket:
+  - smaller per-session context (reduces compaction risk)
+  - <N>x parallel-safe by file
+  - independent rollback if one feature regresses
+
+Continue with single ticket? [y/N]
+```
+
+Default to **N** (do not proceed) — the operator must explicitly answer `y` to continue. The split-or-not decision is the operator's, but the recommendation must be surfaced, never silently skipped.
+
+- Operator answers **N** (or presses enter): stop here. Recommend they close-and-re-file the ticket as `<N>` sub-tickets (or split it in Linear), then re-run `/start-ticket` on the smaller pieces. Do not write a manifest.
+- Operator answers **y**: continue with the single ticket through step 2.5 onward, unchanged.
+
+If any of the three criteria do **not** hold (the AC is one cohesive feature, or the bullets are edge cases / sub-steps of the same change), skip this block silently — do not print the prompt.
+
+**Why (WOR-306 retro, 2026-05-11):** a ticket whose AC enumerated 4 separable TUI improvements ran 77 min wall (5x the smallest bundle peer), consumed 25.3M tokens, hit `input_tokens_max` → mid-session compaction (5.3 min lost), and locked `watcher.py` for the duration — gating two sibling tickets ~60 min. Split into 4 tickets it would have been ~15-20 min each and 4x parallel-safe by file. This check is the systematic fix; WOR-306 was the canary.
+
 ### 2.5. Routing assessment
 
 Before computing implementation_mode, determine the routing for this ticket.


### PR DESCRIPTION
## Summary

Adds a planning-time guardrail that surfaces over-scoped tickets before they get dispatched.

- **start-ticket.md** — new `### 2. Split-on-multi-feature check` between the PO requirement step (1) and routing assessment (2.5). If the AC enumerates **3+ separately-scoped features** touching **distinct files**, each **independently shippable**, it prints a `[y/N]` split recommendation defaulting to **N**. Operator decides; recommendation is never silently skipped.
- **start-epic.md** — same three-criteria check as step `3b.5`, surfaced as a *Split candidates* section in step 4's batching plan with a default "re-file" recommendation.

Pure skill update — **no `app/` code**, no test changes.

## Why

Systematic fix for the WOR-306 failure class: a ticket whose AC enumerated 4 separable TUI improvements ran 77 min wall (5x the smallest bundle peer), 25.3M tokens, hit mid-session compaction, and locked `watcher.py` for the duration — gating two sibling tickets ~60 min. Split into 4 it would have been ~15-20 min each and 4x parallel-safe.

## Smoke test (AC bullet 4)

WOR-306's AC: (1) $0.0000 bug fix, (2) Last Action column, (3) vLLM throughput panel, (4) Queue summary panel — four independently-testable features touching distinct surfaces (TUI render / log parsing / /metrics fetch / manifest scan). All three criteria hold → the new check would print the prompt with N=4. Heuristic verified by inspection.

Closes WOR-443

🤖 Generated with [Claude Code](https://claude.com/claude-code)