### PR TITLE
WOR-491 Watcher contract wave 4 — WOR-446 retro residuals + test-safety (456/450/457/492)

### DIFF
--- a/.claude/commands/implement-ticket.md
+++ b/.claude/commands/implement-ticket.md
@@ -342,6 +342,8 @@ ticket summary in `notes`; keep it focused on unexpected findings.
 }
 ```
 
+**HARD RULE — `checks_passed` must list the manifest's exact `required_checks` strings (WOR-456).** `checks_passed` records that you ran the manifest's `required_checks`, NOT that pre-commit / PostToolUse hooks passed. Copy the exact command strings from `manifest.required_checks` (e.g. `"ruff check ."`, `"mypy app/"`, `"pytest"`, `"lint-imports"`) verbatim into `checks_passed`. Do **not** list pre-commit hook names (`ruff`, `ruff-format`, `bandit`, `trailing-whitespace`, `end-of-file-fixer`, …) — those are not the contract checks, and the watcher now cross-checks the two lists at finalize time. If `checks_passed` does not contain every `required_checks` entry (exact string match), the watcher rejects the result as a contract violation and marks the ticket Blocked — even though you wrote `status: success`. Only write `status: success` after you have actually run every `required_checks` command and it passed.
+
 **On failure:**
 ```json
 {

--- a/app/core/watcher/watcher_finalize.py
+++ b/app/core/watcher/watcher_finalize.py
@@ -31,6 +31,7 @@ from .watcher_finalize_helpers import (
     _record_failure_state,
     _try_post_comment,
     _validate_allowed_paths,
+    _validate_checks_passed,
     _write_wip_sha_to_last_failure,
     _write_wip_state_to_last_failure,
     safe_set_state,
@@ -455,6 +456,37 @@ def finalize_worker(
         )
         _try_post_comment(linear, worker.linear_id, worker.ticket_id, comment)
         return "failure"
+
+    # WOR-456: cross-check the worker's self-reported checks_passed against
+    # the manifest's required_checks. A worker that writes status=success
+    # against pre-commit hook names (ruff, ruff-format, …) instead of the
+    # manifest's required_checks ("mypy app/", "pytest", …) has not run the
+    # contract checks — the same WOR-67-class "thinks it's done but isn't"
+    # failure mode, in the success-reporting path. Only gate the success
+    # signal; genuine failures are handled by the returncode logic in
+    # _execute_finalization. Runs before the retry loop — a contract
+    # violation is not a transient check failure, so retries won't help.
+    if _read_result_status(repo_root, worker.manifest) == "success":
+        missing_checks = _validate_checks_passed(worker.manifest, repo_root)
+        if missing_checks:
+            comment = (
+                f"checks_passed contract violation for `{worker.ticket_id}`. "
+                f"The worker reported `status: success` but its "
+                f"`result.json.checks_passed` does not include these "
+                f"required_checks:\n\n```\n" + "\n".join(missing_checks) + "\n```\n\n"
+                f"Manifest required_checks: `{worker.manifest.required_checks}`. "
+                f"Likely cause: the worker listed pre-commit hook names "
+                f"instead of the manifest's required_checks (WOR-456). "
+                f"PR creation aborted."
+            )
+            _record_failure_state(
+                worker,
+                linear,
+                f"checks_passed contract violation — "
+                f"{len(missing_checks)} required check(s) not reported",
+            )
+            _try_post_comment(linear, worker.linear_id, worker.ticket_id, comment)
+            return "failure"
 
     # WOR-312: in-dispatch retry loop. Helper avoids the slower Linear
     # Blocked -> ReadyForLocal redispatch when checks transiently fail.

--- a/app/core/watcher/watcher_finalize.py
+++ b/app/core/watcher/watcher_finalize.py
@@ -26,8 +26,11 @@ from app.core.metrics import (
 
 from .watcher_finalize_helpers import (
     ATTEMPT_HARDCAP,
+    _artifact_dir_for,
+    _classify_stage,
     _execute_finalization,
     _read_result_status,
+    _record_failure_artifact,
     _record_failure_state,
     _try_post_comment,
     _validate_allowed_paths,
@@ -208,6 +211,17 @@ def attempt_pr(
         except subprocess.CalledProcessError as exc:
             err_detail = (exc.stderr or exc.stdout or str(exc)).strip()
             logger.error("PR creation failed for %s: %s", ticket_id, err_detail)
+            # WOR-457: record a diagnostic artifact for the PR-creation
+            # failure stage. Written before commit_wip_state so the WIP
+            # helpers merge wip_status into the same file. This is the
+            # exact WOR-441 gap: a finalize failure outside run_checks
+            # that previously left no last_failure.json.
+            _record_failure_artifact(
+                _artifact_dir_for(worker),
+                _classify_stage(exc),
+                exception=exc,
+                stderr=err_detail,
+            )
             # Preserve any uncommitted worktree changes so a retry worker
             # can resume from them (WOR-267, WOR-288). attempt_pr does not
             # own the worktree teardown decision — finalize_worker handles
@@ -455,6 +469,12 @@ def finalize_worker(
             f"allowed_paths violation — {len(violations)} file(s) outside scope",
         )
         _try_post_comment(linear, worker.linear_id, worker.ticket_id, comment)
+        # WOR-457: validation-gate failures get a diagnostic artifact too.
+        _record_failure_artifact(
+            _artifact_dir_for(worker),
+            "validate_allowed_paths",
+            stderr="\n".join(violations),
+        )
         return "failure"
 
     # WOR-456: cross-check the worker's self-reported checks_passed against
@@ -486,6 +506,12 @@ def finalize_worker(
                 f"{len(missing_checks)} required check(s) not reported",
             )
             _try_post_comment(linear, worker.linear_id, worker.ticket_id, comment)
+            # WOR-457: validation-gate failures get a diagnostic artifact.
+            _record_failure_artifact(
+                _artifact_dir_for(worker),
+                "validate_checks_passed",
+                stderr="missing required_checks: " + ", ".join(missing_checks),
+            )
             return "failure"
 
     # WOR-312: in-dispatch retry loop. Helper avoids the slower Linear
@@ -503,6 +529,29 @@ def finalize_worker(
             project_id,
         )
     )
+
+    # WOR-457: ensure every "failure" outcome leaves a last_failure.json.
+    # - failed_checks present: the run_checks path already wrote
+    #   {check, stdout}; merge in stage="run_checks" so the WOR-66
+    #   artifact round-trips.
+    # - failed_checks empty: the failure came from a non-check stage
+    #   (rebase/push/pr_create swallowed by attempt_pr, etc.). attempt_pr
+    #   may already have recorded a precise stage; keep_existing_stage
+    #   avoids downgrading it, and "other" is the WOR-441 catch-all when
+    #   nothing more specific was recorded.
+    if outcome == "failure":
+        if failed_checks:
+            _record_failure_artifact(
+                _artifact_dir_for(worker),
+                "run_checks",
+                check=str(failed_checks[0]["check"]),
+            )
+        else:
+            _record_failure_artifact(
+                _artifact_dir_for(worker),
+                "other",
+                keep_existing_stage=True,
+            )
 
     log_path = worker.worktree_path / f".claude/worker_{worker.ticket_id.lower()}.log"
     # WOR-466: single-pass JSONL walk replaces 5 separate parsers. On large

--- a/app/core/watcher/watcher_finalize_helpers.py
+++ b/app/core/watcher/watcher_finalize_helpers.py
@@ -126,6 +126,53 @@ def _validate_allowed_paths(
     return violations
 
 
+def _validate_checks_passed(
+    manifest: ExecutionManifest,
+    repo_root: Path,
+) -> list[str]:
+    """Cross-check the worker's self-reported checks against required_checks.
+
+    Workers sometimes write ``status: success`` to result.json with a
+    ``checks_passed`` list populated from *pre-commit hook names*
+    (``ruff``, ``ruff-format``, ``bandit`` …) instead of the manifest's
+    ``required_checks`` command strings (``mypy app/``, ``pytest`` …) —
+    see WOR-456 / WOR-66. The worker ran pre-commit, saw it pass, and
+    self-reported success without ever invoking the contract checks.
+
+    Returns the list of ``required_checks`` entries the worker did NOT
+    report as passed (exact string match). Empty list = no violation.
+
+    This gate fires *only* when the worker made a **non-empty**
+    ``checks_passed`` claim that fails to cover ``required_checks`` — the
+    exact WOR-456 / WOR-66 bug (worker lists pre-commit hook names instead
+    of the contract checks). It deliberately does NOT fire when:
+
+    - ``required_checks`` is empty (nothing to enforce), or
+    - ``result.json`` is unreadable (the returncode path's job), or
+    - ``checks_passed`` is absent or empty.
+
+    A worker that makes no checks claim at all is a different situation
+    from one that makes a *wrong* claim — the empty case is covered by
+    the returncode logic and the WOR-353 unscoped-pytest soft rule plus
+    the watcher's own ``run_checks`` sweep, not by this contract gate.
+    """
+    if not manifest.required_checks:
+        return []
+    result_path = repo_root / manifest.artifact_paths.result_json
+    try:
+        data = json.loads(result_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return []
+    raw_passed = data.get("checks_passed") if isinstance(data, dict) else None
+    if isinstance(raw_passed, list):
+        passed = {c for c in raw_passed if isinstance(c, str)}
+    else:
+        passed = set()
+    if not passed:
+        return []
+    return [rc for rc in manifest.required_checks if rc not in passed]
+
+
 def safe_set_state(
     linear: LinearClientProtocol,
     linear_id: str,

--- a/app/core/watcher/watcher_finalize_helpers.py
+++ b/app/core/watcher/watcher_finalize_helpers.py
@@ -13,6 +13,7 @@ import logging
 import subprocess  # nosec B404
 import time
 from concurrent.futures import Future, ThreadPoolExecutor
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Callable
 
@@ -480,6 +481,117 @@ def _sonar_requires_escalation(
             "Sonar finding for %s: severity=%s — fix_locally", ticket_id, severity
         )
     return False
+
+
+# WOR-457: known finalize stages for the last_failure.json `stage`
+# discriminator. `check` is retained for backward-compat (watcher.py's
+# retry-hint reader does `data.get("check", "unknown")`).
+_FINALIZE_STAGES = (
+    "run_checks",
+    "rebase",
+    "push",
+    "pr_create",
+    "pr_merge",
+    "validate_allowed_paths",
+    "validate_checks_passed",
+    "parse",
+    "other",
+)
+
+
+def _artifact_dir_for(worker: ActiveWorker) -> Path:
+    """The worktree artifact dir holding result.json / last_failure.json."""
+    return (worker.worktree_path / worker.manifest.artifact_paths.result_json).parent
+
+
+def _classify_stage(exc: BaseException) -> str:
+    """Best-effort map an exception to a finalize stage string (WOR-457)."""
+    if isinstance(exc, json.JSONDecodeError):
+        return "parse"
+    parts: list[str] = [type(exc).__name__.lower(), str(exc).lower()]
+    if isinstance(exc, subprocess.CalledProcessError):
+        cmd = exc.cmd
+        parts.append(
+            cmd.lower()
+            if isinstance(cmd, str)
+            else " ".join(str(c) for c in (cmd or [])).lower()
+        )
+    blob = " ".join(parts)
+    if "rebase" in blob:
+        return "rebase"
+    if "pr create" in blob or "gh pr create" in blob:
+        return "pr_create"
+    if "pr merge" in blob or "auto-merge" in blob:
+        return "pr_merge"
+    if "push" in blob:
+        return "push"
+    if any(c in blob for c in ("pytest", "mypy", "ruff", "lint-imports")):
+        return "run_checks"
+    if "json" in blob or "parse" in blob or "decode" in blob:
+        return "parse"
+    return "other"
+
+
+def _record_failure_artifact(
+    artifact_dir: Path,
+    stage: str,
+    *,
+    exception: BaseException | None = None,
+    check: str | None = None,
+    stdout: str = "",
+    stderr: str = "",
+    keep_existing_stage: bool = False,
+) -> None:
+    """Write/merge last_failure.json for ANY finalize failure (WOR-457).
+
+    Before WOR-457, last_failure.json was written only by the run_checks
+    path (watcher_subprocess). Failures at rebase / push / pr_create /
+    pr_merge / validation gates / parse left the operator with a Linear
+    "Blocked" and no diagnostic artifact (WOR-441 incident).
+
+    `stage` is the new discriminator. `check` is kept (optional) for
+    backward-compat with parsers that read it. The file is *merged* into
+    any existing last_failure.json so wip_status / wip_commit_sha / the
+    run_checks `check` + stdout already written are preserved (the WOR-66
+    artifact round-trips: existing {check:"pytest", stdout:…} gains
+    {stage:"run_checks", failed_at:…}).
+
+    Best-effort — never raises; a diagnostics-write failure must not mask
+    the original error.
+    """
+    failure_file = artifact_dir / "last_failure.json"
+    try:
+        artifact_dir.mkdir(parents=True, exist_ok=True)
+        data: dict[str, object] = {}
+        if failure_file.exists():
+            try:
+                existing = json.loads(failure_file.read_text(encoding="utf-8"))
+                if isinstance(existing, dict):
+                    data.update(existing)
+            except (json.JSONDecodeError, OSError):
+                data = {}
+        # First-failure timestamp wins: a later stage-refinement / wip
+        # merge must not reset failed_at (preserves an already-recorded
+        # failure time across the multiple writers in one finalize run).
+        data.setdefault("failed_at", datetime.now(timezone.utc).isoformat())
+        # keep_existing_stage: a generic catch-all ("other") must not
+        # downgrade a more specific stage a prior writer already set
+        # (e.g. attempt_pr recorded "pr_create" before this runs).
+        if not (keep_existing_stage and data.get("stage")):
+            data["stage"] = stage
+        if check is not None:
+            data["check"] = check
+        elif "check" not in data:
+            data["check"] = None
+        if stdout:
+            data["stdout"] = stdout
+        if stderr:
+            data["stderr"] = stderr
+        if exception is not None:
+            data["exception"] = f"{type(exception).__name__}: {exception}"
+        failure_file.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    except OSError as exc:
+        logger.warning("Could not write last_failure.json (%s): %s", failure_file, exc)
 
 
 def _write_wip_state_to_last_failure(

--- a/app/core/watcher/watcher_worktrees.py
+++ b/app/core/watcher/watcher_worktrees.py
@@ -601,6 +601,39 @@ def cleanup_worktree(repo_root: Path, worktree_path: Path) -> None:
     cleanup failed mid-run, leaving a directory on disk that git no longer
     tracks.
     """
+    # WOR-450: sweep stray untracked files before removing the worktree.
+    # Workers occasionally write a probe log to the worktree ROOT using a
+    # test-fixture filename (e.g. `worker_wor-99.log`); `worker_*.log` is
+    # .gitignore'd so it never gets committed, but it lingers and confuses
+    # retro tooling that scans `*.log`. `-x` is required to reach the
+    # gitignored strays; `-e .claude/artifacts/` preserves the audit
+    # artifacts (preserve_worker_artifacts has already copied them out by
+    # this point in finalize). Best-effort — a clean failure must never
+    # block worktree removal.
+    if worktree_path.exists():
+        try:
+            subprocess.run(  # nosec B603 B607
+                [
+                    "git",
+                    "-C",
+                    str(worktree_path),
+                    "clean",
+                    "-fdx",
+                    "-e",
+                    ".claude/artifacts/",
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+        except (OSError, subprocess.SubprocessError) as exc:
+            logger.warning(
+                "git clean sweep failed for %s (continuing to removal): %s",
+                worktree_path,
+                exc,
+            )
+
     try:
         subprocess.run(  # nosec B603 B607
             [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,9 +54,104 @@ def _block_real_claude_subprocess(
                 "patch('app.core.watcher.watcher_finalize.launch_worker', "
                 "return_value=MagicMock()) inside the test's with-block."
             )
+        if binary in ("wt.exe", "wt"):
+            # WOR-492: the win32 vLLM auto-start opens a real Windows
+            # Terminal tab running `vllm serve` via
+            # ServiceManager._open_vllm_terminal. On the Windows dev box
+            # sys.platform is genuinely "win32", so a full pytest run
+            # spawned real GPU vLLM instances. Raise FileNotFoundError —
+            # _open_vllm_terminal catches it ("wt.exe not found") and the
+            # probe just returns "vLLM down", with no real spawn. Tests
+            # that assert the spawn (test_watcher_services.py) patch
+            # subprocess.Popen wholesale and never reach this guard.
+            raise FileNotFoundError(
+                "test guard (WOR-492): refusing real `wt.exe` vLLM "
+                f"auto-start (argv[0]={first!r})."
+            )
         _REAL_POPEN_INIT(self, args, *rest, **kwargs)
 
     monkeypatch.setattr(subprocess.Popen, "__init__", _guarded_init)
+
+
+@pytest.fixture(autouse=True)
+def _block_vllm_autostart(monkeypatch: pytest.MonkeyPatch) -> None:
+    """WOR-492: never touch a real WSL/vLLM from a test.
+
+    Two leaks, one fixture:
+
+    1. **Spawn.** ``ServiceManager._open_vllm_terminal`` (reached when the
+       health probe fails on a genuine ``win32`` box) writes a WSL script
+       and opens a real ``vllm serve`` in a ``wt.exe`` tab. The
+       ``_block_real_claude_subprocess`` guard only blocked ``claude``;
+       ``wt.exe`` slipped through and a full ``pytest -n 8`` run on
+       Windows spawned two real GPU vLLM instances (the second OOM'd).
+       The ``wt.exe`` branch of that guard now raises
+       ``FileNotFoundError``, which ``_open_vllm_terminal`` catches → no
+       spawn. ``_write_vllm_script_file`` is also no-op'd as defence in
+       depth (no WSL-VM boot via ``subprocess.run(["wsl", …])``).
+
+    2. **Outbound HTTP.** Even with no spawn, if an operator's vLLM is
+       already up on localhost:8000, unmocked tests hit it for real —
+       probe (``GET /v1/models``), metrics (``GET /metrics``) and the
+       Anthropic-mode check (``POST /v1/messages`` — a real inference).
+       All go through ``http.client.HTTPConnection``; this refuses *only*
+       the vLLM host:port, which every call site already wraps in
+       ``except (OSError, …)`` → graceful "vLLM unavailable".
+
+    NB: we deliberately do **not** patch ``sys.platform`` — forcing
+    "linux" on a Windows box breaks ``pytest-qt`` (its plugin calls
+    ``os.getuid()``). The ``wt.exe`` Popen guard achieves the same
+    spawn-prevention without that blast radius.
+
+    Tests that assert the real spawn / HTTP behaviour
+    (``tests/test_watcher_services.py``) patch ``subprocess.Popen`` /
+    ``http.client.HTTPConnection`` wholesale and never reach these guards.
+    """
+    monkeypatch.setattr(
+        "app.core.watcher.watcher_services._write_vllm_script_file",
+        lambda *args, **kwargs: None,
+    )
+
+    # Refuse real *outbound HTTP* to a running
+    # vLLM. The win32 no-op above stops tests *spawning* a server, but if
+    # an operator's vLLM is already up on localhost:8000, unmocked tests
+    # hit it for real — probe (GET /v1/models), metrics capture
+    # (GET /metrics) and the Anthropic-mode check (POST /v1/messages, a
+    # real model inference). All of these go through
+    # http.client.HTTPConnection. Refuse *only* the vLLM host:port so any
+    # other HTTP is untouched; the watcher's `except (OSError, ...)`
+    # arms at every call site turn this into a graceful "vLLM
+    # unavailable" (probe→False, metrics→None). Tests that assert real
+    # HTTP behaviour (tests/test_watcher_services.py) re-patch
+    # http.client.HTTPConnection locally and shadow this default.
+    import http.client as _http_client
+
+    from app.core.watcher import watcher_services as _svc
+
+    _real_http_connection = _http_client.HTTPConnection
+    _vllm_host = str(_svc._VLLM_HOST)
+    _vllm_port = int(_svc._VLLM_PORT)
+
+    class _GuardedHTTPConnection(_real_http_connection):  # type: ignore[valid-type,misc]
+        """HTTPConnection subclass that refuses the vLLM host:port only.
+
+        Must be a real subclass (not a function) so class attributes
+        (``debuglevel`` etc.), ``isinstance`` checks and urllib internals
+        keep working for every non-vLLM connection.
+        """
+
+        def __init__(self, host: Any, port: Any = None, *rest: Any, **kw: Any):
+            same_host = str(host) == _vllm_host
+            same_port = port is None or int(port) == _vllm_port
+            if same_host and same_port:
+                raise OSError(
+                    "test guard (WOR-492): refusing real vLLM connection "
+                    f"to {host}:{port}. Mock http.client.HTTPConnection "
+                    "in the test if it needs the vLLM HTTP path."
+                )
+            super().__init__(host, port, *rest, **kw)
+
+    monkeypatch.setattr(_http_client, "HTTPConnection", _GuardedHTTPConnection)
 
 
 # Session-scoped QApplication fixture (pytest-qt)

--- a/tests/test_vllm_autostart_guard.py
+++ b/tests/test_vllm_autostart_guard.py
@@ -1,0 +1,51 @@
+"""WOR-492: the autouse conftest guards prevent any real WSL/vLLM contact.
+
+Regression guards for the leak where a full pytest run on Windows (a) spawned
+real `vllm serve` GPU processes via ServiceManager's win32 auto-start and
+(b) hammered an already-running vLLM with real GET /v1/models, GET /metrics
+and POST /v1/messages (a real inference) calls.
+"""
+
+from __future__ import annotations
+
+import http.client
+import subprocess  # noqa: S404 — guard assertions only
+from pathlib import Path
+
+import pytest
+
+from app.core.watcher.watcher_services import (
+    _VLLM_HOST,
+    _VLLM_PORT,
+    ServiceManager,
+)
+
+
+def test_guard_blocks_wt_exe_spawn() -> None:
+    """The win32 vLLM auto-start (`wt.exe`) is refused with the same
+    FileNotFoundError `_open_vllm_terminal` already handles gracefully."""
+    with pytest.raises(FileNotFoundError, match="WOR-492"):
+        subprocess.Popen(["wt.exe", "-w", "0", "new-tab", "--", "wsl"])
+
+
+def test_guard_refuses_real_vllm_http_connection() -> None:
+    """A real HTTPConnection to the vLLM host:port is refused so no test
+    can hit a running vLLM by accident."""
+    with pytest.raises(OSError, match="WOR-492"):
+        http.client.HTTPConnection(_VLLM_HOST, _VLLM_PORT, timeout=3)
+
+
+def test_non_vllm_http_connection_still_constructs() -> None:
+    """The HTTP guard is scoped to the vLLM host:port only — other hosts
+    are untouched (constructing the object does not open a socket)."""
+    conn = http.client.HTTPConnection("example.invalid", 1234, timeout=1)
+    assert conn.host == "example.invalid"
+
+
+def test_probe_vllm_health_unmocked_fails_closed(tmp_path: Path) -> None:
+    """With NO local mocks, probe_vllm_health exercises the full path
+    (HTTP refused by the guard, then the win32 terminal branch whose
+    wt.exe Popen is refused) and returns False — no real network call,
+    no real process spawn."""
+    mgr = ServiceManager(tmp_path)
+    assert mgr.probe_vllm_health() is False

--- a/tests/test_watcher_finalize_checks_passed.py
+++ b/tests/test_watcher_finalize_checks_passed.py
@@ -1,0 +1,192 @@
+"""WOR-456: watcher cross-checks result.json.checks_passed vs required_checks.
+
+A worker that writes ``status: success`` with ``checks_passed`` populated from
+pre-commit hook names (``ruff``, ``ruff-format`` …) instead of the manifest's
+``required_checks`` command strings has not run the contract checks. The
+watcher must reject this at finalize time (Blocked) rather than open a PR.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from app.core.escalation_policy import EscalationPolicy
+from app.core.manifest import ArtifactPaths
+from app.core.watcher.watcher_finalize import finalize_worker
+from app.core.watcher.watcher_finalize_helpers import _validate_checks_passed
+from app.core.watcher.watcher_types import ActiveWorker
+from tests.conftest import make_manifest
+
+_REQUIRED = ["ruff check .", "mypy app/", "pytest", "lint-imports"]
+_PRECOMMIT_NAMES = [
+    "ruff",
+    "ruff-format",
+    "bandit",
+    "trailing-whitespace",
+    "end-of-file-fixer",
+]
+
+
+def _write_result(tmp_path: Path, payload: dict[str, object]) -> None:
+    result_path = tmp_path / ".claude" / "artifacts" / "wor_456" / "result.json"
+    result_path.parent.mkdir(parents=True, exist_ok=True)
+    result_path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _make_worker(tmp_path: Path) -> ActiveWorker:
+    manifest = make_manifest(
+        ticket_id="WOR-456",
+        worker_branch="wor-456-test",
+        required_checks=_REQUIRED,
+        artifact_paths=ArtifactPaths.from_ticket_id("WOR-456"),
+    )
+    return ActiveWorker(
+        ticket_id="WOR-456",
+        linear_id="fake-linear-id",
+        manifest=manifest,
+        worktree_path=tmp_path,
+        process=MagicMock(spec=subprocess.Popen),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Unit: _validate_checks_passed
+# ---------------------------------------------------------------------------
+
+
+def test_validate_checks_passed_precommit_names_all_missing(tmp_path: Path) -> None:
+    """Pre-commit hook names → every required_check reported missing."""
+    worker = _make_worker(tmp_path)
+    _write_result(tmp_path, {"status": "success", "checks_passed": _PRECOMMIT_NAMES})
+    missing = _validate_checks_passed(worker.manifest, tmp_path)
+    assert missing == _REQUIRED
+
+
+def test_validate_checks_passed_exact_names_clean(tmp_path: Path) -> None:
+    """Exact required_checks strings → no missing checks."""
+    worker = _make_worker(tmp_path)
+    _write_result(tmp_path, {"status": "success", "checks_passed": _REQUIRED})
+    assert _validate_checks_passed(worker.manifest, tmp_path) == []
+
+
+def test_validate_checks_passed_partial_reports_only_gap(tmp_path: Path) -> None:
+    """Worker ran 3 of 4 → only the unrun check is flagged."""
+    worker = _make_worker(tmp_path)
+    _write_result(
+        tmp_path,
+        {"status": "success", "checks_passed": ["ruff check .", "mypy app/", "pytest"]},
+    )
+    assert _validate_checks_passed(worker.manifest, tmp_path) == ["lint-imports"]
+
+
+def test_validate_checks_passed_empty_required_is_clean(tmp_path: Path) -> None:
+    """Empty required_checks → nothing to enforce."""
+    manifest = make_manifest(
+        ticket_id="WOR-456",
+        worker_branch="wor-456-test",
+        required_checks=[],
+        artifact_paths=ArtifactPaths.from_ticket_id("WOR-456"),
+    )
+    _write_result(tmp_path, {"status": "success", "checks_passed": []})
+    assert _validate_checks_passed(manifest, tmp_path) == []
+
+
+def test_validate_checks_passed_missing_result_is_clean(tmp_path: Path) -> None:
+    """Unreadable result.json is the returncode path's job, not a violation."""
+    worker = _make_worker(tmp_path)
+    assert _validate_checks_passed(worker.manifest, tmp_path) == []
+
+
+# ---------------------------------------------------------------------------
+# Integration: finalize_worker gate
+# ---------------------------------------------------------------------------
+
+
+def test_finalize_rejects_precommit_names_as_contract_violation(
+    tmp_path: Path,
+) -> None:
+    """result.json with pre-commit hook names → Blocked + comment, no PR."""
+    worker = _make_worker(tmp_path)
+    _write_result(tmp_path, {"status": "success", "checks_passed": _PRECOMMIT_NAMES})
+    linear_mock = MagicMock()
+
+    with (
+        patch(
+            "app.core.watcher.watcher_finalize._validate_allowed_paths",
+            return_value=[],
+        ),
+        patch("app.core.watcher.watcher_finalize.compute_tags", return_value=[]),
+        patch("app.core.watcher.watcher_finalize.create_pr") as mock_create_pr,
+        patch("app.core.watcher.watcher_finalize.cleanup_worktree"),
+    ):
+        outcome = finalize_worker(
+            worker,
+            returncode=0,
+            wall_time=1.0,
+            linear=linear_mock,
+            metrics=MagicMock(),
+            escalation_policy=EscalationPolicy.from_toml(),
+            repo_root=tmp_path,
+            mode="default",
+            project_id="proj",
+        )
+
+    assert outcome == "failure"
+    mock_create_pr.assert_not_called()
+    linear_mock.set_state.assert_called_with("fake-linear-id", "Blocked")
+    comment_body: str = linear_mock.post_comment.call_args[0][1]
+    assert "WOR-456" in comment_body
+    assert "checks_passed contract violation" in comment_body
+    assert "PR creation aborted" in comment_body
+
+
+def test_finalize_accepts_exact_required_checks(tmp_path: Path) -> None:
+    """result.json with the manifest's exact required_checks → gate passes."""
+    worker = _make_worker(tmp_path)
+    _write_result(tmp_path, {"status": "success", "checks_passed": _REQUIRED})
+    linear_mock = MagicMock()
+    metrics_mock = MagicMock()
+
+    with (
+        patch(
+            "app.core.watcher.watcher_finalize._validate_allowed_paths",
+            return_value=[],
+        ),
+        patch("app.core.watcher.watcher_finalize.compute_tags", return_value=[]),
+        patch(
+            "app.core.watcher.watcher_finalize_helpers.run_checks",
+            return_value=(True, []),
+        ),
+        patch("app.core.watcher.watcher_finalize_helpers.preserve_worker_artifacts"),
+        patch(
+            "app.core.watcher.watcher_finalize_helpers.fetch_sonar_findings",
+            return_value=None,
+        ),
+        patch(
+            "app.core.watcher.watcher_finalize.create_pr",
+            return_value="https://github.com/example/pr/1",
+        ) as mock_create_pr,
+        patch("app.core.watcher.watcher_finalize.cleanup_worktree"),
+    ):
+        outcome = finalize_worker(
+            worker,
+            returncode=0,
+            wall_time=1.0,
+            linear=linear_mock,
+            metrics=metrics_mock,
+            escalation_policy=EscalationPolicy.from_toml(),
+            repo_root=tmp_path,
+            mode="default",
+            project_id="proj",
+        )
+
+    # Gate did not fire: PR attempted, ticket never set to Blocked.
+    assert outcome == "success"
+    mock_create_pr.assert_called_once()
+    blocked_calls = [
+        c for c in linear_mock.set_state.call_args_list if c.args[1] == "Blocked"
+    ]
+    assert blocked_calls == []

--- a/tests/test_watcher_finalize_stages.py
+++ b/tests/test_watcher_finalize_stages.py
@@ -1,0 +1,200 @@
+"""WOR-457: last_failure.json written for ANY finalize failure stage.
+
+Before WOR-457 the diagnostic artifact was written only by the run_checks
+path. Failures at rebase / push / pr_create / validation gates left the
+operator with a Linear "Blocked" and no last_failure.json (WOR-441).
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from app.core.escalation_policy import EscalationPolicy
+from app.core.manifest import ArtifactPaths
+from app.core.watcher.watcher_finalize import finalize_worker
+from app.core.watcher.watcher_finalize_helpers import (
+    _classify_stage,
+    _record_failure_artifact,
+)
+from app.core.watcher.watcher_types import ActiveWorker
+from tests.conftest import make_manifest
+
+
+def _artifact_dir(tmp_path: Path) -> Path:
+    return tmp_path / ".claude" / "artifacts" / "wor_457"
+
+
+def _make_worker(tmp_path: Path) -> ActiveWorker:
+    manifest = make_manifest(
+        ticket_id="WOR-457",
+        worker_branch="wor-457-test",
+        required_checks=["ruff check .", "mypy app/", "pytest", "lint-imports"],
+        artifact_paths=ArtifactPaths.from_ticket_id("WOR-457"),
+    )
+    return ActiveWorker(
+        ticket_id="WOR-457",
+        linear_id="fake-linear-id",
+        manifest=manifest,
+        worktree_path=tmp_path,
+        process=MagicMock(spec=subprocess.Popen),
+    )
+
+
+# ---------------------------------------------------------------------------
+# _classify_stage
+# ---------------------------------------------------------------------------
+
+
+def test_classify_stage_rebase() -> None:
+    exc = subprocess.CalledProcessError(1, ["git", "rebase", "main"])
+    assert _classify_stage(exc) == "rebase"
+
+
+def test_classify_stage_push() -> None:
+    exc = subprocess.CalledProcessError(1, ["git", "push", "--force-with-lease"])
+    assert _classify_stage(exc) == "push"
+
+
+def test_classify_stage_pr_create() -> None:
+    exc = subprocess.CalledProcessError(1, ["gh", "pr", "create", "--base", "main"])
+    assert _classify_stage(exc) == "pr_create"
+
+
+def test_classify_stage_pr_merge() -> None:
+    exc = subprocess.CalledProcessError(1, ["gh", "pr", "merge", "--auto"])
+    assert _classify_stage(exc) == "pr_merge"
+
+
+def test_classify_stage_run_checks() -> None:
+    exc = subprocess.CalledProcessError(1, ["pytest", "-q"])
+    assert _classify_stage(exc) == "run_checks"
+
+
+def test_classify_stage_parse() -> None:
+    exc = json.JSONDecodeError("bad", "doc", 0)
+    assert _classify_stage(exc) == "parse"
+
+
+def test_classify_stage_other() -> None:
+    assert _classify_stage(RuntimeError("something unexpected")) == "other"
+
+
+# ---------------------------------------------------------------------------
+# _record_failure_artifact
+# ---------------------------------------------------------------------------
+
+
+def test_record_failure_artifact_writes_stage_and_check_none(
+    tmp_path: Path,
+) -> None:
+    d = tmp_path / "art"
+    _record_failure_artifact(d, "pr_create", exception=RuntimeError("boom"))
+    data = json.loads((d / "last_failure.json").read_text(encoding="utf-8"))
+    assert data["stage"] == "pr_create"
+    assert data["check"] is None
+    assert "failed_at" in data
+    assert "RuntimeError: boom" in data["exception"]
+
+
+def test_record_failure_artifact_merges_preserving_check_and_stdout(
+    tmp_path: Path,
+) -> None:
+    """WOR-66 round-trip: run_checks wrote {check, stdout}; adding stage
+    keeps both."""
+    d = tmp_path / "art"
+    d.mkdir()
+    (d / "last_failure.json").write_text(
+        json.dumps({"check": "pytest", "stdout": "FAILED test_x"}),
+        encoding="utf-8",
+    )
+    _record_failure_artifact(d, "run_checks", check="pytest")
+    data = json.loads((d / "last_failure.json").read_text(encoding="utf-8"))
+    assert data["stage"] == "run_checks"
+    assert data["check"] == "pytest"
+    assert data["stdout"] == "FAILED test_x"
+
+
+def test_record_failure_artifact_keep_existing_stage_no_downgrade(
+    tmp_path: Path,
+) -> None:
+    """A generic 'other' must not overwrite a precise prior stage."""
+    d = tmp_path / "art"
+    d.mkdir()
+    (d / "last_failure.json").write_text(
+        json.dumps({"stage": "pr_create"}), encoding="utf-8"
+    )
+    _record_failure_artifact(d, "other", keep_existing_stage=True)
+    data = json.loads((d / "last_failure.json").read_text(encoding="utf-8"))
+    assert data["stage"] == "pr_create"
+
+
+# ---------------------------------------------------------------------------
+# Integration: validation-gate failures produce last_failure.json
+# ---------------------------------------------------------------------------
+
+
+def test_finalize_allowed_paths_violation_writes_stage(tmp_path: Path) -> None:
+    worker = _make_worker(tmp_path)
+    with (
+        patch(
+            "app.core.watcher.watcher_finalize._validate_allowed_paths",
+            return_value=["ALLOWED app/ui/widget.py"],
+        ),
+        patch("app.core.watcher.watcher_finalize.compute_tags", return_value=[]),
+    ):
+        outcome = finalize_worker(
+            worker,
+            returncode=0,
+            wall_time=1.0,
+            linear=MagicMock(),
+            metrics=MagicMock(),
+            escalation_policy=EscalationPolicy.from_toml(),
+            repo_root=tmp_path,
+            mode="default",
+            project_id="proj",
+        )
+
+    assert outcome == "failure"
+    data = json.loads(
+        (_artifact_dir(tmp_path) / "last_failure.json").read_text(encoding="utf-8")
+    )
+    assert data["stage"] == "validate_allowed_paths"
+    assert "app/ui/widget.py" in data["stderr"]
+
+
+def test_finalize_checks_passed_violation_writes_stage(tmp_path: Path) -> None:
+    worker = _make_worker(tmp_path)
+    result_path = _artifact_dir(tmp_path) / "result.json"
+    result_path.parent.mkdir(parents=True, exist_ok=True)
+    result_path.write_text(
+        json.dumps({"status": "success", "checks_passed": ["ruff", "bandit"]}),
+        encoding="utf-8",
+    )
+    with (
+        patch(
+            "app.core.watcher.watcher_finalize._validate_allowed_paths",
+            return_value=[],
+        ),
+        patch("app.core.watcher.watcher_finalize.compute_tags", return_value=[]),
+    ):
+        outcome = finalize_worker(
+            worker,
+            returncode=0,
+            wall_time=1.0,
+            linear=MagicMock(),
+            metrics=MagicMock(),
+            escalation_policy=EscalationPolicy.from_toml(),
+            repo_root=tmp_path,
+            mode="default",
+            project_id="proj",
+        )
+
+    assert outcome == "failure"
+    data = json.loads(
+        (_artifact_dir(tmp_path) / "last_failure.json").read_text(encoding="utf-8")
+    )
+    assert data["stage"] == "validate_checks_passed"
+    assert "missing required_checks" in data["stderr"]

--- a/tests/test_watcher_worktrees.py
+++ b/tests/test_watcher_worktrees.py
@@ -466,11 +466,12 @@ def test_cleanup_worktree_rmtree_fallback_when_not_a_working_tree(
     orphan.mkdir(parents=True)
     (orphan / "leftover.txt").write_text("stale", encoding="utf-8")
 
-    call_count = {"n": 0}
-
     def _side_effect(*args: object, **kwargs: object) -> MagicMock:
-        call_count["n"] += 1
-        if call_count["n"] == 1:
+        cmd = args[0] if args else []
+        # WOR-450 added a `git clean` sweep before `git worktree remove`;
+        # branch on the command rather than call order so the fallback is
+        # triggered by the real `worktree remove`, not the sweep.
+        if isinstance(cmd, list) and "worktree" in cmd and "remove" in cmd:
             raise subprocess.CalledProcessError(
                 128,
                 "git",
@@ -491,6 +492,69 @@ def test_cleanup_worktree_rmtree_fallback_when_not_a_working_tree(
         "Untracked worktree directory removed via rmtree" in r.message
         for r in caplog.records
     )
+
+
+def test_cleanup_worktree_sweeps_stray_files_before_remove(tmp_path: Path) -> None:
+    """WOR-450: `git clean -fdx -e .claude/artifacts/` runs before remove."""
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    worktree = tmp_path / "worktrees" / "wor-450-test"
+    worktree.mkdir(parents=True)
+
+    calls: list[list[str]] = []
+
+    def _record(*args: object, **kwargs: object) -> MagicMock:
+        cmd = args[0] if args else []
+        if isinstance(cmd, list):
+            calls.append([str(c) for c in cmd])
+        mock = MagicMock()
+        mock.returncode = 0
+        return mock
+
+    with patch("subprocess.run", side_effect=_record):
+        cleanup_worktree(repo_root, worktree)
+
+    clean_idx = next(
+        i for i, c in enumerate(calls) if "clean" in c and "worktree" not in c
+    )
+    remove_idx = next(
+        i for i, c in enumerate(calls) if "worktree" in c and "remove" in c
+    )
+    # Sweep must precede worktree removal.
+    assert clean_idx < remove_idx
+    sweep = calls[clean_idx]
+    # -x reaches the .gitignore'd worker_*.log strays; the artifacts dir
+    # is excluded so audit artifacts are preserved.
+    assert "-fdx" in sweep
+    assert "-e" in sweep
+    assert ".claude/artifacts/" in sweep
+
+
+def test_cleanup_worktree_sweep_failure_does_not_block_removal(
+    tmp_path: Path,
+) -> None:
+    """A `git clean` failure is swallowed; worktree removal still proceeds."""
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    worktree = tmp_path / "worktrees" / "wor-450-test"
+    worktree.mkdir(parents=True)
+
+    removed = {"called": False}
+
+    def _side_effect(*args: object, **kwargs: object) -> MagicMock:
+        cmd = args[0] if args else []
+        if isinstance(cmd, list) and "clean" in cmd and "worktree" not in cmd:
+            raise subprocess.CalledProcessError(1, "git", stderr="clean boom")
+        if isinstance(cmd, list) and "worktree" in cmd and "remove" in cmd:
+            removed["called"] = True
+        mock = MagicMock()
+        mock.returncode = 0
+        return mock
+
+    with patch("subprocess.run", side_effect=_side_effect):
+        cleanup_worktree(repo_root, worktree)
+
+    assert removed["called"], "worktree remove must still run after sweep failure"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Epic→main review surface for the WOR-491 wave. Four commits, four sub-tickets.

## WOR-456 — result.json checks_passed cross-check
`_validate_checks_passed` (watcher_finalize_helpers) + a gate in `finalize_worker` mirroring `_validate_allowed_paths`: a worker reporting `status: success` with a non-empty `checks_passed` that doesn't cover the manifest's `required_checks` (the WOR-66 bug — pre-commit hook names) is marked Blocked, no PR. implement-ticket.md step 5 gets a hard rule. Gate fires only on a non-empty *wrong* claim so existing finalize tests are unaffected.

## WOR-450 — worktree stray-file sweep
`cleanup_worktree` runs `git clean -fdx -e .claude/artifacts/` before `git worktree remove` (`-x` reaches the .gitignore'd `worker_*.log` strays; artifacts preserved — preserve_worker_artifacts already ran). Best-effort; never blocks removal.

## WOR-457 — last_failure.json for any finalize stage
`_classify_stage` + `_record_failure_artifact` + `_artifact_dir_for`. last_failure.json now carries a `stage` discriminator (run_checks|rebase|push|pr_create|pr_merge|validate_allowed_paths|validate_checks_passed|parse|other); `check` kept for back-compat; merged so the WOR-66 artifact round-trips; `failed_at` first-write-wins. Record points: attempt_pr's CalledProcessError (the WOR-441 gap), both validation gates, post-retry-loop catch-all (keep_existing_stage so a precise stage is never downgraded).

## WOR-492 — tests no longer touch a real WSL/vLLM
Surfaced live during this wave: a full `pytest -n 8` on the Windows box spawned **two real GPU `vllm serve`** processes (the second OOM'd) and hammered an already-running vLLM with real GET /v1/models, GET /metrics and POST /v1/messages (a real inference). Autouse conftest guard: the Popen guard now raises `FileNotFoundError` for `wt.exe` (caught by `_open_vllm_terminal` → no spawn), `_write_vllm_script_file` no-op'd, and a `GuardedHTTPConnection` subclass refuses **only** the vLLM host:port (every call site wraps the constructor in `except (OSError, …)`). Deliberately does **not** patch `sys.platform` — forcing 'linux' on Windows broke pytest-qt (`os.getuid`) and urllib (`HTTPConnection.debuglevel`); the subprocess + subclass-HTTP guards prevent the leak without that blast radius.

## Verification
ruff ✓ · mypy ✓ · lint-imports (8 contracts) ✓ · `pytest -n 8` full suite **1892 passed, 0 failed**, no real WSL/vLLM contact.

Root-cause blocker WOR-462 (pytest.ini override) was already Done — the package runs clean. Stale blockers WOR-455/458 already Done.

Closes WOR-456
Closes WOR-450
Closes WOR-457
Closes WOR-492
Closes WOR-491

🤖 Generated with [Claude Code](https://claude.com/claude-code)