### PR TITLE
WOR-509 SonarCloud Tier-1 cleanup: 5 mechanical watcher code-smells

### DIFF
--- a/app/core/watcher/watcher_finalize.py
+++ b/app/core/watcher/watcher_finalize.py
@@ -434,6 +434,17 @@ def _post_improvement_log(linear: LinearClientProtocol, worker: ActiveWorker) ->
         )
 
 
+def _billing_bucket(eff: str) -> str:
+    """Billing pool for a run (WOR-472): local workers are free; cloud
+    spend moves to the Agent-SDK credit pool on 2026-06-15, subscription
+    before."""
+    if eff == "local":
+        return "local"
+    if datetime.now(timezone.utc) >= datetime(2026, 6, 15, tzinfo=timezone.utc):
+        return "agent_sdk_credit"
+    return "subscription"
+
+
 def finalize_worker(
     worker: ActiveWorker,
     *,
@@ -681,16 +692,7 @@ def finalize_worker(
             input_tokens_first=behavior.input_tokens_first,
             input_tokens_last=behavior.input_tokens_last,
             redundant_reads_count=behavior.redundant_reads_count,
-            billing_bucket=(
-                "local"
-                if eff == "local"
-                else (
-                    "agent_sdk_credit"
-                    if datetime.now(timezone.utc)
-                    >= datetime(2026, 6, 15, tzinfo=timezone.utc)
-                    else "subscription"
-                )
-            ),
+            billing_bucket=_billing_bucket(eff),
         )
     )
 

