### PR TITLE
WOR-293 Watcher TUI: surface routing distribution + local-vs-cloud savings panel

### DIFF
--- a/app/core/metrics.py
+++ b/app/core/metrics.py
@@ -21,6 +21,7 @@ from app.core.metrics_models import (
     EpicSummary,
     ImplementationMode,
     Outcome,
+    RoutingDistribution,
     TicketMetrics,
     TicketRunLog,
 )
@@ -36,6 +37,7 @@ __all__ = [
     "ImplementationMode",
     "MetricsStore",
     "Outcome",
+    "RoutingDistribution",
     "TicketMetrics",
     "TicketRunLog",
     "compute_tags",

--- a/app/core/metrics_models.py
+++ b/app/core/metrics_models.py
@@ -341,3 +341,35 @@ class CostRollup:
     local_saved: float = 0.0
     cloud_ticket_count: int = 0
     local_ticket_count: int = 0
+
+
+@dataclass
+class RoutingDistribution:
+    """Routing distribution and savings breakdown.
+
+    *local_preferred* = ``billing_bucket='local'`` — tickets that cost-economics
+    consider local-first (most sub-ticket implementations).
+    *cloud_preferred* = ``billing_bucket='subscription'`` — tickets that are
+    inherently cloud (e.g. Linear API calls, CI).  *cloud_only* = rows where
+    ``billing_bucket IS NULL`` — legacy/unknown bucket, assumed cloud.
+
+    ``cloud_preferred_local_ran`` counts cloud_preferred tickets whose
+    ``implementation_mode`` is ``local`` — cloud-preferred but ran on local
+    hardware (e.g. Linear API call fallback).
+
+    ``total_savings`` is the computed savings from
+    ``cloud_preferred_local_ran`` tickets: their local_saved minus their
+    cloud_cost_estimate (positive means local ran cheaper than cloud would
+    have).
+    """
+
+    local_preferred_count: int = 0
+    cloud_preferred_count: int = 0
+    cloud_only_count: int = 0
+    cloud_preferred_local_ran: int = 0
+    cloud_preferred_cloud_ran: int = 0
+    local_preferred_local_ran: int = 0
+    local_preferred_cloud_ran: int = 0
+    total_local_saved: float = 0.0
+    total_cloud_cost: float = 0.0
+    total_savings: float = 0.0

--- a/app/core/metrics_store.py
+++ b/app/core/metrics_store.py
@@ -19,6 +19,7 @@ from app.core.metrics_models import (
     CheckStats,
     CostRollup,
     EpicSummary,
+    RoutingDistribution,
     TicketMetrics,
     TicketRunLog,
 )
@@ -177,6 +178,46 @@ _COST_ROLLUP_SQL_TODAY_GROUPED = (
     "    AND recorded_at >= date('now', 'start of day')"
     "    GROUP BY billing_bucket"
 )
+# Routing distribution — single aggregation over ticket_metrics.
+# billing_bucket drives the "preferred" classification; implementation_mode
+# drives what actually ran.  NULL billing_bucket → cloud_only.
+
+_ROUTING_DISTRIBUTION_SQL = """
+SELECT
+    -- Preferred counts by billing_bucket
+    COALESCE(SUM(CASE WHEN billing_bucket = 'local'        THEN 1 ELSE 0 END), 0)
+        AS local_preferred_count,
+    COALESCE(SUM(CASE WHEN billing_bucket = 'subscription' THEN 1 ELSE 0 END), 0)
+        AS cloud_preferred_count,
+    COALESCE(SUM(CASE WHEN billing_bucket IS NULL           THEN 1 ELSE 0 END), 0)
+        AS cloud_only_count,
+    -- cloud_preferred (subscription) actual run breakdown
+    COALESCE(SUM(CASE WHEN billing_bucket = 'subscription'
+               AND implementation_mode = 'local'    THEN 1 ELSE 0 END), 0)
+        AS cloud_preferred_local_ran,
+    COALESCE(SUM(CASE WHEN billing_bucket = 'subscription'
+               AND implementation_mode = 'cloud'    THEN 1 ELSE 0 END), 0)
+        AS cloud_preferred_cloud_ran,
+    -- local_preferred (local bucket) actual run breakdown
+    COALESCE(SUM(CASE WHEN billing_bucket = 'local'
+               AND implementation_mode = 'local'    THEN 1 ELSE 0 END), 0)
+        AS local_preferred_local_ran,
+    COALESCE(SUM(CASE WHEN billing_bucket = 'local'
+               AND implementation_mode = 'cloud'    THEN 1 ELSE 0 END), 0)
+        AS local_preferred_cloud_ran,
+    -- Savings: local bucket, local_used=1
+    COALESCE(SUM(CASE WHEN billing_bucket = 'local' AND local_used = 1
+             THEN local_input_tokens * 3.0 / 1e6
+                + local_output_tokens * 15.0 / 1e6
+             ELSE 0 END), 0)
+        AS total_local_saved,
+    -- Cloud cost: local bucket, cloud_used=1
+    COALESCE(SUM(CASE WHEN billing_bucket = 'local' AND cloud_used = 1
+             THEN cloud_cost_estimate ELSE 0 END), 0)
+        AS total_cloud_cost
+FROM ticket_metrics
+"""
+
 _COST_ROLLUP_SQL_WEEK_GROUPED = (
     "SELECT billing_bucket,"
     "        COALESCE(SUM(CASE WHEN cloud_used = 1"
@@ -658,6 +699,31 @@ class MetricsStore:
             local_saved=row["local_saved"],
             cloud_ticket_count=row["cloud_ticket_count"],
             local_ticket_count=row["local_ticket_count"],
+        )
+
+    def get_routing_distribution(self) -> RoutingDistribution:
+        """Return the routing distribution across the entire metrics table.
+
+        Computed on read — a SQL aggregation with no persisted rollup table.
+        ``billing_bucket`` drives the "preferred" classification;
+        ``implementation_mode`` drives what actually ran.  Rows with
+        ``billing_bucket IS NULL`` are classified as cloud_only (legacy).
+        """
+        with self._connect() as conn:
+            row = conn.execute(_ROUTING_DISTRIBUTION_SQL).fetchone()
+        total_local_saved = row["total_local_saved"] or 0.0
+        total_cloud_cost = row["total_cloud_cost"] or 0.0
+        return RoutingDistribution(
+            local_preferred_count=row["local_preferred_count"],
+            cloud_preferred_count=row["cloud_preferred_count"],
+            cloud_only_count=row["cloud_only_count"],
+            cloud_preferred_local_ran=row["cloud_preferred_local_ran"],
+            cloud_preferred_cloud_ran=row["cloud_preferred_cloud_ran"],
+            local_preferred_local_ran=row["local_preferred_local_ran"],
+            local_preferred_cloud_ran=row["local_preferred_cloud_ran"],
+            total_local_saved=total_local_saved,
+            total_cloud_cost=total_cloud_cost,
+            total_savings=total_local_saved - total_cloud_cost,
         )
 
     def record_run(self, entry: TicketRunLog) -> None:

--- a/app/core/watcher/watcher_tui.py
+++ b/app/core/watcher/watcher_tui.py
@@ -26,7 +26,7 @@ from rich.live import Live
 from rich.logging import RichHandler
 from rich.table import Table
 
-from app.core.metrics import CostRollup
+from app.core.metrics import CostRollup, RoutingDistribution
 
 logger = logging.getLogger(__name__)
 
@@ -84,6 +84,9 @@ class TUIState:
     tracked_prs: list[TrackedPR] = field(default_factory=list)
     vllm_metrics: dict[str, float] | None = None
     queue_state: QueueState = field(default_factory=QueueState)
+    routing_distribution: RoutingDistribution = field(
+        default_factory=RoutingDistribution
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -152,7 +155,11 @@ class WatcherDisplay:
             Layout(name="middle"),
             Layout(name="bottom"),
         )
-        layout["top"].split_row(self._cost_table(state), self._rollup_table(state))
+        layout["top"].split_row(
+            self._cost_table(state),
+            self._routing_table(state),
+            self._rollup_table(state),
+        )
         # Workers claims the grow weight (middle = one panel only).
         layout["middle"].update(
             Layout(self._worker_table(state), name="workers", ratio=3),
@@ -239,6 +246,55 @@ class WatcherDisplay:
         for pr in state.tracked_prs:
             if pr.last_status == "MERGED":
                 table.add_row(f"PR #{pr.number}", "MERGED")
+        return table
+
+    def _routing_table(self, state: TUIState) -> Table:
+        rd = state.routing_distribution
+        table = Table(title="Routing", show_header=True, expand=True)
+        table.add_column("Route", style="cyan")
+        table.add_column("Count", justify="right")
+        table.add_column("Saved", justify="right")
+        has_data = (
+            rd.local_preferred_count
+            or rd.cloud_preferred_count
+            or rd.cloud_only_count
+            or rd.total_local_saved
+            or rd.total_savings
+        )
+        if not has_data:
+            table.add_row("—", "—", "No data yet", "—")
+            return table
+        # local_preferred — tickets that cost-economics consider local-first
+        table.add_row(
+            "Local Pref",
+            str(rd.local_preferred_count),
+            self._format_cost(rd.total_local_saved),
+        )
+        # cloud_preferred breakdown
+        cloud_pref_total = rd.cloud_preferred_local_ran + rd.cloud_preferred_cloud_ran
+        table.add_row(
+            "Cloud Pref",
+            str(cloud_pref_total),
+            self._format_cost(rd.total_cloud_cost),
+        )
+        if cloud_pref_total:
+            local_pct = (rd.cloud_preferred_local_ran / cloud_pref_total) * 100
+            table.add_row(
+                "  Ran Local",
+                str(rd.cloud_preferred_local_ran),
+                f"{local_pct:.0f}%",
+            )
+        table.add_row(
+            "Cloud Only",
+            str(rd.cloud_only_count),
+            "—",
+        )
+        table.add_row(
+            "Total Savings",
+            "",
+            self._format_cost(rd.total_savings),
+            "",
+        )
         return table
 
     @staticmethod
@@ -353,6 +409,15 @@ class WatcherDisplay:
                     f"[COST {period.capitalize()}] "
                     f"cloud_spent={cr.cloud_spent:.4f} local_saved={cr.local_saved:.4f}"
                 )
+        # Routing distribution summary
+        rd = state.routing_distribution
+        if rd.local_preferred_count or rd.cloud_preferred_count or rd.cloud_only_count:
+            lines.append(
+                f"[ROUTING] local_pref={rd.local_preferred_count} "
+                f"cloud_pref={rd.cloud_preferred_count} "
+                f"cloud_only={rd.cloud_only_count} "
+                f"savings={rd.total_savings:.4f}"
+            )
         for msg in lines:
             logger.info("TUI: %s", msg)
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1309,3 +1309,331 @@ class TestCostRollupByBucket:
         store = MetricsStore(db_path=tmp_path / "app.db")
         result = store.get_cost_rollup("all", by_bucket=True)
         assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# WOR-293: Routing distribution
+# ---------------------------------------------------------------------------
+
+
+class TestRoutingDistribution:
+    """get_routing_distribution — SQL aggregation on read."""
+
+    def test_empty_table_returns_zeros(self, tmp_path):
+        """No rows → all counts and savings are zero."""
+        store = _store(tmp_path)
+        rd = store.get_routing_distribution()
+        assert rd.local_preferred_count == 0
+        assert rd.cloud_preferred_count == 0
+        assert rd.cloud_only_count == 0
+        assert rd.total_local_saved == 0.0
+        assert rd.total_savings == 0.0
+
+    def test_local_preferred_local_ran(self, tmp_path):
+        """billing_bucket='local' + implementation_mode='local'."""
+        store = _store(tmp_path)
+        store.record(
+            _ticket(
+                ticket_id="WOR-1",
+                local_used=True,
+                local_input_tokens=100_000,
+                local_output_tokens=5_000,
+                local_wall_time=60.0,
+                billing_bucket="local",
+                implementation_mode="local",
+            )
+        )
+        rd = store.get_routing_distribution()
+        assert rd.local_preferred_count == 1
+        assert rd.local_preferred_local_ran == 1
+        assert rd.cloud_preferred_count == 0
+        assert rd.cloud_preferred_local_ran == 0
+
+    def test_local_preferred_cloud_ran(self, tmp_path):
+        """billing_bucket='local' + implementation_mode='cloud'."""
+        store = _store(tmp_path)
+        store.record(
+            _ticket(
+                ticket_id="WOR-1",
+                cloud_used=True,
+                cloud_cost_estimate=0.15,
+                billing_bucket="local",
+                implementation_mode="cloud",
+            )
+        )
+        rd = store.get_routing_distribution()
+        assert rd.local_preferred_count == 1
+        assert rd.local_preferred_cloud_ran == 1
+        assert rd.local_preferred_local_ran == 0
+
+    def test_cloud_preferred_local_ran(self, tmp_path):
+        """billing_bucket='subscription' + implementation_mode='local'."""
+        store = _store(tmp_path)
+        store.record(
+            _ticket(
+                ticket_id="WOR-1",
+                local_used=True,
+                local_input_tokens=100_000,
+                local_output_tokens=5_000,
+                local_wall_time=60.0,
+                billing_bucket="subscription",
+                implementation_mode="local",
+            )
+        )
+        rd = store.get_routing_distribution()
+        assert rd.cloud_preferred_count == 1
+        assert rd.cloud_preferred_local_ran == 1
+
+    def test_cloud_preferred_cloud_ran(self, tmp_path):
+        """billing_bucket='subscription' + implementation_mode='cloud'."""
+        store = _store(tmp_path)
+        store.record(
+            _ticket(
+                ticket_id="WOR-1",
+                cloud_used=True,
+                cloud_cost_estimate=0.15,
+                billing_bucket="subscription",
+                implementation_mode="cloud",
+            )
+        )
+        rd = store.get_routing_distribution()
+        assert rd.cloud_preferred_count == 1
+        assert rd.cloud_preferred_cloud_ran == 1
+
+    def test_cloud_only_null_bucket(self, tmp_path):
+        """Rows with billing_bucket=NULL are classified as cloud_only."""
+        store = _store(tmp_path)
+        store.record(
+            _ticket(
+                ticket_id="WOR-1",
+                cloud_used=True,
+                cloud_cost_estimate=0.10,
+                billing_bucket=None,
+                implementation_mode="cloud",
+            )
+        )
+        rd = store.get_routing_distribution()
+        assert rd.cloud_only_count == 1
+        # NULL bucket rows are NOT counted in any other category
+        assert rd.local_preferred_count == 0
+        assert rd.cloud_preferred_count == 0
+
+    def test_total_savings_computed_correctly(self, tmp_path):
+        """total_savings = total_local_saved - total_cloud_cost for local_preferred."""
+        store = _store(tmp_path)
+        # Local-preferred ticket that ran locally
+        store.record(
+            _ticket(
+                ticket_id="WOR-1",
+                local_used=True,
+                local_input_tokens=100_000,
+                local_output_tokens=5_000,
+                local_wall_time=60.0,
+                billing_bucket="local",
+                implementation_mode="local",
+            )
+        )
+        # Local-preferred ticket that ran on cloud (costs $0.15)
+        store.record(
+            _ticket(
+                ticket_id="WOR-2",
+                cloud_used=True,
+                cloud_cost_estimate=0.15,
+                billing_bucket="local",
+                implementation_mode="cloud",
+            )
+        )
+        # subscription bucket doesn't contribute to local_preferred savings
+        store.record(
+            _ticket(
+                ticket_id="WOR-3",
+                local_used=True,
+                local_input_tokens=200_000,
+                local_output_tokens=10_000,
+                local_wall_time=120.0,
+                billing_bucket="subscription",
+                implementation_mode="local",
+            )
+        )
+        rd = store.get_routing_distribution()
+        # Total local saved = local_saved for billing_bucket='local' only
+        # WOR-1: 100000 * 3e-6 + 5000 * 15e-6 = 0.3 + 0.075 = 0.375
+        expected_local_saved = 0.375
+        assert rd.total_local_saved == pytest.approx(expected_local_saved)
+        assert rd.total_cloud_cost == pytest.approx(0.15)
+        assert rd.total_savings == pytest.approx(expected_local_saved - 0.15)
+
+    def test_null_bucket_ignored_in_local_preferred(self, tmp_path):
+        """NULL billing_bucket rows do not appear in local_preferred."""
+        store = _store(tmp_path)
+        store.record(
+            _ticket(
+                ticket_id="WOR-1",
+                local_used=True,
+                local_input_tokens=100_000,
+                billing_bucket=None,
+                implementation_mode="local",
+            )
+        )
+        rd = store.get_routing_distribution()
+        assert rd.local_preferred_count == 0
+        assert rd.cloud_only_count == 1
+        # NULL rows don't contribute to savings
+        assert rd.total_local_saved == 0.0
+
+    def test_multiple_rows_aggregate(self, tmp_path):
+        """Multiple rows are aggregated correctly."""
+        store = _store(tmp_path)
+        for i in range(3):
+            store.record(
+                _ticket(
+                    ticket_id=f"WOR-{i}",
+                    local_used=True,
+                    local_input_tokens=100_000,
+                    local_output_tokens=5_000,
+                    local_wall_time=60.0,
+                    billing_bucket="local",
+                    implementation_mode="local",
+                )
+            )
+        rd = store.get_routing_distribution()
+        assert rd.local_preferred_count == 3
+        assert rd.local_preferred_local_ran == 3
+        assert rd.total_local_saved == pytest.approx(0.375 * 3)
+
+    def test_savings_positive_when_local_cheaper(self, tmp_path):
+        """total_savings > 0 when local_preferred tickets ran locally."""
+        store = _store(tmp_path)
+        # Large local run (lots of savings vs cloud)
+        store.record(
+            _ticket(
+                ticket_id="WOR-1",
+                local_used=True,
+                local_input_tokens=500_000,
+                local_output_tokens=50_000,
+                local_wall_time=300.0,
+                billing_bucket="local",
+                implementation_mode="local",
+            )
+        )
+        # Tiny cloud run (low cost on cloud)
+        store.record(
+            _ticket(
+                ticket_id="WOR-2",
+                cloud_used=True,
+                cloud_cost_estimate=0.02,
+                billing_bucket="local",
+                implementation_mode="cloud",
+            )
+        )
+        rd = store.get_routing_distribution()
+        # local_saved = 500000*3e-6 + 50000*15e-6 = 1.5 + 0.75 = 2.25
+        # cloud_cost = 0.02
+        # savings = 2.25 - 0.02 = 2.23
+        assert rd.total_savings == pytest.approx(2.23)
+        assert rd.total_savings > 0
+
+
+class TestRoutingDistributionRender:
+    """TUI snapshot tests for the routing distribution panel."""
+
+    def test_routing_table_no_data(self) -> None:
+        """Empty routing distribution shows 'No data yet'."""
+        from rich.console import Console
+
+        from app.core.metrics import RoutingDistribution
+        from app.core.watcher.watcher_tui import TUIState, WatcherDisplay
+
+        state = TUIState(routing_distribution=RoutingDistribution())
+        display = WatcherDisplay()
+        table = display._routing_table(state)
+        console = Console(record=True, width=120, force_terminal=True)
+        console.print(table)
+        text = console.export_text()
+        assert "No data yet" in text
+        assert "Routing" in text
+
+    def test_routing_table_with_data(self) -> None:
+        """Panel renders counts and savings when data is present."""
+        from rich.console import Console
+
+        from app.core.metrics import RoutingDistribution
+        from app.core.watcher.watcher_tui import TUIState, WatcherDisplay
+
+        state = TUIState(
+            routing_distribution=RoutingDistribution(
+                local_preferred_count=5,
+                cloud_preferred_count=2,
+                cloud_only_count=1,
+                cloud_preferred_local_ran=1,
+                cloud_preferred_cloud_ran=1,
+                local_preferred_local_ran=4,
+                local_preferred_cloud_ran=1,
+                total_local_saved=12.5,
+                total_cloud_cost=3.0,
+                total_savings=9.5,
+            )
+        )
+        display = WatcherDisplay()
+        table = display._routing_table(state)
+        console = Console(record=True, width=120, force_terminal=True)
+        console.print(table)
+        text = console.export_text()
+        assert "Routing" in text
+        assert "Local Pref" in text
+        assert "Cloud Pref" in text
+        assert "Cloud Only" in text
+        assert "Total Savings" in text
+        assert "12.50" in text  # total_local_saved formatted
+
+    def test_layout_includes_routing_panel(self) -> None:
+        """Top row of layout contains routing table alongside cost and rollup."""
+        from app.core.metrics import RoutingDistribution
+        from app.core.watcher.watcher_tui import TUIState, WatcherDisplay
+
+        state = TUIState(
+            routing_distribution=RoutingDistribution(
+                local_preferred_count=3,
+            )
+        )
+        display = WatcherDisplay()
+        layout = display._build_layout(state)
+        assert layout["top"] is not None
+        # Top should be a split_row with 3 children: cost, routing, rollup
+        assert len(layout["top"].children) == 3
+
+    def test_render_line_includes_routing(self) -> None:
+        """_render_line emits routing distribution summary line."""
+        from unittest.mock import patch
+
+        from app.core.metrics import RoutingDistribution
+        from app.core.watcher.watcher_tui import TUIState, WatcherDisplay
+
+        state = TUIState(
+            routing_distribution=RoutingDistribution(
+                local_preferred_count=5,
+                cloud_preferred_count=2,
+            )
+        )
+        display = WatcherDisplay()
+        with patch("app.core.watcher.watcher_tui.logger") as mock_logger:
+            display._render_line(state)
+        calls = [call[0][1] for call in mock_logger.info.call_args_list]
+        routing_lines = [c for c in calls if "[ROUTING]" in c]
+        assert len(routing_lines) == 1
+        assert "local_pref=5" in routing_lines[0]
+        assert "cloud_pref=2" in routing_lines[0]
+        assert "savings=" in routing_lines[0]
+
+
+# ---------------------------------------------------------------------------
+# Import RoutingDistribution at module level (facade export test)
+# ---------------------------------------------------------------------------
+
+
+def test_routing_distribution_importable_from_facade():
+    """RoutingDistribution is re-exported from app.core.metrics."""
+    from app.core.metrics import RoutingDistribution
+
+    rd = RoutingDistribution()
+    assert rd.local_preferred_count == 0


### PR DESCRIPTION
Closes WOR-293

Routing-distribution + savings panel driven by an additive on-read metrics aggregation; all-time savings matches metrics.db; tests cover it; ruff/mypy/pytest/lint-imports green.