### PR TITLE
WOR-500 Auto-scope allowed_paths in /start-ticket & /start-epic

### DIFF
--- a/.claude/commands/start-epic.md
+++ b/.claude/commands/start-epic.md
@@ -205,7 +205,7 @@ git checkout main
 
 **5b. Write the execution manifest**
 
-Before writing, run these three pre-flight checks for each ticket:
+Before writing, run these four pre-flight checks for each ticket:
 
 **A. Context snippets** — Read the key functions the worker will call or test from `related_files_hint`. If any function's behaviour depends on a constant defined in another module or a non-obvious path indirection (e.g. `repo_root.parent / _WORKTREE_BASE` where `_WORKTREE_BASE` is in `watcher_types.py`), copy those lines verbatim into `context_snippets` as `"# <file>:<start>-<end>\n<lines>"`. Rule: if you needed to read a second file to understand the first, the worker needs it too — inline it as a snippet.
 
@@ -213,6 +213,8 @@ Before writing, run these three pre-flight checks for each ticket:
 `"Fix code by editing test files directly with Edit/Write tools. Do not use Bash to experiment with Python path logic or prototype solutions — reason from the source code, then edit."`
 
 **C. AC function name validation** — For any function or method name mentioned in `acceptance_criteria`, verify it exists in the source: `grep -rn "def <name>" app/`. Correct any mismatch before writing — this prevents the worker from testing non-existent symbols.
+
+**D. Auto-scope allowed_paths (WOR-500)** — expand `allowed_paths` so a correct cross-cutting edit is never Blocked (over-broad never Blocks correct work; under-scoped Blocked flawless implementations — WOR-290, WOR-502): (1) if any entry is `app/core/manifest.py` or `tests/conftest.py` (or another widely-imported shared model/fixture), also add `tests/conftest.py`, `app/core/manifest_builder.py`, and `tests/test_*.py` — a model-field change ripples to the shared `make_manifest` fixture and every manifest-constructing test; (2) re-read every `risk_flag` — any module a risk_flag names as where logic "lives"/"belongs"/"is located" is **required** in `allowed_paths` (a risk_flag naming another module is the scope hole already spotted — close it, don't just describe it); (3) CLI-flag tickets must include the argparse module (`app/cli/parser.py`), not only the consumer; dispatch/admission tickets must include `app/core/watcher/dispatch.py`, not only `watcher.py`. When uncertain, over-scope.
 
 Write to `.claude/artifacts/<ticket_id_lower>/manifest.json`:
 

--- a/.claude/commands/start-ticket.md
+++ b/.claude/commands/start-ticket.md
@@ -419,6 +419,41 @@ unchanged. Non-test paths (e.g. `app/core/metrics.py`) are left unchanged.
 The architect does NOT need to enumerate sibling tests manually — this step
 handles it mechanically before the manifest is written.
 
+### 5.9. Auto-scope allowed_paths for shared-model + risk_flag ripple (WOR-500)
+
+After the WOR-353 test-glob expansion and before writing the manifest, expand
+`allowed_paths` so a *correct* cross-cutting edit is never Blocked. An
+over-broad `allowed_paths` never Blocks correct work; an under-scoped one
+Blocks flawless implementations — WOR-290 (a clean 21-file refactor,
+ruff/lint-imports/mypy clean, 1911 pytest passing, Blocked solely for this)
+and WOR-502 (a correct KV-admission feature Blocked because `parser.py` /
+`dispatch.py` were omitted).
+
+Apply all three rules mechanically:
+
+1. **Shared model/fixture ripple.** If any `allowed_paths` entry is
+   `app/core/manifest.py` or `tests/conftest.py` (or another widely-imported
+   shared model/fixture that many tests construct), also add
+   `tests/conftest.py`, `app/core/manifest_builder.py`, and `tests/test_*.py`.
+   A model-field change unavoidably ripples to the shared `make_manifest`
+   fixture and every manifest-constructing test.
+
+2. **risk_flag meta-rule.** Re-read every `risk_flag` written in step 3. If a
+   risk_flag names a module/file as where logic "lives", "belongs", "is
+   located", or must be "found" (e.g. "the arg-parser is in another module",
+   "admission belongs in the dispatch path"), that file is **required** in
+   `allowed_paths`. A risk_flag naming another module is you having already
+   spotted the scope hole — close it here, do not merely describe it.
+
+3. **Common implicit pairs.** If the ticket adds or changes a CLI flag,
+   include the argparse module (`app/cli/parser.py`), not only the consumer
+   (`app/cli/operator.py`). If it adds watcher dispatch/admission logic,
+   include `app/core/watcher/dispatch.py`, not only
+   `app/core/watcher/watcher.py`.
+
+When uncertain, over-scope. The architect does NOT need to perfectly predict
+the worker's file set — these rules close the systematic under-scoping gaps.
+
 ### 5.6. After human approves the plan — generate the execution manifest
 
 Once the human says to proceed, generate and write an `ExecutionManifest` JSON to disk. This is the handoff artifact the local worker reads — it must not require re-reading Linear or re-planning.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -417,6 +417,8 @@ and convert every match to `patch("new.module.path.function_name")`.
 
 **Test allowed_paths are auto-globbed at `/start-ticket` time.** When the architect lists `tests/test_X.py` in `allowed_paths`, the manifest writer expands it to `tests/test_X*.py` so sibling test files are explicitly in scope. Architects do NOT need to enumerate sibling tests manually. Already-globbed entries (e.g. `tests/test_*.py`) are left unchanged.
 
