### PR TITLE
WOR-521 Scope _validate_allowed_paths to the worker's own commits (fix epic-bundle contamination)

### DIFF
--- a/app/core/watcher/watcher_finalize_helpers.py
+++ b/app/core/watcher/watcher_finalize_helpers.py
@@ -112,9 +112,22 @@ def _validate_allowed_paths(
 ) -> list[str]:
     """Validate the worker diff against allowed_paths and forbidden_paths.
 
-    Runs ``git diff --name-only <base_branch>...HEAD`` inside the worktree,
+    Enumerates the files touched by THIS worker's own commits
+    (``git log <base_branch>..HEAD --name-only``) inside the worktree,
     then matches each changed file against the manifest's ``allowed_paths``
     and ``forbidden_paths`` globs using ``fnmatch``.
+
+    WOR-521: the old ``git diff <base>...HEAD`` (three-dot ≡
+    merge-base..HEAD) cross-contaminated concurrent / sequential tickets
+    on a shared base — when ``<base>`` advanced after the worker branched
+    (a sibling or an earlier ticket merged into the shared base/main), the
+    stale merge-base made the diff include the base's new commits' files,
+    spuriously failing this ticket's allowed_paths. ``git log
+    <base>..HEAD`` selects only commits reachable from HEAD but NOT from
+    the current ``<base>`` tip (anything already merged into base is
+    excluded) and lists exactly the files those commits changed — immune
+    to base advancement and free of the ``git diff`` inversion artifact
+    for un-rebased branches.
 
     Returns a list of violation strings.  Empty list means the diff is clean
     and the PR path is safe to continue.  Each violation is tagged with
@@ -122,24 +135,67 @@ def _validate_allowed_paths(
     """
     violations: list[str] = []
 
-    # Get the list of changed files since the merge-base.
+    # WOR-521: list only the files THIS worker's own commits touched,
+    # compared against the CURRENT base tip. Root cause of the
+    # contamination: `git diff <base>...HEAD` (three-dot ≡ merge-base)
+    # against a *stale local* <base> ref — when the base advanced after
+    # the worker branched (a sibling / earlier-merged ticket), the diff
+    # picked up the base's new files. Fix: best-effort fetch the base,
+    # prefer the fresh `origin/<base>` tip, and use `git log <tip>..HEAD`
+    # (commits reachable from HEAD but not the tip → only the worker's own
+    # commits; no `git diff` inversion artifact for un-rebased branches).
+    base = manifest.base_branch
     try:
