### PR TITLE
WOR-439 Make vLLM /metrics solo-snapshot failure observable + gpu_ alias compat

### DIFF
--- a/app/core/watcher/dispatch.py
+++ b/app/core/watcher/dispatch.py
@@ -17,7 +17,7 @@ from app.core.manifest import ExecutionManifest
 
 from .watcher_finalize import safe_set_state
 from .watcher_helpers import (
-    capture_vllm_metrics,
+    capture_vllm_metrics_diagnostic,
     check_allowed_paths_overlap,
     count_main_ahead_of_epic,
     get_active_parent_ids,
@@ -26,7 +26,7 @@ from .watcher_helpers import (
 )
 from .watcher_services import ServiceManager
 from .watcher_subprocess import launch_worker
-from .watcher_types import ActiveWorker, LinearClientProtocol
+from .watcher_types import _VLLM_BASE_URL, ActiveWorker, LinearClientProtocol
 from .watcher_worktrees import (
     backup_plan_files,
     cleanup_orphan_dir,
@@ -429,15 +429,27 @@ def _snapshot_vllm_solo(
     """WOR-370: vLLM /metrics attribution gate.
 
     1. Solo (dispatch_concurrency==0): snapshot /metrics for later delta;
-       returns (snapshot, True) on success or (None, False) if probe fails.
+       returns (snapshot, True) on success; on probe failure logs a
+       WARNING with the diagnostic reason and returns (None, False)
+       (WOR-439 — the failure used to be silent at debug level).
     2. Not solo: clear remained_solo on any peer that previously had it set
        — their deltas would now be polluted by this worker's traffic.
        Returns (None, False).
     """
     if dispatch_concurrency == 0:
-        snapshot = capture_vllm_metrics()
+        snapshot, reason = capture_vllm_metrics_diagnostic()
         if snapshot is not None:
             return snapshot, True
+        logger.warning(
+            "vLLM /metrics solo snapshot failed (reason=%s, base_url=%s) — "
+            "vllm_* columns will be NULL for this dispatch. If "
+            "'unreachable', start vLLM or set WATCHER_VLLM_BASE_URL; if "
+            "'no_counters_matched', this vLLM build renamed its Prometheus "
+            "counters and _VLLM_COUNTERS / _VLLM_COUNTER_ALIASES need a "
+            "verified update (WOR-439).",
+            reason,
+            _VLLM_BASE_URL,
+        )
         return None, False
     for peer in (*_local_active, *_cloud_active):
         if peer.remained_solo:

--- a/app/core/watcher/watcher_helpers.py
+++ b/app/core/watcher/watcher_helpers.py
@@ -49,6 +49,7 @@ __all__ = [
     "suppress_dedup",
     "count_main_ahead_of_epic",
     "capture_vllm_metrics",
+    "capture_vllm_metrics_diagnostic",
     "compute_vllm_metrics_delta",
     "picker_sort_key",
     "WorkerBehavior",
@@ -489,6 +490,16 @@ _VLLM_COUNTERS = (
     "vllm:num_preemptions_total",
 )
 
+# vLLM has shipped the prefix-cache counters under both the bare name and a
+# ``gpu_`` prefix across engine versions (V0 vs V1). Accept either spelling
+# and fold it into the canonical key so a vLLM upgrade does not silently
+# blank these columns (WOR-439). Add verified spellings here as they are
+# observed against a live /metrics surface.
+_VLLM_COUNTER_ALIASES: dict[str, str] = {
+    "vllm:gpu_prefix_cache_hits_total": "vllm:prefix_cache_hits_total",
+    "vllm:gpu_prefix_cache_queries_total": "vllm:prefix_cache_queries_total",
+}
+
 
 def _fetch_vllm_metrics_body(timeout: float) -> str | None:
     """Fetch raw vLLM /metrics body via http.client; returns None on failure."""
@@ -529,20 +540,32 @@ def _parse_metric_line(line: str, targets: set[str]) -> tuple[str | None, float 
     return metric_name, value
 
 
-def capture_vllm_metrics(timeout: float = 5.0) -> dict[str, float] | None:
-    """Snapshot vLLM Prometheus metrics for per-ticket attribution.
+def capture_vllm_metrics_diagnostic(
+    timeout: float = 5.0,
+) -> tuple[dict[str, float] | None, str]:
+    """Snapshot vLLM Prometheus counters, with a failure reason (WOR-439).
 
-    Returns a dict {metric_name: aggregated_value} or None if the endpoint
-    is unreachable / malformed / not a vLLM /metrics surface. Aggregates
-    values across label combinations (typically one model/engine combo).
+    Returns ``(snapshot, reason)`` where ``reason`` is one of:
+
+    - ``"ok"`` — ``snapshot`` is a non-empty aggregated dict
+    - ``"unreachable"`` — /metrics did not respond, timed out, or
+      returned a non-200 status
+    - ``"no_counters_matched"`` — /metrics responded but none of the
+      expected counters were present (a vLLM build that renamed its
+      Prometheus metrics — the silent-NULL trap WOR-439 chases)
+
+    Counter names are matched against ``_VLLM_COUNTERS`` plus the
+    version-variant spellings in ``_VLLM_COUNTER_ALIASES`` (each folded
+    into its canonical key). Aggregates values across label combinations.
     """
     body = _fetch_vllm_metrics_body(timeout)
     if body is None:
-        return None
+        return None, "unreachable"
 
-    targets = set(_VLLM_COUNTERS)
-    aggregated: dict[str, float] = dict.fromkeys(targets, 0.0)
-    seen: dict[str, bool] = dict.fromkeys(targets, False)
+    canonical = set(_VLLM_COUNTERS)
+    targets = canonical | set(_VLLM_COUNTER_ALIASES)
+    aggregated: dict[str, float] = dict.fromkeys(canonical, 0.0)
+    seen: dict[str, bool] = dict.fromkeys(canonical, False)
 
     for raw in body.splitlines():
         line = raw.strip()
@@ -551,12 +574,25 @@ def capture_vllm_metrics(timeout: float = 5.0) -> dict[str, float] | None:
         name, value = _parse_metric_line(line, targets)
         if name is None or value is None:
             continue
-        aggregated[name] += value
-        seen[name] = True
+        canon = _VLLM_COUNTER_ALIASES.get(name, name)
+        aggregated[canon] += value
+        seen[canon] = True
 
     if not any(seen.values()):
-        return None
-    return aggregated
+        return None, "no_counters_matched"
+    return aggregated, "ok"
+
+
+def capture_vllm_metrics(timeout: float = 5.0) -> dict[str, float] | None:
+    """Snapshot vLLM Prometheus metrics for per-ticket attribution.
+
+    Back-compat thin wrapper over :func:`capture_vllm_metrics_diagnostic`
+    that discards the diagnostic reason. Returns the aggregated snapshot
+    dict, or ``None`` if the endpoint is unreachable / malformed / not a
+    vLLM /metrics surface.
+    """
+    snapshot, _reason = capture_vllm_metrics_diagnostic(timeout)
+    return snapshot
 
 
 def compute_vllm_metrics_delta(

--- a/tests/test_vllm_metrics_capture.py
+++ b/tests/test_vllm_metrics_capture.py
@@ -11,6 +11,7 @@ Three layers:
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -18,6 +19,7 @@ import pytest
 
 from app.core.watcher.watcher_helpers import (
     capture_vllm_metrics,
+    capture_vllm_metrics_diagnostic,
     compute_vllm_metrics_delta,
 )
 
@@ -208,8 +210,8 @@ def test_dispatch_captures_vllm_snapshot_when_solo(tmp_path: Path) -> None:
         patch("app.core.watcher.dispatch.launch_worker", return_value=MagicMock()),
         patch("app.core.watcher.dispatch.safe_set_state"),
         patch(
-            "app.core.watcher.dispatch.capture_vllm_metrics",
-            return_value=sample_snapshot,
+            "app.core.watcher.dispatch.capture_vllm_metrics_diagnostic",
+            return_value=(sample_snapshot, "ok"),
         ) as mock_capture,
     ):
         start_ticket(
@@ -285,8 +287,8 @@ def test_dispatch_invalidates_solo_peer_when_second_worker_launches(
         patch("app.core.watcher.dispatch.safe_set_state"),
         # Should NOT be called: dispatch_concurrency > 0 means no snapshot
         patch(
-            "app.core.watcher.dispatch.capture_vllm_metrics",
-            return_value={"vllm:prompt_tokens_total": 200.0},
+            "app.core.watcher.dispatch.capture_vllm_metrics_diagnostic",
+            return_value=({"vllm:prompt_tokens_total": 200.0}, "ok"),
         ) as mock_capture,
     ):
         start_ticket(
@@ -317,8 +319,10 @@ def test_dispatch_invalidates_solo_peer_when_second_worker_launches(
 
 def test_dispatch_skips_snapshot_when_metrics_endpoint_unreachable(
     tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """If /metrics returns None (unreachable), worker proceeds without solo flag."""
+    """If /metrics returns None (unreachable), worker proceeds without solo
+    flag — and the failure is logged loudly (WOR-439), not silent."""
     from app.core.watcher.dispatch import start_ticket
     from tests.conftest import make_manifest
 
@@ -329,6 +333,7 @@ def test_dispatch_skips_snapshot_when_metrics_endpoint_unreachable(
     services = _services()
     local_active: list = []
     cloud_active: list = []
+    caplog.set_level(logging.WARNING, logger="app.core.watcher.dispatch")
 
     with (
         patch(
@@ -341,8 +346,8 @@ def test_dispatch_skips_snapshot_when_metrics_endpoint_unreachable(
         patch("app.core.watcher.dispatch.launch_worker", return_value=MagicMock()),
         patch("app.core.watcher.dispatch.safe_set_state"),
         patch(
-            "app.core.watcher.dispatch.capture_vllm_metrics",
-            return_value=None,  # endpoint unreachable
+            "app.core.watcher.dispatch.capture_vllm_metrics_diagnostic",
+            return_value=(None, "unreachable"),  # endpoint unreachable
         ),
     ):
         start_ticket(
@@ -365,6 +370,11 @@ def test_dispatch_skips_snapshot_when_metrics_endpoint_unreachable(
     assert worker.dispatch_concurrency == 0
     assert worker.vllm_metrics_before is None
     assert worker.remained_solo is False
+    # WOR-439: the failure must be observable, not silent at debug level.
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1
+    assert "solo snapshot failed" in warnings[0].message
+    assert "unreachable" in caplog.text
 
 
 # ---------------------------------------------------------------------------
@@ -418,3 +428,145 @@ def test_finalize_writes_sentinel_artifact_for_concurrent_session(
     assert "before" in payload  # before is still useful for audit
     assert "after" not in payload
     assert "deltas" not in payload
+
+
+# ---------------------------------------------------------------------------
+# WOR-439: diagnostic reason, gpu_ alias compat, loud solo-failure warning,
+# and the _capture_vllm_post happy path
+# ---------------------------------------------------------------------------
+
+
+def test_diagnostic_reason_ok() -> None:
+    conn = _conn_with_response(200, _SAMPLE_METRICS)
+    with patch("http.client.HTTPConnection", return_value=conn):
+        snap, reason = capture_vllm_metrics_diagnostic()
+    assert reason == "ok"
+    assert snap is not None
+    assert snap["vllm:prefix_cache_hits_total"] == 1454624.0
+
+
+def test_diagnostic_reason_unreachable() -> None:
+    conn = MagicMock()
+    conn.request.side_effect = OSError("network down")
+    with patch("http.client.HTTPConnection", return_value=conn):
+        snap, reason = capture_vllm_metrics_diagnostic()
+    assert snap is None
+    assert reason == "unreachable"
+
+
+def test_diagnostic_reason_no_counters_matched() -> None:
+    """Reachable + 200 but renamed metrics — the silent-NULL trap."""
+    body = b'# random\nsome_unrelated{foo="bar"} 1.0\n'
+    conn = _conn_with_response(200, body)
+    with patch("http.client.HTTPConnection", return_value=conn):
+        snap, reason = capture_vllm_metrics_diagnostic()
+    assert snap is None
+    assert reason == "no_counters_matched"
+
+
+def test_gpu_prefixed_counters_fold_into_canonical() -> None:
+    """vLLM version-variant gpu_-prefixed counters map to canonical keys."""
+    body = (
+        b'vllm:gpu_prefix_cache_hits_total{engine="0"} 80.0\n'
+        b'vllm:gpu_prefix_cache_queries_total{engine="0"} 100.0\n'
+        b'vllm:prompt_tokens_total{engine="0"} 5.0\n'
+    )
+    conn = _conn_with_response(200, body)
+    with patch("http.client.HTTPConnection", return_value=conn):
+        snap, reason = capture_vllm_metrics_diagnostic()
+    assert reason == "ok"
+    assert snap is not None
+    assert snap["vllm:prefix_cache_hits_total"] == 80.0
+    assert snap["vllm:prefix_cache_queries_total"] == 100.0
+
+
+def test_capture_wrapper_is_backward_compatible() -> None:
+    """The thin wrapper still returns just the dict (no signature churn)."""
+    conn = _conn_with_response(200, _SAMPLE_METRICS)
+    with patch("http.client.HTTPConnection", return_value=conn):
+        result = capture_vllm_metrics()
+    assert isinstance(result, dict)
+    assert result["vllm:num_preemptions_total"] == 0.0
+
+
+def test_snapshot_solo_failure_logs_one_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """WOR-439 AC: a failed solo snapshot logs ONE clear warning, not silence."""
+    from app.core.watcher.dispatch import _snapshot_vllm_solo
+
+    with patch(
+        "app.core.watcher.dispatch.capture_vllm_metrics_diagnostic",
+        return_value=(None, "unreachable"),
+    ):
+        with caplog.at_level(logging.WARNING, logger="app.core.watcher.dispatch"):
+            snap, solo = _snapshot_vllm_solo(0, [], [])
+    assert snap is None
+    assert solo is False
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1
+    assert "solo snapshot failed" in warnings[0].message
+    assert "unreachable" in caplog.text
+
+
+def test_snapshot_solo_success_logs_nothing(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    from app.core.watcher.dispatch import _snapshot_vllm_solo
+
+    with patch(
+        "app.core.watcher.dispatch.capture_vllm_metrics_diagnostic",
+        return_value=({"vllm:prompt_tokens_total": 1.0}, "ok"),
+    ):
+        with caplog.at_level(logging.WARNING, logger="app.core.watcher.dispatch"):
+            snap, solo = _snapshot_vllm_solo(0, [], [])
+    assert snap == {"vllm:prompt_tokens_total": 1.0}
+    assert solo is True
+    assert not [r for r in caplog.records if r.levelno == logging.WARNING]
+
+
+def test_capture_vllm_post_returns_non_none_deltas_for_solo(
+    tmp_path: Path,
+) -> None:
+    """WOR-439 AC: non-None deltas when before+after snapshots both have data."""
+    from app.core.watcher.watcher_finalize import _capture_vllm_post
+    from app.core.watcher.watcher_types import ActiveWorker
+    from tests.conftest import make_manifest
+
+    worker = ActiveWorker(
+        ticket_id="WOR-70",
+        linear_id="lin-70",
+        manifest=make_manifest(ticket_id="WOR-70"),
+        worktree_path=tmp_path / "wt-70",
+        process=MagicMock(),
+        vllm_metrics_before={
+            "vllm:prefix_cache_hits_total": 100.0,
+            "vllm:prefix_cache_queries_total": 200.0,
+            "vllm:prompt_tokens_total": 1000.0,
+            "vllm:generation_tokens_total": 50.0,
+            "vllm:time_to_first_token_seconds_sum": 5.0,
+            "vllm:time_to_first_token_seconds_count": 10.0,
+            "vllm:num_preemptions_total": 0.0,
+        },
+        remained_solo=True,
+    )
+    after = {
+        "vllm:prefix_cache_hits_total": 196.0,
+        "vllm:prefix_cache_queries_total": 300.0,
+        "vllm:prompt_tokens_total": 1500.0,
+        "vllm:generation_tokens_total": 70.0,
+        "vllm:time_to_first_token_seconds_sum": 11.0,
+        "vllm:time_to_first_token_seconds_count": 14.0,
+        "vllm:num_preemptions_total": 1.0,
+    }
+    with patch(
+        "app.core.watcher.watcher_finalize.capture_vllm_metrics",
+        return_value=after,
+    ):
+        attributable, deltas = _capture_vllm_post(worker, tmp_path)
+    assert attributable is True
+    assert deltas  # non-empty
+    assert deltas["prefix_cache_hits"] == 96
+    assert deltas["prefix_cache_hit_ratio"] == pytest.approx(0.96)
+    artifact = tmp_path / ".claude" / "artifacts" / "wor_70" / "vllm_metrics.json"
+    assert artifact.exists()


### PR DESCRIPTION
## Summary

Fixes **WOR-439** — every `vllm_*` column NULL on every row (0/101) despite the WOR-370 attribution machinery being in place.

**Root cause, verified live (vLLM brought up for this):** the capture / parse / delta / solo-gate code is *correct*. Live `/metrics` emits exactly the names in `_VLLM_COUNTERS`; `capture_vllm_metrics_diagnostic()` returns `ok` with a populated snapshot; `_snapshot_vllm_solo(0, [], [])` → full snapshot + `remained_solo=True`; the before→after→delta path works end-to-end. The real defect is **observability**: a failed dispatch-time snapshot fell back silently through `logger.debug`, so weeks of dead telemetry were invisible — nobody could see *why* it was NULL (unreachable vs renamed metrics vs never-solo).

## Changes

- **`capture_vllm_metrics_diagnostic()`** — returns `(snapshot, reason)` with `reason ∈ {ok, unreachable, no_counters_matched}`. `capture_vllm_metrics` is now a thin back-compat wrapper (zero caller churn — existing tests pass unchanged, no parallel-impl drift).
- **`_snapshot_vllm_solo`** — on solo-snapshot failure logs **one clear WARNING** with the reason + `base_url` and the fix hint (AC bullet 3: no longer silent at debug level). Concurrent dispatch still skips by design (cross-session attribution is explicitly out of scope).
- **`_VLLM_COUNTER_ALIASES`** — accepts vLLM's `gpu_`-prefixed prefix-cache counter variant and folds it into the canonical key, so a future vLLM rename can't silently re-blank the columns (the exact failure mode in the ticket title).

## Test plan

- [x] `ruff check .` — clean
- [x] `mypy app/` — clean (48 files)
- [x] `pytest` — **1996 passed** (full suite; +8, zero regressions from the `dispatch` import rename)
- [x] `lint-imports` — 8 kept, 0 broken
- [x] Live verification: counter names confirmed against running vLLM 0.20.0; diagnostic returns `ok`; solo gate + delta sound end-to-end
- [x] AC bullet 4: new `_capture_vllm_post` happy-path test asserts non-None deltas when before+after both have data; existing `_capture_vllm_post`/`capture_vllm_metrics` tests still pass

**Operational AC (post-merge):** "next 3 solo-dispatched tickets show non-NULL `vllm_*`" verifies on the operator's next real run — the fix makes that run *self-diagnosing*: it either populates the columns or logs exactly why once.

**Milestone:** Operator UX & Watcher Resilience

Closes WOR-439

🤖 Generated with [Claude Code](https://claude.com/claude-code)
