### PR TITLE
WOR-523 Make daemon-not-running gesture tests hermetic vs a live daemon

### DIFF
--- a/tests/test_watcher_gestures.py
+++ b/tests/test_watcher_gestures.py
@@ -427,8 +427,11 @@ class TestWatcherForcestop:
 
     def test_forcestop_when_daemon_not_running(self, tmp_path: Path) -> None:
         """When the PID file is absent, force-stop returns an error."""
-        args = argparse.Namespace()
-        rc = _run_watcher_forcestop(args)
+        # WOR-523: isolate cwd so a concurrently-running real daemon's
+        # .claude/watcher.pid is never observed — mirrors the
+        # *_succeeds_when_running siblings (per-test isolation, WOR-506/511).
+        with patch.object(Path, "cwd", return_value=tmp_path):
+            rc = _run_watcher_forcestop(argparse.Namespace())
         assert rc == 1
 
     def test_forcestop_succeeds_when_running(self, tmp_path: Path) -> None:
@@ -453,8 +456,11 @@ class TestWatcherPause:
 
     def test_pause_when_daemon_not_running(self, tmp_path: Path) -> None:
         """When the PID file is absent, pause returns an error."""
-        args = argparse.Namespace()
-        rc = _run_watcher_pause(args)
+        # WOR-523: isolate cwd so a concurrently-running real daemon's
+        # .claude/watcher.pid is never observed — mirrors the
+        # *_succeeds_when_running siblings (per-test isolation, WOR-506/511).
+        with patch.object(Path, "cwd", return_value=tmp_path):
+            rc = _run_watcher_pause(argparse.Namespace())
         assert rc == 1
 
     def test_pause_succeeds_when_running(self, tmp_path: Path) -> None:
@@ -510,8 +516,11 @@ class TestWatcherKill:
 
     def test_kill_no_pid_file(self, tmp_path: Path) -> None:
         """When the PID file is absent, kill returns an error."""
-        args = argparse.Namespace(ticket_ids=["WOR-10"])
-        rc = _run_watcher_kill(args)
+        # WOR-523: isolate cwd so a concurrently-running real daemon's
+        # .claude/watcher.pid is never observed — mirrors the
+        # *_succeeds_when_running siblings (per-test isolation, WOR-506/511).
+        with patch.object(Path, "cwd", return_value=tmp_path):
+            rc = _run_watcher_kill(argparse.Namespace(ticket_ids=["WOR-10"]))
         assert rc == 1
 
     def test_kill_no_ticket_ids(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

`tests/test_watcher_gestures.py::{TestWatcherForcestop::test_forcestop_when_daemon_not_running, TestWatcherPause::test_pause_when_daemon_not_running, TestWatcherKill::test_kill_no_pid_file}` failed **deterministically** whenever a real `python -m app.cli watcher` daemon was alive. Unlike their `*_succeeds_when_running` siblings, the three "not running" tests did not isolate `Path.cwd`, so the operator gesture handlers resolved the real repo `.claude/watcher.pid`, observed the live daemon, and returned `0` where the tests assert `1`.

This broke the "full suite is green" signal during any unattended/autonomous run where the daemon is intentionally live (the WOR-519/522 scenario), masking real regressions.

## Fix

Wrap the three handler calls in `patch.object(Path, "cwd", return_value=tmp_path)` — the exact per-test isolation pattern the `*_succeeds_when_running` siblings in this same file already use. **Test-only change; `app/cli/operator.py` is untouched** (zero production change, no weakening of real interactive gesture behaviour).

The resolver-injection route suggested in the ticket was evaluated and **rejected**: `app/cli/operator.py` imports `pid_file_path` via `from ... import`, a bound name the WOR-506 `_isolate_watcher_pid_file` monkeypatch (a module-attribute patch) cannot reach. Routing handlers through it left tests un-isolated, corrupted the live daemon's real pid file, and broke `test_cli_operator`. Per-test `cwd` isolation is the minimal, WOR-506/511-consistent fix that touches no production code.

## Test plan

- [x] `pytest tests/test_watcher_gestures.py -n0` with a **live daemon** (pid 301480): 37 passed, 0 failed (the previously-deterministic-fail condition)
- [x] Full suite `pytest -n8` with a **live daemon**: **2061 passed, 0 failed** (the environmental artifact eliminated)
- [x] `.claude/watcher.pid` intact after the suite (no real-state corruption)
- [x] ruff / mypy / lint-imports clean
- [x] `app/cli/operator.py` unchanged vs main

Closes WOR-523

🤖 Generated with [Claude Code](https://claude.com/claude-code)
