### PR TITLE
WOR-483 Anti-thrash PostToolUse hook: flag 5+ edits to same file in 5min

### DIFF
--- a/.claude/hooks/posttooluse_thrash_detector.py
+++ b/.claude/hooks/posttooluse_thrash_detector.py
@@ -1,0 +1,161 @@
+"""PostToolUse hook to flag 5+ edits to the same file within 5 minutes.
+
+Detects the WOR-401-class mock-path thrash pattern — an operator editing
+the same file repeatedly in one session, typically chasing a mock path
+that keeps breaking.  Five edits in five minutes is treated as a signal
+to pause and follow the CLAUDE.md mock-path migration rules.
+
+State file: ``<repo>/.claude/.thrash_state.json``.  Keyed by
+``session_id`` so a stale file from a prior session does not leak into
+the current one.  Persisted before any potential print so the count is
+always durable.
+
+The state file is anchored to the hook script's location (``__file__``),
+not the cwd from the payload.
+
+Wire in ``.claude/settings.json``::
+
+    "hooks": {
+      "PostToolUse": [
+        {
+          "matcher": "Edit|Write",
+          "hooks": [
+            {
+              "type": "command",
+              "command": "python .claude/hooks/posttooluse_thrash_detector.py"
+            }
+          ]
+        }
+      ]
+    }
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import time
+from pathlib import Path
+
+EDITS_CAP = 5
+WINDOW_SECONDS = 300  # 5 minutes
+
+STATE_FILENAME = ".thrash_state.json"
+
+
+def _warn(message: str) -> int:
+    print(json.dumps({"thrash_warning": message}))
+    return 0
+
+
+def _prune_timestamps(timestamps: list[float], now: float) -> list[float]:
+    cutoff = now - WINDOW_SECONDS
+    return [t for t in timestamps if t > cutoff]
+
+
+def main(state_path: Path | None = None) -> int:
+    print("posttooluse_thrash_detector: fired", file=sys.stderr, flush=True)
+    try:
+        payload = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        return 0
+
+    if not isinstance(payload, dict):
+        return 0
+
+    tool_name = payload.get("tool_name", "")
+    if tool_name not in ("Edit", "Write"):
+        return 0
+
+    # Both Edit and Write pass the target path under file_path.
+    file_path_raw = payload.get("tool_input", {}).get("file_path")
+    if not file_path_raw:
+        return 0
+
+    session_id = payload.get("session_id", "")
+
+    # State file lives at <repo>/.claude/.thrash_state.json.
+    # Anchor to the hook script's own location, not the cwd from the
+    # payload.
+    if state_path is None:
+        hook_dir = Path(__file__).resolve().parent  # <repo>/.claude/hooks
+        state_path = hook_dir.parent / STATE_FILENAME
+
+    # Normalize the file path so different relative spellings of the same
+    # file collapse to one key.
+    try:
+        candidate = Path(file_path_raw)
+        if not candidate.is_absolute():
+            candidate = Path.cwd() / candidate
+        normalized = str(candidate.resolve())
+    except (OSError, RuntimeError):
+        normalized = file_path_raw
+
+    # Load existing state; reset if session_id changed (stale from prior run).
+    # Always build a fresh state dict so edits don't leak across sessions.
+    edits: dict[str, list[float]] = {}
+    state: dict[str, object] = {"session_id": session_id, "edits": edits}
+    if state_path.exists():
+        try:
+            existing = json.loads(state_path.read_text(encoding="utf-8"))
+            if isinstance(existing, dict) and existing.get("session_id") == session_id:
+                raw_edits = existing.get("edits") or {}
+                if isinstance(raw_edits, dict):
+                    # Copy edits so mutations don't affect the raw loaded dict.
+                    for k, v in raw_edits.items():
+                        if isinstance(v, list):
+                            edits[k] = v[:]
+                        else:
+                            edits[k] = []
+                state = {"session_id": session_id, "edits": edits}
+        except (OSError, json.JSONDecodeError):
+            pass
+
+    now = time.time()
+
+    # Initialize timestamps list for this file if needed.
+    if normalized not in edits:
+        edits[normalized] = []
+
+    timestamps = edits[normalized]
+    if not isinstance(timestamps, list):
+        timestamps = []
+        edits[normalized] = timestamps
+
+    # Prune stale timestamps outside the rolling window.
+    timestamps[:] = _prune_timestamps(timestamps, now)
+
+    # Record this edit.
+    timestamps.append(now)
+
+    state["session_id"] = session_id
+
+    # Persist BEFORE deciding — if write fails, fail open (don't warn
+    # on infra issues).
+    try:
+        state_path.parent.mkdir(parents=True, exist_ok=True)
+        state_path.write_text(json.dumps(state), encoding="utf-8")
+    except OSError:
+        return 0
+
+    # Count is the number of edits within the window.
+    count = len(timestamps)
+
+    if count >= EDITS_CAP:
+        elapsed_minutes = (
+            (timestamps[-1] - timestamps[0]) / 60.0 if len(timestamps) > 1 else 0
+        )
+        leaf = Path(file_path_raw).name
+        message = (
+            f"{count}th edit to {leaf} in {elapsed_minutes:.0f} minutes "
+            f"— iterating on test mocks? "
+            f"See CLAUDE.md mock-path migration rules "
+            f"(anchor: mock-path migration section)"
+        )
+        return _warn(message)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_posttooluse_thrash_detector.py
+++ b/tests/test_posttooluse_thrash_detector.py
@@ -1,0 +1,326 @@
+"""Tests for .claude/hooks/posttooluse_thrash_detector.py."""
+
+import json
+import sys
+import time
+from pathlib import Path
+from types import ModuleType
+from unittest import mock
+
+_HOOK_DIR = Path(__file__).resolve().parent.parent / ".claude" / "hooks"
+_HOOK_PATH = _HOOK_DIR / "posttooluse_thrash_detector.py"
+
+
+def _load_module() -> ModuleType:
+    """Load the hook module fresh."""
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("_thrash_detector", str(_HOOK_PATH))
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["_thrash_detector"] = mod
+    spec.loader.exec_module(mod)
+    del sys.modules["_thrash_detector"]
+    return mod
+
+
+def _make_payload(
+    file_path: str = "app/core/example.py",
+    tool_name: str = "Edit",
+    session_id: str = "sess-1",
+) -> dict:
+    return {
+        "tool_name": tool_name,
+        "tool_input": {"file_path": file_path},
+        "session_id": session_id,
+    }
+
+
+def _run_main(mod, payload, state_file):
+    """Run mod.main(state_path=...) with mocked stdin and print.
+
+    Returns (returncode, list_of_json_output_lines — i.e. lines from _warn).
+    """
+    captured: list[str] = []
+
+    def capture(*args, **kwargs):
+        if args:
+            captured.append(str(args[0]))
+
+    json.dumps(payload)
+
+    with (
+        mock.patch("builtins.print", side_effect=capture),
+        mock.patch("json.load", return_value=payload),
+    ):
+        rc = mod.main(state_path=state_file)
+
+    # Only keep JSON output lines (from _warn), skip stderr debug prints.
+    json_lines = [s for s in captured if s.startswith("{")]
+    return rc, json_lines
+
+
+class TestThrashDetector:
+    """Tests for the PostToolUse thrash detector hook."""
+
+    # -- trigger tests --
+
+    def test_no_warning_on_first_edit(self, tmp_path: Path):
+        mod = _load_module()
+        state_file = tmp_path / mod.STATE_FILENAME
+        state_file.write_text(
+            '{"session_id": "old-session", "edits": {}}', encoding="utf-8"
+        )
+
+        payload = _make_payload("app/core/example.py")
+        rc, captured = _run_main(mod, payload, state_file)
+        assert rc == 0
+        data = json.loads("".join(captured)) if captured else {}
+        assert "thrash_warning" not in data
+
+    def test_no_warning_on_four_edits(self, tmp_path: Path):
+        mod = _load_module()
+        state_file = tmp_path / mod.STATE_FILENAME
+        state_file.write_text('{"session_id": "sess-1", "edits": {}}', encoding="utf-8")
+
+        last = None
+        for _ in range(4):
+            payload = _make_payload("app/core/example.py")
+            last = _run_main(mod, payload, state_file)
+
+        assert last is not None
+        rc, captured = last
+        data = json.loads("".join(captured)) if captured else {}
+        assert "thrash_warning" not in data
+
+    def test_warning_on_fifth_edit(self, tmp_path: Path):
+        mod = _load_module()
+        state_file = tmp_path / mod.STATE_FILENAME
+        state_file.write_text('{"session_id": "sess-1", "edits": {}}', encoding="utf-8")
+
+        last = None
+        for _ in range(5):
+            payload = _make_payload("app/core/example.py")
+            last = _run_main(mod, payload, state_file)
+
+        rc, captured = last
+        data = json.loads("".join(captured)) if captured else {}
+        assert "thrash_warning" in data
+        assert "example.py" in data["thrash_warning"]
+        assert "5" in data["thrash_warning"]
+
+    def test_edit_and_write_both_count(self, tmp_path: Path):
+        mod = _load_module()
+        state_file = tmp_path / mod.STATE_FILENAME
+        state_file.write_text('{"session_id": "sess-1", "edits": {}}', encoding="utf-8")
+
+        last = None
+        for tool in ("Edit", "Write", "Edit", "Write", "Edit"):
+            payload = _make_payload("app/core/example.py", tool_name=tool)
+            last = _run_main(mod, payload, state_file)
+
+        rc, captured = last
+        data = json.loads("".join(captured)) if captured else {}
+        assert "thrash_warning" in data
+
+    # -- session isolation --
+
+    def test_no_cross_session_bleed(self, tmp_path: Path):
+        """Verify that different session_ids produce independent edit counts."""
+        # Seed with session-3 state (neither mod uses).
+        state_file = tmp_path / ".thrash_state.json"
+        state_file.write_text(
+            json.dumps(
+                {
+                    "session_id": "sess-3",
+                    "edits": {"app/core/example.py": [time.time() - 1] * 5},
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        # mod1 uses session-1 — session mismatches on first call,
+        # then state file gets updated to "sess-1" and subsequent
+        # calls accumulate. After 5 calls, triggers.
+        mod1 = _load_module()
+        last = None
+        for _ in range(5):
+            payload = _make_payload("app/core/example.py", session_id="sess-1")
+            last = _run_main(mod1, payload, state_file)
+
+        rc, captured = last
+        data = json.loads("".join(captured)) if captured else {}
+        assert "thrash_warning" in data  # triggers after accumulating 5
+
+        # mod2 uses session-2 — starts fresh because mod1's file has "sess-1".
+        # After 5 calls, triggers again — no bleed from mod1.
+        mod2 = _load_module()
+        for _ in range(5):
+            payload = _make_payload("app/core/example.py", session_id="sess-2")
+            last = _run_main(mod2, payload, state_file)
+
+        rc, captured = last
+        data = json.loads("".join(captured)) if captured else {}
+        assert "thrash_warning" in data  # also triggers independently
+        # Verify the edit count is 5, not 10.
+        assert "5" in data["thrash_warning"]
+
+    def test_session_id_reset_on_change(self, tmp_path: Path):
+        mod = _load_module()
+        state_file = tmp_path / mod.STATE_FILENAME
+        old_ts = [time.time() - 10] * 5
+        state = {"session_id": "sess-1", "edits": {"app/core/example.py": old_ts}}
+        state_file.write_text(json.dumps(state), encoding="utf-8")
+
+        # 1 edit under sess-2 should not trigger (reset).
+        payload = _make_payload("app/core/example.py", session_id="sess-2")
+        rc, captured = _run_main(mod, payload, state_file)
+
+        assert rc == 0
+        data = json.loads("".join(captured)) if captured else {}
+        assert "thrash_warning" not in data
+
+    # -- per-file independence --
+
+    def test_different_files_dont_mix(self, tmp_path: Path):
+        mod = _load_module()
+        state_file = tmp_path / mod.STATE_FILENAME
+        state_file.write_text('{"session_id": "sess-1", "edits": {}}', encoding="utf-8")
+
+        # 4 edits to file A.
+        for _ in range(4):
+            _run_main(mod, _make_payload("app/core/fileA.py"), state_file)
+
+        # 1 edit to file B = total 5, but split across 2 files.
+        payload = _make_payload("app/core/fileB.py")
+        rc, captured = _run_main(mod, payload, state_file)
+
+        assert rc == 0
+        data = json.loads("".join(captured)) if captured else {}
+        assert "thrash_warning" not in data
+
+    def test_window_expiry_clears_count(self, tmp_path: Path):
+        mod = _load_module()
+        state_file = tmp_path / mod.STATE_FILENAME
+        old_ts = [time.time() - 600] * 4  # 10 minutes old
+        state = {"session_id": "sess-1", "edits": {"app/core/example.py": old_ts}}
+        state_file.write_text(json.dumps(state), encoding="utf-8")
+
+        # New edit should prune old ones and start fresh.
+        payload = _make_payload("app/core/example.py")
+        rc, captured = _run_main(mod, payload, state_file)
+
+        assert rc == 0
+        data = json.loads("".join(captured)) if captured else {}
+        assert "thrash_warning" not in data
+
+    # -- non-trigger paths --
+
+    def test_non_edit_tools_ignored(self, tmp_path: Path):
+        mod = _load_module()
+        state_file = tmp_path / mod.STATE_FILENAME
+        state_file.write_text('{"session_id": "sess-1", "edits": {}}', encoding="utf-8")
+
+        for tool in ("Bash", "Read", "Grep", "Agent"):
+            payload = _make_payload("app/core/example.py", tool_name=tool)
+            rc, _ = _run_main(mod, payload, state_file)
+            assert rc == 0
+
+    def test_no_file_path_ignored(self, tmp_path: Path):
+        mod = _load_module()
+        state_file = tmp_path / mod.STATE_FILENAME
+        state_file.write_text('{"session_id": "sess-1", "edits": {}}', encoding="utf-8")
+
+        payload = {"tool_name": "Edit", "tool_input": {}}
+        rc, _ = _run_main(mod, payload, state_file)
+        assert rc == 0
+
+    # -- error handling --
+
+    def test_malformed_json(self, tmp_path: Path):
+        mod = _load_module()
+        state_file = tmp_path / mod.STATE_FILENAME
+        state_file.write_text('{"session_id": "sess-1", "edits": {}}', encoding="utf-8")
+
+        rc, _ = _run_main(mod, "not json", state_file)
+        assert rc == 0
+
+    def test_non_dict_payload(self, tmp_path: Path):
+        mod = _load_module()
+        state_file = tmp_path / mod.STATE_FILENAME
+        state_file.write_text('{"session_id": "sess-1", "edits": {}}', encoding="utf-8")
+
+        rc, _ = _run_main(mod, [1, 2, 3], state_file)
+        assert rc == 0
+
+    def test_empty_input(self, tmp_path: Path):
+        mod = _load_module()
+        state_file = tmp_path / mod.STATE_FILENAME
+        state_file.write_text('{"session_id": "sess-1", "edits": {}}', encoding="utf-8")
+
+        rc, _ = _run_main(mod, "", state_file)
+        assert rc == 0
+
+    def test_stale_state_file(self, tmp_path: Path):
+        mod = _load_module()
+        state_file = tmp_path / mod.STATE_FILENAME
+        state_file.write_text("this is not json", encoding="utf-8")
+
+        payload = _make_payload("app/core/example.py")
+        rc, _ = _run_main(mod, payload, state_file)
+        assert rc == 0
+
+    def test_empty_state_dict(self, tmp_path: Path):
+        mod = _load_module()
+        state_file = tmp_path / mod.STATE_FILENAME
+        state_file.write_text('{"session_id": "sess-1"}', encoding="utf-8")
+
+        payload = _make_payload("app/core/example.py")
+        rc, _ = _run_main(mod, payload, state_file)
+        assert rc == 0
+
+    # -- message content --
+
+    def test_warning_message_content(self, tmp_path: Path):
+        mod = _load_module()
+        state_file = tmp_path / mod.STATE_FILENAME
+        state_file.write_text('{"session_id": "sess-1", "edits": {}}', encoding="utf-8")
+
+        last = None
+        for _ in range(5):
+            payload = _make_payload("app/core/watcher.py")
+            last = _run_main(mod, payload, state_file)
+
+        rc, captured = last
+        data = json.loads("".join(captured)) if captured else {}
+        assert "thrash_warning" in data
+        msg = data["thrash_warning"]
+        assert "mock" in msg.lower()
+        assert "watcher.py" in msg
+        assert "5" in msg
+
+    def test_no_warning_on_four_edits_strict(self, tmp_path: Path):
+        """Edge: exactly 4 edits — no warning, regardless of file."""
+        mod = _load_module()
+        state_file = tmp_path / mod.STATE_FILENAME
+        state_file.write_text('{"session_id": "sess-1", "edits": {}}', encoding="utf-8")
+
+        for _ in range(4):
+            payload = _make_payload("app/core/different.py")
+            rc, _ = _run_main(mod, payload, state_file)
+            assert rc == 0
+
+    def test_stale_edits_dont_carry_to_new_session(self, tmp_path: Path):
+        """A stale state file with old session_id is ignored."""
+        mod = _load_module()
+        state_file = tmp_path / mod.STATE_FILENAME
+        old_ts = [time.time() - 5] * 10  # 10 old edits under old session
+        state = {"session_id": "old-session", "edits": {"app/core/example.py": old_ts}}
+        state_file.write_text(json.dumps(state), encoding="utf-8")
+
+        # New session should see session mismatch and reset.
+        payload = _make_payload("app/core/example.py", session_id="new-sess")
+        rc, captured = _run_main(mod, payload, state_file)
+
+        assert rc == 0
+        data = json.loads("".join(captured)) if captured else {}
+        assert "thrash_warning" not in data


### PR DESCRIPTION
Salvage of WOR-483 — anti-thrash PostToolUse hook (5+ edits/5min detector).

Worker implementation substantively correct (session-scoped per-file
edit-timestamp store, trigger/non-trigger tests). Two issues handled:
- Real defect: 2 auto-fixable ruff violations the worker left despite
  reporting checks green (WOR-456-class). Architect fix applied:
  ruff check --fix + ruff format; disclosed here.
- Blocked with no last_failure.json + a WIP-message commit (WOR-501 class).

Independently re-verified after the fix on the current epic tip:
- ruff         : clean
- mypy app/    : 0 issues, 48 files
- lint-imports : 8 kept, 0 broken
- pytest       : 1958 passed, 0 failed

NB: hook inert until registered in .claude/settings.json — tracked WOR-494.

Part of WOR-493.

Generated with Claude Code
