### PR TITLE
WOR-507 Persist vLLM metrics in MetricsStore.record() INSERT — the real 0/101 root cause

### DIFF
--- a/app/core/metrics_store.py
+++ b/app/core/metrics_store.py
@@ -462,6 +462,12 @@ class MetricsStore:
                     thinking_blocks, thinking_chars_total,
                     input_tokens_max, input_tokens_first, input_tokens_last,
                     redundant_reads_count,
+                    -- WOR-439: per-session vLLM /metrics delta capture
+                    vllm_metrics_attributable, vllm_prefix_cache_hits,
+                    vllm_prefix_cache_queries, vllm_prefix_cache_hit_ratio,
+                    vllm_prompt_tokens, vllm_generation_tokens,
+                    vllm_ttft_seconds_sum, vllm_ttft_count,
+                    vllm_ttft_mean_seconds, vllm_preemptions,
                     billing_bucket
                 ) VALUES (
                     :ticket_id, :project_id, :epic_id, :implementation_mode,
@@ -483,6 +489,12 @@ class MetricsStore:
                     :thinking_blocks, :thinking_chars_total,
                     :input_tokens_max, :input_tokens_first, :input_tokens_last,
                     :redundant_reads_count,
+                    -- WOR-439: per-session vLLM /metrics delta capture
+                    :vllm_metrics_attributable, :vllm_prefix_cache_hits,
+                    :vllm_prefix_cache_queries, :vllm_prefix_cache_hit_ratio,
+                    :vllm_prompt_tokens, :vllm_generation_tokens,
+                    :vllm_ttft_seconds_sum, :vllm_ttft_count,
+                    :vllm_ttft_mean_seconds, :vllm_preemptions,
                     :billing_bucket
                 )
                 """,

--- a/tests/test_vllm_metrics_capture.py
+++ b/tests/test_vllm_metrics_capture.py
@@ -12,11 +12,14 @@ from __future__ import annotations
 
 import json
 import logging
+import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 
+from app.core.escalation_policy import EscalationPolicy
+from app.core.manifest import ArtifactPaths
 from app.core.watcher.watcher_helpers import (
     capture_vllm_metrics,
     capture_vllm_metrics_diagnostic,
@@ -523,6 +526,246 @@ def test_snapshot_solo_success_logs_nothing(
     assert snap == {"vllm:prompt_tokens_total": 1.0}
     assert solo is True
     assert not [r for r in caplog.records if r.levelno == logging.WARNING]
+
+
+# ---------------------------------------------------------------------------
+# WOR-507: persistence — successful solo finalize_worker records vLLM deltas
+# ---------------------------------------------------------------------------
+
+
+def test_solo_finalize_persists_attributable_vllm_metrics(tmp_path: Path) -> None:
+    """WOR-439 operational lock: a successful solo finalize_worker records a
+    TicketMetrics row with vllm_metrics_attributable=1 and non-NULL delta
+    columns — via MetricsStore.get_by_ticket, NOT through a mock store."""
+    from app.core.metrics import MetricsStore
+    from app.core.watcher.watcher_finalize import finalize_worker
+    from app.core.watcher.watcher_types import ActiveWorker
+    from tests.conftest import make_manifest
+
+    repo_root = tmp_path
+    art_dir = tmp_path / ".claude" / "artifacts" / "wor_507"
+    art_dir.mkdir(parents=True, exist_ok=True)
+
+    # Write result.json with proper checks_passed (exact required_checks strings)
+    result_path = art_dir / "result.json"
+    result_path.write_text(
+        json.dumps(
+            {
+                "status": "success",
+                "checks_passed": [
+                    "ruff check .",
+                    "mypy app/",
+                    "pytest",
+                    "lint-imports",
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    store = MetricsStore(db_path=tmp_path / "test_metrics.db")
+
+    worker = ActiveWorker(
+        ticket_id="WOR-507",
+        linear_id="fake-linear-507",
+        manifest=make_manifest(
+            ticket_id="WOR-507",
+            worker_branch="wor-507-test",
+            base_branch="main",
+            required_checks=["ruff check .", "mypy app/", "pytest", "lint-imports"],
+            allowed_paths=["tests/test_vllm_metrics_capture.py"],
+            artifact_paths=ArtifactPaths.from_ticket_id("WOR-507"),
+        ),
+        worktree_path=tmp_path,
+        process=MagicMock(spec=subprocess.Popen),
+        vllm_metrics_before={
+            "vllm:prefix_cache_hits_total": 1000.0,
+            "vllm:prefix_cache_queries_total": 2000.0,
+            "vllm:prompt_tokens_total": 50000.0,
+            "vllm:generation_tokens_total": 2500.0,
+            "vllm:time_to_first_token_seconds_sum": 120.0,
+            "vllm:time_to_first_token_seconds_count": 80.0,
+            "vllm:num_preemptions_total": 0.0,
+        },
+        remained_solo=True,
+    )
+
+    after_snapshot = {
+        "vllm:prefix_cache_hits_total": 1960.0,
+        "vllm:prefix_cache_queries_total": 3800.0,
+        "vllm:prompt_tokens_total": 95000.0,
+        "vllm:generation_tokens_total": 4800.0,
+        "vllm:time_to_first_token_seconds_sum": 240.0,
+        "vllm:time_to_first_token_seconds_count": 160.0,
+        "vllm:num_preemptions_total": 1.0,
+    }
+
+    after_deltas = compute_vllm_metrics_delta(
+        worker.vllm_metrics_before,  # type: ignore[arg-type]
+        after_snapshot,
+    )
+
+    with (
+        patch(
+            "app.core.watcher.watcher_finalize_helpers.run_checks",
+            return_value=(True, []),
+        ),
+        patch(
+            "app.core.watcher.watcher_finalize.attempt_pr",
+            return_value=("success", "https://github.com/test/repo/pull/9999"),
+        ),
+        patch(
+            "app.core.watcher.watcher_finalize._capture_vllm_post",
+            return_value=(True, after_deltas),
+        ),
+        patch("app.core.watcher.watcher_finalize_helpers.preserve_worker_artifacts"),
+        patch("app.core.watcher.watcher_finalize.cleanup_worktree"),
+        patch(
+            "app.core.watcher.watcher_finalize.commit_wip_state",
+        ) as mock_wip,
+    ):
+        from app.core.watcher.watcher_worktrees import WipPreservationResult
+
+        mock_wip.return_value = WipPreservationResult(
+            status="clean", sha=None, backup_path=None, error=None
+        )
+        outcome = finalize_worker(
+            worker,
+            returncode=0,
+            wall_time=45.2,
+            linear=MagicMock(),
+            metrics=store,
+            escalation_policy=EscalationPolicy.from_toml(),
+            repo_root=repo_root,
+            mode="default",
+            project_id="wor-507-proj",
+        )
+
+    assert outcome == "success"
+
+    # Assert via a real MetricsStore query — the operational lock target
+    row = store.get_by_ticket("WOR-507", "wor-507-proj")
+    assert row is not None
+
+    # vllm_metrics_attributable must be truthy (1 = true)
+    assert row.vllm_metrics_attributable is True or row.vllm_metrics_attributable == 1
+
+    # All vLLM delta columns must be non-NULL
+    assert row.vllm_prefix_cache_hits is not None
+    assert row.vllm_prefix_cache_queries is not None
+    assert row.vllm_prefix_cache_hit_ratio is not None
+    assert row.vllm_prompt_tokens is not None
+    assert row.vllm_generation_tokens is not None
+    assert row.vllm_ttft_seconds_sum is not None
+    assert row.vllm_ttft_count is not None
+    assert row.vllm_ttft_mean_seconds is not None
+    assert row.vllm_preemptions is not None
+
+    # Delta values must match the after-before math
+    assert row.vllm_prefix_cache_hits == 960
+    assert row.vllm_prefix_cache_hit_ratio == pytest.approx(960 / 1800)
+    assert row.vllm_prompt_tokens == 45000
+    assert row.vllm_generation_tokens == 2300
+
+
+def test_solo_finalize_no_false_positive_without_before(tmp_path: Path) -> None:
+    """A solo run with no before-snapshot (vllm_metrics_before=None) must NOT
+    record attributable vLLM metrics — guard against false-positive NULL-to-
+    non-NULL regressions."""
+    from app.core.metrics import MetricsStore
+    from app.core.watcher.watcher_finalize import finalize_worker
+    from app.core.watcher.watcher_types import ActiveWorker
+    from tests.conftest import make_manifest
+
+    repo_root = tmp_path
+    art_dir = tmp_path / ".claude" / "artifacts" / "wor_507b"
+    art_dir.mkdir(parents=True, exist_ok=True)
+
+    result_path = art_dir / "result.json"
+    result_path.write_text(
+        json.dumps(
+            {
+                "status": "success",
+                "checks_passed": [
+                    "ruff check .",
+                    "mypy app/",
+                    "pytest",
+                    "lint-imports",
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    store = MetricsStore(db_path=tmp_path / "test_metrics_b.db")
+
+    worker = ActiveWorker(
+        ticket_id="WOR-507b",
+        linear_id="fake-linear-507b",
+        manifest=make_manifest(
+            ticket_id="WOR-507b",
+            worker_branch="wor-507b-test",
+            base_branch="main",
+            required_checks=["ruff check .", "mypy app/", "pytest", "lint-imports"],
+            allowed_paths=["tests/test_vllm_metrics_capture.py"],
+            artifact_paths=ArtifactPaths.from_ticket_id("WOR-507b"),
+        ),
+        worktree_path=tmp_path,
+        process=MagicMock(spec=subprocess.Popen),
+        vllm_metrics_before=None,  # no pre-snapshot → no attribution
+        remained_solo=True,
+    )
+
+    with (
+        patch(
+            "app.core.watcher.watcher_finalize_helpers.run_checks",
+            return_value=(True, []),
+        ),
+        patch(
+            "app.core.watcher.watcher_finalize.attempt_pr",
+            return_value=("success", "https://github.com/test/repo/pull/9998"),
+        ),
+        patch(
+            "app.core.watcher.watcher_finalize._capture_vllm_post",
+            return_value=(False, {}),
+        ),
+        patch("app.core.watcher.watcher_finalize_helpers.preserve_worker_artifacts"),
+        patch("app.core.watcher.watcher_finalize.cleanup_worktree"),
+        patch(
+            "app.core.watcher.watcher_finalize.commit_wip_state",
+        ) as mock_wip,
+    ):
+        from app.core.watcher.watcher_worktrees import WipPreservationResult
+
+        mock_wip.return_value = WipPreservationResult(
+            status="clean", sha=None, backup_path=None, error=None
+        )
+        outcome = finalize_worker(
+            worker,
+            returncode=0,
+            wall_time=10.0,
+            linear=MagicMock(),
+            metrics=store,
+            escalation_policy=EscalationPolicy.from_toml(),
+            repo_root=repo_root,
+            mode="default",
+            project_id="wor-507-proj",
+        )
+
+    assert outcome == "success"
+
+    row = store.get_by_ticket("WOR-507b", "wor-507-proj")
+    assert row is not None
+
+    # vllm_metrics_attributable must be falsy/NULL (no before → no attribution)
+    assert row.vllm_metrics_attributable is False or row.vllm_metrics_attributable == 0
+
+    # All vLLM delta columns must be NULL
+    assert row.vllm_prefix_cache_hits is None
+    assert row.vllm_prefix_cache_queries is None
+    assert row.vllm_prefix_cache_hit_ratio is None
+    assert row.vllm_prompt_tokens is None
+    assert row.vllm_generation_tokens is None
 
 
 def test_capture_vllm_post_returns_non_none_deltas_for_solo(


### PR DESCRIPTION
## Summary

**The real 0/101 root cause — found by the WOR-507 verification run.**

WOR-507 was filed as a test-only ticket to *lock* WOR-439's persistence. The local worker, writing that test, discovered it **could not pass**: `MetricsStore.record()`'s INSERT listed columns straight from `redundant_reads_count` → `billing_bucket`, **omitting all 10 `vllm_*` columns**. The columns existed in the table (added via `ALTER TABLE` migration) but were *never in the INSERT* — so every recorded row wrote NULL to all `vllm_*` regardless of whether capture worked. WOR-439 (#1031) fixed the silent `/metrics` *capture*; this was the separate, downstream reason the deltas still never reached the DB. Capture-fixed-but-never-persisted = the actual 0/101 cause, missed by #1031 and its analysis.

## Changes

- `app/core/metrics_store.py` (+12) — add the 10 `vllm_*` columns + `:named` params to the `record()` INSERT (between `redundant_reads_count` and `billing_bucket`). `TicketMetrics` already carries the fields; the table already has the columns; only the INSERT was incomplete.
- `tests/test_vllm_metrics_capture.py` (+243) — regression lock: `test_solo_finalize_persists_attributable_vllm_metrics` (successful solo `finalize_worker` → `TicketMetrics` row with `vllm_metrics_attributable` truthy + non-NULL deltas, real tmp `MetricsStore`, mocked capture) and `test_solo_finalize_no_false_positive_without_before` (no before-snapshot → falsy/NULL).

## Provenance

Implemented by the local worker on the WOR-507 verification ticket — asked to write the lock test, it root-caused why the test couldn't pass and produced the fix. Salvaged after the **correct, deliberate** test-only `allowed_paths` gate blocked the production change (`forbidden_paths: app/**`). `.claude/.thrash_state.json` hook-scratch excluded from the salvage commit.

**WOR-501 validated live in production:** the block left an operator-visible `last_failure.json` (`stage: validate_allowed_paths`, `stderr: FORBIDDEN app/core/metrics_store.py`) in the main-repo artifact dir — exactly the diagnostic that was *absent* before WOR-501; root-caused in one read instead of git forensics.

## Test plan

- [x] `ruff check .` — clean
- [x] `mypy app/` — clean (48 files)
- [x] `lint-imports` — 8 kept, 0 broken
- [x] `pytest` — **2013 passed**, 0 failures (full unscoped suite, no flakes this run)
- [x] New integration tests fail without the `metrics_store.py` fix, pass with it (the lock works)

## WOR-439 operational status

This **completes WOR-439's operational gap**: `vllm_*` will now persist on solo runs. The new integration tests lock it at test level (real `MetricsStore`); the final *live* confirmation is the next post-merge solo worker run showing a non-NULL `ticket_metrics.vllm_*` row (WOR-507's own run was gate-blocked before the metrics-record step, so it produced no row — but it found the bug, which is the better outcome).

Closes WOR-507

🤖 Generated with [Claude Code](https://claude.com/claude-code)
