### PR TITLE
WOR-501 Operator-visible last_failure.json + result.json path tolerance

### DIFF
--- a/.claude/commands/implement-ticket.md
+++ b/.claude/commands/implement-ticket.md
@@ -366,6 +366,19 @@ is already at its documented audit path. (Earlier skill text instructed a
 the model attempted to `cp` a file onto itself before realizing the
 redundancy. WOR-322 paid ~12 minutes of wall time to this. WOR-356.)
 
+**Do NOT `git add` / commit `.claude/artifacts/**` into the branch.**
+`result.json` and `last_failure.json` live under `.claude/artifacts/`, which is
+gitignored on purpose. Never `git add -f` (force) them or otherwise commit them
+into the worker branch. The watcher reads `result.json` from the **main-repo**
+artifact path, not from a branch commit — a committed-into-branch result.json is
+invisible to `finalize_worker` (the run is then treated as "no result" → Blocked
+even when the work is perfect), and the committed file also bloats the diff,
+which can itself trip the allowed_paths gate. Write the result artifact in place
+(step 5) and leave it **uncommitted**; the watcher preserves it. (WOR-501: a
+sound max-effort implementation was lost exactly this way — finalize is now also
+tolerant of a worktree-located result.json as a backstop, but workers must still
+never commit it.)
+
 ### 6. Linear updates (comments only — state is owned by the watcher)
 
 **On success:** do nothing in Linear. The watcher reads the result artifact and handles PR creation and state transitions. Do not call `/finalize-ticket`.