+**allowed_paths auto-scoping for shared-model + risk_flag ripple (WOR-500).** Beyond the test-glob, the `/start-ticket` and `/start-epic` manifest writers also expand `allowed_paths`: (a) if it touches `app/core/manifest.py` or `tests/conftest.py`, they add `tests/conftest.py` + `app/core/manifest_builder.py` + `tests/test_*.py` (a model-field change ripples to the shared `make_manifest` fixture and every manifest-constructing test); (b) any module a `risk_flag` names as where logic "lives"/"belongs" is force-added; (c) CLI-flag tickets include `app/cli/parser.py`, dispatch tickets include `app/core/watcher/dispatch.py`. An over-broad `allowed_paths` never Blocks correct work; an under-scoped one Blocked flawless implementations (WOR-290's clean 21-file refactor, WOR-502's correct KV-admission feature).
+
 ---
 
 ## Escalation policy


### PR DESCRIPTION
## Summary

Fixes **WOR-500** — architect-written manifest `allowed_paths` repeatedly Blocked *flawless* local-worker implementations because correct cross-cutting edits fell outside the declared scope. Live evidence: **WOR-290** (clean 21-file routing refactor — ruff/lint-imports/mypy clean, 1911 pytest passing — Blocked solely for the manifest/conftest ripple) and **WOR-502** (correct KV-admission feature Blocked because `app/cli/parser.py` and `app/core/watcher/dispatch.py` were omitted, even though a manifest risk_flag *named* them).

Adds a mechanical auto-scoping step to both skills + a CLAUDE.md regression note. Three rules:

1. **Shared model/fixture ripple** *(WOR-500 stated scope)* — `allowed_paths` touching `app/core/manifest.py` or `tests/conftest.py` auto-adds `tests/conftest.py` + `app/core/manifest_builder.py` + `tests/test_*.py`.
2. **risk_flag meta-rule** *(WOR-502 lesson, folded in — same surface, same root cause)* — any module a `risk_flag` names as where logic "lives"/"belongs"/"is located" is **required** in `allowed_paths`. A model/fixture-only fix would *not* have prevented the WOR-502 block, so the narrow scope is closed together with the general one.
3. **Common implicit pairs** — CLI-flag tickets include `app/cli/parser.py`; dispatch tickets include `app/core/watcher/dispatch.py`.

Guiding invariant documented in all three places: *an over-broad `allowed_paths` never Blocks correct work; an under-scoped one Blocks flawless implementations.*

## Files

- `.claude/commands/start-ticket.md` — new §5.9 (after the WOR-353 test-glob, before manifest write)
- `.claude/commands/start-epic.md` — pre-flight check **D** (alongside A/B/C); count updated three→four
- `CLAUDE.md` — Worker-efficiency allowed_paths regression note

## Test plan

Docs/skill-text only — no Python touched; ruff/mypy/pytest/lint-imports N/A. pre-commit (whitespace/EOF) passed on commit. The fix is instructional (consumed by the architect-LLM running the skills); validation is the absence of the WOR-290/502 block class on the next manifest/shared-model/CLI-flag/dispatch ticket.

**Retires the manual workaround** in operator memory `feedback-manifest-allowed-paths-shared-model` once merged.

Closes WOR-500

🤖 Generated with [Claude Code](https://claude.com/claude-code)
