### PR TITLE
WOR-511 Isolate the finalize-test repo_root cwd bleed (xdist)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -377,12 +377,18 @@ shared filesystem does. Two rules keep new tests deterministic under `-n 8`:
    group-serialise it. The fix pattern: give the production code a
    call-time indirection (a resolver function like `pid_file_path()`, or an
    env override like `READ_CAP_STATE_PATH`), then add an `autouse=True`
-   conftest fixture that points it at `tmp_path`. Two reference fixtures to
+   conftest fixture that points it at `tmp_path`. Reference patterns to
    copy: `_isolate_watcher_pid_file` (resolver) and `_isolate_read_cap_state`
-   (env override). xdist *grouping* (`@pytest.mark.xdist_group` /
-   `--dist loadgroup`) was evaluated and rejected — it globally reschedules
-   collection, exposing further latent bleeds while losing parallelism;
-   per-resource isolation is the only mechanism that scales.
+   (env override) for production paths; `make_isolated_repo_root()` (WOR-511)
+   for a test-harness default that would otherwise resolve a `repo_root` /
+   artifact path against the shared cwd (`Path(".")`). xdist *grouping*
+   (`@pytest.mark.xdist_group` / `--dist loadgroup`) was evaluated and
+   rejected — it globally reschedules collection, exposing further latent
+   bleeds while losing parallelism; per-resource isolation is the only
+   mechanism that scales. The suite is now deterministic under *both*
+   `--dist load` (CI) and `--dist loadgroup` — verify new stateful tests
+   with `make flake-hunt` (optionally `--dist loadgroup` for the aggressive
+   scheduler).
 
 3. **Mock concurrent SUTs by command identity, never call order.**
    `run_checks` runs the 4 checks in parallel (WOR-413); `finalize_worker`

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import subprocess
+import tempfile
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock
@@ -327,3 +328,29 @@ def make_command_keyed_run(
         return result
 
     return _run
+
+
+# ---------------------------------------------------------------------------
+# WOR-511: isolated finalize repo_root
+# ---------------------------------------------------------------------------
+
+
+def make_isolated_repo_root() -> Path:
+    """A unique throwaway dir for a `_call_finalize(...)` default `repo_root`.
+
+    WOR-511: the three finalize test harnesses defaulted `repo_root` to
+    ``Path(".")`` — the real shared repo cwd. `finalize_worker` then
+    resolved ``repo_root / artifact_paths.result_json`` and the WOR-457
+    `last_failure.json` writer to ``./.claude/artifacts/<slug>/`` (slug is
+    the conftest `make_manifest` default `wor_10` for every ticket), so
+    concurrent finalize tests on different `pytest -n8` xdist workers
+    clobbered the one real path (`PermissionError [WinError 32]` on
+    Windows; silent corruption on Linux). A fresh per-call dir makes every
+    default-`repo_root` finalize run collision-proof regardless of xdist
+    schedule or the shared slug. Same cross-worker shared-FS bleed class as
+    the watcher pid file / read-cap state file (WOR-506).
+
+    Tests that assert on artifact contents pass an explicit `repo_root`
+    (usually their own `tmp_path`); this only replaces the unsafe default.
+    """
+    return Path(tempfile.mkdtemp(prefix="wor511_finalize_repo_"))

--- a/tests/test_watcher_finalize.py
+++ b/tests/test_watcher_finalize.py
@@ -18,7 +18,7 @@ from app.core.watcher.watcher_helpers import (
     WorkerTelemetry,
 )
 from app.core.watcher.watcher_types import ActiveWorker
-from tests.conftest import make_manifest
+from tests.conftest import make_isolated_repo_root, make_manifest
 
 # ---------------------------------------------------------------------------
 # Shared helpers
@@ -49,7 +49,7 @@ def _call_finalize(
             linear=linear or MagicMock(),
             metrics=metrics or MagicMock(),
             escalation_policy=EscalationPolicy.from_toml(),
-            repo_root=repo_root or Path("."),
+            repo_root=repo_root or make_isolated_repo_root(),
             mode=mode,
             project_id=_DEFAULT_PROJECT,
         )

--- a/tests/test_watcher_finalize_metrics.py
+++ b/tests/test_watcher_finalize_metrics.py
@@ -18,7 +18,7 @@ import pytest
 from app.core.escalation_policy import EscalationPolicy
 from app.core.watcher.watcher_finalize import finalize_worker
 from app.core.watcher.watcher_types import ActiveWorker
-from tests.conftest import make_manifest
+from tests.conftest import make_isolated_repo_root, make_manifest
 
 # ---------------------------------------------------------------------------
 # Shared helpers
@@ -44,7 +44,7 @@ def _call_finalize(
         linear=linear or MagicMock(),
         metrics=metrics or MagicMock(),
         escalation_policy=EscalationPolicy.from_toml(),
-        repo_root=repo_root or Path("."),
+        repo_root=repo_root or make_isolated_repo_root(),
         mode=mode,
         project_id=_DEFAULT_PROJECT,
     )

--- a/tests/test_watcher_finalize_recovery.py
+++ b/tests/test_watcher_finalize_recovery.py
@@ -20,7 +20,7 @@ from app.core.manifest import ArtifactPaths, FailurePolicy
 from app.core.watcher.watcher_finalize import finalize_worker
 from app.core.watcher.watcher_types import ActiveWorker
 from app.core.watcher.watcher_worktrees import WipPreservationResult
-from tests.conftest import make_manifest
+from tests.conftest import make_isolated_repo_root, make_manifest
 
 # ---------------------------------------------------------------------------
 # Shared helpers
@@ -46,7 +46,7 @@ def _call_finalize(
         linear=linear or MagicMock(),
         metrics=metrics or MagicMock(),
         escalation_policy=EscalationPolicy.from_toml(),
-        repo_root=repo_root or Path("."),
+        repo_root=repo_root or make_isolated_repo_root(),
         mode=mode,
         project_id=_DEFAULT_PROJECT,
     )


### PR DESCRIPTION
## Summary

Follow-up from WOR-506. Eliminates the **last** test-reachable instance of
the cwd-relative shared-FS bleed class that the WOR-506 `--dist loadgroup`
probe surfaced. The suite is now deterministic under **any** xdist dist
mode.

## Root cause (verified, not hypothesised)

The three finalize test harnesses (`test_watcher_finalize.py`,
`_metrics.py`, `_recovery.py`) each defaulted `_call_finalize`'s
`repo_root` to **`Path(".")`** — the real shared repo cwd. `finalize_worker`
resolves `repo_root / artifact_paths.result_json` and the WOR-457
`last_failure.json` writer against it, and the conftest `make_manifest`
default gives **every** ticket the same artifact slug (`wor_10`). So
concurrent finalize tests on different `pytest -n8` workers all wrote
`./.claude/artifacts/wor_10/{result,last_failure}.json` — clobbering one
real path. Reproduced under `--dist loadgroup` with a real traceback:

```
PermissionError [WinError 32] ... '.claude\artifacts\wor_10\last_failure.json'
```

## Fix (the WOR-506 pattern — per-resource isolation, zero call-site churn)

- `conftest.make_isolated_repo_root()` → a unique throwaway dir per call.
- the three `_call_finalize` helpers default to it instead of `Path(".")`.
- Tests that assert artifact contents already pass an explicit
  `repo_root` (their own `tmp_path`) — only the unsafe default changed.

## Audit (WOR-511 AC — remaining surface)

Static sweep: **no `__file__`-anchored writes** in `app/` beyond the
read-cap hook already fixed in WOR-506 (only read-only
`escalation_policy.toml` / templates dir). The `.claude/artifacts/...`
strings in `manifest*.py` are relative constructors always joined with a
caller-provided root in production — proven non-bleeding by 3 clean
full-suite runs under the aggressive `loadgroup` scheduler.

## Test plan

- [x] Full suite green under **both** schedulers ×3 each — `-n8 --dist
      load` (CI) and `-n8 --dist loadgroup` (aggressive): `2016 passed`,
      0 flakes
- [x] Targeted loadgroup reproducer 0/8 failures (was ~33–66%)
- [x] ruff / lint-imports clean
- [x] No call-site churn; explicit-`repo_root` tests unaffected

Closes WOR-511

🤖 Generated with [Claude Code](https://claude.com/claude-code)
