### PR TITLE
WOR-336 Spike: vLLM max-num-seqs sensitivity — seqs is not the bottleneck (KV is)

### DIFF
--- a/app/core/watcher/watcher_helpers.py
+++ b/app/core/watcher/watcher_helpers.py
@@ -53,6 +53,9 @@ __all__ = [
     "picker_sort_key",
     "WorkerBehavior",
     "_parse_worker_behavior",
+    "kv_concurrency_ceiling",
+    "PRODUCTION_KV_CACHE_TOKENS",
+    "COMPACTION_CONTEXT_CEILING",
 ]
 from .watcher_types import (
     _ENV_VARS_TO_STRIP_FOR_CLOUD,
@@ -62,6 +65,83 @@ from .watcher_types import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# KV-budget concurrency ceiling (WOR-336 spike)
+# ---------------------------------------------------------------------------
+
+# Measured vLLM KV-cache token capacity for the production server config
+# (Qwen3.6-35B-A3B-NVFP4, --max-model-len 262144, --max-num-seqs 16,
+# --kv-cache-dtype fp8 on a 32 GiB RTX 5090): the paged-KV pool holds
+# ~148,816 tokens (~5.73 GiB). Source: WOR-336 forensic + live 6->2 A/B
+# (docs/spikes/vllm-max-num-seqs-sensitivity.md).
+PRODUCTION_KV_CACHE_TOKENS = 148_816
+
+# Observed peak per-worker input context before Claude Code compaction
+# fires (CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=75 over a 240k window). Heavy
+# real-worker tickets in ticket_metrics topped out at input_tokens_max
+# ~134,643; one such worker single-handedly fills most of the KV pool.
+COMPACTION_CONTEXT_CEILING = 134_000
+
+
+def kv_concurrency_ceiling(
+    per_worker_context_tokens: int,
+    *,
+    kv_cache_tokens: int = PRODUCTION_KV_CACHE_TOKENS,
+    utilization_target: float = 0.9,
+    min_workers: int = 1,
+) -> int:
+    """Max concurrent local workers before vLLM KV-cache oversubscription.
+
+    Each in-flight worker holds roughly ``per_worker_context_tokens`` of
+    paged-KV state (its accumulated conversation, up to the compaction
+    ceiling). Once the aggregate working set exceeds the KV pool, vLLM
+    evicts prefix-cache blocks between turns and every subsequent turn
+    re-prefills the worker's full context. WOR-336 measured this collapse
+    directly: prefix-cache hit-rate ~67% at 2-way concurrency vs ~15% at
+    6-way, effective throughput ~40 -> ~4 tok/s — even though the
+    controlled NVFP4 bench shows raw decode sustains ~120 tok/s per
+    stream up to 8 concurrent streams (962 tok/s aggregate, VRAM-safe).
+    The binding limit is KV bytes, not ``--max-num-seqs`` slots.
+
+    Keep aggregate KV demand at or below ``utilization_target`` of
+    capacity so prefix-cache blocks survive across a worker's turns.
+
+    Args:
+        per_worker_context_tokens: typical/peak active context per
+            worker. Pass ``COMPACTION_CONTEXT_CEILING`` for the worst
+            case.
+        kv_cache_tokens: total KV-pool token capacity for the running
+            vLLM config. Defaults to the measured production value.
+        utilization_target: fraction of the pool to budget
+            (0 < x <= 1). Headroom below 1.0 leaves room for
+            prefix-cache reuse rather than 100% live-KV packing.
+        min_workers: floor on the return value. A single worker always
+            runs even if its context alone exceeds the pool (it just
+            forfeits cross-turn prefix-cache reuse).
+
+    Returns:
+        The largest worker count whose combined KV demand stays within
+        ``utilization_target * kv_cache_tokens``, never below
+        ``min_workers``.
+
+    Raises:
+        ValueError: if any argument is out of range.
+    """
+    if kv_cache_tokens <= 0:
+        raise ValueError("kv_cache_tokens must be positive")
+    if per_worker_context_tokens <= 0:
+        raise ValueError("per_worker_context_tokens must be positive")
+    if not 0.0 < utilization_target <= 1.0:
+        raise ValueError("utilization_target must be in (0, 1]")
+    if min_workers < 1:
+        raise ValueError("min_workers must be >= 1")
+
+    budget = kv_cache_tokens * utilization_target
+    ceiling = int(budget // per_worker_context_tokens)
+    return max(min_workers, ceiling)
+
 
 # ---------------------------------------------------------------------------
 # Escalation-policy flag names (also used by watcher.py orchestrator)

--- a/docs/spikes/vllm-max-num-seqs-sensitivity.md
+++ b/docs/spikes/vllm-max-num-seqs-sensitivity.md
@@ -1,0 +1,276 @@
+# Spike: vLLM server-config sweep — `max-num-seqs` sensitivity & the KV ceiling
+
+**Ticket:** WOR-336 (child of WOR-301 — Local-LLM tuning spikes)
+**Status:** Analytical portion **complete** — answered from existing
+telemetry + a live in-session A/B. No new GPU campaign was required for
+the headline decision. One narrowly-scoped GPU follow-up remains (large
+`--max-num-batched-tokens` values) and is split out below.
+**Date:** 2026-05-16
+**Method:** read-only forensic on the production metrics DB
+(`app.db` — `ticket_metrics` n=101, `ticket_run_log` n=133,
+`bench_run` n=1889) plus a live 6→2 concurrency A/B observed during the
+WOR-493 overnight run. Reproduce with:
+
+```bash
+python scripts/spikes/wor336_throughput_forensic.py        # human-readable
+python scripts/spikes/wor336_throughput_forensic.py --json # machine-readable
+```
+
+---
+
+## TL;DR / Recommendation
+
+**Keep `--max-num-seqs 16`. It is not the bottleneck and never was.**
+
+1. Existing controlled-bench data already contains the seqs sweep the
+   ticket asked for. `seqs=8` and `seqs=16` are throughput-identical at
+   c=1–2; `seqs=16` sustains **8 concurrent streams at ~982 tok/s
+   aggregate with VRAM flat at 29.2 GB** (3 GB headroom on the 32 GB
+   5090). `seqs=200` is *slower* (113.8 vs 171.9 tok/s at c=1) and runs
+   the card to **31.3 GB (near-OOM)** — re-confirming the standing
+   "never seqs=200" finding.
+2. The "8× unexplained solo-throughput variance" that bumped this spike
+   to P2 **was largely an artifact of the pre-WOR-285 token
+   under-count** (~3×) compounded with raw turn-count differences. After
+   the corrected counts there is no GPU mystery to explain.
+3. The real production limit is **KV-cache bytes, not sequence slots**.
+   Concurrent real workers each carry a large, divergent, monotonically
+   growing context (~134 K tokens at the compaction ceiling). Their
+   aggregate KV working set oversubscribes the ~148,816-token pool, vLLM
+   evicts prefix-cache blocks between turns, and every turn re-prefills
+   the full context. The lever is **KV-budget-aware concurrency**
+   (WOR-502), for which this spike ships a validated pure helper
+   (`kv_concurrency_ceiling`).
+4. Blocking gap surfaced: **every `vllm_*` telemetry column is NULL for
+   all 101 tickets** (the WOR-439 capture bug). The prefix-cache-vs-
+   concurrency hypothesis is therefore *unanswerable from telemetry*
+   until WOR-439 lands; the only direct evidence is the live A/B below.
+
+Production config is **already correct**. No `CLAUDE.md` change needed.
+
+---
+
+## H1 — Solo-throughput variance: the keystone correction
+
+The ticket cited four "structurally identical SOLO" runs varying 8×.
+Re-pulled from `ticket_metrics` with the post-WOR-285 corrected token
+counts:
+
+| Ticket | In-ticket (pre-WOR-285) | **Corrected** | Turns | Tools | Wall |
+|--------|-------------------------|---------------|-------|-------|------|
+| WOR-305 | 68 K out, 39 tok/s | **211 K out, 120.3 tok/s** | 294 | 121 | 29 m |
+| WOR-338 | 45 K out, 9.7 tok/s | **132 K out, 28.6 tok/s** | 307 | 119 | 77 m |
+| WOR-332 | 58 K out, 7.3 tok/s | **162 K out, 20.2 tok/s** | 399 | 146 | 134 m |
+| WOR-277 | 49 K out, 5 tok/s | **134 K out, 13.8 tok/s** | 266 | 109 | 163 m |
+
+Output tokens were under-counted ~2.7–3.1× across the board (exactly the
+WOR-285 bug). After correction these runs are **not** structurally
+identical: they differ 1.5× in turn count and 5.6× in wall time at
+similar output volume, all pinned at the ~134 K compaction ceiling for
+max input. `output_tokens_per_wall_second` is **not a GPU-speed metric**
+— it is `tokens_generated / (turns × (tool_roundtrip + prefill_of_~134K
++ decode))`. The spread is dominated by turns and per-turn prefill, not
+decode rate.
+
+Full solo distribution (n=85): min 0.38, p25 4.7, median 8.0, p75 26.0,
+max 120.3 tok/s. The extreme low tail is **not throughput data**:
+
+- **WOR-319** — 12 turns, 6 tools, 1,968 output tokens, **87 min wall**
+- **WOR-314** — 12 turns, 6 tools, 2,771 output tokens, **74 min wall**
+
+12 turns cannot consume 80 minutes of GPU. These are hung/idle sessions
+(external wait or a stuck tool), an outlier class to investigate
+separately — **not** a tuning signal. They are excluded from all
+throughput conclusions here.
+
+---
+
+## H2 — Concurrency → throughput (production regime, `ticket_metrics`)
+
+Effective tok/s by `dispatch_concurrency` (local workers only):
+
+| concurrency | n | mean tok/s |
+|-------------|---|------------|
+| 0 (solo)    | 49 | 21.3 |
+| 1           | 5  | 9.2  |
+| 2           | 6  | 6.1  |
+| 3           | 4  | 5.2  |
+| 4           | 4  | 5.8  |
+| 5           | 1  | 4.7  |
+| 6           | 1  | 2.3  |
+| (pre-column)| 31 | 16.5 |
+
+Monotonic collapse with concurrency **in the production regime**. Note
+the low absolute numbers reflect the H1 wall-time confound (tool-bound
+tickets), but the *relative* shape is real and is the opposite of the
+controlled bench (H4) — see the reconciliation.
+
+---
+
+## H3 — Prefix-cache vs concurrency: telemetry is BLIND (WOR-439)
+
+`vllm_metrics_attributable`, `vllm_prefix_cache_hit_ratio`,
+`vllm_preemptions`, `vllm_prompt_tokens`, `vllm_ttft_mean_seconds`:
+**0 / 101 non-null.** The robust parser exists
+(`watcher_helpers.capture_vllm_metrics` / `compute_vllm_metrics_delta`)
+— the gap is the **WOR-439 capture/attribution bug**, not missing code.
+**WOR-439 is a hard blocker for answering this spike's headline
+hypothesis from telemetry.** Until it lands, the only direct evidence is
+the live A/B:
+
+> **Live 6→2 A/B (WOR-493 overnight, this session):** at 6 concurrent
+> real workers the vLLM prefix-cache hit-rate collapsed to ~15% and
+> effective throughput to ~4 tok/s; dropping the pool to 2 recovered the
+> hit-rate to ~67% and throughput to ~40 tok/s. This is the
+> KV-oversubscription signature.
+
+---
+
+## H4 — Controlled bench sweep (the seqs answer, already in `bench_run`)
+
+The WOR-221 campaign (2026-04-26 → 29) already captured the seqs sweep.
+Per-stream tok/s, NVFP4 production model:
+
+**`seqs=8` vs `seqs=16` (apples-to-apples):**
+
+| concurrency | seqs=8 tok/s | seqs=16 tok/s | seqs=16 aggregate | VRAM |
+|-------------|--------------|---------------|-------------------|------|
+| 1 | 168.6 | 171.9 | 171.9 | 29.2 GB |
+| 2 | 144.3 | 148.2 | 296.4 | 29.2 GB |
+| 3 | — | 134.1 | 402.3 | 29.2 GB |
+| 4 | — | 136.9 | 547.6 | 29.2 GB |
+| 5 | — | 126.9 | 634.5 | 29.2 GB |
+| 6 | — | 128.8 | 772.8 | 29.3 GB |
+| 7 | — | 124.8 | 873.6 | 29.2 GB |
+| 8 | — | 122.8 | **982.4** | 29.2 GB |
+
+**`seqs=200` check:** c=1 113.8 tok/s (−34% vs seqs=16), VRAM **31.3 GB**.
+Slower *and* near-OOM. Decisively rejected.
+
+Per-stream throughput is **flat (~120–172 tok/s)** across c=1→8;
+aggregate scales **near-linearly to ~982 tok/s**; VRAM is **rock-stable
+at ~29 GB** even at c=8 / ~218 K context. There is **no `max-num-seqs`
+ceiling and no KV collapse in the controlled bench.** Lowering seqs to 8
+buys nothing and caps concurrency; 16 is correct.
+
+**Bonus signal for the batched-tokens arm:** `chunk_off_4096` 115.8 vs
+`chunk_on_4096` 102.3 tok/s at c=1 — the current 4096 chunked-prefill
+cap costs ~12% on long-context traffic. This *motivates* (does not yet
+answer) the larger-`max-num-batched-tokens` sweep.
+
+---
+
+## H5 — Compaction interaction (hypothesis killed)
+
+`with_compaction` mean 32.1 tok/s (n=11) vs `no_compaction` 14.9 tok/s
+(n=90). Compaction correlates with the **fastest** runs because it only
+fires on long, high-output sessions where decode dominates wall time
+(WOR-305: 211 K output, 1 compaction, 120 tok/s). Compaction is a
+*symptom* of high-throughput sessions, not a cause of slow ones. The
+"compaction makes runs slow" hypothesis is **false**.
+
+---
+
+## Reconciliation — why the bench scales but production collapses
+
+Two real datasets, opposite shapes, both correct:
+
+| | Controlled bench (H4) | Production workers (H2 + live A/B) |
+|---|---|---|
+| Prompt shape | fixed, low-divergence | growing, divergent per turn |
+| Per-stream tok/s vs concurrency | **flat** to c=8 | **collapses** |
+| Aggregate @ c=8 | ~982 tok/s | thrashes |
+| KV working set | bounded by fixed prompt | ~134 K × N workers |
+
+The GPU sustains 8 full-speed concurrent decode streams (proven). Real
+concurrent workers each hold a ~134 K-token growing context; at the
+~148,816-token KV pool, **two heavy workers already oversubscribe it**.
+vLLM then evicts prefix-cache blocks between turns → every turn
+re-prefills ~134 K tokens → effective tok/s craters even though raw
+decode capacity is ~120 tok/s/stream. The 2.17× "ceiling" is this
+KV-bytes-vs-context ratio, not a sequence-slot limit.
+
+**Therefore the lever is KV-budget-aware concurrency, not `seqs`.**
+
+---
+
+## Decision matrix
+
+| Knob | Verdict | Evidence |
+|------|---------|----------|
+| `--max-num-seqs` 8 | Reject | identical to 16 at c≤2, caps concurrency (H4) |
+| `--max-num-seqs` 16 | **Keep** | 982 tok/s @ c=8, VRAM-safe (H4) |
+| `--max-num-seqs` 24/32/48 | Not worth GPU time | 16 already non-binding; no headroom problem |
+| `--max-num-seqs` 200 | Reject | −34% tok/s, 31.3 GB near-OOM (H4) |
+| KV-budget concurrency cap | **Adopt (WOR-502)** | H2 + live A/B + reconciliation |
+| `--max-num-batched-tokens` >4096 | Worth one GPU sweep | chunk_off>chunk_on +12% (H4 bonus) |
+
+---
+
+## What shipped in this spike PR (automatable, no GPU)
+
+1. `docs/spikes/vllm-max-num-seqs-sensitivity.md` — this report.
+2. `scripts/spikes/wor336_throughput_forensic.py` — reproducible
+   read-only forensic over `app.db`.
+3. `app/core/watcher/watcher_helpers.kv_concurrency_ceiling()` — pure,
+   tested helper that computes max safe concurrent workers from KV
+   capacity and per-worker context. **This is the function WOR-502
+   (effort-aware adaptive concurrency) consumes.** Constants
+   `PRODUCTION_KV_CACHE_TOKENS = 148_816`,
+   `COMPACTION_CONTEXT_CEILING = 134_000`.
+4. `tests/test_wor336_kv_ceiling.py` — unit tests.
+
+---
+
+## Split out — remaining work (not in this PR)
+
+The headline seqs decision is **made**. Deferred items:
+
+### A. (GPU) `--max-num-batched-tokens` sweep — *the one real GPU arm*
+
+Motivated by the H4 bonus signal (4096 chunked-prefill costs ~12% on
+long context). This is the absorbed ex-WOR-385 scope. Filed as a
+focused follow-up child of WOR-301 (see Linear). Bench commands, ready
+to run when a GPU window is free (do **not** auto-run):
+
+```bash
+# corrected configs (gpu-mem-util 0.95; cap batched-tokens at 65536
+# given KV=148,816; probe --scheduler-reserve-full-isl first)
+python scripts/bench/run_bench.py --tier speed --config config/bench-bt-4096.toml
+python scripts/bench/run_bench.py --tier speed --config config/bench-bt-8192.toml
+python scripts/bench/run_bench.py --tier speed --config config/bench-bt-16384.toml
+python scripts/bench/run_bench.py --tier speed --config config/bench-bt-32768.toml
+python scripts/bench/run_bench.py --tier speed --config config/bench-bt-65536.toml
+python scripts/bench/run_bench.py --compare run_<a> run_<b> ...
+```
+
+### B. (Blocked on WOR-439) prefix-cache-vs-concurrency telemetry
+
+Cannot be answered from `app.db` until WOR-439 fixes vLLM `/metrics`
+capture (currently 0/101). The live A/B is the only direct evidence
+until then. WOR-439 should be prioritised — it gates *quantitative*
+confirmation of the central finding.
+
+### C. (Implementation, not spike) KV-budget adaptive concurrency
+
+WOR-502 consumes `kv_concurrency_ceiling()`. Out of spike scope.
+
+### Dropped (answered, no ticket)
+
+- seqs 24/32/48 sweep — 16 is provably non-binding; new GPU runs would
+  only re-confirm. Not worth the campaign.
+- 3-scenario solo-degradation protocol — the "solo variance" it was
+  designed to chase was the WOR-285 artifact (H1). Moot.
+
+---
+
+## References
+
+- `scripts/spikes/wor336_throughput_forensic.py` — reproducible forensic
+- WOR-285 — token-aggregation fix (the correction behind H1)
+- WOR-439 — vLLM `/metrics` capture (blocks H3 telemetry)
+- WOR-502 — effort-aware adaptive concurrency (consumes the helper)
+- WOR-287 — prefix-cache verification (~87% solo; extended by the live A/B)
+- `docs/spikes/vllm-benchmark-plan.md` — production config + bench harness
+- memory `project_vllm_concurrent_throughput.md`,
+  `project_vllm_production_config.md`

--- a/scripts/spikes/wor336_throughput_forensic.py
+++ b/scripts/spikes/wor336_throughput_forensic.py
@@ -1,0 +1,315 @@
+"""WOR-336 spike — automatable throughput forensic (no GPU required).
+
+Reads the production metrics DB (``app.db``) and answers the WOR-336
+hypotheses that do NOT need a fresh GPU benchmark campaign:
+
+1. Solo-throughput variance — is there really a 4-8x spread across
+   structurally similar SOLO worker runs?
+2. Concurrency -> throughput — does effective tok/s collapse as
+   ``dispatch_concurrency`` rises (the 2.17x KV-ceiling hypothesis)?
+3. Prefix-cache vs concurrency — the smoking gun: does
+   ``vllm_prefix_cache_hit_ratio`` fall and ``vllm_preemptions`` rise
+   together with concurrency?
+4. Controlled bench sweep — ``bench_run`` aggregate/per-stream tok/s and
+   peak VRAM by ``concurrency`` (the WOR-221 / later sweep data).
+5. Compaction interaction — do ``context_compactions`` co-occur with the
+   slow runs?
+
+Run::
+
+    python scripts/spikes/wor336_throughput_forensic.py
+    python scripts/spikes/wor336_throughput_forensic.py --db /path/to/app.db
+    python scripts/spikes/wor336_throughput_forensic.py --json   # machine-readable
+
+This is a read-only forensic. It opens the DB read-only and never writes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sqlite3
+import statistics
+from collections.abc import Sequence
+from typing import Any
+
+
+def _default_db_path() -> str:
+    """Best-effort location of the production metrics DB."""
+    env = os.environ.get("REPO_SCAFFOLD_DB")
+    if env and os.path.exists(env):
+        return env
+    candidates = [
+        os.path.join(
+            os.path.expanduser("~"), "AppData", "Roaming", "repo-scaffold", "app.db"
+        ),
+        os.path.join(
+            os.path.expanduser("~"), ".local", "share", "repo-scaffold", "app.db"
+        ),
+        os.path.join(os.path.expanduser("~"), ".repo-scaffold", "app.db"),
+        "app.db",
+    ]
+    for c in candidates:
+        if os.path.exists(c) and os.path.getsize(c) > 0:
+            return c
+    return candidates[0]
+
+
+def _connect_ro(path: str) -> sqlite3.Connection:
+    """Open the DB strictly read-only via URI."""
+    uri = f"file:{os.path.abspath(path)}?mode=ro"
+    con = sqlite3.connect(uri, uri=True)
+    con.row_factory = sqlite3.Row
+    return con
+
+
+def _spread(values: Sequence[float]) -> dict[str, float]:
+    """Summary stats + max/min ratio for a list of throughputs."""
+    vals = sorted(v for v in values if v is not None and v > 0)
+    if not vals:
+        return {}
+    out: dict[str, float] = {
+        "n": float(len(vals)),
+        "min": round(vals[0], 3),
+        "max": round(vals[-1], 3),
+        "median": round(statistics.median(vals), 3),
+        "mean": round(statistics.fmean(vals), 3),
+    }
+    if len(vals) >= 4:
+        q = statistics.quantiles(vals, n=4)
+        out["p25"] = round(q[0], 3)
+        out["p75"] = round(q[2], 3)
+    out["max_min_ratio"] = round(vals[-1] / vals[0], 2) if vals[0] > 0 else 0.0
+    return out
+
+
+def _concurrency_bucket(c: int | None) -> str:
+    """Bucket a dispatch concurrency into solo / low / mid / high."""
+    if c is None:
+        return "unknown"
+    if c <= 1:
+        return "solo (<=1)"
+    if c <= 2:
+        return "2"
+    if c <= 4:
+        return "3-4"
+    return "5+"
+
+
+def analyse_solo_variance(con: sqlite3.Connection) -> dict[str, Any]:
+    """Hypothesis 1 — spread of tok/s across SOLO worker runs."""
+    rows = con.execute(
+        """
+        SELECT ticket_id, output_tokens_per_wall_second AS tps,
+               local_wall_time AS wall, local_output_tokens AS out_tok,
+               dispatch_concurrency AS conc, context_compactions AS comp
+        FROM ticket_metrics
+        WHERE local_used = 1
+          AND output_tokens_per_wall_second IS NOT NULL
+          AND output_tokens_per_wall_second > 0
+          AND (dispatch_concurrency IS NULL OR dispatch_concurrency <= 1)
+        ORDER BY tps
+        """
+    ).fetchall()
+    tps = [r["tps"] for r in rows]
+    return {
+        "spread": _spread(tps),
+        "slowest": [
+            {
+                "ticket": r["ticket_id"],
+                "tps": round(r["tps"], 2),
+                "wall_s": r["wall"],
+                "out_tok": r["out_tok"],
+                "compactions": r["comp"],
+            }
+            for r in rows[:5]
+        ],
+        "fastest": [
+            {
+                "ticket": r["ticket_id"],
+                "tps": round(r["tps"], 2),
+                "wall_s": r["wall"],
+                "out_tok": r["out_tok"],
+                "compactions": r["comp"],
+            }
+            for r in rows[-5:]
+        ],
+    }
+
+
+def analyse_concurrency_throughput(con: sqlite3.Connection) -> dict[str, Any]:
+    """Hypothesis 2 — effective tok/s by dispatch_concurrency bucket."""
+    rows = con.execute(
+        """
+        SELECT dispatch_concurrency AS conc,
+               output_tokens_per_wall_second AS tps
+        FROM ticket_metrics
+        WHERE local_used = 1
+          AND output_tokens_per_wall_second IS NOT NULL
+          AND output_tokens_per_wall_second > 0
+        """
+    ).fetchall()
+    buckets: dict[str, list[float]] = {}
+    for r in rows:
+        buckets.setdefault(_concurrency_bucket(r["conc"]), []).append(r["tps"])
+    return {b: _spread(v) for b, v in sorted(buckets.items(), key=lambda kv: kv[0])}
+
+
+def analyse_prefix_cache(con: sqlite3.Connection) -> dict[str, Any]:
+    """Hypothesis 3 — prefix-cache hit ratio & preemptions vs concurrency."""
+    rows = con.execute(
+        """
+        SELECT dispatch_concurrency AS conc,
+               vllm_prefix_cache_hit_ratio AS hit,
+               vllm_preemptions AS preempt,
+               output_tokens_per_wall_second AS tps,
+               vllm_metrics_attributable AS attributable
+        FROM ticket_metrics
+        WHERE local_used = 1
+          AND vllm_prefix_cache_hit_ratio IS NOT NULL
+        """
+    ).fetchall()
+    by_bucket: dict[str, dict[str, list[float]]] = {}
+    for r in rows:
+        b = _concurrency_bucket(r["conc"])
+        d = by_bucket.setdefault(b, {"hit": [], "preempt": [], "tps": []})
+        if r["hit"] is not None:
+            d["hit"].append(r["hit"])
+        if r["preempt"] is not None:
+            d["preempt"].append(float(r["preempt"]))
+        if r["tps"] is not None and r["tps"] > 0:
+            d["tps"].append(r["tps"])
+    summary = {}
+    for b, d in sorted(by_bucket.items()):
+        summary[b] = {
+            "n": len(d["hit"]),
+            "mean_prefix_hit_ratio": (
+                round(statistics.fmean(d["hit"]), 4) if d["hit"] else None
+            ),
+            "mean_preemptions": (
+                round(statistics.fmean(d["preempt"]), 2) if d["preempt"] else None
+            ),
+            "mean_tps": (round(statistics.fmean(d["tps"]), 2) if d["tps"] else None),
+        }
+    return {
+        "rows_with_vllm_metrics": len(rows),
+        "by_concurrency": summary,
+    }
+
+
+def analyse_bench_sweep(con: sqlite3.Connection) -> dict[str, Any]:
+    """Hypothesis 4 — controlled bench_run tok/s & VRAM by concurrency."""
+    rows = con.execute(
+        """
+        SELECT concurrency AS conc,
+               COUNT(*) AS n,
+               AVG(throughput_tok_s) AS mean_tps,
+               MIN(throughput_tok_s) AS min_tps,
+               MAX(throughput_tok_s) AS max_tps,
+               AVG(peak_vram_gb) AS mean_vram,
+               MAX(peak_vram_gb) AS max_vram,
+               AVG(context_size) AS mean_ctx
+        FROM bench_run
+        WHERE outcome = 'ok' AND throughput_tok_s IS NOT NULL
+        GROUP BY concurrency
+        ORDER BY concurrency
+        """
+    ).fetchall()
+    return {
+        "by_concurrency": [
+            {
+                "concurrency": r["conc"],
+                "n": r["n"],
+                "mean_per_stream_tok_s": round(r["mean_tps"], 2),
+                "min_tok_s": round(r["min_tps"], 2),
+                "max_tok_s": round(r["max_tps"], 2),
+                "implied_aggregate_tok_s": round(r["mean_tps"] * (r["conc"] or 1), 2),
+                "mean_peak_vram_gb": (
+                    round(r["mean_vram"], 2) if r["mean_vram"] is not None else None
+                ),
+                "max_peak_vram_gb": (
+                    round(r["max_vram"], 2) if r["max_vram"] is not None else None
+                ),
+                "mean_ctx": int(r["mean_ctx"]) if r["mean_ctx"] is not None else None,
+            }
+            for r in rows
+        ]
+    }
+
+
+def analyse_compaction(con: sqlite3.Connection) -> dict[str, Any]:
+    """Hypothesis 5 — do compactions co-occur with the slow runs?"""
+    rows = con.execute(
+        """
+        SELECT context_compactions AS comp,
+               AVG(output_tokens_per_wall_second) AS mean_tps,
+               COUNT(*) AS n
+        FROM ticket_metrics
+        WHERE local_used = 1
+          AND output_tokens_per_wall_second IS NOT NULL
+          AND output_tokens_per_wall_second > 0
+          AND context_compactions IS NOT NULL
+        GROUP BY (context_compactions > 0)
+        """
+    ).fetchall()
+    out = {}
+    for r in rows:
+        key = "with_compaction" if (r["comp"] or 0) > 0 else "no_compaction"
+        out[key] = {"n": r["n"], "mean_tps": round(r["mean_tps"], 2)}
+    return out
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="WOR-336 throughput forensic")
+    ap.add_argument("--db", default=_default_db_path(), help="path to app.db")
+    ap.add_argument("--json", action="store_true", help="emit JSON only")
+    args = ap.parse_args(argv)
+
+    if not os.path.exists(args.db) or os.path.getsize(args.db) == 0:
+        print(f"ERROR: metrics DB not found or empty at {args.db}")
+        return 1
+
+    con = _connect_ro(args.db)
+    try:
+        result = {
+            "db": os.path.abspath(args.db),
+            "h1_solo_variance": analyse_solo_variance(con),
+            "h2_concurrency_throughput": analyse_concurrency_throughput(con),
+            "h3_prefix_cache_vs_concurrency": analyse_prefix_cache(con),
+            "h4_bench_concurrency_sweep": analyse_bench_sweep(con),
+            "h5_compaction_interaction": analyse_compaction(con),
+        }
+    finally:
+        con.close()
+
+    if args.json:
+        print(json.dumps(result, indent=2))
+        return 0
+
+    print(f"WOR-336 throughput forensic — {result['db']}\n")
+    print("== H1: SOLO throughput variance ==")
+    print(" ", result["h1_solo_variance"]["spread"])
+    print("  slowest:", result["h1_solo_variance"]["slowest"])
+    print("  fastest:", result["h1_solo_variance"]["fastest"])
+    print("\n== H2: tok/s by dispatch_concurrency ==")
+    for b, s in result["h2_concurrency_throughput"].items():
+        print(f"  {b}: {s}")
+    print("\n== H3: prefix-cache & preemptions vs concurrency ==")
+    print(
+        "  rows with vLLM metrics:",
+        result["h3_prefix_cache_vs_concurrency"]["rows_with_vllm_metrics"],
+    )
+    for b, s in result["h3_prefix_cache_vs_concurrency"]["by_concurrency"].items():
+        print(f"  {b}: {s}")
+    print("\n== H4: controlled bench_run sweep ==")
+    for r in result["h4_bench_concurrency_sweep"]["by_concurrency"]:
+        print(f"  {r}")
+    print("\n== H5: compaction interaction ==")
+    for k, v in result["h5_compaction_interaction"].items():
+        print(f"  {k}: {v}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_wor336_kv_ceiling.py
+++ b/tests/test_wor336_kv_ceiling.py
@@ -1,0 +1,97 @@
+"""WOR-336 — tests for the KV-budget concurrency-ceiling helper.
+
+Pure-function tests. The helper encodes the spike's central finding:
+the local-worker throughput limit is KV-cache bytes (prefix-cache
+eviction under oversubscription), not ``--max-num-seqs`` sequence slots.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.core.watcher.watcher_helpers import (
+    COMPACTION_CONTEXT_CEILING,
+    PRODUCTION_KV_CACHE_TOKENS,
+    kv_concurrency_ceiling,
+)
+
+
+class TestKvConcurrencyCeiling:
+    def test_heavy_worker_at_compaction_ceiling_is_solo(self) -> None:
+        """A worker near the ~134k compaction ceiling fills the pool —
+        only one fits at the default 0.9 utilization target."""
+        assert kv_concurrency_ceiling(COMPACTION_CONTEXT_CEILING) == 1
+
+    def test_light_worker_scales_up(self) -> None:
+        """A 30k-token worker leaves room for several concurrent peers."""
+        # floor(148816 * 0.9 / 30000) = floor(4.46) = 4
+        assert kv_concurrency_ceiling(30_000) == 4
+
+    def test_mid_worker(self) -> None:
+        # floor(148816 * 0.9 / 67000) = floor(1.999) = 1
+        assert kv_concurrency_ceiling(67_000) == 1
+        # at full utilisation two mid workers fit
+        assert kv_concurrency_ceiling(67_000, utilization_target=1.0) == 2
+
+    def test_monotonic_decreasing_in_context_size(self) -> None:
+        """Larger per-worker context never yields a higher ceiling."""
+        prev = None
+        for ctx in range(10_000, 150_000, 5_000):
+            c = kv_concurrency_ceiling(ctx)
+            if prev is not None:
+                assert c <= prev
+            prev = c
+
+    def test_utilization_target_raises_ceiling(self) -> None:
+        low = kv_concurrency_ceiling(20_000, utilization_target=0.5)
+        high = kv_concurrency_ceiling(20_000, utilization_target=1.0)
+        assert high >= low
+        # floor(148816*0.5/20000)=3 ; floor(148816*1.0/20000)=7
+        assert low == 3
+        assert high == 7
+
+    def test_min_workers_floor_when_context_exceeds_pool(self) -> None:
+        """Even an over-pool context returns at least one worker."""
+        assert (
+            kv_concurrency_ceiling(PRODUCTION_KV_CACHE_TOKENS * 3, min_workers=1) == 1
+        )
+        assert (
+            kv_concurrency_ceiling(PRODUCTION_KV_CACHE_TOKENS * 3, min_workers=2) == 2
+        )
+
+    def test_custom_kv_pool(self) -> None:
+        # double the pool -> double the ceiling for the same context
+        base = kv_concurrency_ceiling(
+            20_000, kv_cache_tokens=100_000, utilization_target=1.0
+        )
+        big = kv_concurrency_ceiling(
+            20_000, kv_cache_tokens=200_000, utilization_target=1.0
+        )
+        assert base == 5
+        assert big == 10
+
+    @pytest.mark.parametrize(
+        ("kwargs",),
+        [
+            ({"kv_cache_tokens": 0},),
+            ({"kv_cache_tokens": -1},),
+            ({"utilization_target": 0.0},),
+            ({"utilization_target": 1.5},),
+            ({"utilization_target": -0.1},),
+            ({"min_workers": 0},),
+        ],
+    )
+    def test_invalid_args_raise(self, kwargs: dict[str, object]) -> None:
+        with pytest.raises(ValueError):
+            kv_concurrency_ceiling(50_000, **kwargs)  # type: ignore[arg-type]
+
+    def test_invalid_context_raises(self) -> None:
+        with pytest.raises(ValueError):
+            kv_concurrency_ceiling(0)
+        with pytest.raises(ValueError):
+            kv_concurrency_ceiling(-100)
+
+    def test_production_constant_sanity(self) -> None:
+        """Guard against an accidental edit to the measured constants."""
+        assert PRODUCTION_KV_CACHE_TOKENS == 148_816
+        assert COMPACTION_CONTEXT_CEILING == 134_000


### PR DESCRIPTION
## Summary

Analytical portion of the **WOR-336** `max-num-seqs` sensitivity spike —
answered from existing telemetry + a live 6→2 concurrency A/B, **no new
GPU campaign required** for the headline decision.

**Recommendation: keep `--max-num-seqs 16`. It is not, and never was,
the bottleneck.**

- The WOR-221 sweep already in `bench_run` answers the seqs question:
  `seqs=8` ≡ `seqs=16` at c≤2; `seqs=16` sustains **982 tok/s aggregate
  at c=8, VRAM flat 29.2 GB**; `seqs=200` is −34% and near-OOM.
- The "8× unexplained solo variance" that bumped this to P2 was a
  **pre-WOR-285 token-undercount artifact (~3×)** plus turn-count
  differences — no GPU mystery (WOR-305 was 211 K out / 120 tok/s, not
  68 K / 39).
- Real limit is **KV-cache bytes, not sequence slots**: concurrent
  workers at the ~134 K compaction ceiling oversubscribe the
  ~148,816-token KV pool → prefix-cache eviction → re-prefill every turn
  (live A/B: 67 % hit @ c2 → 15 % @ c6). Lever is KV-budget concurrency
  (**WOR-502**), not seqs.
- **All `vllm_*` telemetry is 0/101** (the **WOR-439** capture bug) — the
  headline hypothesis is telemetry-blind until WOR-439 lands.

## Ships

- `docs/spikes/vllm-max-num-seqs-sensitivity.md` — decision-grade report
- `scripts/spikes/wor336_throughput_forensic.py` — reproducible
  read-only `app.db` forensic
- `app/core/watcher/watcher_helpers.kv_concurrency_ceiling()` — pure,
  tested helper **consumed by WOR-502**; constants
  `PRODUCTION_KV_CACHE_TOKENS`, `COMPACTION_CONTEXT_CEILING`
- `tests/test_wor336_kv_ceiling.py`

## Test plan

- [x] `ruff check .` — clean
- [x] `mypy app/` — clean (48 files)
- [x] `pytest` — 1988 passed
- [x] `lint-imports` — 8 kept, 0 broken
- [x] Forensic script runs read-only against production `app.db`

## Split out (not in this PR)

- **GPU:** `--max-num-batched-tokens` sweep (motivated by the doc's
  chunk_off > chunk_on +12 % signal; absorbed ex-WOR-385 scope) — filed
  as a focused follow-up under WOR-301.
- **Blocked on WOR-439:** quantitative prefix-cache-vs-concurrency
  confirmation from telemetry.
- **WOR-502:** KV-budget adaptive concurrency consumes the shipped helper.

**Milestone:** Local-LLM Tuning

🚦 Spike PR — **human review required, no auto-merge.**

Part of WOR-336

🤖 Generated with [Claude Code](https://claude.com/claude-code)
