### PR TITLE
WOR-430 WOR-309 wip_status round-trip test + WOR-419 multi-dispatch end-to-end test + watcher_heartbeat coverage

### DIFF
--- a/tests/test_watcher_finalize_stages.py
+++ b/tests/test_watcher_finalize_stages.py
@@ -198,3 +198,155 @@ def test_finalize_checks_passed_violation_writes_stage(tmp_path: Path) -> None:
     )
     assert data["stage"] == "validate_checks_passed"
     assert "missing required_checks" in data["stderr"]
+
+
+# ---------------------------------------------------------------------------
+# wip_status round-trip: commit_wip_state → last_failure.json
+# ---------------------------------------------------------------------------
+
+
+def test_finalize_worker_writes_clean_wip_status(tmp_path: Path) -> None:
+    """clean tree → last_failure.json contains wip_status=clean."""
+    worker = _make_worker(tmp_path)
+    with (
+        patch("app.core.watcher.watcher_finalize.commit_wip_state") as mock_wip,
+        patch("app.core.watcher.watcher_finalize.cleanup_worktree"),
+        patch("app.core.watcher.watcher_finalize.preserve_worker_artifacts"),
+        patch(
+            "app.core.watcher.watcher_finalize._validate_allowed_paths",
+            return_value=[],
+        ),
+        patch("app.core.watcher.watcher_finalize.compute_tags", return_value=[]),
+    ):
+        from app.core.watcher.watcher_worktrees import WipPreservationResult
+
+        mock_wip.return_value = WipPreservationResult(
+            status="clean", sha=None, backup_path=None, error=None
+        )
+        finalize_worker(
+            worker,
+            returncode=0,
+            wall_time=1.0,
+            linear=MagicMock(),
+            metrics=MagicMock(),
+            escalation_policy=EscalationPolicy.from_toml(),
+            repo_root=tmp_path,
+            mode="default",
+            project_id="proj",
+        )
+
+    data = json.loads(
+        (_artifact_dir(tmp_path) / "last_failure.json").read_text(encoding="utf-8")
+    )
+    assert data["wip_status"] == "clean"
+
+
+def test_finalize_worker_writes_pushed_wip_status(tmp_path: Path) -> None:
+    """Successful push → wip_status=pushed with sha."""
+    worker = _make_worker(tmp_path)
+    with (
+        patch("app.core.watcher.watcher_finalize.commit_wip_state") as mock_wip,
+        patch("app.core.watcher.watcher_finalize.cleanup_worktree"),
+        patch("app.core.watcher.watcher_finalize.preserve_worker_artifacts"),
+        patch(
+            "app.core.watcher.watcher_finalize._validate_allowed_paths",
+            return_value=[],
+        ),
+        patch("app.core.watcher.watcher_finalize.compute_tags", return_value=[]),
+    ):
+        from app.core.watcher.watcher_worktrees import WipPreservationResult
+
+        mock_wip.return_value = WipPreservationResult(
+            status="pushed", sha="abc1234", backup_path=None, error=None
+        )
+        finalize_worker(
+            worker,
+            returncode=0,
+            wall_time=1.0,
+            linear=MagicMock(),
+            metrics=MagicMock(),
+            escalation_policy=EscalationPolicy.from_toml(),
+            repo_root=tmp_path,
+            mode="default",
+            project_id="proj",
+        )
+
+    data = json.loads(
+        (_artifact_dir(tmp_path) / "last_failure.json").read_text(encoding="utf-8")
+    )
+    assert data["wip_status"] == "pushed"
+    assert data["wip_commit_sha"] == "abc1234"
+
+
+def test_finalize_worker_writes_backup_wip_status(tmp_path: Path) -> None:
+    """Commit failed, backup succeeded → wip_status=backup with path."""
+    worker = _make_worker(tmp_path)
+    with (
+        patch("app.core.watcher.watcher_finalize.commit_wip_state") as mock_wip,
+        patch("app.core.watcher.watcher_finalize.cleanup_worktree"),
+        patch("app.core.watcher.watcher_finalize.preserve_worker_artifacts"),
+        patch(
+            "app.core.watcher.watcher_finalize._validate_allowed_paths",
+            return_value=[],
+        ),
+        patch("app.core.watcher.watcher_finalize.compute_tags", return_value=[]),
+    ):
+        from app.core.watcher.watcher_worktrees import WipPreservationResult
+
+        backup_path = tmp_path / ".claude" / "artifacts" / "wor_457" / "wip"
+        mock_wip.return_value = WipPreservationResult(
+            status="backup", sha=None, backup_path=backup_path, error="push failed"
+        )
+        finalize_worker(
+            worker,
+            returncode=0,
+            wall_time=1.0,
+            linear=MagicMock(),
+            metrics=MagicMock(),
+            escalation_policy=EscalationPolicy.from_toml(),
+            repo_root=tmp_path,
+            mode="default",
+            project_id="proj",
+        )
+
+    data = json.loads(
+        (_artifact_dir(tmp_path) / "last_failure.json").read_text(encoding="utf-8")
+    )
+    assert data["wip_status"] == "backup"
+    assert data["wip_backup_path"] == str(backup_path)
+
+
+def test_finalize_worker_writes_failed_wip_status(tmp_path: Path) -> None:
+    """commit + push + backup all failed → wip_status=failed."""
+    worker = _make_worker(tmp_path)
+    with (
+        patch("app.core.watcher.watcher_finalize.commit_wip_state") as mock_wip,
+        patch("app.core.watcher.watcher_finalize.cleanup_worktree"),
+        patch("app.core.watcher.watcher_finalize.preserve_worker_artifacts"),
+        patch(
+            "app.core.watcher.watcher_finalize._validate_allowed_paths",
+            return_value=[],
+        ),
+        patch("app.core.watcher.watcher_finalize.compute_tags", return_value=[]),
+    ):
+        from app.core.watcher.watcher_worktrees import WipPreservationResult
+
+        mock_wip.return_value = WipPreservationResult(
+            status="failed", sha=None, backup_path=None, error="git error"
+        )
+        finalize_worker(
+            worker,
+            returncode=0,
+            wall_time=1.0,
+            linear=MagicMock(),
+            metrics=MagicMock(),
+            escalation_policy=EscalationPolicy.from_toml(),
+            repo_root=tmp_path,
+            mode="default",
+            project_id="proj",
+        )
+
+    data = json.loads(
+        (_artifact_dir(tmp_path) / "last_failure.json").read_text(encoding="utf-8")
+    )
+    assert data["wip_status"] == "failed"

