### PR TITLE
WOR-512 _handle_assistant_event CC 18→≤15 (S3776, PR-b fallout)

### DIFF
--- a/app/core/watcher/watcher_log_parsing.py
+++ b/app/core/watcher/watcher_log_parsing.py
@@ -591,6 +591,32 @@ class _TelemetryAccum:
         self.read_counts: dict[str, int] = {}
 
 
+def _accumulate_assistant_blocks(content: Any, acc: _TelemetryAccum) -> None:
+    """Per-content-block behavior accumulation for one assistant event.
+
+    WOR-512 (S3776): extracted verbatim from :func:`_handle_assistant_event`
+    so that handler stays ≤15 cognitive complexity — WOR-510 PR-b's
+    branch-extraction relocated this nested loop into the handler rather
+    than eliminating it. ``content`` is the raw ``message.content`` list
+    (falsy → no-op). Same accumulator mutations in the same order —
+    behaviour identical.
+    """
+    for blk in content or []:
+        if not isinstance(blk, dict):
+            continue
+        _accumulate_content_block(
+            blk, acc.behavior_accum, acc.tool_breakdown, acc.read_counts
+        )
+        if blk.get("type") == "tool_use":
+            name = blk.get("name")
+            if name == "Task":
+                acc.subagent_spawns += 1
+            elif name == "Bash":
+                token = _is_violation_bash_command(blk)
+                if token and token in _HOOK_VIOLATION_TOKENS:
+                    acc.hook_violations += 1
+
+
 def _handle_assistant_event(obj: dict[str, Any], acc: _TelemetryAccum) -> None:
     """Apply one ``type=="assistant"`` event (WOR-510 — verbatim from the
     former inline branch; usage + behavior + spawns + hook violations)."""
@@ -617,20 +643,7 @@ def _handle_assistant_event(obj: dict[str, Any], acc: _TelemetryAccum) -> None:
     )
 
     # --- behavior content + spawns + hook violations ---
-    for blk in msg.get("content") or []:
-        if not isinstance(blk, dict):
-            continue
-        _accumulate_content_block(
-            blk, acc.behavior_accum, acc.tool_breakdown, acc.read_counts
-        )
-        if blk.get("type") == "tool_use":
-            name = blk.get("name")
-            if name == "Task":
-                acc.subagent_spawns += 1
-            elif name == "Bash":
-                token = _is_violation_bash_command(blk)
-                if token and token in _HOOK_VIOLATION_TOKENS:
-                    acc.hook_violations += 1
+    _accumulate_assistant_blocks(msg.get("content"), acc)
 
 
 def _handle_system_event(obj: dict[str, Any], acc: _TelemetryAccum) -> None:


### PR DESCRIPTION
## Summary

The one open SonarCloud CRITICAL — and it was **WOR-510 PR-b fallout**,
caught honestly.

`python:S3776` — `watcher_log_parsing.py:594` `_handle_assistant_event`
CC 18 > 15. PR-b decomposed `_parse_worker_telemetry` into `_handle_*`
handlers; the *assistant* branch carried its nested content-block loop
(`for blk` → `isinstance` → `tool_use` → `Task`/`Bash` → hook-token
check) into the new handler — the extraction **relocated** the
complexity rather than eliminating it, and Clean-as-You-Code flagged the
new function.

## Fix

Extract that loop verbatim into `_accumulate_assistant_blocks(content,
acc)`. `_handle_assistant_event` → CC ~3; the helper is CC < 15.
`content` is the raw `message.content` (falsy → no-op, identical to the
former `for blk in msg.get("content") or []`). Same accumulator
mutations, same order — **behaviour identical**.

> Lesson: a single-level extraction of a CC-N branch can yield a CC-N
> helper — a nested sub-loop needs its own extraction.

## Test plan

- [x] ruff / mypy / lint-imports clean (8 contracts kept, 0 broken)
- [x] 76 telemetry/behavior parser tests pass
- [x] Full **unscoped** pytest `2016 passed` (identical count —
      behaviour-identity; telemetry feeds the metrics DB, cf. WOR-439)
- [x] SonarCloud open-issue count → 0 after merge

Closes WOR-512

🤖 Generated with [Claude Code](https://claude.com/claude-code)
