### PR TITLE
WOR-447 Recompute cost/last-action/economics/session-totals every TUI tick

### DIFF
--- a/app/core/watcher/watcher_heartbeat.py
+++ b/app/core/watcher/watcher_heartbeat.py
@@ -25,9 +25,10 @@ if TYPE_CHECKING:
     from app.core.metrics import MetricsStore
     from app.core.watcher.watcher_types import ActiveWorker, LinearClientProtocol
 
-# Estimated cost per output token for local workers (rough vLLM hardware cost).
-# Used to produce a live cost estimate from output_token count during running.
-_LOCAL_COST_PER_TOKEN = 15e-6  # $15 per million output tokens
+# Estimated cost per input/output token for local workers (sonnet-4-6 pricing).
+# Used to produce a live cost estimate from the JSONL token counts during running.
+_LOCAL_COST_PER_INPUT_TOKEN = 3e-6  # $3 per million input tokens
+_LOCAL_COST_PER_OUTPUT_TOKEN = 15e-6  # $15 per million output tokens
 
 
 logger = logging.getLogger(__name__)
@@ -154,11 +155,13 @@ def _build_local_worker_log_path(worker: "ActiveWorker") -> Path:
     )
 
 
-def _live_cost_estimate(output_tokens: int | None) -> float:
-    """Estimate dollar cost from output token count."""
-    if output_tokens is None or output_tokens == 0:
+def _live_cost_estimate(input_tokens: int | None, output_tokens: int | None) -> float:
+    """Estimate dollar cost from input + output token counts."""
+    if input_tokens is None and output_tokens is None:
         return 0.0
