### PR TITLE
WOR-510 PR-a: 3 CC-18 helper extractions (S3776)

### DIFF
--- a/app/core/watcher/watcher_finalize.py
+++ b/app/core/watcher/watcher_finalize.py
@@ -445,21 +445,20 @@ def _billing_bucket(eff: str) -> str:
     return "subscription"
 
 
-def finalize_worker(
+def _run_pre_retry_validation_gates(
     worker: ActiveWorker,
-    *,
-    returncode: int,
-    wall_time: float,
     linear: LinearClientProtocol,
-    metrics: MetricsStore,
-    escalation_policy: EscalationPolicy,
     repo_root: Path,
-    mode: str,
-    project_id: str,
-    tracked_prs: list[TrackedPR] | None = None,
-) -> Outcome:
-    eff = resolve_effective_mode(mode, worker.manifest.implementation_mode)
+) -> Outcome | None:
+    """The two pre-retry scope/contract gates (WOR-510, S3776 CC reduction).
 
+    Extracted verbatim from :func:`finalize_worker` to keep its cognitive
+    complexity ≤15. Behaviour identical: returns ``"failure"`` if either
+    gate trips (allowed_paths violation, or a success-claim that fails the
+    required_checks contract), else ``None`` to continue into the retry
+    loop. Both gates run BEFORE the retry loop — violations are scope /
+    contract failures, not transient check failures, so retries won't help.
+    """
     # Validate that the worker only touched allowed_paths / did not touch
     # forbidden_paths.  Run BEFORE the retry loop — violations are a scope
     # failure, not a transient check failure, so retries won't help.
@@ -534,6 +533,32 @@ def finalize_worker(
                 stderr="missing required_checks: " + ", ".join(missing_checks),
             )
             return "failure"
+
+    return None
+
+
+def finalize_worker(
+    worker: ActiveWorker,
+    *,
+    returncode: int,
+    wall_time: float,
+    linear: LinearClientProtocol,
+    metrics: MetricsStore,
+    escalation_policy: EscalationPolicy,
+    repo_root: Path,
+    mode: str,
+    project_id: str,
+    tracked_prs: list[TrackedPR] | None = None,
+) -> Outcome:
+    eff = resolve_effective_mode(mode, worker.manifest.implementation_mode)
+
+    # WOR-510: the two pre-retry scope/contract gates (allowed_paths +
+    # checks_passed) are extracted to keep finalize_worker's cognitive
+    # complexity ≤15 (S3776). Behaviour identical — either gate trips →
+    # return "failure" before the retry loop.
+    gate_outcome = _run_pre_retry_validation_gates(worker, linear, repo_root)
+    if gate_outcome is not None:
+        return gate_outcome
 
     # WOR-312: in-dispatch retry loop. Helper avoids the slower Linear
     # Blocked -> ReadyForLocal redispatch when checks transiently fail.

--- a/app/core/watcher/watcher_finalize_helpers.py
+++ b/app/core/watcher/watcher_finalize_helpers.py
@@ -71,6 +71,41 @@ def _get_sonar_executor() -> ThreadPoolExecutor:
     return _sonar_executor
 
 