-        diff_proc = subprocess.run(  # nosec B603 B607
+        subprocess.run(  # nosec B603 B607
+            ["git", "-C", str(worktree_path), "fetch", "origin", base],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        compare = f"origin/{base}"
+        rev = subprocess.run(  # nosec B603 B607
             [
                 "git",
                 "-C",
                 str(worktree_path),
-                "diff",
+                "rev-parse",
+                "--verify",
+                "--quiet",
+                compare,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if rev.returncode != 0:
+            # No origin/<base> (e.g. local-only branch) — fall back to the
+            # local ref. Still `git log`, still scoped to the worker's
+            # commits.
+            compare = base
+        log_proc = subprocess.run(  # nosec B603 B607
+            [
+                "git",
+                "-C",
+                str(worktree_path),
+                "log",
                 "--name-only",
-                f"{manifest.base_branch}...HEAD",
+                "--format=",
+                f"{compare}..HEAD",
             ],
             capture_output=True,
             text=True,
             timeout=30,
         )
-        files = (diff_proc.stdout or "").strip().splitlines()
+        files = sorted(
+            {
+                line.strip()
+                for line in (log_proc.stdout or "").splitlines()
+                if line.strip()
+            }
+        )
     except (OSError, subprocess.TimeoutExpired):
-        # If we can't read the diff, allow it — a git error is not a scope
+        # If we can't read the log, allow it — a git error is not a scope
         # violation. The finalize checks (ruff/mypy/pytest) will still catch
         # most problems.
         return []

--- a/tests/test_watcher_finalize_allowed_paths_scope.py
+++ b/tests/test_watcher_finalize_allowed_paths_scope.py
@@ -1,0 +1,121 @@
+"""WOR-521 regression: _validate_allowed_paths must scope to the worker's
+OWN commits, immune to the base branch advancing after the worker branched
+(sibling / earlier-merged ticket). Builds a real temp git repo with an
+`origin` remote and a base that advances post-branch.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from app.core.watcher.watcher_finalize_helpers import _validate_allowed_paths
+from tests.conftest import make_manifest
+
+
+def _git(cwd: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", "-C", str(cwd), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _write_commit(repo: Path, rel: str, content: str, msg: str) -> None:
+    p = repo / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(content, encoding="utf-8")
+    _git(repo, "add", rel)
+    _git(repo, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-m", msg)
+
+
+def test_validate_allowed_paths_ignores_base_advancement(tmp_path: Path) -> None:
+    """Base advances with an UNRELATED file after the worker branched →
+    that file must NOT be reported as this ticket's violation (WOR-521)."""
+    origin = tmp_path / "origin.git"
+    subprocess.run(
+        ["git", "init", "--bare", str(origin)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    wt = tmp_path / "wt"
+    subprocess.run(
+        ["git", "clone", str(origin), str(wt)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    _git(wt, "symbolic-ref", "HEAD", "refs/heads/main")
+    _write_commit(wt, "base_file.py", "x = 0\n", "C0 base")
+    _git(wt, "branch", "-M", "main")
+    _git(wt, "push", "origin", "main")
+
+    # worker branches off C0
+    _git(wt, "checkout", "-b", "wor-521-worker")
+    _write_commit(wt, "app/core/mine.py", "y = 1\n", "worker change")
+
+    # base advances on origin with an UNRELATED file (the sibling / 520)
+    _git(wt, "checkout", "main")
+    _write_commit(wt, "app/core/watcher/watcher_worktrees.py", "z=2\n", "sibling")
+    _git(wt, "push", "origin", "main")
+
+    # worker is NOT rebased; local `main` ref now also points past C0
+    _git(wt, "checkout", "wor-521-worker")
+
+    manifest = make_manifest(
+        ticket_id="WOR-521",
+        base_branch="main",
+        worker_branch="wor-521-worker",
+        allowed_paths=["app/core/mine.py"],
+        forbidden_paths=[],
+    )
+
+    violations = _validate_allowed_paths(manifest, wt)
+
+    # The sibling/base-advanced file must NOT be flagged; the worker's own
+    # in-scope file is allowed → zero violations.
+    assert violations == [], f"base-advancement contaminated scope: {violations}"
+
+
+def test_validate_allowed_paths_still_flags_worker_out_of_scope(
+    tmp_path: Path,
+) -> None:
+    """The fix must NOT weaken real enforcement: a file the WORKER itself
+    touched outside allowed_paths is still flagged."""
+    origin = tmp_path / "origin.git"
+    subprocess.run(
+        ["git", "init", "--bare", str(origin)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    wt = tmp_path / "wt"
+    subprocess.run(
+        ["git", "clone", str(origin), str(wt)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    _git(wt, "symbolic-ref", "HEAD", "refs/heads/main")
+    _write_commit(wt, "base_file.py", "x = 0\n", "C0 base")
+    _git(wt, "branch", "-M", "main")
+    _git(wt, "push", "origin", "main")
+
+    _git(wt, "checkout", "-b", "wor-521-worker")
+    _write_commit(wt, "app/core/mine.py", "y = 1\n", "in scope")
+    _write_commit(wt, "app/ui/forbidden.py", "u = 9\n", "OUT of scope")
+
+    manifest = make_manifest(
+        ticket_id="WOR-521",
+        base_branch="main",
+        worker_branch="wor-521-worker",
+        allowed_paths=["app/core/mine.py"],
+        forbidden_paths=[],
+    )
+
+    violations = _validate_allowed_paths(manifest, wt)
+
+    assert any("app/ui/forbidden.py" in v for v in violations), violations
+    assert not any("app/core/mine.py" in v for v in violations), violations


### PR DESCRIPTION
## Summary

Fixes the contamination bug that Blocked WOR-293/514 on the WOR-519 epic and then **Blocked its own fix** (WOR-521 Blocked on WOR-520's `watcher_worktrees.py` right after #1067 merged). Implemented **outside the broken pipeline** (the watcher provably can't ship it — its own buggy gate contaminates it whenever the base advances mid-run).

## Root cause
`_validate_allowed_paths` ran `git diff --name-only {base}...HEAD` (three-dot ≡ merge-base..HEAD). A stale merge-base — when the shared base advanced after the worker branched (sibling / earlier-merged ticket) — pulled the base's new files into the diff → the gate Blocked the worker for files it never touched.

## Why not two-dot diff
Raised in review: `git diff base..HEAD` (two-dot) has the **inversion artifact** (base-advanced files appear as spurious deletions) — which is why the original used three-dot. **Neither diff form is safe.** The fix uses neither.

## Fix
`git log <tip>..HEAD --name-only` — a commit-range *selection* (commits reachable from HEAD but not the base tip), not a tree diff → lists exactly the files **this worker's own commits** touched, no inversion. Anchored on a best-effort-fetched **`origin/<base>`** tip (falls back to the local ref for origin-less branches) so a stale local base ref can't contaminate it. Correct whether or not the worktree was rebased.

## Tests (new — real temp git repo + origin remote)
- base advances with an unrelated file after the worker branched → **0 violations** (was: spurious Block)
- a file the worker itself touched outside allowed_paths → **still flagged** (enforcement not weakened)

## Verification
- 2 new tests pass; ruff / mypy / lint-imports clean
- Full unscoped pytest **2020 passed**
- The only 3 failures (`test_watcher_gestures` "daemon not running" / "no pid file") are **pre-existing & unrelated** — stash-proven: they fail identically on clean `main`+WOR-520 *without* this change. They trip only because a real watcher daemon runs concurrently with the suite (a WOR-511-residual test-isolation gap, filed separately) — not caused by this PR.

Closes WOR-521

🤖 Generated with [Claude Code](https://claude.com/claude-code)
