### PR TITLE
WOR-525 Refuse dispatch of tickets already in a terminal Linear state

### DIFF
--- a/app/core/watcher/dispatch.py
+++ b/app/core/watcher/dispatch.py
@@ -385,22 +385,48 @@ def _check_path_overlap(
     return False
 
 
+# WOR-525: a freshly-restarted daemon has no in-process memory of which
+# tickets it already handled, so a stale ``ReadyForLocal`` manifest in
+# .claude/artifacts/ for an already-completed ticket gets re-dispatched
+# (observed live: WOR-515/516/517 re-run after a restart, all already merged
+# via the WOR-519 epic). These workflow-state names are terminal in the
+# repo-scaffold-desktop Linear workflow; a ticket in any of them must never
+# be (re-)dispatched regardless of its manifest status.
+_TERMINAL_STATE_NAMES = frozenset(
+    {"Done", "MergedToEpic", "Cancelled", "Canceled", "Duplicate"}
+)
+
+
 def _check_in_progress_local(
     linear: LinearClientProtocol,
     linear_id: str,
     ticket_id: str,
 ) -> bool:
-    """WOR-458: guard against double-launch when Linear state is InProgressLocal.
+    """WOR-458 + WOR-525: refuse dispatch when the ticket's Linear state
+    means it must not be (re-)run.
 
-    A ticket that is already ``InProgressLocal`` must not be dispatched again —
-    the Linear state lock prevents the watcher from picking it up, but this check
-    acts as a safety net for edge cases (e.g. state race during dispatch).
+    Refuses ``InProgressLocal`` (WOR-458 double-launch guard) and any
+    terminal state — ``Done`` / ``MergedToEpic`` / ``Cancelled`` /
+    ``Duplicate`` (WOR-525). The Linear state lock normally keeps the
+    watcher from picking these up, but a freshly-restarted daemon would
+    otherwise re-dispatch a completed ticket from a stale ReadyForLocal
+    manifest in .claude/artifacts/ — this reconciles against Linear's
+    authoritative state before any worktree is created.
     """
     state_name = linear.get_current_state_name(linear_id)
     if state_name == "InProgressLocal":
         logger.warning(
             "Deferring %s — ticket is already InProgressLocal (state=%s). "
             "Double-launch guard.",
+            ticket_id,
+            state_name,
+        )
+        return False
+    if state_name in _TERMINAL_STATE_NAMES:
+        logger.warning(
+            "Skipping %s — Linear state is terminal (state=%s); not "
+            "re-dispatching a completed ticket from a stale ReadyForLocal "
+            "manifest (WOR-525).",
             ticket_id,
             state_name,
         )

--- a/tests/test_watcher_dispatch_loop.py
+++ b/tests/test_watcher_dispatch_loop.py
@@ -1122,3 +1122,84 @@ def test_start_ticket_proceeds_when_state_not_found(
 
     assert len(w._local_active) == 1
     assert w._local_active[0].ticket_id == "WOR-458"
+
+
+# ---------------------------------------------------------------------------
+# WOR-525 — terminal-state guard: stale ReadyForLocal manifest must not be
+# re-dispatched when the ticket is already Done/MergedToEpic/Cancelled/Duplicate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "terminal_state", ["Done", "MergedToEpic", "Cancelled", "Duplicate"]
+)
+def test_start_ticket_blocked_when_state_terminal(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture, terminal_state: str
+) -> None:
+    """WOR-525: a freshly-restarted daemon (no in-process memory) must NOT
+    re-dispatch a ticket whose Linear state is already terminal, even though
+    its .claude/artifacts manifest is stale at ReadyForLocal. This is the
+    exact scenario that re-ran the already-merged WOR-515/516/517."""
+    manifest = _make_manifest(
+        ticket_id="WOR-515",
+        worker_branch="wor-515-fetch-sonar-token-or-sonarcloud-token",
+        base_branch="epic/wor-519-half-wired-cleanup",
+        allowed_paths=["app/core/foo.py"],
+    )
+    linear_mock = MagicMock()
+    linear_mock.get_open_blockers.return_value = []
+    linear_mock.get_current_state_name.return_value = terminal_state
+    linear_mock.list_ready_for_local.return_value = []
+
+    w = Watcher(linear_client=linear_mock, repo_root=tmp_path)
+
+    with (
+        patch.object(w, "_load_manifest", return_value=manifest),
+        patch("app.core.watcher.dispatch.create_worktree") as mock_create,
+        caplog.at_level(logging.WARNING, logger="app.core.watcher"),
+    ):
+        w._start_ticket("WOR-515", "fake-linear-id")
+
+    # No worktree created, no active worker — the stale manifest is ignored.
+    assert len(w._local_active) == 0
+    mock_create.assert_not_called()
+    assert any("terminal" in m and "WOR-525" in m for m in caplog.messages)
+    w._linear.get_current_state_name.assert_called_once_with("fake-linear-id")
+
+
+def test_start_ticket_still_proceeds_for_ready_for_local_after_wor525(
+    tmp_path: Path,
+) -> None:
+    """WOR-525 regression guard: the terminal-state gate must NOT block a
+    legitimately ReadyForLocal ticket."""
+    manifest = _make_manifest(
+        ticket_id="WOR-10",
+        worker_branch="wor-10-test-ticket",
+        base_branch="main",
+        allowed_paths=["app/core/foo.py"],
+    )
+    linear_mock = MagicMock()
+    linear_mock.get_open_blockers.return_value = []
+    linear_mock.get_current_state_name.return_value = "ReadyForLocal"
+
+    w = Watcher(linear_client=linear_mock, repo_root=tmp_path)
+    fake_process = MagicMock(spec=subprocess.Popen)
+
+    with (
+        patch.object(w, "_load_manifest", return_value=manifest),
+        patch("app.core.watcher.dispatch.create_worktree", return_value=tmp_path),
+        patch("app.core.watcher.dispatch.copy_manifest_to_worktree"),
+        patch("app.core.watcher.dispatch.write_worker_pytest_config"),
+        patch("app.core.watcher.dispatch.safe_set_state"),
+        patch("app.core.watcher.dispatch.backup_plan_files", return_value=[]),
+        patch(
+            "app.core.watcher.dispatch.launch_worker",
+            return_value=fake_process,
+        ),
+        patch.object(w._services, "ensure_vllm_anthropic_mode"),
+        patch.object(w._services, "probe_vllm_health", return_value=True),
+    ):
+        w._start_ticket("WOR-10", "fake-linear-id")
+
+    assert len(w._local_active) == 1
+    assert w._local_active[0].ticket_id == "WOR-10"


### PR DESCRIPTION
## Summary

A freshly-restarted watcher has **no in-process memory** of which tickets it already handled, so a stale `"status": "ReadyForLocal"` manifest in `.claude/artifacts/` for an already-completed ticket gets re-dispatched. Observed live during WOR-523: a restart re-ran **WOR-515 / WOR-516 / WOR-517 — all already Done and merged to main via the WOR-519 epic** (#1062/#1063/#1064 → #1076), creating junk worktrees on shipped code. Sibling of WOR-524 (daemon-restart reliability class).

## Fix

Minimal extension of the existing **WOR-458** `_check_in_progress_local` guard in `dispatch.start_ticket` (the same guard that already refuses `InProgressLocal`). It now also refuses the terminal Linear states `Done` / `MergedToEpic` / `Cancelled` / `Canceled` / `Duplicate`. The guard runs **before any worktree is created**, so the dispatch path reconciles against Linear's authoritative state regardless of stale manifest status — directly satisfying the AC's "dispatch path reconciles against Linear before creating a worktree". No refactor; one new module constant + one branch.

## Test plan

- [x] New parametrized regression test `test_start_ticket_blocked_when_state_terminal` (Done/MergedToEpic/Cancelled/Duplicate) — asserts no worktree created, no active worker, WOR-525 warning logged, `get_current_state_name` consulted
- [x] `test_start_ticket_still_proceeds_for_ready_for_local_after_wor525` — regression guard that the new gate does not block legitimate ReadyForLocal dispatch
- [x] Existing WOR-458 `InProgressLocal` / ReadyForLocal / state-not-found tests still pass (no regression)
- [x] `tests/test_watcher_dispatch_loop.py -n0`: 37 passed
- [x] Full suite: **2066 passed, 0 failed**
- [x] ruff / mypy / lint-imports clean

Closes WOR-525

🤖 Generated with [Claude Code](https://claude.com/claude-code)