+def _forbidden_path_violations(files: list[str], patterns: list[str]) -> list[str]:
+    """Files matching any forbidden_paths glob, tagged ``FORBIDDEN``.
+
+    One violation per file (first matching pattern wins). Empty *patterns*
+    → no violations (no restriction). Extracted from
+    :func:`_validate_allowed_paths` (WOR-510, S3776 CC reduction) — pure,
+    no side effects, behaviour identical to the inline loop.
+    """
+    out: list[str] = []
+    if not patterns:
+        return out
+    for fpath in files:
+        for pattern in patterns:
+            if fnmatch.fnmatch(fpath, pattern):
+                out.append(f"FORBIDDEN {fpath}")
+                break  # one match per file is enough
+    return out
+
+
+def _disallowed_path_violations(files: list[str], patterns: list[str]) -> list[str]:
+    """Files matching NO allowed_paths glob, tagged ``ALLOWED``.
+
+    Empty *patterns* → no restriction (anything goes), so no violations.
+    Extracted from :func:`_validate_allowed_paths` (WOR-510, S3776).
+    """
+    out: list[str] = []
+    if not patterns:
+        return out
+    for fpath in files:
+        if any(fnmatch.fnmatch(fpath, pat) for pat in patterns):
+            continue  # file matches an allowed pattern
+        out.append(f"ALLOWED {fpath}")
+    return out
+
+
 def _validate_allowed_paths(
     manifest: ExecutionManifest,
     worktree_path: Path,
@@ -109,21 +144,9 @@ def _validate_allowed_paths(
         # most problems.
         return []
 
-    # Check against forbidden_paths first (they override).
-    if manifest.forbidden_paths:
-        for fpath in files:
-            for pattern in manifest.forbidden_paths:
-                if fnmatch.fnmatch(fpath, pattern):
-                    violations.append(f"FORBIDDEN {fpath}")
-                    break  # one match per file is enough
-
-    # Check against allowed_paths.  Empty list = no restriction (anything goes).
-    if manifest.allowed_paths:
-        for fpath in files:
-            if any(fnmatch.fnmatch(fpath, pat) for pat in manifest.allowed_paths):
-                continue  # file matches an allowed pattern
-            violations.append(f"ALLOWED {fpath}")
-
+    # forbidden_paths override allowed_paths; check them first.
+    violations.extend(_forbidden_path_violations(files, manifest.forbidden_paths))
+    violations.extend(_disallowed_path_violations(files, manifest.allowed_paths))
     return violations
 
 

--- a/app/core/watcher/watcher_subprocess.py
+++ b/app/core/watcher/watcher_subprocess.py
@@ -190,6 +190,60 @@ def _run_single_check(
     return check_cmd, result, duration
 
 
+def _collect_check_outcomes(
+    checks: list[str],
+    results: dict[str, tuple[subprocess.CompletedProcess[str], float]],
+    artifact_dir: Path,
+    failure_artifact: Path,
+    *,
+    metrics: MetricsStore | None,
+    ticket_id: str,
+    project_id: str,
+) -> list[dict[str, int | str]]:
+    """Process check results in manifest order (WOR-510, S3776 CC reduction).
+
+    Extracted verbatim from :func:`run_checks` to keep its cognitive
+    complexity ≤15. Deterministic regardless of thread completion order:
+    records each check to check_run_log (when *metrics* given), collects
+    failures, and writes ``last_failure.json`` for the FIRST manifest-order
+    failure only. Behaviour identical to the former inline loop.
+    """
+    failed_checks: list[dict[str, int | str]] = []
+    first_failure_written = False
+    for check_cmd in checks:
+        result, duration = results[check_cmd]
+        if metrics is not None and ticket_id:
+            metrics.record_check_run(
+                CheckRunEntry(
+                    ticket_id=ticket_id,
+                    project_id=project_id,
+                    check_cmd=check_cmd,
+                    outcome="passed" if result.returncode == 0 else "failed",
+                    duration_s=round(duration, 3),
+                )
+            )
+        if result.returncode != 0:
+            logger.error(
+                "Check failed: %s\n%s", check_cmd, result.stdout + result.stderr
+            )
+            failed_checks.append({"check": check_cmd, "exit_code": result.returncode})
+            if not first_failure_written:
+                artifact_dir.mkdir(parents=True, exist_ok=True)
+                failure_artifact.write_text(
+                    json.dumps(
+                        {
+                            "failed_at": datetime.now(timezone.utc).isoformat(),
+                            "check": check_cmd,
+                            "stdout": result.stdout[:4000],
+                            "stderr": result.stderr,
+                        }
+                    ),
+                    encoding="utf-8",
+                )
+                first_failure_written = True
+    return failed_checks
+
+
 def run_checks(
     manifest: ExecutionManifest,
     worktree_path: Path,
@@ -254,39 +308,16 @@ def run_checks(
 
     # Process in manifest order so output / metrics / last_failure.json
     # write order is deterministic regardless of thread completion order.
-    failed_checks: list[dict[str, int | str]] = []
-    first_failure_written = False
-    for check_cmd in checks:
-        result, duration = results[check_cmd]
-        if metrics is not None and ticket_id:
-            metrics.record_check_run(
-                CheckRunEntry(
-                    ticket_id=ticket_id,
-                    project_id=project_id,
-                    check_cmd=check_cmd,
-                    outcome="passed" if result.returncode == 0 else "failed",
-                    duration_s=round(duration, 3),
-                )
-            )
-        if result.returncode != 0:
-            logger.error(
-                "Check failed: %s\n%s", check_cmd, result.stdout + result.stderr
-            )
-            failed_checks.append({"check": check_cmd, "exit_code": result.returncode})
-            if not first_failure_written:
-                artifact_dir.mkdir(parents=True, exist_ok=True)
-                failure_artifact.write_text(
-                    json.dumps(
-                        {
-                            "failed_at": datetime.now(timezone.utc).isoformat(),
-                            "check": check_cmd,
-                            "stdout": result.stdout[:4000],
-                            "stderr": result.stderr,
-                        }
-                    ),
-                    encoding="utf-8",
-                )
-                first_failure_written = True
+    # WOR-510: loop extracted to _collect_check_outcomes (S3776 CC ≤15).
+    failed_checks = _collect_check_outcomes(
+        checks,
+        results,
+        artifact_dir,
+        failure_artifact,
+        metrics=metrics,
+        ticket_id=ticket_id,
+        project_id=project_id,
+    )
 
     if not failed_checks and failure_artifact.exists():
         failure_artifact.unlink()


### PR DESCRIPTION
## Summary

**WOR-510 PR-a of 3** (the ticket explicitly sequences ≥2-3 PRs to keep
each restructure of just-stabilized hot paths in its own focused review).
This is the low-risk batch: three S3776 cognitive-complexity reductions,
each a **verbatim block move** into a same-purpose helper — behaviour
identical by construction.

| File | Function | S3776 | Extraction |
|---|---|---|---|
| `watcher_finalize.py` | `finalize_worker` | CC 18→≤15 | two pre-retry gates → `_run_pre_retry_validation_gates() -> Outcome \| None` |
| `watcher_finalize_helpers.py` | `_validate_allowed_paths` | CC 18→≤15 | nested forbidden/allowed loops → pure `_forbidden_path_violations` / `_disallowed_path_violations` |
| `watcher_subprocess.py` | `run_checks` | CC 18→≤15 | manifest-order result loop → `_collect_check_outcomes()` |

Semantics preserved exactly: the two gates still return `"failure"`
before the retry loop; the empty-patterns guard is kept as the helper's
early return (`extend()`×2 == the prior inline appends); `run_checks`
keeps deterministic manifest-order processing, first-failure-only
`last_failure.json`, and concurrent-safe metrics recording.

## Not in this PR (per the ticket's own sequencing)

- **PR-b**: the CC-47 `watcher_helpers.py:932` monster — genuine
  decomposition, its own PR.
- **PR-c**: S107 15-param `start_ticket` → dispatch-args dataclass +
  `dispatch.py:52` CC (shared surface, ripples to `_dispatch_next_ticket`
  + all `start_ticket` tests — high blast radius, own PR + full sweep).

## Test plan

- [x] ruff / mypy / lint-imports clean
- [x] Full **unscoped** pytest `2016 passed` ×3 (behaviour-identity —
      identical count, all `watcher_finalize` / `subprocess` tests green
      with the extracted helpers)
- [x] Suite stays deterministic on the paths just stabilised by
      WOR-506/511

Part of WOR-510

🤖 Generated with [Claude Code](https://claude.com/claude-code)
