### PR TITLE
WOR-503 Lowercase ticket id in _build_local_worker_log_path

### DIFF
--- a/app/core/watcher/watcher_heartbeat.py
+++ b/app/core/watcher/watcher_heartbeat.py
@@ -151,7 +151,7 @@ def _build_local_worker_log_path(worker: "ActiveWorker") -> Path:
         worker.worktree_path
         / _CLAUDE_DIR
         / "logs"
-        / f"{worker.ticket_id.replace('-', '_')}.jsonl"
+        / f"{worker.ticket_id.lower().replace('-', '_')}.jsonl"
     )
 
 

--- a/tests/test_watcher_heartbeat.py
+++ b/tests/test_watcher_heartbeat.py
@@ -111,10 +111,12 @@ def test_live_cost_estimate_scales_linearly() -> None:
 
 def test_build_local_worker_log_path_normalises_ticket_id(tmp_path: Path) -> None:
     """Hyphen in ticket_id → underscore in JSONL filename; lives under
-    <worktree>/.claude/logs/. Case is preserved."""
+    <worktree>/.claude/logs/. ticket_id is lowercased to match the
+    repo-wide artifact convention (ArtifactPaths.from_ticket_id); a
+    case-preserving path fails on case-sensitive Linux CI (WOR-503)."""
     w = _make_active_worker(ticket_id="WOR-123", worktree_path=tmp_path)
     p = _build_local_worker_log_path(w)
-    assert p == tmp_path / ".claude" / "logs" / "WOR_123.jsonl"
+    assert p == tmp_path / ".claude" / "logs" / "wor_123.jsonl"
 
 
 # ── emit_idle_line ──────────────────────────────────────────────────────────


### PR DESCRIPTION
Fix epic-branch regression from WOR-447 (#1022) blocking the WOR-493 close.

`watcher_heartbeat._build_local_worker_log_path` built the worker log
filename via `ticket_id.replace('-', '_')` → `WOR_TEST.jsonl`
(uppercase), inconsistent with the repo-wide lowercase artifact
convention (`ArtifactPaths.from_ticket_id` → `wor_447`). WOR-447's
`test_build_tui_state_cost_uses_input_and_output_tokens` writes
`wor_test.jsonl` (lowercase, correct).

- Case-insensitive Windows: same file → passed in the worker run and
  the Windows salvage re-verification.
- Case-sensitive Linux CI: file not found → `_parse_worker_usage`
  returns `(None, None)` → cost `0.0` → `assert 0.0 == 0.033` fails on
  every PR to the epic (#1024, #1025).

One-line fix: add `.lower()`, matching `ArtifactPaths.from_ticket_id`.

NB: this cannot be reproduced locally on the Windows dev box (case-
insensitive FS) — Linux CI on this PR is the authoritative verification.

Part of WOR-493.

Generated with Claude Code
