### PR TITLE
WOR-448 Watcher TUI: heartbeat log messages escape rich.Live frame and distort the top half

### DIFF
--- a/app/core/watcher/watcher_tui.py
+++ b/app/core/watcher/watcher_tui.py
@@ -23,6 +23,7 @@ from dataclasses import dataclass, field
 from rich.console import Console
 from rich.layout import Layout
 from rich.live import Live
+from rich.logging import RichHandler
 from rich.table import Table
 
 from app.core.metrics import CostRollup
@@ -108,6 +109,8 @@ class WatcherDisplay:
         self._console = console or Console()
         self._live: Live | None = None
         self._rollup_cache: dict[str, tuple[float, CostRollup]] = {}
+        self._logger_handler: logging.Handler | None = None
+        self._original_handlers: list[logging.Handler] | None = None
 
     # ------------------------------------------------------------------
     # State update — single entry point from watcher poll loop
@@ -138,6 +141,7 @@ class WatcherDisplay:
                 auto_refresh=False,
             )
             self._live.start(refresh=True)
+            self._install_log_handler()
             return
         self._live.update(layout, refresh=True)
 
@@ -353,11 +357,45 @@ class WatcherDisplay:
             logger.info("TUI: %s", msg)
 
     # ------------------------------------------------------------------
+    # Live-aware logging handler lifecycle (WOR-448)
+    # ------------------------------------------------------------------
+
+    def _install_log_handler(self) -> None:
+        """Replace root logger handlers with a RichHandler bound to ``self._console``.
+
+        The ``RichHandler`` writes log output to the same console that the
+        ``rich.Live`` widget renders to, keeping log messages visible to the
+        operator while preventing them from escaping to the raw stderr stream
+        and corrupting the Live frame.
+
+        The original root logger handlers are captured so they can be restored
+        exactly on :meth:`stop`.
+        """
+        root = logging.getLogger()
+        self._original_handlers = list(root.handlers)
+        self._logger_handler = RichHandler(console=self._console)
+        root.handlers = [self._logger_handler]
+
+    def _remove_log_handler(self) -> None:
+        """Restore the original root logger handlers.
+
+        Called on :meth:`stop` to revert the handler swap so that non-TTY
+        logging continues to work as before.
+        """
+        if self._logger_handler is not None:
+            root = logging.getLogger()
+            if self._original_handlers is not None:
+                root.handlers = self._original_handlers
+            else:
+                root.handlers = [self._logger_handler]
+            self._logger_handler = None
+
+    # ------------------------------------------------------------------
     # Cleanup
     # ------------------------------------------------------------------
 
     def stop(self) -> None:
-        """Stop the live display.
+        """Stop the live display and restore the original root logger handlers.
 
         Best-effort: rich.live.Live.stop() can raise OSError on broken/closed
         terminal handles during shutdown. Swallow that case explicitly so the
@@ -369,6 +407,7 @@ class WatcherDisplay:
             except OSError as exc:
                 logger.debug("Live.stop() failed during shutdown: %s", exc)
             self._live = None
+        self._remove_log_handler()
 
     def update_pr(
         self,

--- a/tests/test_watcher_tui.py
+++ b/tests/test_watcher_tui.py
@@ -480,6 +480,103 @@ def test_build_layout_has_correct_structure() -> None:
 
 
 # ---------------------------------------------------------------------------
+# WOR-448 -- logging handler lifecycle (install / restore)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _restore_root_handlers() -> None:
+    """WOR-448: restore root logger handlers after each test."""
+    import logging
+
+    root = logging.getLogger()
+    snapshot = list(root.handlers)
+    yield
+    root.handlers = snapshot
+
+
+def test_log_handler_installed_on_live_start() -> None:
+    """Handler is installed during _render_live when Live is first created."""
+    import logging
+    from unittest.mock import MagicMock, patch
+
+    from rich.logging import RichHandler
+
+    display = WatcherDisplay()
+    with (
+        patch("app.core.watcher.watcher_tui._is_tty", return_value=True),
+        patch("app.core.watcher.watcher_tui.Live") as MockLive,
+    ):
+        mock_instance = MagicMock()
+        MockLive.return_value = mock_instance
+        display._render_live()
+
+    # Live.start must have been called
+    mock_instance.start.assert_called_once_with(refresh=True)
+    # And a RichHandler must have been installed on the root logger
+
+    root = logging.getLogger()
+
+    assert isinstance(root.handlers[0], RichHandler)
+    # The display must track the installed handler for restoration
+    assert display._logger_handler is not None
+    assert isinstance(display._logger_handler, RichHandler)
+
+
+def test_log_handler_restored_on_stop() -> None:
+    """stop() restores the original root logger handlers after Live.stop()."""
+    import logging
+    from unittest.mock import MagicMock, patch
+
+    root = logging.getLogger()
+    # Seed with a known handler so we can verify restore
+    test_handler = logging.Handler()
+    root.handlers.append(test_handler)
+
+    # Snapshot before install
+    pre_handler_count = len(root.handlers)
+
+    display = WatcherDisplay()
+
+    # Simulate the TTY path: Live already created and handler already installed
+    with patch("app.core.watcher.watcher_tui._is_tty", return_value=True):
+        with patch("app.core.watcher.watcher_tui.Live") as MockLive:
+            mock_instance = MagicMock()
+            MockLive.return_value = mock_instance
+            display._render_live()
+
+    # Stop the display
+    display.stop()
+
+    # The original handler(s) must be restored (same count, same objects)
+    assert len(root.handlers) == pre_handler_count
+    assert test_handler in root.handlers
+    assert display._logger_handler is None
+
+
+def test_log_handler_snapshot_restore_roundtrip() -> None:
+    """Original handlers are captured, replaced, and fully restored."""
+    import logging
+
+    root = logging.getLogger()
+    before_count = len(root.handlers)
+
+    display = WatcherDisplay()
+
+    with patch("app.core.watcher.watcher_tui._is_tty", return_value=True):
+        with patch("app.core.watcher.watcher_tui.Live") as MockLive:
+            MockLive.return_value = MagicMock()
+            display._render_live()
+
+    # After install, root has exactly one handler (the RichHandler)
+    assert len(root.handlers) == 1
+
+    # After stop, the original handlers list is fully restored
+    display.stop()
+    assert len(root.handlers) == before_count
+
+
+# ---------------------------------------------------------------------------
 # _build_tui_state -- empty workers list
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes WOR-448

With --tui active, watcher log messages render inside/with the Live frame instead of corrupting it; non-TUI logging unchanged; original root-logger handlers restored on stop; tests assert install+restore; ruff/mypy/pytest/lint-imports green.