-    return output_tokens * _LOCAL_COST_PER_TOKEN
+    in_cost = (input_tokens or 0) * _LOCAL_COST_PER_INPUT_TOKEN
+    out_cost = (output_tokens or 0) * _LOCAL_COST_PER_OUTPUT_TOKEN
+    return in_cost + out_cost
 
 
 def _count_queue_items(
@@ -218,8 +221,8 @@ def build_tui_state(
     for w in local_active:
         elapsed = time.monotonic() - w.start_time
         log_path = _build_local_worker_log_path(w)
-        _, out_tok, _, _ = _parse_worker_usage(log_path)
-        cost = _live_cost_estimate(out_tok)
+        in_tok, out_tok, _, _ = _parse_worker_usage(log_path)
+        cost = _live_cost_estimate(in_tok, out_tok)
         last_act = last_tool_call(log_path)
         workers.append(
             WorkerState(

--- a/app/core/watcher/watcher_tui.py
+++ b/app/core/watcher/watcher_tui.py
@@ -184,6 +184,15 @@ class WatcherDisplay:
         table.add_column("Local Saved", justify="right")
         table.add_column("Cloud #", justify="right")
         table.add_column("Local #", justify="right")
+        all_empty = not any(
+            (isinstance(v, CostRollup) and (v.cloud_spent != 0 or v.local_saved != 0))
+            for v in (
+                state.cost_rollups if isinstance(state.cost_rollups, dict) else {}
+            ).values()
+        )
+        if all_empty:
+            table.add_row("—", "—", "No data yet", "—", "—")
+            return table
         for period in ("today", "week", "all"):
             cr = state.cost_rollups.get(period, CostRollup())
             if period in state.cost_rollups:
@@ -201,10 +210,23 @@ class WatcherDisplay:
         table = Table(title="Session Totals", show_header=True, expand=True)
         table.add_column("Metric", style="cyan")
         table.add_column("Value", justify="right")
+        if not state.workers:
+            table.add_row("—", "—", "No data yet", "—")
+            return table
         total_cloud = sum(w.cloud_cost for w in state.workers if w.mode == "cloud")
         total_local = sum(w.local_saved for w in state.workers if w.mode == "local")
         table.add_row("Session Cloud Spent", "$" + f"{total_cloud:.4f}")
         table.add_row("Session Local Saved", "$" + f"{total_local:.4f}")
+        today_rollup = state.cost_rollups.get("today", CostRollup())
+        if isinstance(today_rollup, CostRollup):
+            table.add_row(
+                "Tickets Dispatched Today",
+                str(today_rollup.cloud_ticket_count + today_rollup.local_ticket_count),
+            )
+            table.add_row(
+                "Total Cost Saved Estimate",
+                "$" + f"{today_rollup.local_saved:.4f}",
+            )
         table.add_row("Active Workers", str(len(state.workers)))
         for pr in state.tracked_prs:
             if pr.last_status == "MERGED":

--- a/tests/test_watcher_heartbeat.py
+++ b/tests/test_watcher_heartbeat.py
@@ -89,21 +89,21 @@ def _write_manifest(art_dir: Path, ticket_id: str, status: str) -> None:
 
 
 def test_live_cost_estimate_none_returns_zero() -> None:
-    """None output_tokens → 0.0."""
-    assert _live_cost_estimate(None) == 0.0
+    """Both None → 0.0."""
+    assert _live_cost_estimate(None, None) == 0.0
 
 
 def test_live_cost_estimate_zero_returns_zero() -> None:
-    """0 output_tokens → 0.0 (avoid division by zero artifacts)."""
-    assert _live_cost_estimate(0) == 0.0
+    """0 tokens → 0.0 (avoid division by zero artifacts)."""
+    assert _live_cost_estimate(0, 0) == 0.0
 
 
 def test_live_cost_estimate_scales_linearly() -> None:
     """Cost scales linearly at $15/M output tokens."""
-    # 1M tokens at $15/M = $15
-    assert _live_cost_estimate(1_000_000) == 15.0
-    # 100k tokens → $1.50
-    assert abs(_live_cost_estimate(100_000) - 1.50) < 1e-9
+    # 1M output tokens at $15/M = $15
+    assert _live_cost_estimate(None, 1_000_000) == 15.0
+    # 100k output tokens → $1.50
+    assert abs(_live_cost_estimate(None, 100_000) - 1.50) < 1e-9
 
 
 # ── _build_local_worker_log_path ────────────────────────────────────────────

--- a/tests/test_watcher_tui.py
+++ b/tests/test_watcher_tui.py
@@ -9,10 +9,12 @@ and _render_line sub-widgets directly.
 
 from __future__ import annotations
 
+import json
 import time
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
 from rich.console import Console
 from rich.live import Live
 
@@ -630,3 +632,214 @@ def test_queue_table_shows_counts() -> None:
     assert "2" in text
     assert "1" in text
     assert "0" in text
+
+
+# ---------------------------------------------------------------------------
+# WOR-447 - Cost Economics table "no data yet" placeholder
+# ---------------------------------------------------------------------------
+
+
+def test_cost_table_shows_no_data_when_all_zero() -> None:
+    """When all cost rollups are zero, the table shows a 'No data yet' row."""
+    state = _tui_state(
+        cost_rollups={
+            "today": CostRollup(),  # all zeros
+            "week": CostRollup(),
+            "all": CostRollup(),
+        },
+    )
+    display = WatcherDisplay()
+    table = display._cost_table(state)
+    console = Console(record=True, width=120, force_terminal=True)
+    console.print(table)
+    text = console.export_text()
+
+    assert "No data yet" in text
+    assert "Cost Economics" in text
+
+
+def test_cost_table_hides_no_data_when_any_period_has_data() -> None:
+    """When at least one period has non-zero cost, no 'No data yet' placeholder."""
+    state = _tui_state(
+        cost_rollups={
+            "today": CostRollup(
+                cloud_spent=66.0,
+                local_saved=2.22,
+                cloud_ticket_count=3,
+                local_ticket_count=5,
+            ),
+            "week": CostRollup(),
+            "all": CostRollup(),
+        },
+    )
+    display = WatcherDisplay()
+    table = display._cost_table(state)
+    console = Console(record=True, width=120, force_terminal=True)
+    console.print(table)
+    text = console.export_text()
+
+    assert "No data yet" not in text
+    assert "Today" in text  # the non-empty period row
+
+
+# ---------------------------------------------------------------------------
+# WOR-447 - Session Totals "no data yet" when no workers
+# ---------------------------------------------------------------------------
+
+
+def test_session_totals_no_data_when_no_workers() -> None:
+    """When no active workers, Session Totals shows 'No data yet'."""
+    state = _tui_state(workers=[])
+    display = WatcherDisplay()
+    table = display._rollup_table(state)
+    console = Console(record=True, width=120, force_terminal=True)
+    console.print(table)
+    text = console.export_text()
+
+    assert "No data yet" in text
+    assert "Session Totals" in text
+
+
+def test_session_totals_shows_worked_data_with_workers() -> None:
+    """When active workers exist, Session Totals shows live metrics."""
+    state = _tui_state(
+        workers=[
+            WorkerState(
+                ticket_id="WOR-50",
+                mode="local",
+                status="running",
+                elapsed_s=125.0,
+                local_saved=3.75,
+            ),
+        ],
+        cost_rollups={
+            "today": CostRollup(cloud_spent=10.0, local_saved=5.0),
+            "week": CostRollup(),
+            "all": CostRollup(),
+        },
+    )
+    display = WatcherDisplay()
+    table = display._rollup_table(state)
+    console = Console(record=True, width=120, force_terminal=True)
+    console.print(table)
+    text = console.export_text()
+
+    assert "No data yet" not in text
+    assert "Session Local Saved" in text
+    assert "Active Workers" in text
+
+
+def test_session_totals_includes_tickets_dispatched_today() -> None:
+    """Session Totals includes 'Tickets Dispatched Today' row."""
+    state = _tui_state(
+        workers=[
+            WorkerState(
+                ticket_id="WOR-50",
+                mode="local",
+                status="running",
+                elapsed_s=60.0,
+            ),
+        ],
+        cost_rollups={
+            "today": CostRollup(
+                cloud_spent=10.0,
+                local_saved=5.0,
+                cloud_ticket_count=2,
+                local_ticket_count=3,
+            ),
+            "week": CostRollup(),
+            "all": CostRollup(),
+        },
+    )
+    display = WatcherDisplay()
+    table = display._rollup_table(state)
+    console = Console(record=True, width=120, force_terminal=True)
+    console.print(table)
+    text = console.export_text()
+
+    assert "Tickets Dispatched Today" in text
+    assert "5" in text  # 2 + 3
+
+
+def test_session_totals_includes_cost_saved_estimate() -> None:
+    """Session Totals includes 'Total Cost Saved Estimate' row."""
+    state = _tui_state(
+        workers=[
+            WorkerState(
+                ticket_id="WOR-50",
+                mode="local",
+                status="running",
+                elapsed_s=60.0,
+            ),
+        ],
+        cost_rollups={
+            "today": CostRollup(
+                cloud_spent=10.0,
+                local_saved=5.0,
+                cloud_ticket_count=2,
+                local_ticket_count=3,
+            ),
+            "week": CostRollup(),
+            "all": CostRollup(),
+        },
+    )
+    display = WatcherDisplay()
+    table = display._rollup_table(state)
+    console = Console(record=True, width=120, force_terminal=True)
+    console.print(table)
+    text = console.export_text()
+
+    assert "Total Cost Saved Estimate" in text
+    assert "$5.0000" in text
+
+
+# ---------------------------------------------------------------------------
+# WOR-447 - cost computation with input + output tokens
+# ---------------------------------------------------------------------------
+
+
+def test_build_tui_state_cost_uses_input_and_output_tokens(tmp_path: Path) -> None:
+    """build_tui_state computes cost from both input and output tokens."""
+    from app.core.watcher.watcher import Watcher
+
+    w = Watcher(
+        linear_client=MagicMock(),
+        repo_root=tmp_path,
+        no_epic_shutdown=True,
+    )
+
+    worker = MagicMock()
+    worker.ticket_id = "WOR-TEST"
+    worker.start_time = time.monotonic() - 60
+    # Create a log path that _parse_worker_usage can read
+    log_dir = tmp_path / "wor_test" / ".claude" / "logs"
+    log_dir.mkdir(parents=True)
+    log_path = log_dir / "wor_test.jsonl"
+    # Write an assistant event with usage (input + output tokens)
+    log_path.write_text(
+        json.dumps(
+            {
+                "type": "assistant",
+                "message": {
+                    "usage": {"input_tokens": 1000, "output_tokens": 2000},
+                    "content": [{"type": "text", "text": "hello"}],
+                },
+            }
+        )
+        + "\n"
+    )
+    worker.worktree_path = tmp_path / "wor_test"
+    w._local_active.append(worker)
+
+    state = build_tui_state(
+        w._local_active,
+        w._cloud_active,
+        w._metrics,
+        w._tracked_prs,
+    )
+
+    assert len(state.workers) == 1
+    ws = state.workers[0]
+    assert ws.mode == "local"
+    # Cost = 1000 * 3e-6 + 2000 * 15e-6 = 0.003 + 0.03 = 0.033
+    assert ws.local_saved == pytest.approx(0.033)


### PR DESCRIPTION
Salvage of WOR-447 — unfreeze the watcher TUI Cost / Last Action /
Cost Economics / Session Totals panels.

The local worker's implementation is correct and complete — a single
clean 4-file commit, no stray artifacts. It Blocked solely on
under-scoped allowed_paths (architect error, WOR-500): the frozen
Cost Economics panel is computed in watcher_heartbeat.py, which the fix
necessarily edits, but the manifest scoped only watcher_tui.py /
watcher_log_parsing.py / metrics_store.py / test_watcher_tui*.

Independently re-verified on the current epic tip (includes the merged
WOR-290 + WOR-471):
- ruff check .   : clean
- mypy app/      : 0 issues, 48 files
- lint-imports   : 8 kept, 0 broken
- pytest         : 1940 passed, 0 failed

Third architect-scoping block of sound work this batch
(WOR-290 / WOR-471 / WOR-447) — root cause tracked as WOR-500,
pipeline blind spot as WOR-501.

Part of WOR-493.

Generated with Claude Code