--- a/tests/test_watcher_heartbeat.py
+++ b/tests/test_watcher_heartbeat.py
@@ -290,3 +290,87 @@ def test_count_queue_items_skips_unreadable_manifest(tmp_path: Path) -> None:
     qs = _count_queue_items(linear, tmp_path)
 
     assert qs.waiting == 1
+
+
+# ── emit_heartbeat — suppression & 30s boundary ─────────────────────────────
+
+
+def test_emit_heartbeat_skips_when_tick_not_advanced() -> None:
+    """When elapsed is still within the last 30s window, heartbeat is skipped."""
+    w = _make_active_worker(ticket_id="WOR-SKIP", elapsed_seconds=35)
+    heartbeat: dict[str, tuple[float, int]] = {"WOR-SKIP": (35.0, 1)}
+
+    result = emit_heartbeat([w], [], heartbeat)
+
+    # Still at tick=1, elapsed still gives tick 1 → skip
+    assert "WOR-SKIP" not in result or result["WOR-SKIP"] == (35.0, 1)
+
+
+def test_emit_heartbeat_crosses_30s_boundary() -> None:
+    """When elapsed crosses to a new 30s tick, heartbeat is emitted."""
+    w = _make_active_worker(ticket_id="WOR-CROSS", elapsed_seconds=65)
+    heartbeat: dict[str, tuple[float, int]] = {"WOR-CROSS": (30.0, 1)}
+
+    result = emit_heartbeat([w], [], heartbeat)
+
+    assert "WOR-CROSS" in result
+    assert result["WOR-CROSS"][1] == 2
+
+
+def test_emit_heartbeat_first_emission_at_30s_boundary() -> None:
+    """First emission at exactly 30s should emit (tick=1)."""
+    w = _make_active_worker(ticket_id="WOR-BOUND", elapsed_seconds=30.0)
+    heartbeat: dict[str, tuple[float, int]] = {}
+
+    result = emit_heartbeat([w], [], heartbeat)
+
+    assert "WOR-BOUND" in result
+    assert result["WOR-BOUND"][1] == 1
+
+
+# ── build_tui_state ─────────────────────────────────────────────────────────
+
+
+def test_build_tui_state_includes_cloud_workers() -> None:
+    """Cloud workers appear in TUI state with mode='cloud' and status='running'."""
+    from app.core.watcher.watcher_heartbeat import build_tui_state
+
+    local_w = _make_active_worker(ticket_id="WOR-LOCAL", elapsed_seconds=100.0)
+    cloud_w = _make_active_worker(ticket_id="WOR-CLOUD", elapsed_seconds=100.0)
+
+    metrics_mock = MagicMock()
+    metrics_mock.get_cost_rollup.return_value = MagicMock(total_cost=10.0)
+
+    state = build_tui_state(
+        local_active=[local_w],
+        cloud_active=[cloud_w],
+        metrics=metrics_mock,
+        tracked_prs=[],
+    )
+
+    worker_ids = {w.ticket_id for w in state.workers}
+    assert "WOR-LOCAL" in worker_ids
+    assert "WOR-CLOUD" in worker_ids
+
+    cloud_worker = next(w for w in state.workers if w.ticket_id == "WOR-CLOUD")
+    assert cloud_worker.mode == "cloud"
+    assert cloud_worker.status == "running"
+
+
+def test_build_tui_state_includes_cost_rollups() -> None:
+    """TUI state contains cost rollups for today, week, and all."""
+    from app.core.watcher.watcher_heartbeat import build_tui_state
+
+    metrics_mock = MagicMock()
+    metrics_mock.get_cost_rollup.return_value = MagicMock(total_cost=42.0)
+
+    state = build_tui_state(
+        local_active=[],
+        cloud_active=[],
+        metrics=metrics_mock,
+        tracked_prs=[],
+    )
+
+    assert "today" in state.cost_rollups
+    assert "week" in state.cost_rollups
+    assert "all" in state.cost_rollups

