### PR TITLE
WOR-505 Give ExecutionManifest.routing a default so WOR-290 back-compat works

### DIFF
--- a/app/core/manifest.py
+++ b/app/core/manifest.py
@@ -135,7 +135,7 @@ class ExecutionManifest(BaseModel):
     decide where to dispatch a ticket.
     """
 
-    routing: Literal["local", "cloud_preferred", "cloud_only"]
+    routing: Literal["local", "cloud_preferred", "cloud_only"] = "local"
     """Routing decision for the watcher — where to dispatch the ticket.
 
     ``local``   — dispatch to a local worker (default for backwards

--- a/schemas/execution_manifest.schema.json
+++ b/schemas/execution_manifest.schema.json
@@ -136,6 +136,7 @@
       "type": "string"
     },
     "routing": {
+      "default": "local",
       "enum": [
         "local",
         "cloud_preferred",
@@ -412,7 +413,6 @@
     "parallel_safe",
     "risk_level",
     "implementation_mode",
-    "routing",
     "review_mode",
     "base_branch",
     "worker_branch",

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -105,7 +105,6 @@ def test_failure_policy_default_abort():
         "parallel_safe",
         "risk_level",
         "implementation_mode",
-        "routing",
         "review_mode",
         "base_branch",
         "worker_branch",
@@ -118,6 +117,37 @@ def test_manifest_missing_required_field_raises(missing_field):
     del payload[missing_field]
     with pytest.raises(ValidationError):
         ExecutionManifest(**payload)
+
+
+# ---------------------------------------------------------------------------
+# WOR-505: routing back-compat default (legacy manifests have no routing key)
+# ---------------------------------------------------------------------------
+
+
+def test_routing_defaults_to_local_when_absent_legacy_manifest():
+    """A pre-WOR-290 manifest has no ``routing`` key. It must load — the
+    WOR-290 mode='after' shim assumed a 'local' default that was never
+    added, so legacy manifests previously crashed the epic scan."""
+    payload = _minimal_manifest()
+    del payload["routing"]
+    m = ExecutionManifest(**payload)  # must not raise
+    assert m.routing == "local"
+
+
+@pytest.mark.parametrize("legacy_mode", ["cloud", "hybrid"])
+def test_routing_derived_from_implementation_mode_for_legacy(legacy_mode):
+    """With routing absent, the WOR-290 shim now actually fires:
+    implementation_mode cloud/hybrid derives routing='cloud_preferred'."""
+    payload = _minimal_manifest(implementation_mode=legacy_mode)
+    del payload["routing"]
+    m = ExecutionManifest(**payload)
+    assert m.routing == "cloud_preferred"
+
+
+def test_explicit_routing_is_not_overridden_by_shim():
+    """An explicit non-local routing decision is preserved."""
+    m = _make_manifest(routing="cloud_only", implementation_mode="local")
+    assert m.routing == "cloud_only"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes **WOR-505** — `ExecutionManifest.routing` was `Literal[...]` with **no default**, but the WOR-290 back-compat shim `_derive_routing_from_implementation_mode` is `@model_validator(mode="after")` and its docstring explicitly assumes routing defaults to `"local"`. Pydantic raises `Field required` *before* `mode="after"` validators run, so the shim was dead code and every legacy (pre-WOR-290) manifest crashed the `watcher_epic` scan.

**Observed live (2026-05-16):** ~221 stale artifact manifests → ~221 `ValidationError` WARNINGs per poll cycle, watcher log unusable, run appeared broken while setting up WOR-502 for the WOR-439 telemetry verification.

## Changes

- **`app/core/manifest.py`** — `routing: Literal[...] = "local"`. One line; exactly what the shim's own docstring already documents. Legacy manifests now load and derive `cloud_preferred` from `implementation_mode` as designed.
- **`tests/test_manifest.py`** — dropped `"routing"` from the missing-required-field parametrize (no longer required — that case would now wrongly expect a raise: the WOR-430/503 contradictory-test trap). Added positive regression tests: absent routing → `local`; absent + `implementation_mode` cloud/hybrid → `cloud_preferred`; explicit `cloud_only` preserved.
- **`schemas/execution_manifest.schema.json`** — regenerated per the drift test's documented command (`+"default": "local"`, `routing` out of `required`).

## Test plan

- [x] `ruff check .` — clean
- [x] `mypy app/` — clean (48 files)
- [x] `pytest` — **1999 passed** (full suite)
- [x] `lint-imports` — 8 kept, 0 broken
- [x] `test_committed_schema_file_matches_model` passes (regenerated)

**Note:** the 221 stale local artifact dirs that triggered the live spam were `.claude/artifacts/` gitignored scratch from long-done tickets; moved out of the repo tree (reversible) — orthogonal to this code fix, which prevents recurrence.

Closes WOR-505

🤖 Generated with [Claude Code](https://claude.com/claude-code)