--- a/app/core/watcher/watcher_finalize.py
+++ b/app/core/watcher/watcher_finalize.py
@@ -30,6 +30,7 @@ from .watcher_finalize_helpers import (
     _artifact_dir_for,
     _classify_stage,
     _execute_finalization,
+    _main_artifact_dir_for,
     _read_result_status,
     _record_failure_artifact,
     _record_failure_state,
@@ -470,9 +471,12 @@ def finalize_worker(
             f"allowed_paths violation — {len(violations)} file(s) outside scope",
         )
         _try_post_comment(linear, worker.linear_id, worker.ticket_id, comment)
-        # WOR-457: validation-gate failures get a diagnostic artifact too.
+        # WOR-457 + WOR-501: validation-gate failures get a diagnostic
+        # artifact, written to the operator-visible MAIN-REPO dir — this
+        # gate returns before the worktree-artifact-preservation step, so
+        # a worktree-located last_failure.json would be lost on cleanup.
         _record_failure_artifact(
-            _artifact_dir_for(worker),
+            _main_artifact_dir_for(repo_root, worker),
             "validate_allowed_paths",
             stderr="\n".join(violations),
         )
@@ -487,7 +491,10 @@ def finalize_worker(
     # signal; genuine failures are handled by the returncode logic in
     # _execute_finalization. Runs before the retry loop — a contract
     # violation is not a transient check failure, so retries won't help.
-    if _read_result_status(repo_root, worker.manifest) == "success":
+    if (
+        _read_result_status(repo_root, worker.manifest, worker.worktree_path)
+        == "success"
+    ):
         missing_checks = _validate_checks_passed(worker.manifest, repo_root)
         if missing_checks:
             comment = (
@@ -507,9 +514,11 @@ def finalize_worker(
                 f"{len(missing_checks)} required check(s) not reported",
             )
             _try_post_comment(linear, worker.linear_id, worker.ticket_id, comment)
-            # WOR-457: validation-gate failures get a diagnostic artifact.
+            # WOR-457 + WOR-501: diagnostic artifact to the operator-visible
+            # MAIN-REPO dir — this gate also returns before artifact
+            # preservation, so a worktree-located file would be lost.
             _record_failure_artifact(
-                _artifact_dir_for(worker),
+                _main_artifact_dir_for(repo_root, worker),
                 "validate_checks_passed",
                 stderr="missing required_checks: " + ", ".join(missing_checks),
             )

--- a/app/core/watcher/watcher_finalize_helpers.py
+++ b/app/core/watcher/watcher_finalize_helpers.py
@@ -229,7 +229,11 @@ def safe_set_state_and_comment(
     f2.result()
 
 
-def _read_result_status(repo_root: Path, manifest: ExecutionManifest) -> str | None:
+def _read_result_status(
+    repo_root: Path,
+    manifest: ExecutionManifest,
+    worktree_path: Path | None = None,
+) -> str | None:
     """Return the worker's self-reported status from result.json, or None.
 
     Workers write a ``status`` field of ``"success"`` or ``"failure"`` (or
@@ -238,20 +242,33 @@ def _read_result_status(repo_root: Path, manifest: ExecutionManifest) -> str | N
     subprocess exit code (which can be non-zero even after a successful run
     due to Claude Code CLI teardown quirks — see WOR-286).
 
-    Returns None when the file is missing or unreadable; callers should treat
-    that as "no in-band signal" rather than success.
+    WOR-501: a worker that ``git add -f``'d result.json into its branch
+    leaves it only at ``worktree_path/<result_json>`` — the normally
+    gitignored main-repo path stays empty, so the watcher would read
+    nothing and wrongly route a sound run to failure. When *worktree_path*
+    is given and the main-repo copy yields no status, fall back to the
+    worktree copy before declaring "no in-band signal". The main-repo
+    path keeps precedence (it is the canonical location).
+
+    Returns None when no readable result.json with a string ``status`` is
+    found in either location.
     """
-    result_path = repo_root / manifest.artifact_paths.result_json
-    try:
-        raw = result_path.read_text(encoding="utf-8")
-    except OSError:
-        return None
-    try:
-        data = json.loads(raw)
-    except ValueError:
-        return None
-    status = data.get("status") if isinstance(data, dict) else None
-    return status if isinstance(status, str) else None
+    for base in (repo_root, worktree_path):
+        if base is None:
+            continue
+        result_path = base / manifest.artifact_paths.result_json
+        try:
+            raw = result_path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        try:
+            data = json.loads(raw)
+        except ValueError:
+            continue
+        status = data.get("status") if isinstance(data, dict) else None
+        if isinstance(status, str):
+            return status
+    return None
 
 
 def _record_failure_state(
@@ -308,7 +325,7 @@ def _execute_finalization(
     # during teardown after a fully successful run — that should not destroy
     # the work. Only treat non-zero exit as failure when result.json is
     # missing or also reports failure.
-    result_status = _read_result_status(repo_root, manifest)
+    result_status = _read_result_status(repo_root, manifest, worker.worktree_path)
     if returncode != 0 and result_status != "success":
         logger.error(
             "Worker %s exited non-zero (%d); result.json status=%s — "
@@ -502,6 +519,20 @@ _FINALIZE_STAGES = (
 def _artifact_dir_for(worker: ActiveWorker) -> Path:
     """The worktree artifact dir holding result.json / last_failure.json."""
     return (worker.worktree_path / worker.manifest.artifact_paths.result_json).parent
+
+
+def _main_artifact_dir_for(repo_root: Path, worker: ActiveWorker) -> Path:
+    """Operator-visible (main-repo) artifact dir — survives worktree cleanup.
+
+    WOR-501: the two pre-retry validation gates (validate_allowed_paths,
+    validate_checks_passed) ``return "failure"`` *before* the
+    artifact-preservation step that copies the worktree dir out, so a
+    last_failure.json written via :func:`_artifact_dir_for` (worktree)
+    is invisible to the operator and lost on cleanup. Those gates must
+    write here — the same main-repo path :func:`_read_result_status`
+    and the operator look in.
+    """
+    return (repo_root / worker.manifest.artifact_paths.result_json).parent
 
 
 def _classify_stage(exc: BaseException) -> str:

--- a/tests/test_watcher_finalize_stages.py
+++ b/tests/test_watcher_finalize_stages.py
@@ -17,6 +17,7 @@ from app.core.manifest import ArtifactPaths
 from app.core.watcher.watcher_finalize import finalize_worker
 from app.core.watcher.watcher_finalize_helpers import (
     _classify_stage,
+    _read_result_status,
     _record_failure_artifact,
 )
 from app.core.watcher.watcher_types import ActiveWorker
@@ -198,6 +199,150 @@ def test_finalize_checks_passed_violation_writes_stage(tmp_path: Path) -> None:
     )
     assert data["stage"] == "validate_checks_passed"
     assert "missing required_checks" in data["stderr"]
+
+
+# ---------------------------------------------------------------------------
+# WOR-501 Defect 1: early-return gates write last_failure.json to the
+# operator-visible MAIN-REPO dir, not the worktree (which is cleaned).
+# These tests use DISTINCT repo_root and worktree dirs — the pre-WOR-501
+# tests above coincidentally used the same tmp_path for both, so they
+# never exercised the worktree-vs-main-repo distinction.
+# ---------------------------------------------------------------------------
+
+
+def _worker_with_worktree(worktree: Path) -> ActiveWorker:
+    manifest = make_manifest(
+        ticket_id="WOR-457",
+        worker_branch="wor-457-test",
+        required_checks=["ruff check .", "mypy app/", "pytest", "lint-imports"],
+        artifact_paths=ArtifactPaths.from_ticket_id("WOR-457"),
+    )
+    return ActiveWorker(
+        ticket_id="WOR-457",
+        linear_id="fake-linear-id",
+        manifest=manifest,
+        worktree_path=worktree,
+        process=MagicMock(spec=subprocess.Popen),
+    )
+
+
+def test_allowed_paths_block_writes_to_operator_visible_dir(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    worktree = tmp_path / "wt"
+    repo_root.mkdir()
+    worktree.mkdir()
+    worker = _worker_with_worktree(worktree)
+    with (
+        patch(
+            "app.core.watcher.watcher_finalize._validate_allowed_paths",
+            return_value=["ALLOWED app/ui/widget.py"],
+        ),
+        patch("app.core.watcher.watcher_finalize.compute_tags", return_value=[]),
+    ):
+        outcome = finalize_worker(
+            worker,
+            returncode=0,
+            wall_time=1.0,
+            linear=MagicMock(),
+            metrics=MagicMock(),
+            escalation_policy=EscalationPolicy.from_toml(),
+            repo_root=repo_root,
+            mode="default",
+            project_id="proj",
+        )
+    assert outcome == "failure"
+    main_lf = repo_root / ".claude" / "artifacts" / "wor_457" / "last_failure.json"
+    wt_lf = worktree / ".claude" / "artifacts" / "wor_457" / "last_failure.json"
+    assert main_lf.exists(), "last_failure.json must be operator-visible (main-repo)"
+    assert not wt_lf.exists(), "must not be written only to the (cleaned) worktree"
+    data = json.loads(main_lf.read_text(encoding="utf-8"))
+    assert data["stage"] == "validate_allowed_paths"
+    assert "app/ui/widget.py" in data["stderr"]
+
+
+def test_checks_passed_block_writes_to_operator_visible_dir(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    worktree = tmp_path / "wt"
+    worktree.mkdir()
+    art = repo_root / ".claude" / "artifacts" / "wor_457"
+    art.mkdir(parents=True)
+    (art / "result.json").write_text(
+        json.dumps({"status": "success", "checks_passed": ["ruff"]}),
+        encoding="utf-8",
+    )
+    worker = _worker_with_worktree(worktree)
+    with (
+        patch(
+            "app.core.watcher.watcher_finalize._validate_allowed_paths",
+            return_value=[],
+        ),
+        patch("app.core.watcher.watcher_finalize.compute_tags", return_value=[]),
+    ):
+        outcome = finalize_worker(
+            worker,
+            returncode=0,
+            wall_time=1.0,
+            linear=MagicMock(),
+            metrics=MagicMock(),
+            escalation_policy=EscalationPolicy.from_toml(),
+            repo_root=repo_root,
+            mode="default",
+            project_id="proj",
+        )
+    assert outcome == "failure"
+    main_lf = art / "last_failure.json"
+    wt_lf = worktree / ".claude" / "artifacts" / "wor_457" / "last_failure.json"
+    assert main_lf.exists()
+    assert not wt_lf.exists()
+    data = json.loads(main_lf.read_text(encoding="utf-8"))
+    assert data["stage"] == "validate_checks_passed"
+
+
+# ---------------------------------------------------------------------------
+# WOR-501 Defect 2: _read_result_status worktree fallback (a worker that
+# git-add-f'd result.json into its branch leaves it only in the worktree).
+# ---------------------------------------------------------------------------
+
+
+def _result_manifest():
+    return make_manifest(
+        ticket_id="WOR-457",
+        artifact_paths=ArtifactPaths.from_ticket_id("WOR-457"),
+    )
+
+
+def test_read_result_status_main_repo_takes_precedence(tmp_path: Path) -> None:
+    manifest = _result_manifest()
+    repo_root = tmp_path / "repo"
+    worktree = tmp_path / "wt"
+    for base, status in ((repo_root, "success"), (worktree, "failure")):
+        p = base / manifest.artifact_paths.result_json
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(json.dumps({"status": status}), encoding="utf-8")
+    assert _read_result_status(repo_root, manifest, worktree) == "success"
+
+
+def test_read_result_status_falls_back_to_worktree(tmp_path: Path) -> None:
+    manifest = _result_manifest()
+    repo_root = tmp_path / "repo"
+    worktree = tmp_path / "wt"
+    p = worktree / manifest.artifact_paths.result_json
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(json.dumps({"status": "success"}), encoding="utf-8")
+    assert _read_result_status(repo_root, manifest, worktree) == "success"
+
+
+def test_read_result_status_none_when_both_missing(tmp_path: Path) -> None:
+    manifest = _result_manifest()
+    assert _read_result_status(tmp_path / "repo", manifest, tmp_path / "wt") is None
+
+
+def test_read_result_status_backward_compatible_without_worktree(
+    tmp_path: Path,
+) -> None:
+    """No worktree_path arg → identical to the pre-WOR-501 behaviour."""
+    manifest = _result_manifest()
+    assert _read_result_status(tmp_path, manifest) is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes **WOR-501** — two finalize-pipeline defects that made the watcher *silently fail correct work with no diagnostic trail*. Hit live this session: WOR-290 (clean 21-file refactor) and WOR-502 (correct KV-admission feature) were both Blocked and left only `manifest.json` in the operator-visible artifact dir — diagnosis required `git -C <worktree> diff` + `watcher.log` forensics.

### Defect 1 — early-return gates wrote `last_failure.json` to the worktree

`validate_allowed_paths` and `validate_checks_passed` `return "failure"` **before** `preserve_worker_artifacts`. They wrote the diagnostic via `_artifact_dir_for` (worktree) → invisible to the operator, lost on worktree cleanup. Added `_main_artifact_dir_for(repo_root, worker)`; both gates now write to the operator-visible **main-repo** artifact dir. The post-retry / `attempt_pr` paths flow *through* preservation and are deliberately unchanged — the fix is surgical to the two pre-retry gates.

### Defect 2 — `_read_result_status` read only the main-repo path

A worker that `git add -f`'d `result.json` into its branch left it only in the worktree → the watcher saw nothing → routed a sound run to failure. Added an optional `worktree_path` fallback (**main-repo keeps precedence**; backward-compatible — default `None` = pre-WOR-501 behaviour). Threaded `worker.worktree_path` at the two gating callers (`finalize_worker` success gate, `_execute_finalization`). `implement-ticket.md` gains a hard rule: never `git add`/commit `.claude/artifacts/**` into the branch.

## Tests

`tests/test_watcher_finalize_stages.py` — the new tests use **distinct `repo_root` vs `worktree` dirs** (the pre-WOR-501 tests reused the same `tmp_path` for both, which is exactly why the bug escaped): allowed_paths/checks_passed block ⇒ `last_failure.json` in the main-repo dir *and not* the worktree, with the correct `stage`; plus `_read_result_status` precedence / worktree-fallback / both-missing / backward-compat (no `worktree_path` arg).

## Test plan

- [x] `ruff check .` — clean
- [x] `mypy app/` — clean (48 files)
- [x] `lint-imports` — 8 kept, 0 broken
- [x] `pytest` — **2008 passed**; 3 failures in `tests/test_watcher_gestures.py` (forcestop/pause/kill *daemon-not-running*) are a **pre-existing xdist parallel-state-bleed flake** — they **pass isolated/serial** and have zero coupling to the finalize changes (same class as the WOR-502 `test_watcher_sonar_concurrent` flake; different tests collide run-to-run). Windows-local is necessary-not-sufficient — **CI (Linux) authoritative.**
- [x] Targeted `test_watcher_finalize_stages.py` — 22/22

## Spotted (not filed — needs approval)

The watcher test suite has a recurring **xdist parallel-isolation flake**: tests writing `.claude/watcher.pid` / shared state to the repo root (not `tmp_path`) race under `-n8` — bit this session twice (WOR-502 sonar_concurrent, WOR-501 gestures). Worth a dedicated test-isolation hardening ticket.

**Retires** the manual workaround in operator memory `feedback-manifest-allowed-paths-shared-model`'s sibling pipeline-gap note once merged.

Closes WOR-501

🤖 Generated with [Claude Code](https://claude.com/claude-code)