--- a/tests/test_watcher_multidispatch.py
+++ b/tests/test_watcher_multidispatch.py
@@ -393,3 +393,75 @@ class TestFailureDoesNotConsumeLimit:
         assert len(calls) == 2
         assert calls[0][0][0] == "WOR-FAIL"
         assert calls[1][0][0] == "WOR-10"
+
+
+class TestMultiDispatchTimingE2E:
+    """End-to-end timing: 4 tickets → 3 inter-dispatch sleep(2.5) calls."""
+
+    def test_4_dispatches_with_timing_assertion(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Given 4 eligible tickets and an empty pool, watcher dispatches all
+        4 in one cycle with exactly 3 inter-dispatch gaps of 2.5s."""
+        sleep_times: list[float] = []
+
+        def record_sleep(seconds: float) -> None:
+            sleep_times.append(seconds)
+
+        manifests = [
+            _make_manifest(
+                ticket_id=f"WOR-{i}",
+                worker_branch=f"wor-{i}-test-ticket",
+                allowed_paths=[f"app/core/{chr(97 + i)}.py"],
+            )
+            for i in range(4)
+        ]
+
+        linear_mock = MagicMock()
+        linear_mock.get_open_blockers.return_value = []
+        linear_mock.list_ready_for_local.return_value = [
+            _regular_ticket(f"WOR-{i}") for i in range(4)
+        ]
+
+        w = Watcher(
+            linear_client=linear_mock,
+            repo_root=tmp_path,
+            max_local_workers=8,
+        )
+
+        load_index = [0]
+
+        def capture_load(ticket_id: str):
+            idx = load_index[0]
+            load_index[0] += 1
+            return manifests[idx]
+
+        fake_process = MagicMock(spec=subprocess.Popen)
+
+        with (
+            patch.object(w, "_load_manifest", side_effect=capture_load),
+            patch("app.core.watcher.dispatch.create_worktree", return_value=tmp_path),
+            patch("app.core.watcher.dispatch.copy_manifest_to_worktree"),
+            patch("app.core.watcher.dispatch.write_worker_pytest_config"),
+            patch("app.core.watcher.dispatch.safe_set_state"),
+            patch("app.core.watcher.dispatch.backup_plan_files", return_value=[]),
+            patch(
+                "app.core.watcher.dispatch.launch_worker",
+                return_value=fake_process,
+            ),
+            patch.object(w._services, "ensure_vllm_anthropic_mode"),
+            patch.object(w._services, "probe_vllm_health", return_value=True),
+            patch("app.core.watcher.watcher.time.sleep", record_sleep),
+        ):
+            w._dispatch_next_ticket()
+
+        # 4 dispatches, 3 sleep calls between them
+        assert len(sleep_times) == 3
+        for t in sleep_times:
+            assert t == 2.5
+
+        # All 4 tickets should have been dispatch_count
+        for tid in ("WOR-0", "WOR-1", "WOR-2", "WOR-3"):
+            assert any(w._local_active[i].ticket_id == tid for i in range(4)), (
+                f"{tid} not in local_active"
+            )


### PR DESCRIPTION
Closes WOR-430

Three test additions landed (wip_status 4-outcome round-trip, 4-ticket single-cycle multi-dispatch with timing assertion, watcher_heartbeat >=85% coverage); no app/ source modified; no conftest.py modified; ruff/mypy/pytest/lint-imports green.