### PR TITLE
WOR-471 Tag ticket_metrics with billing_bucket for 2026-06-15 policy split

### DIFF
--- a/app/core/metrics_models.py
+++ b/app/core/metrics_models.py
@@ -248,6 +248,13 @@ class TicketMetrics(BaseModel):
             "or for cap-exceeded violations that slipped through."
         ),
     )
+    billing_bucket: str | None = Field(
+        default=None,
+        description=(
+            "Billing bucket for 2026-06-15 policy split: 'local', 'subscription', "
+            "'agent_sdk_credit', or 'unknown' (legacy rows without a value)."
+        ),
+    )
 
 
 class EpicSummary(BaseModel):

--- a/app/core/metrics_store.py
+++ b/app/core/metrics_store.py
@@ -12,7 +12,7 @@ import platform
 import sqlite3
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Generator, Literal
+from typing import Generator, Literal, overload
 
 from app.core.metrics_models import (
     CheckRunEntry,
@@ -122,14 +122,82 @@ SELECT
     COALESCE(SUM(CASE WHEN local_used = 1 THEN 1 ELSE 0 END), 0)
         AS local_ticket_count
 FROM ticket_metrics
+WHERE billing_bucket IS NULL
+   OR (billing_bucket = 'local' OR billing_bucket = 'subscription'
+       OR billing_bucket = 'agent_sdk_credit')
 """
 _COST_ROLLUP_SQL_TODAY = (
-    _COST_ROLLUP_SQL_BASE + "WHERE recorded_at >= date('now', 'start of day')"
+    _COST_ROLLUP_SQL_BASE + "AND recorded_at >= date('now', 'start of day')"
 )
 _COST_ROLLUP_SQL_WEEK = (
-    _COST_ROLLUP_SQL_BASE + "WHERE recorded_at >= date('now', '-7 days')"
+    _COST_ROLLUP_SQL_BASE + "AND recorded_at >= date('now', '-7 days')"
 )
 _COST_ROLLUP_SQL_ALL = _COST_ROLLUP_SQL_BASE
+
+
+# Grouped queries for by_bucket=True: GROUP BY billing_bucket.
+_COST_ROLLUP_SQL_ALL_GROUPED = (
+    "SELECT billing_bucket,"
+    "        COALESCE(SUM(CASE WHEN cloud_used = 1"
+    "                THEN cloud_cost_estimate ELSE 0 END), 0)"
+    "            AS cloud_spent,"
+    "        COALESCE(SUM(CASE WHEN cloud_used = 1 THEN 1 ELSE 0 END), 0)"
+    "            AS cloud_ticket_count,"
+    "        COALESCE(SUM(CASE WHEN local_used = 1"
+    "                THEN local_input_tokens * 3.0 / 1e6"
+    "                     + local_output_tokens * 15.0 / 1e6"
+    "                ELSE 0 END), 0)"
+    "            AS local_saved,"
+    "        COALESCE(SUM(CASE WHEN local_used = 1 THEN 1 ELSE 0 END), 0)"
+    "            AS local_ticket_count"
+    "    FROM ticket_metrics"
+    "    WHERE billing_bucket IS NOT NULL"
+    "      AND (billing_bucket = 'local' OR billing_bucket = 'subscription'"
+    "           OR billing_bucket = 'agent_sdk_credit')"
+    "    GROUP BY billing_bucket"
+)
+_COST_ROLLUP_SQL_TODAY_GROUPED = (
+    "SELECT billing_bucket,"
+    "        COALESCE(SUM(CASE WHEN cloud_used = 1"
+    "                THEN cloud_cost_estimate ELSE 0 END), 0)"
+    "            AS cloud_spent,"
+    "        COALESCE(SUM(CASE WHEN cloud_used = 1 THEN 1 ELSE 0 END), 0)"
+    "            AS cloud_ticket_count,"
+    "        COALESCE(SUM(CASE WHEN local_used = 1"
+    "                THEN local_input_tokens * 3.0 / 1e6"
+    "                     + local_output_tokens * 15.0 / 1e6"
+    "                ELSE 0 END), 0)"
+    "            AS local_saved,"
+    "        COALESCE(SUM(CASE WHEN local_used = 1 THEN 1 ELSE 0 END), 0)"
+    "            AS local_ticket_count"
+    "    FROM ticket_metrics"
+    "    WHERE billing_bucket IS NOT NULL"
+    "      AND (billing_bucket = 'local' OR billing_bucket = 'subscription'"
+    "           OR billing_bucket = 'agent_sdk_credit')"
+    "    AND recorded_at >= date('now', 'start of day')"
+    "    GROUP BY billing_bucket"
+)
+_COST_ROLLUP_SQL_WEEK_GROUPED = (
+    "SELECT billing_bucket,"
+    "        COALESCE(SUM(CASE WHEN cloud_used = 1"
+    "                THEN cloud_cost_estimate ELSE 0 END), 0)"
+    "            AS cloud_spent,"
+    "        COALESCE(SUM(CASE WHEN cloud_used = 1 THEN 1 ELSE 0 END), 0)"
+    "            AS cloud_ticket_count,"
+    "        COALESCE(SUM(CASE WHEN local_used = 1"
+    "                THEN local_input_tokens * 3.0 / 1e6"
+    "                     + local_output_tokens * 15.0 / 1e6"
+    "                ELSE 0 END), 0)"
+    "            AS local_saved,"
+    "        COALESCE(SUM(CASE WHEN local_used = 1 THEN 1 ELSE 0 END), 0)"
+    "            AS local_ticket_count"
+    "    FROM ticket_metrics"
+    "    WHERE billing_bucket IS NOT NULL"
+    "      AND (billing_bucket = 'local' OR billing_bucket = 'subscription'"
+    "           OR billing_bucket = 'agent_sdk_credit')"
+    "    AND recorded_at >= date('now', '-7 days')"
+    "    GROUP BY billing_bucket"
+)
 
 
 class MetricsStore:
@@ -309,6 +377,10 @@ class MetricsStore:
             "redundant_reads_count",
             "ALTER TABLE ticket_metrics ADD COLUMN redundant_reads_count INTEGER",
         ),
+        (
+            "billing_bucket",
+            "ALTER TABLE ticket_metrics ADD COLUMN billing_bucket TEXT",
+        ),
     ]
 
     def _migrate(self, conn: sqlite3.Connection) -> None:
@@ -389,7 +461,8 @@ class MetricsStore:
                     turn_count, tool_calls_total, tool_calls_breakdown,
                     thinking_blocks, thinking_chars_total,
                     input_tokens_max, input_tokens_first, input_tokens_last,
-                    redundant_reads_count
+                    redundant_reads_count,
+                    billing_bucket
                 ) VALUES (
                     :ticket_id, :project_id, :epic_id, :implementation_mode,
                     :cloud_used, :cloud_model, :cloud_tokens, :cloud_cost_estimate,
@@ -409,7 +482,8 @@ class MetricsStore:
                     :turn_count, :tool_calls_total, :tool_calls_breakdown,
                     :thinking_blocks, :thinking_chars_total,
                     :input_tokens_max, :input_tokens_first, :input_tokens_last,
-                    :redundant_reads_count
+                    :redundant_reads_count,
+                    :billing_bucket
                 )
                 """,
                 {
@@ -508,7 +582,28 @@ class MetricsStore:
             sonar_findings_total=row["sonar_findings_total"],
         )
 
-    def get_cost_rollup(self, period: Literal["today", "week", "all"]) -> CostRollup:
+    @overload
+    def get_cost_rollup(
+        self,
+        period: Literal["today", "week", "all"],
+        *,
+        by_bucket: Literal[False] = False,
+    ) -> CostRollup: ...
+
+    @overload
+    def get_cost_rollup(
+        self,
+        period: Literal["today", "week", "all"],
+        *,
+        by_bucket: Literal[True],
+    ) -> dict[str, CostRollup]: ...
+
+    def get_cost_rollup(
+        self,
+        period: Literal["today", "week", "all"],
+        *,
+        by_bucket: bool = False,
+    ) -> CostRollup | dict[str, CostRollup]:
         """Return aggregated cost economics for *period*.
 
         *today*   = rows where ``recorded_at >= date('now', 'start of day')``
@@ -518,16 +613,33 @@ class MetricsStore:
         cloud_spent  = SUM(cloud_cost_estimate) where cloud_used=1
         local_saved  = SUM(local_input_tokens * input_rate + local_output_tokens
                          * output_rate) where local_used=1; sonnet-4-6 pricing
+
+        When *by_bucket* is True, returns a dict mapping bucket name to
+        ``CostRollup`` (only ``local``, ``subscription``, ``agent_sdk_credit``
+        rows are included; legacy NULL rows are excluded).
         """
-        # Pre-built SQL strings keyed by period — no f-string interpolation,
-        # no user input ever touches these queries (period is a Literal type
-        # constrained to the dict keys at the call site).
         queries = {
             "today": _COST_ROLLUP_SQL_TODAY,
             "week": _COST_ROLLUP_SQL_WEEK,
             "all": _COST_ROLLUP_SQL_ALL,
         }
+        grouped_queries = {
+            "today": _COST_ROLLUP_SQL_TODAY_GROUPED,
+            "week": _COST_ROLLUP_SQL_WEEK_GROUPED,
+            "all": _COST_ROLLUP_SQL_ALL_GROUPED,
+        }
         with self._connect() as conn:
+            if by_bucket:
+                rows = conn.execute(grouped_queries[period]).fetchall()
+                return {
+                    row["billing_bucket"]: CostRollup(
+                        cloud_spent=row["cloud_spent"],
+                        local_saved=row["local_saved"],
+                        cloud_ticket_count=row["cloud_ticket_count"],
+                        local_ticket_count=row["local_ticket_count"],
+                    )
+                    for row in rows
+                }
             row = conn.execute(queries[period]).fetchone()
         return CostRollup(
             cloud_spent=row["cloud_spent"],

--- a/app/core/watcher/watcher_finalize.py
+++ b/app/core/watcher/watcher_finalize.py
@@ -11,6 +11,7 @@ import logging
 import os
 import subprocess  # nosec B404
 import threading
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -671,6 +672,16 @@ def finalize_worker(
             input_tokens_first=behavior.input_tokens_first,
             input_tokens_last=behavior.input_tokens_last,
             redundant_reads_count=behavior.redundant_reads_count,
+            billing_bucket=(
+                "local"
+                if eff == "local"
+                else (
+                    "agent_sdk_credit"
+                    if datetime.now(timezone.utc)
+                    >= datetime(2026, 6, 15, tzinfo=timezone.utc)
+                    else "subscription"
+                )
+            ),
         )
     )
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -9,6 +9,7 @@ import pytest
 from app.core.metrics import (
     CheckRunEntry,
     CheckStats,
+    CostRollup,
     EpicSummary,
     MetricsStore,
     TicketMetrics,
@@ -1136,3 +1137,175 @@ class TestUpdateSonarCount:
         store.update_sonar_count("WOR-99", "proj-a", 5)
         # Should complete without error
         store.get_by_ticket("WOR-99", "proj-a") is None
+
+
+class TestBillingBucketMigration:
+    def test_migration_adds_billing_bucket(self, tmp_path):
+        """Billing bucket column is added by _migrate."""
+        store = MetricsStore(db_path=tmp_path / "app.db")
+        store.record(_ticket(ticket_id="T1", local_used=True))
+        row = store.get_by_ticket("T1", "proj-a")
+        assert row.billing_bucket is None
+
+    def test_billing_bucket_defaults_to_none(self, tmp_path):
+        """New rows have billing_bucket=None until finalize writes it."""
+        store = MetricsStore(db_path=tmp_path / "app.db")
+        row = store.get_by_ticket("T1", "proj-a")
+        assert row is None  # no rows yet
+
+    def test_migration_idempotent(self, tmp_path):
+        """Second _migrate call does not raise."""
+        store = MetricsStore(db_path=tmp_path / "app.db")
+        with store._connect() as conn:
+            store._migrate(conn)
+            store._migrate(conn)
+
+
+class TestBillingBucketAssignment:
+    def test_local_assignment(self, tmp_path):
+        """eff=='local' always maps to 'local' bucket."""
+        store = MetricsStore(db_path=tmp_path / "app.db")
+        store.record(
+            _ticket(
+                implementation_mode="local",
+                local_used=True,
+                billing_bucket="local",
+            )
+        )
+        result = store.get_by_ticket("WOR-1", "proj-a")
+        assert result is not None
+        assert result.billing_bucket == "local"
+
+    def test_subscription_assignment(self, tmp_path):
+        """Pre-cutover cloud tickets map to 'subscription'."""
+        store = MetricsStore(db_path=tmp_path / "app.db")
+        store.record(
+            _ticket(
+                implementation_mode="cloud",
+                cloud_used=True,
+                billing_bucket="subscription",
+            )
+        )
+        result = store.get_by_ticket("WOR-1", "proj-a")
+        assert result is not None
+        assert result.billing_bucket == "subscription"
+
+    def test_agent_sdk_credit_assignment(self, tmp_path):
+        """Post-cutover cloud tickets map to 'agent_sdk_credit'."""
+        store = MetricsStore(db_path=tmp_path / "app.db")
+        store.record(
+            _ticket(
+                implementation_mode="cloud",
+                cloud_used=True,
+                billing_bucket="agent_sdk_credit",
+            )
+        )
+        result = store.get_by_ticket("WOR-1", "proj-a")
+        assert result is not None
+        assert result.billing_bucket == "agent_sdk_credit"
+
+    def test_legacy_unknown(self, tmp_path):
+        """Rows with billing_bucket=None remain None (legacy)."""
+        store = MetricsStore(db_path=tmp_path / "app.db")
+        store.record(_ticket(ticket_id="WOR-1", local_used=True))
+        result = store.get_by_ticket("WOR-1", "proj-a")
+        assert result.billing_bucket is None
+
+
+class TestCostRollupByBucket:
+    def test_by_bucket_segregates_cloud_local(self, tmp_path):
+        """Bucket-segregated rollup returns dict with separate cloud/local entries."""
+        store = MetricsStore(db_path=tmp_path / "app.db")
+        store.record(
+            _ticket(
+                ticket_id="WOR-1",
+                local_used=True,
+                local_input_tokens=100_000,
+                local_output_tokens=5_000,
+                local_wall_time=60.0,
+                billing_bucket="local",
+            )
+        )
+        store.record(
+            _ticket(
+                ticket_id="WOR-2",
+                cloud_used=True,
+                cloud_cost_estimate=0.15,
+                billing_bucket="subscription",
+            )
+        )
+        result = store.get_cost_rollup("all", by_bucket=True)
+        assert isinstance(result, dict)
+        assert "local" in result
+        assert "subscription" in result
+
+    def test_by_bucket_ignores_none_buckets(self, tmp_path):
+        """Legacy rows with billing_bucket=None do not appear in by_bucket result."""
+        store = MetricsStore(db_path=tmp_path / "app.db")
+        store.record(_ticket(ticket_id="WOR-1", local_used=True, billing_bucket=None))
+        store.record(
+            _ticket(
+                ticket_id="WOR-2",
+                local_used=True,
+                local_input_tokens=100_000,
+                local_output_tokens=5_000,
+                billing_bucket="local",
+            )
+        )
+        result = store.get_cost_rollup("all", by_bucket=True)
+        assert "local" in result
+        assert None not in result
+
+    def test_by_bucket_all_buckets(self, tmp_path):
+        """Multiple buckets (local, subscription, agent_sdk_credit) coexist."""
+        store = MetricsStore(db_path=tmp_path / "app.db")
+        store.record(
+            _ticket(
+                ticket_id="WOR-1",
+                local_used=True,
+                billing_bucket="local",
+            )
+        )
+        store.record(
+            _ticket(
+                ticket_id="WOR-2",
+                cloud_used=True,
+                cloud_cost_estimate=0.10,
+                billing_bucket="subscription",
+            )
+        )
+        store.record(
+            _ticket(
+                ticket_id="WOR-3",
+                cloud_used=True,
+                cloud_cost_estimate=0.20,
+                billing_bucket="agent_sdk_credit",
+            )
+        )
+        result = store.get_cost_rollup("all", by_bucket=True)
+        assert isinstance(result, dict)
+        assert len(result) == 3
+        assert set(result.keys()) == {"local", "subscription", "agent_sdk_credit"}
+
+    def test_by_bucket_false_returns_single_rollup(self, tmp_path):
+        """Default (by_bucket=False) returns CostRollup, not dict."""
+        store = MetricsStore(db_path=tmp_path / "app.db")
+        store.record(
+            _ticket(
+                ticket_id="WOR-1",
+                local_used=True,
+                local_input_tokens=100_000,
+                local_output_tokens=5_000,
+                local_wall_time=60.0,
+                billing_bucket="local",
+            )
+        )
+        result = store.get_cost_rollup("all")
+        assert isinstance(result, CostRollup)
+        assert result.local_ticket_count == 1
+
+    def test_by_bucket_no_rows(self, tmp_path):
+        """Empty table returns empty dict when by_bucket=True."""
+        store = MetricsStore(db_path=tmp_path / "app.db")
+        result = store.get_cost_rollup("all", by_bucket=True)
+        assert result == {}


### PR DESCRIPTION
Salvage of WOR-471 — billing_bucket telemetry for the 2026-06-15 Agent
SDK credit split.

The local worker's billing_bucket implementation is substantively
correct (data-driven migration, finalize-site population, by_bucket
rollup, 12 new tests). It Blocked because (a) it committed a stray
result.json at the repo root — watcher couldn't read it and it tripped
allowed_paths (pipeline gap tracked as WOR-501), and (b) the worker's
by_bucket union return (CostRollup | dict) broke watcher_heartbeat.py:246
under mypy with no @overload.

Architect finalize fix applied: added an @overload pair on
get_cost_rollup so by_bucket=False narrows to CostRollup (resolves the
consumer) — ~6 lines, disclosed here for review. Stray result.json
commit dropped.

Independently re-verified after the fix:
- ruff check .   : clean
- mypy app/      : 0 issues, 48 files
- lint-imports   : 8 kept, 0 broken
- pytest         : 1904 passed, 0 failed

Targets the epic branch per the standard sub-to-epic-to-main flow;
human review at the epic-to-main gate.

Part of WOR-493.

Generated with Claude Code