--- a/app/core/watcher/watcher_finalize_helpers.py
+++ b/app/core/watcher/watcher_finalize_helpers.py
@@ -503,6 +503,8 @@ def _sonar_requires_escalation(
 # WOR-457: known finalize stages for the last_failure.json `stage`
 # discriminator. `check` is retained for backward-compat (watcher.py's
 # retry-hint reader does `data.get("check", "unknown")`).
+_LAST_FAILURE_FILENAME = "last_failure.json"
+
 _FINALIZE_STAGES = (
     "run_checks",
     "rebase",
@@ -590,7 +592,7 @@ def _record_failure_artifact(
     Best-effort — never raises; a diagnostics-write failure must not mask
     the original error.
     """
-    failure_file = artifact_dir / "last_failure.json"
+    failure_file = artifact_dir / _LAST_FAILURE_FILENAME
     try:
         artifact_dir.mkdir(parents=True, exist_ok=True)
         data: dict[str, object] = {}
@@ -640,7 +642,7 @@ def _write_wip_state_to_last_failure(
         worker.worktree_path / worker.manifest.artifact_paths.result_json
     ).parent
     artifact_dir.mkdir(parents=True, exist_ok=True)
-    failure_file = artifact_dir / "last_failure.json"
+    failure_file = artifact_dir / _LAST_FAILURE_FILENAME
     try:
         data: dict[str, object] = {}
         if failure_file.exists():
@@ -669,7 +671,7 @@ def _write_wip_sha_to_last_failure(
     artifact_dir = (
         worker.worktree_path / worker.manifest.artifact_paths.result_json
     ).parent
-    failure_file = artifact_dir / "last_failure.json"
+    failure_file = artifact_dir / _LAST_FAILURE_FILENAME
     try:
         data: dict[str, object] = {}
         if failure_file.exists():

--- a/app/core/watcher/watcher_helpers.py
+++ b/app/core/watcher/watcher_helpers.py
@@ -530,9 +530,12 @@ def count_main_ahead_of_epic(epic_branch: str, repo_root: Path) -> int:
 # parsing stay in sync. Each entry: (metric_name, kind) where kind is
 # "counter" (cumulative; produce delta = after-before) or "gauge" (point-in-
 # time; produce just `before` and `after` snapshots, no delta).
+_M_PREFIX_CACHE_HITS = "vllm:prefix_cache_hits_total"
+_M_PREFIX_CACHE_QUERIES = "vllm:prefix_cache_queries_total"
+
 _VLLM_COUNTERS = (
-    "vllm:prefix_cache_hits_total",
-    "vllm:prefix_cache_queries_total",
+    _M_PREFIX_CACHE_HITS,
+    _M_PREFIX_CACHE_QUERIES,
     "vllm:prompt_tokens_total",
     "vllm:generation_tokens_total",
     "vllm:time_to_first_token_seconds_sum",
@@ -546,8 +549,8 @@ _VLLM_COUNTERS = (
 # blank these columns (WOR-439). Add verified spellings here as they are
 # observed against a live /metrics surface.
 _VLLM_COUNTER_ALIASES: dict[str, str] = {
-    "vllm:gpu_prefix_cache_hits_total": "vllm:prefix_cache_hits_total",
-    "vllm:gpu_prefix_cache_queries_total": "vllm:prefix_cache_queries_total",
+    "vllm:gpu_prefix_cache_hits_total": _M_PREFIX_CACHE_HITS,
+    "vllm:gpu_prefix_cache_queries_total": _M_PREFIX_CACHE_QUERIES,
 }
 
 
@@ -665,8 +668,8 @@ def compute_vllm_metrics_delta(
     def _delta(key: str) -> float:
         return float(after.get(key, 0.0)) - float(before.get(key, 0.0))
 
-    hits = _delta("vllm:prefix_cache_hits_total")
-    queries = _delta("vllm:prefix_cache_queries_total")
+    hits = _delta(_M_PREFIX_CACHE_HITS)
+    queries = _delta(_M_PREFIX_CACHE_QUERIES)
     prompt = _delta("vllm:prompt_tokens_total")
     gen = _delta("vllm:generation_tokens_total")
     ttft_sum = _delta("vllm:time_to_first_token_seconds_sum")
@@ -733,7 +736,7 @@ def get_active_parent_ids(workers: list[ActiveWorker]) -> set[str]:
 def picker_sort_key(
     candidate: dict[str, Any],
     active_parent_ids: set[str],
-    candidate_index: int,
+    _candidate_index: int,
 ) -> tuple[int, int, str]:
     """Sort key for candidate tickets at dispatch pick time.
 


### PR DESCRIPTION
## Summary

**WOR-509 Tier 1** — the 5 mechanical, zero-behaviour-change SonarCloud fixes (of 11 open watcher CODE_SMELLs; the 6 CC/signature refactors are carved to a follow-up — see WOR-510 — to avoid churning the watcher core just stabilized across WOR-439/500/501/502/507/508).

- **S1192** `watcher_helpers.py` — `_M_PREFIX_CACHE_HITS` / `_M_PREFIX_CACHE_QUERIES` constants replace the literal `"vllm:prefix_cache_hits_total"` / `"vllm:prefix_cache_queries_total"` (×3 each: `_VLLM_COUNTERS`, `_VLLM_COUNTER_ALIASES` values, `compute_vllm_metrics_delta`).
- **S1192** `watcher_finalize_helpers.py` — `_LAST_FAILURE_FILENAME` constant replaces the 3 `artifact_dir / "last_failure.json"` joins.
- **S1172** `watcher_helpers.py` — `picker_sort_key`'s unused `candidate_index` → `_candidate_index` (Sonar-sanctioned intentionally-unused prefix; **zero blast radius** — the 1 caller + 6 test sites pass it positionally as `0`, so no signature/caller/test changes).
- **S3358** `watcher_finalize.py` — the `billing_bucket` nested conditional extracted into a `_billing_bucket(eff)` helper (behaviour-identical).

## Test plan

- [x] `ruff check .` — clean
- [x] `mypy app/` — clean (48 files)
- [x] `lint-imports` — 8 kept, 0 broken
- [x] `pytest` — **2016 passed**, 0 failures, no flakes (full unscoped suite)

No behaviour change anywhere. SonarCloud re-scan should resolve these 5 (2× S1192 by literal, +1 S1192, S1172, S3358).

Closes WOR-509

🤖 Generated with [Claude Code](https://claude.com/claude-code)
